### PR TITLE
Add script for testing compatibility with CoffeeScript

### DIFF
--- a/build/test-compat.coffee
+++ b/build/test-compat.coffee
@@ -1,0 +1,49 @@
+###
+This script tries running Civet on the specified files, and repeatedly
+removes lines where Civet complains about a syntax error, to see how many
+lines successfully compile.  This gives a rough idea of backward
+compatibility with CoffeeScript (but doesn't test for correct compilation).
+It adds "civet coffeeCompat" to .coffee files if there isn't already a
+leading civet directive.
+###
+
+fs = require 'fs'
+civet = require '..'
+
+countLines = (lines) ->
+  lines.length - (if lines.at(-1) == '' then 1 else 0)
+
+if process.argv.length <= 2
+  console.log "> Provide one of more filenames to try running through Civet"
+  process.exit 1
+
+for filename in process.argv[2..]
+  console.log '*', filename
+  input = fs.readFileSync filename, encoding: 'utf8'
+
+  if filename.endsWith('.coffee') and not input.startsWith('"civet')
+    input = """
+      "civet coffeeCompat"
+      #{input}
+    """
+
+  lines = input.split '\n'
+  origCount = countLines lines
+
+  loop
+    try
+      civet.compile input
+      break
+    catch e
+      match = e.message.match /^\s*unknown:(\d+)/
+      unless match?
+        console.error "Unrecognized error message #{JSON.stringify e.message}; counts will be inaccurate"
+        break
+      line = match[1] - 1  # convert 1-base to 0-base
+      #console.log 'Removing line', line
+      lines[line..line] = []
+      input = lines.join '\n'
+
+  newCount = countLines lines
+  removedCount = origCount - newCount
+  console.log "#{(newCount / origCount * 100).toFixed 1}% success (removed #{removedCount} out of #{origCount} lines)"


### PR DESCRIPTION
Current results on CoffeeScript source:

```
* browser.coffee
Unrecognized error message "Unknown node"
97.2% success (removed 3 out of 108 lines)
* cake.coffee
98.9% success (removed 1 out of 89 lines)
* grammar.coffee
98.6% success (removed 14 out of 1004 lines)
* optparse.coffee
81.3% success (removed 31 out of 166 lines)
* register.coffee
100.0% success (removed 0 out of 56 lines)
* repl.coffee
99.5% success (removed 1 out of 221 lines)
```

The other files not listed above crash with errors that don't contain line numbers. In some cases the error just needs to be replaced (e.g. `by clause not yet implement in non-range for in loops`) and in other cases they're probably bugs (`Cannot read properties of undefined`).