### PR TITLE
Allow and= / or= by default (not just coffeeCompat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Things Kept from CoffeeScript
 - `is` -> `===`
 - `or` -> `||`
 - `and` -> `&&`
+- `or=` -> `||=`
+- `and=` -> `&&=`
 - `loop` -> `while(true)`
 - `unless exp` -> `if(!exp)`
 - `until condition` -> `while(!condition)`
@@ -111,7 +113,6 @@ Civet.
 - `for from` (use JS `for of`, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for own of` (use JS `for in` and check manually, switch to `Map#keys/values/entries`, or use `Object.create(null)`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for ... when <condition>` (use `continue if exp` inside loop, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
-- `and=`, `or=` (don't mix and match words and symbols, or use `"civet coffeeCompat"`, or `"civet coffeeWordAssignment"`)
 - `a ? b` (use `a ?? b`, though it doesn't check for undeclared variables, `"civet coffeeCompat"`, or `"civet coffeeBinaryExistential"` enables this at the cost of losing JS ternary operator)
 - `a of b` (use `a in b` matching JS, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)
 - Iteration expression results
@@ -249,11 +250,10 @@ coffeeInterpolation (`"a string with #{myVar}"`)
 coffeeIsnt     (`isnt` -> `!==`)
 coffeeNot      (`not` -> "!") (currently doesn't support `not instanceof`, `not of`)
 coffeeOf       (`a of b` -> `a in b`, `a in b` -> `b.indexOf(a) >= 0`, `a not in b` -> `b.indexOf(a) < 0`)
-coffeeWordAssignment (Allow `and=`, `or=`)
 ```
 
 You can use these with `"civet coffeeCompat"` to opt in to all or use them bit by bit with `"civet coffeeComment coffeeEq coffeeInterpolation"`.
-Another posibility is to slowly remove them to provide a way to migrate files a little at a time `"civet coffeeCompat -coffeeBooleans -coffeeComment -coffeeEq"`.
+Another possibility is to slowly remove them to provide a way to migrate files a little at a time `"civet coffeeCompat -coffeeBooleans -coffeeComment -coffeeEq"`.
 Both camel case and hyphens work when specifying options `"civet coffee-compat"`. More options will be added over time until 97+% compatibility is achieved.
 
 Using Civet in your Node.js Environment

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1550,7 +1550,7 @@ AssignmentOpSymbol
   "??="
   "?=" -> "??="
   "="
-  CoffeeWordAssignmentEnabled CoffeeWordAssignmentOp -> $2
+  CoffeeWordAssignmentOp -> $1
 
 CoffeeWordAssignmentOp
   "and=" -> "&&="
@@ -3661,11 +3661,6 @@ CoffeeOfEnabled
     if(module.config.coffeeOf) return
     return $skip
 
-CoffeeWordAssignmentEnabled
-  "" ->
-    if(module.config.coffeeWordAssignment) return
-    return $skip
-
 # Reset module level data
 Reset
   "" ->
@@ -3701,7 +3696,6 @@ Reset
       coffeeLineContinuation: false,
       coffeeNot: false,
       coffeeOf: false,
-      coffeeWordAssignment: false,
       implicitReturns: true,
     }
 
@@ -3769,7 +3763,6 @@ Reset
           this.coffeeLineContinuation = true
           this.coffeeNot = true
           this.coffeeOf = true
-          this.coffeeWordAssignment = true
         } else {
           this.autoVar = false
           this.coffeeBinaryExistential = false
@@ -3784,7 +3777,6 @@ Reset
           this.coffeeLineContinuation = false
           this.coffeeNot = false
           this.coffeeOf = false
-          this.coffeeWordAssignment = false
         }
       }
     })

--- a/test/compat/coffee-word-assignment.civet
+++ b/test/compat/coffee-word-assignment.civet
@@ -4,7 +4,6 @@ describe "coffeeWordAssignment", ->
   testCase """
     or=
     ---
-    "civet coffeeWordAssignment"
     a or= b
     ---
     a ||= b
@@ -13,7 +12,6 @@ describe "coffeeWordAssignment", ->
   testCase """
     and=
     ---
-    "civet coffeeWordAssignment"
     a and= b
     ---
     a &&= b


### PR DESCRIPTION
* Remove "civet coffeeWordAssignment" configuration option
* Enable `and=` / `or=` always, by symmetry with `and` and `or`
* Small typo fix in README