### PR TITLE
Indentation flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ could be a valid property `1.e10` -> `1..e10`. The workaround is to add a traili
 CoffeeScript Compatibility
 ---
 
-Civet provides a compatability prologue directive that aims to be 97+% compatible with existing CoffeeScript2 code (still a work in progress).
+Civet provides a compatibility prologue directive that aims to be 97+% compatible with existing CoffeeScript2 code (still a work in progress).
 
 | Configuration       | What it enables |
 |---------------------|---------------------------------------------------------------------|
@@ -255,10 +255,22 @@ Civet provides a compatability prologue directive that aims to be 97+% compatibl
 | coffeeNot           | `not` -> `!`, `a not instanceof b` -> `!(a instanceof b)`, `a not of b` -> `!(a in b)`    |
 | coffeeOf            | `a of b` -> `a in b`, `a in b` -> `b.indexOf(a) >= 0`, `a not in b` -> `b.indexOf(a) < 0` |
 
-
 You can use these with `"civet coffeeCompat"` to opt in to all or use them bit by bit with `"civet coffeeComment coffeeEq coffeeInterpolation"`.
 Another possibility is to slowly remove them to provide a way to migrate files a little at a time `"civet coffeeCompat -coffeeBooleans -coffeeComment -coffeeEq"`.
 Both camel case and hyphens work when specifying options `"civet coffee-compat"`. More options will be added over time until 97+% compatibility is achieved.
+
+Other Options
+---
+
+The `"civet"` prologue directive can also specify the following options:
+
+| Configuration       | What it enables |
+|---------------------|---------------------------------------|
+| tab=NNN             | treat tab like NNN spaces (default=1) |
+
+For example, `"civet tab=2"` or `"civet tab=4"` lets you mix tabs and spaces
+in a file and be treated like they'd render in VSCode with `editor.tabSize`
+set accordingly.
 
 Using Civet in your Node.js Environment
 ---

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3943,6 +3943,7 @@ Reset
       coffeeNot: false,
       coffeeOf: false,
       implicitReturns: true,
+      tab: undefined, // default behavior = same as space
     }
 
     let indexOfRef, hasPropRef, spliceRef
@@ -5054,24 +5055,19 @@ Init
 # EOS/Nested rules are used carefully and if we only compare to the
 # pushed value.
 Indent
-  ( " " / "\t" )* ->
+  /[ \t]*/ ->
     let level
     if (module.config.tab) {
-      level = 0
-      $1.forEach((whitespace) => {
-        if (whitespace === "\t") {
-          level += module.config.tab
-        } else {
-          level++
-        }
-      });
+      const tabs = $0.match(/\t/g)
+      const numTabs = tabs ? tabs.length : 0
+      level = numTabs * module.config.tab + /*spaces*/ ($0.length - numTabs)
     } else {
-      level = $1.length
+      level = $0.length
     }
 
     return {
       $loc,
-      token: $1.join(''),
+      token: $0,
       level
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3756,14 +3756,21 @@ CivetPrologueContent
     }
 
 CivetOption
-  /\s+([+-]?)([a-zA-Z0-9-]+)/ ->
+  /\s+([+-]?)([a-zA-Z0-9-]+)(\s*=\s*([a-zA-Z0-9.+-]*))?/ ->
     // Normalize option names to camelCase
     const optionName = $2.replace(/-+([a-z]?)/g, (_, l) => {
       if (l) return l.toUpperCase()
       return ""
     })
     // - is disabled, + is enabled, no prefix is enabled
-    const value = ($1 === "-") ? false : true
+    // =value sets the value to any value (used for `tab`)
+    let value =
+      $3 ? $4 : ($1 === "-") ? false : true
+    // Some options are automatically converted to numbers
+    if (optionName === "tab") {
+      value = parseFloat(value)
+      if (isNaN(value)) value = 0
+    }
 
     return [optionName, value]
 
@@ -5048,7 +5055,19 @@ Init
 # pushed value.
 Indent
   ( " " / "\t" )* ->
-    const level = $1.length
+    let level
+    if (module.config.tab) {
+      level = 0
+      $1.forEach((whitespace) => {
+        if (whitespace === "\t") {
+          level += module.config.tab
+        } else {
+          level++
+        }
+      });
+    } else {
+      level = $1.length
+    }
 
     return {
       $loc,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5047,7 +5047,7 @@ Init
 # EOS/Nested rules are used carefully and if we only compare to the
 # pushed value.
 Indent
-  ( "  " / "\t" )* ->
+  ( " " / "\t" )* ->
     const level = $1.length
 
     return {

--- a/test/indent.civet
+++ b/test/indent.civet
@@ -96,3 +96,53 @@ describe "indent", ->
        return null
     }
   """
+
+  testCase """
+    tabs and spaces
+    ---
+    if true
+     if false
+      return true
+    \telse
+    \t return false
+    ---
+    if (true) {
+     if (false) {
+      return true
+     }
+    \telse {
+    \t return false
+     }
+    }
+  """
+
+  testCase """
+    custom tabs and spaces
+    ---
+    "civet tab=2"
+    if true
+      if false
+        return true
+    \telse
+    \t\treturn false
+    ---
+    if (true) {
+      if (false) {
+        return true
+      }
+    \telse {
+    \t\treturn false
+      }
+    }
+  """
+
+  throws """
+    mismatched custom tabs and spaces
+    ---
+    "civet tab=3"
+    if true
+      if false
+        return true
+    \telse
+    \t\treturn false
+  """

--- a/test/indent.civet
+++ b/test/indent.civet
@@ -1,0 +1,98 @@
+{ testCase, throws } from ./helper.civet
+
+describe "indent", ->
+  testCase """
+    two spaces
+    ---
+    if true
+      if false
+        return true
+      else
+        return false
+    else
+      return null
+    ---
+    if (true) {
+      if (false) {
+        return true
+      }
+      else {
+        return false
+      }
+    }
+    else {
+      return null
+    }
+  """
+
+  testCase """
+    three spaces
+    ---
+    if true
+       if false
+          return true
+       else
+          return false
+    else
+       return null
+    ---
+    if (true) {
+       if (false) {
+          return true
+       }
+       else {
+          return false
+       }
+    }
+    else {
+       return null
+    }
+  """
+
+  testCase """
+    one space
+    ---
+    if true
+     if false
+      return true
+     else
+      return false
+    else
+     return null
+    ---
+    if (true) {
+     if (false) {
+      return true
+     }
+     else {
+      return false
+     }
+    }
+    else {
+     return null
+    }
+  """
+
+  testCase """
+    mixed spaces
+    ---
+    if true
+     if false
+       return true
+     else
+         return false
+    else
+       return null
+    ---
+    if (true) {
+     if (false) {
+       return true
+     }
+     else {
+         return false
+     }
+    }
+    else {
+       return null
+    }
+  """


### PR DESCRIPTION
1. [Allow arbitrary spaces in indentation](https://github.com/DanielXMoore/Civet/commit/c6633644dc50c3bf5e2f3f5cac392c775bcdb086), instead of an even number of spaces. In particular allows for 3-space indent, or mixtures.
2. [Custom unification of tabs and spaces](https://github.com/DanielXMoore/Civet/commit/7e0619b10a18ed09add88a5d42489fc049c74973) via `"civet tab=NNN"` option.