### PR TITLE
Indentation-based JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Things Added that CoffeeScript didn't
   - function call `x.map &.callback a, b` -> `x.map($ => $.callback(a, b))`
   - unary operators `x.map !!&`, -> `x.map($ => !!$)`
   - binary operators `x.map &+1` -> `x.map($ => $+1)`
+- Indentation JSX: instead of explicitly closing `<tag>`s or `<>`s,
+  you can indent the children and Civet will close your tags for you
 - CoffeeScript improvements
   - Postfix loop `run() loop` -> `while(true) run()`
   - Character range literals `["a".."z"]`, `['f'..'a']`, `['0'..'9']`

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -1,6 +1,6 @@
 "civet coffeeCompat"
 
-{ parse } = parser = require "./parser"
+{ parse } = require "./parser"
 { prune } = gen = require "./generate"
 { SourceMap, base64Encode } = util = require "./util.coffee"
 
@@ -88,7 +88,7 @@ makeCache = ->
         else
           cache.set(state.pos, result)
 
-      if parser.verbose and result
+      if parse.config.verbose and result
         console.log "Parsed #{JSON.stringify state.input[state.pos...result.pos]} [pos #{state.pos}-#{result.pos}] as #{ruleName}"#, JSON.stringify(result.value)
 
       return

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -1,6 +1,6 @@
 "civet coffeeCompat"
 
-{ parse } = require "./parser"
+{ parse } = parser = require "./parser"
 { prune } = gen = require "./generate"
 { SourceMap, base64Encode } = util = require "./util.coffee"
 
@@ -85,6 +85,9 @@ makeCache = ->
           cache.set(state.pos, {...result})
         else
           cache.set(state.pos, result)
+
+      if parser.verbose and result
+        console.log "Parsed #{JSON.stringify state.input[state.pos...result.pos]} [pos #{state.pos}-#{result.pos}] as #{ruleName}"#, JSON.stringify(result.value)
 
       return
 

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -69,11 +69,13 @@ makeCache = ->
             "CallExpression", "CallExpressionRest", "LeftHandSideExpression", "ActualAssignment", "UpdateExpression",\
             "UnaryExpression", "BinaryOpExpression", "BinaryOpRHS", "ConditionalExpression", "ShortCircuitExpression",\
             "NestedPropertyDefinitions", "NestedObject", "NestedImplicitObjectLiteral", "NestedImplicitPropertyDefinitions", "NestedBlockStatement",\
-            "NestedInterfaceProperty",\
+            "NestedElement", "NestedElementList", "NestedBindingElement", "NestedBindingElements", "NestedInterfaceProperty",\
+            "MemberExpression", "PrimaryExpression",\
             "IndentedApplicationAllowed", "ExpressionWithIndentedApplicationSuppressed", "SuppressIndentedApplication",\
             "AssignmentExpressionTail", "AssignmentExpression", "ExtendedExpression", "Expression", "MemberExpressionRest",\
             "ElseClause",\
-            "CoffeeCommentEnabled", "SingleLineComment", "Debugger"
+            "CoffeeCommentEnabled", "SingleLineComment", "Debugger",\
+            "JSXElement", "JSXChild", "JSXChildren", "JSXFragment", "JSXNestedChildren"
 
             break
           else

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3465,12 +3465,14 @@ Yield
 # https://facebook.github.io/jsx/#prod-JSXElement
 JSXElement
   JSXSelfClosingElement
-  JSXOpeningElement JSXChildren* __ JSXClosingElement ->
+  JSXOpeningElement JSXChildren? __ JSXClosingElement ->
     // Check that tags match
     if ($1[1] !== $4[2]) {
       throw new Error(`mismatched closing tags at ${JSON.stringify($loc)}`)
     }
     return $0
+  JSXOpeningElement:open JSXNestedChildren InsertNewline InsertIndent ->
+    return [...$0, ["</", open[1], ">"]]
 
 # https://facebook.github.io/jsx/#prod-JSXSelfClosingElement
 JSXSelfClosingElement
@@ -3536,6 +3538,9 @@ JSXAttributeValue
 JSXChildren
   ( __ JSXChild )*
 
+JSXNestedChildren
+  PushIndent ( Nested JSXChild )+ PopIndent
+
 # https://facebook.github.io/jsx/#prod-JSXChild
 JSXChild
   JSXText
@@ -3546,7 +3551,9 @@ JSXChild
 # https://facebook.github.io/jsx/#prod-JSXText
 JSXText
   # NOTE: not currently excluding https://facebook.github.io/jsx/#prod-HTMLCharacterReference
-  [^{}<>]+
+  # NOTE: Additionally forbidding leading whitespace so it can be used for
+  # indentation (by JSXNestedChildren) or ignored by JSXChildren.
+  [^{}<>\s][^{}<>\n\r]*
 
 # https://facebook.github.io/jsx/#prod-JSXChildExpression
 JSXChildExpression

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3940,8 +3940,7 @@ Reset
       })
     }
 
-    module.verbose = false
-    module.config = {
+    module.config = parse.config = {
       autoVar: false,
       coffeeBinaryExistential: false,
       coffeeBooleans: false,
@@ -3956,6 +3955,7 @@ Reset
       coffeeNot: false,
       coffeeOf: false,
       implicitReturns: true,
+      verbose: false,
     }
 
     let indexOfRef, hasPropRef, spliceRef
@@ -5084,7 +5084,7 @@ TrackIndented
     if (level <= module.currentIndent.level) {
       return $skip
     }
-    if (module.verbose) {
+    if (module.config.verbose) {
       console.log("pushing indent", indent)
     }
 
@@ -5117,7 +5117,7 @@ PushIndent
 
 PopIndent
   "" ->
-    if (module.verbose) {
+    if (module.config.verbose) {
       console.log("popping indent", module.indentLevels[module.indentLevels.length-1], "->", module.indentLevels[module.indentLevels.length-2])
     }
     module.indentLevels./**/pop()
@@ -5126,11 +5126,11 @@ Nested
   EOS:eos Indent:indent ->
     const { level } = indent
     const currentIndent = module.currentIndent
-    if (module.verbose) {
+    if (module.config.verbose) {
       console.log("Indented", level, currentIndent)
     }
     if (level !== currentIndent.level) {
-      if (module.verbose) {
+      if (module.config.verbose) {
         console.log("skipped nested")
       }
       return $skip

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3465,14 +3465,14 @@ Yield
 # https://facebook.github.io/jsx/#prod-JSXElement
 JSXElement
   JSXSelfClosingElement
+  JSXOpeningElement:open JSXNestedChildren InsertNewline InsertIndent ->
+    return [...$0, ["</", open[1], ">"]]
   JSXOpeningElement JSXChildren? __ JSXClosingElement ->
     // Check that tags match
     if ($1[1] !== $4[2]) {
       throw new Error(`mismatched closing tags at ${JSON.stringify($loc)}`)
     }
     return $0
-  JSXOpeningElement:open JSXNestedChildren InsertNewline InsertIndent ->
-    return [...$0, ["</", open[1], ">"]]
 
 # https://facebook.github.io/jsx/#prod-JSXSelfClosingElement
 JSXSelfClosingElement
@@ -3539,7 +3539,9 @@ JSXChildren
   ( __ JSXChild )*
 
 JSXNestedChildren
-  PushIndent ( Nested JSXChild )+ PopIndent
+  PushIndent ( Nested JSXChild )* PopIndent ->
+    if ($2.length) return $0
+    return $skip
 
 # https://facebook.github.io/jsx/#prod-JSXChild
 JSXChild

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2558,9 +2558,15 @@ ThrowExpression
     }
 
 MaybeNestedExpression
+  # Not nested case
   !EOS ExtendedExpression ->
     return $2
-  &EOS ObjectLiteral -> $2
+  # Avoid wrapping object return value in parentheses.
+  &EOS ObjectLiteral ->
+    return $2
+  # Value after `return` needs to be wrapped in parentheses
+  # if it starts on another line.
+  &EOS InsertSpace InsertOpenParen PushIndent Nested ExtendedExpression PopIndent InsertNewline InsertIndent InsertCloseParen
 
 # https://262.ecma-international.org/#prod-ImportDeclaration
 ImportDeclaration

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1694,8 +1694,8 @@ BinaryOpSymbol
   ">="
   "<<"
   # NOTE: Avoid matching JSX opening tag by requiring non-identifier character
-  # (e.g. whitespace) after "<", or no whitespace before "<" (for e.g. "1<2").
-  /<(?!\p{ID_Start}|[_$])|(?<=\S)</ ->
+  # (e.g. whitespace) after "<".  This does forbid 1<2 or x<y.
+  /<(?!\p{ID_Start}|[_$])/ ->
     return "<"
   ">>>"
   ">>"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1693,7 +1693,10 @@ BinaryOpSymbol
   "<="
   ">="
   "<<"
-  "<"
+  # NOTE: Avoid matching JSX opening tag by requiring non-identifier character
+  # (e.g. whitespace) after "<", or no whitespace before "<" (for e.g. "1<2").
+  /<(?!\p{ID_Start}|[_$])|(?<=\S)</ ->
+    return "<"
   ">>>"
   ">>"
   ">"
@@ -3465,14 +3468,18 @@ Yield
 # https://facebook.github.io/jsx/#prod-JSXElement
 JSXElement
   JSXSelfClosingElement
-  JSXOpeningElement:open JSXNestedChildren InsertNewline InsertIndent ->
-    return [...$0, ["</", open[1], ">"]]
   JSXOpeningElement JSXChildren? __ JSXClosingElement ->
     // Check that tags match
-    if ($1[1] !== $4[2]) {
-      throw new Error(`mismatched closing tags at ${JSON.stringify($loc)}`)
-    }
+    if ($1[1] !== $4[2]) return $skip
     return $0
+  JSXOpeningElement:open JSXNestedChildren:children InsertNewline InsertIndent ->
+    if (children.length) {
+      return [...$0, ["</", open[1], ">"]]
+    } else {
+      return [$1.slice(0, -1), " />"]
+    }
+  JSXOpeningElement ->
+    throw new Error(`could not parse JSX element "${$0.join('')}" at ${$loc.start.line}:${$loc.start.column}`)
 
 # https://facebook.github.io/jsx/#prod-JSXSelfClosingElement
 JSXSelfClosingElement
@@ -3489,6 +3496,8 @@ JSXClosingElement
 # https://facebook.github.io/jsx/#prod-JSXFragment
 JSXFragment
   "<>" JSXChildren? "</>"
+  "<>" JSXNestedChildren InsertNewline InsertIndent ->
+    return [...$0, "</>"]
 
 # https://facebook.github.io/jsx/#prod-JSXElementName
 JSXElementName
@@ -3540,8 +3549,10 @@ JSXChildren
 
 JSXNestedChildren
   PushIndent ( Nested JSXChild )* PopIndent ->
-    if ($2.length) return $0
+    if ($2.length) return $2
     return $skip
+  &EOS ->
+    return []
 
 # https://facebook.github.io/jsx/#prod-JSXChild
 JSXChild

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5073,6 +5073,9 @@ TrackIndented
     if (level <= module.currentIndent.level) {
       return $skip
     }
+    if (module.verbose) {
+      console.log("pushing indent", indent)
+    }
 
     module.indentLevels.push(indent)
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3472,14 +3472,15 @@ JSXElement
     // Check that tags match
     if ($1[1] !== $4[2]) return $skip
     return $0
-  JSXOpeningElement:open JSXNestedChildren:children InsertNewline InsertIndent ->
-    if (children.length) {
+  # NOTE: c1 matches "same-line" children, while c2 matches indented children
+  JSXOpeningElement:open (_ / JSXChild)*:c1 JSXNestedChildren:c2 InsertNewline InsertIndent ->
+    if (c1.length || c2.length) {
       return [...$0, ["</", open[1], ">"]]
     } else {
-      return [$1.slice(0, -1), " />"]
+      return [open.slice(0, -1), " />"]
     }
   JSXOpeningElement ->
-    throw new Error(`could not parse JSX element "${$0.join('')}" at ${$loc.start.line}:${$loc.start.column}`)
+    throw new Error(`could not parse JSX element "${require('./generate')($0)}" at pos ${$loc.pos}`)
 
 # https://facebook.github.io/jsx/#prod-JSXSelfClosingElement
 JSXSelfClosingElement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3548,7 +3548,7 @@ JSXChildren
   ( __ JSXChild )*
 
 JSXNestedChildren
-  PushIndent ( Nested JSXChild )* PopIndent ->
+  PushIndent ( Nested JSXChild+ )* PopIndent ->
     if ($2.length) return $2
     return $skip
   &EOS ->
@@ -3564,8 +3564,9 @@ JSXChild
 # https://facebook.github.io/jsx/#prod-JSXText
 JSXText
   # NOTE: not currently excluding https://facebook.github.io/jsx/#prod-HTMLCharacterReference
-  # NOTE: Additionally forbidding leading whitespace so it can be used for
-  # indentation (by JSXNestedChildren) or ignored by JSXChildren.
+  # NOTE: Additionally forbidding leading whitespace, so it can be used for
+  # indentation (by JSXNestedChildren) or ignored by JSXChildren,
+  # and newlines which we leave for the next indentation.
   [^{}<>\s][^{}<>\n\r]*
 
 # https://facebook.github.io/jsx/#prod-JSXChildExpression

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -183,19 +183,37 @@ describe "Indentation-based JSX", ->
   """
 
   testCase """
-    SolidJS example
+    SolidJS example from https://playground.solidjs.com/
     ---
     function Counter()
       [count, setCount] := createSignal 1
-      increment = -> setCount count() + 1
+      increment := -> setCount count() + 1
       <button type="button" onClick={increment}>
         {count()}
     ---
     function Counter() {
       const [count, setCount] = createSignal(1)
-      increment = function() { return setCount(count() + 1) }
+      function increment () { return setCount(count() + 1) }
       return <button type="button" onClick={increment}>
         {count()}
       </button>
     }
+  """
+
+  testCase """
+    SolidJS example from https://www.solidjs.com/tutorial/introduction_jsx
+    ---
+    return
+      <>
+        <div>
+          Hello {name}!
+        {svg}
+    ---
+    return
+      <>
+        <div>
+          Hello {name}!
+        </div>
+        {svg}
+    </>
   """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -14,6 +14,55 @@ describe "Indentation-based JSX", ->
   """
 
   testCase """
+    mixture of indentation and same line
+    ---
+    return
+      <div>Hello
+        world, it's {today}!
+    console.log 'unreachable'
+    ---
+    return
+      <div>Hello
+        world, it's {today}!
+    </div>
+    console.log('unreachable')
+  """
+
+  testCase """
+    full tag on same line
+    ---
+    return
+      <div><h1>Hello world</h1> It's
+        <b>{today}
+        !
+    console.log 'unreachable'
+    ---
+    return
+      <div><h1>Hello world</h1> It's
+        <b>{today}
+        </b>
+        !
+    </div>
+    console.log('unreachable')
+  """
+
+  testCase """
+    another start tag on same line
+    ---
+    return
+      <div><h1>Hello
+        world, it's {today}!
+    console.log 'unreachable'
+    ---
+    return
+      <div><h1>Hello
+        world, it's {today}!
+    </h1>
+    </div>
+    console.log('unreachable')
+  """
+
+  testCase """
     indentation for every tag
     ---
     return
@@ -160,6 +209,27 @@ describe "Indentation-based JSX", ->
       <div>
       </div>,
       <b />
+    ]
+  """
+
+  testCase """
+    array with indented tags
+    ---
+    [
+      <div>
+        <b>Bold
+        <i>Bold
+      <div>
+    ]
+    ---
+    [
+      <div>
+        <b>Bold
+        </b>
+        <i>Bold
+        </i>
+      </div>,
+      <div />
     ]
   """
 

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -8,8 +8,9 @@ describe "Indentation-based JSX", ->
       <div>
     console.log 'unreachable'
     ---
-    return
+    return (
       <div />
+    )
     console.log('unreachable')
   """
 
@@ -21,10 +22,11 @@ describe "Indentation-based JSX", ->
         world, it's {today}!
     console.log 'unreachable'
     ---
-    return
+    return (
       <div>Hello
         world, it's {today}!
-    </div>
+      </div>
+    )
     console.log('unreachable')
   """
 
@@ -37,12 +39,13 @@ describe "Indentation-based JSX", ->
         !
     console.log 'unreachable'
     ---
-    return
+    return (
       <div><h1>Hello world</h1> It's
         <b>{today}
         </b>
         !
-    </div>
+      </div>
+    )
     console.log('unreachable')
   """
 
@@ -54,11 +57,12 @@ describe "Indentation-based JSX", ->
         world, it's {today}!
     console.log 'unreachable'
     ---
-    return
+    return (
       <div><h1>Hello
         world, it's {today}!
-    </h1>
-    </div>
+      </h1>
+      </div>
+    )
     console.log('unreachable')
   """
 
@@ -73,7 +77,7 @@ describe "Indentation-based JSX", ->
           Italic
     console.log 'unreachable'
     ---
-    return
+    return (
       <div>
         <b>
           Bold
@@ -81,7 +85,8 @@ describe "Indentation-based JSX", ->
         <i>
           Italic
         </i>
-    </div>
+      </div>
+    )
     console.log('unreachable')
   """
 
@@ -93,10 +98,11 @@ describe "Indentation-based JSX", ->
     console.log 'unreachable'
       </div>
     ---
-    return
+    return (
       <div>
     console.log 'unreachable'
       </div>
+    )
   """
 
   testCase """
@@ -110,7 +116,7 @@ describe "Indentation-based JSX", ->
           Italic
     console.log 'unreachable'
     ---
-    return
+    return (
       <>
         <b>
           Bold
@@ -118,7 +124,8 @@ describe "Indentation-based JSX", ->
         <i>
           Italic
         </i>
-    </>
+      </>
+    )
     console.log('unreachable')
   """
 
@@ -131,11 +138,12 @@ describe "Indentation-based JSX", ->
         <i>Italic</i>
     console.log 'unreachable'
     ---
-    return
+    return (
       <div>
         <b>Bold</b>
         <i>Italic</i>
-    </div>
+      </div>
+    )
     console.log('unreachable')
   """
 
@@ -151,15 +159,16 @@ describe "Indentation-based JSX", ->
       </div>
     console.log 'unreachable'
     ---
-    return
+    return (
       <div>
         <b>
           Bold
-    </b>
+      </b>
         <i>
           Italic
-    </i>
+      </i>
       </div>
+    )
     console.log('unreachable')
   """
 
@@ -279,11 +288,12 @@ describe "Indentation-based JSX", ->
           Hello {name}!
         {svg}
     ---
-    return
+    return (
       <>
         <div>
           Hello {name}!
         </div>
         {svg}
-    </>
+      </>
+    )
   """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -1,0 +1,25 @@
+{testCase, throws} from ../helper.civet
+
+describe "Indentation-based JSX", ->
+  testCase """
+    indentation for every tag
+    ---
+    return
+      <div>
+        <b>
+          Bold
+        <i>
+          Italic
+    console.log 'unreachable'
+    ---
+    return
+      <div>
+        <b>
+          Bold
+        </b>
+        <i>
+          Italic
+        </i>
+    </div>
+    console.log('unreachable')
+  """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -2,6 +2,18 @@
 
 describe "Indentation-based JSX", ->
   testCase """
+    no children
+    ---
+    return
+      <div>
+    console.log 'unreachable'
+    ---
+    return
+      <div />
+    console.log('unreachable')
+  """
+
+  testCase """
     indentation for every tag
     ---
     return
@@ -22,4 +34,168 @@ describe "Indentation-based JSX", ->
         </i>
     </div>
     console.log('unreachable')
+  """
+
+  testCase """
+    not actually indentation
+    ---
+    return
+      <div>
+    console.log 'unreachable'
+      </div>
+    ---
+    return
+      <div>
+    console.log 'unreachable'
+      </div>
+  """
+
+  testCase """
+    indented fragments
+    ---
+    return
+      <>
+        <b>
+          Bold
+        <i>
+          Italic
+    console.log 'unreachable'
+    ---
+    return
+      <>
+        <b>
+          Bold
+        </b>
+        <i>
+          Italic
+        </i>
+    </>
+    console.log('unreachable')
+  """
+
+  testCase """
+    outer indentation, inner closed tags
+    ---
+    return
+      <div>
+        <b>Bold</b>
+        <i>Italic</i>
+    console.log 'unreachable'
+    ---
+    return
+      <div>
+        <b>Bold</b>
+        <i>Italic</i>
+    </div>
+    console.log('unreachable')
+  """
+
+  testCase """
+    inner indentation, outer closed tags
+    ---
+    return
+      <div>
+        <b>
+          Bold
+        <i>
+          Italic
+      </div>
+    console.log 'unreachable'
+    ---
+    return
+      <div>
+        <b>
+          Bold
+    </b>
+        <i>
+          Italic
+    </i>
+      </div>
+    console.log('unreachable')
+  """
+
+  testCase """
+    fragment of same-level tags
+    ---
+    <>
+      <div>
+      <b>
+      <i>
+    ---
+    <>
+      <div />
+      <b />
+      <i />
+    </>
+  """
+
+  testCase """
+    array of same-level tags
+    ---
+    [
+      <div>
+      <b>
+      <i>
+    ]
+    ---
+    [
+      <div />,
+      <b />,
+      <i />
+    ]
+  """
+
+  testCase """
+    array of same-level tags with one closing
+    ---
+    [
+      <div>
+      <div>
+      </div>
+      <b>
+    ]
+    ---
+    [
+      <div />,
+      <div>
+      </div>,
+      <b />
+    ]
+  """
+
+  testCase """
+    array with indented closed tags
+    ---
+    [
+      <div>
+        <b>Bold</b>
+        <i>Bold</i>
+      <div>
+    ]
+    ---
+    [
+      <div>
+        <b>Bold</b>
+        <i>Bold</i>
+      </div>,
+      <div />
+    ]
+  """
+
+  testCase """
+    SolidJS example
+    ---
+    function Counter()
+      [count, setCount] := createSignal 1
+      increment = -> setCount count() + 1
+      <button type="button" onClick={increment}>
+        {count()}
+    ---
+    function Counter() {
+      const [count, setCount] = createSignal(1)
+      increment = function() { return setCount(count() + 1) }
+      return <button type="button" onClick={increment}>
+        {count()}
+      </button>
+    }
   """


### PR DESCRIPTION
This is an attempt at implementing basic auto-closing JSX tags via indentation, while co-existing with explicitly closed tags, as discussed in #20.

Here's an example:

```coffee
return
  <div>
    <b>
      Bold
    <i>
      Italic
console.log 'hi'
```

But it currently compiles to:

```js
return
  <div>
    <b>
      Bold
</b>
    <i>
      Italic
</i>
</div>
console.log('hi')
```

The issue is that the added closing tags aren't indented properly. @STRd6 Could you explain how I'm using `IndentIndent` incorrectly? I haven't been able to figure it out, despite matching the `Nested` (as far as I can tell). Is the function associated with the `JSXElement` rule just called too late, and I need to add an `InsertClosingTag` rule? If so, how would I give it the opening tag?