### PR TITLE
More consistent use of paths vs. file URIs

### DIFF
--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -21,7 +21,7 @@ const {
 } = ts
 
 import { TextDocument } from "vscode-languageserver-textdocument"
-import { fileURLToPath } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
 import { createRequire } from "module"
 // TODO: project Coffee version?
 import { compile as coffeeCompile } from "coffeescript"
@@ -149,7 +149,7 @@ function TSHost(compilationSettings: CompilerOptions, initialFileNames: string[]
       const path = fileURLToPath(doc.uri)
 
       // Something may have changed so notify TS by updating the project version
-      // Still not too sure exactly how TS uses this. Read `sychronizeHostData` in `typescript/src/sercivces/services.ts` for more info.
+      // Still not too sure exactly how TS uses this. Read `synchronizeHostData` in `typescript/src/sercivces/services.ts` for more info.
       projectVersion++
 
       const extension = getExtensionFromPath(path)
@@ -335,7 +335,8 @@ function TSHost(compilationSettings: CompilerOptions, initialFileNames: string[]
   function initTranspiledDoc(path: string) {
     // Create an empty document, it will be updated on-demand when `getScriptSnapshot` is called
     // `path` must be the in the format that TypeScript Language Service expects
-    const transpiledDoc = TextDocument.create(path, "none", -1, "")
+    const uri = pathToFileURL(path).toString()
+    const transpiledDoc = TextDocument.create(uri, "none", -1, "")
     // Add transpiled doc
     documents.add(transpiledDoc)
     pathMap.set(path, transpiledDoc)
@@ -413,8 +414,9 @@ function TSService(projectURL = "./") {
       const civetFiles = sys.readDirectory(civetFolder)
 
       // One day it would be nice to load plugins that could be transpiled but that is a whole can of worms.
-      // VSCode Node verions, esm loaders, etc.
+      // VSCode Node versions, esm loaders, etc.
       const pluginFiles = civetFiles.filter(file => file.endsWith("plugin.mjs"))
+      .map(file => pathToFileURL(file).toString())
 
       for (const filePath of pluginFiles) {
         console.info("Loading plugin", filePath)

--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -25,7 +25,7 @@ import { convertNavTree, forwardMap, getCompletionItemKind, convertDiagnostic } 
 import assert from "assert"
 
 import ts, { displayPartsToString, GetCompletionsAtPositionOptions } from 'typescript';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
@@ -141,7 +141,8 @@ connection.onHover(({ textDocument, position }) => {
     // console.log("onHover2", sourcePath, position)
 
     const p = transpiledDoc.offsetAt(position)
-    info = service.getQuickInfoAtPosition(transpiledDoc.uri, p)
+    const transpiledPath = documentToSourcePath(transpiledDoc)
+    info = service.getQuickInfoAtPosition(transpiledPath, p)
     // console.log("onHover3", info)
 
   }
@@ -214,7 +215,8 @@ connection.onCompletion(({ textDocument, position, context: _context }) => {
   }
 
   const p = transpiledDoc.offsetAt(position)
-  const completions = service.getCompletionsAtPosition(transpiledDoc.uri, p, completionOptions)
+  const transpiledPath = documentToSourcePath(transpiledDoc)
+  const completions = service.getCompletionsAtPosition(transpiledPath, p, completionOptions)
   if (!completions) return;
 
   return convertCompletions(completions)
@@ -253,7 +255,8 @@ connection.onDefinition(({ textDocument, position }) => {
     }
 
     const p = transpiledDoc.offsetAt(position)
-    definitions = service.getDefinitionAtPosition(transpiledDoc.uri, p)
+    const transpiledPath = documentToSourcePath(transpiledDoc)
+    definitions = service.getDefinitionAtPosition(transpiledPath, p)
   }
 
   if (!definitions) return
@@ -296,7 +299,8 @@ connection.onDocumentSymbol(({ textDocument }) => {
     assert(transpiledDoc)
 
     document = transpiledDoc
-    navTree = service.getNavigationTree(transpiledDoc.uri)
+    const transpiledPath = documentToSourcePath(transpiledDoc)
+    navTree = service.getNavigationTree(transpiledPath)
     sourcemapLines = meta.sourcemapLines
   }
 


### PR DESCRIPTION
This fixes some lsp bugs on Windows, but sadly not all of them.

(It's still the case that updates to files don't trigger updates to the view. `getScriptSnapshot` seems to be returning the correct data (updated transpiled file), but as far as I can tell it's getting called *after* the TypeScript service returns results, which seems... wrong?)

Before merging, please test on other operating systems that this doesn't break anything.