### PR TITLE
Support for unbraced `export x, y`

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Things Added that CoffeeScript didn't
 - Convenience for ES6+ Features
   - Const assignment shorthand `a := b` -> `const a = b`; `{a, b} := c` -> `const {a, b} = c`
   - `@#id` -> `this.#id` shorthand for private identifiers
-  - `import` shorthand `x from ./x` -> `import x from "./x"`
+  - `import` shorthand: `x from ./x` -> `import x from "./x"`
+  - `export` shorthand: `export x, y` -> `export {x, y}`
   - Triple backtick Template Strings remove leading indentation for clarity
   - Class constructor shorthand `@( ... )`
   - ClassStaticBlock `@ { ... }`

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1482,9 +1482,8 @@ NestedPropertyDefinition
     }))
 
 InlineObjectLiteral
-  InsertOpenBrace:open SnugNamedProperty ImplicitInlineObjectPropertyDelimiter ( NamedProperty ImplicitInlineObjectPropertyDelimiter )* InsertCloseBrace:close ->
-    // Drop leading space from inserted brace
-    return [open[1], $2, $3, ...$4, close]
+  InsertInlineOpenBrace:open SnugNamedProperty ImplicitInlineObjectPropertyDelimiter ( NamedProperty ImplicitInlineObjectPropertyDelimiter )* InsertCloseBrace:close ->
+    return [open, $2, $3, ...$4, close]
 
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
 # Instead we see if the next line matches a NamedProperty and if so we insert a comma
@@ -2675,7 +2674,9 @@ ExportDeclaration
   # NOTE: Using ExtendedExportDeclaration to allow If/Switch expressions
   Export __ "default" NonIdContinue __ ( HoistableDeclaration / ClassDeclaration / ExtendedExpression )
   Export __ ExportFromClause __ FromClause
-  Export __ ( NamedExports / VariableStatement / Declaration )
+  # NOTE: Declaration should come before NamedExports
+  # so that NamedExports doesn't grab function, async, type, etc.
+  Export __ ( Declaration / NamedExports / VariableStatement )
 
 # https://262.ecma-international.org/#prod-ExportFromClause
 ExportFromClause
@@ -2685,10 +2686,16 @@ ExportFromClause
 # https://262.ecma-international.org/#prod-NamedExports
 NamedExports
   OpenBrace ExportSpecifier* (__ Comma )? __ CloseBrace
+  # Unbraced version: export x, y
+  InsertInlineOpenBrace:open ImplicitExportSpecifier ( _ ImplicitExportSpecifier )* InsertCloseBrace:close ->
+    return [open, $2, ...$3, close]
 
 # https://262.ecma-international.org/#prod-ExportSpecifier
 ExportSpecifier
   __ ModuleExportName ( __ As __ ModuleExportName )? ObjectPropertyDelimiter
+
+ImplicitExportSpecifier
+  !"default" ModuleExportName ( __ As __ ModuleExportName )? ImplicitInlineObjectPropertyDelimiter
 
 # https://262.ecma-international.org/#prod-Declaration
 Declaration
@@ -3791,6 +3798,10 @@ InsertOpenBrace
   # NOTE: Includes a preceding space
   "" ->
     return [{ $loc, token: " " }, { $loc, token: "{" } ]
+
+InsertInlineOpenBrace
+  "" ->
+    return [{ $loc, token: "{" } ]
 
 InsertCloseBrace
   "" ->

--- a/test/export.civet
+++ b/test/export.civet
@@ -40,10 +40,24 @@ describe "export", ->
   """
 
   testCase """
+    unbraced named
+    ---
+    export a
+    export a,
+    export a, b, c
+    ---
+    export {a}
+    export {a,}
+    export {a, b, c}
+  """
+
+  testCase """
     from
     ---
+    export {a} from "./cool.js"
     export * from "./cool.js"
     ---
+    export {a} from "./cool.js"
     export * from "./cool.js"
   """
 
@@ -85,6 +99,14 @@ describe "export", ->
       b as B,
       c as C,
       d as D}
+  """
+
+  testCase """
+    braceless as
+    ---
+    export a as A, b as B, c as C, d as D
+    ---
+    export {a as A, b as B, c as C, d as D}
   """
 
   testCase """


### PR DESCRIPTION
This PR adds support for `export x, y` shorthand for `export {x, y}`.  Also supports `export x as foo, y as bar`.

It's meant as a step toward `export x = 5` from CoffeeScript, but I haven't gotten there yet.  It seems useful by itself.  It feels like a natural extension to CoffeeScript's implicit object literals.

Also not yet supported:
* `export x, y from 'foo'`.  This seems like it should be supported by the grammar as I wrote it, but it won't parse. Any ideas?
* Multi-line implicit objects: (I couldn't quite figure out how this works with `ImplicitObjectLiteral`)
  ```
  export x,
    y
    z
  ```
  
I'm also a little uncomfortable with why I needed to re-order `Declaration` and `NamedExports`. I thought both branches would try to parse...?