### PR TITLE
JSX object shorthand

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1571,7 +1571,11 @@ PropertyName
   IdentifierName
   # https://262.ecma-international.org/#prod-ComputedPropertyName
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
-  OpenBracket ExtendedExpression __ CloseBracket
+  OpenBracket ExtendedExpression __ CloseBracket ->
+    return {
+      type: "ComputedPropertyName",
+      children: $0,
+    }
 
 Decorator
   AtAt IdentifierReference Arguments?
@@ -3572,7 +3576,8 @@ JSXAttribute
   # {...foo} is a special case.
   BracedObjectLiteral ->
     const {children} = $1
-    const parts = []
+    const parts = [] // JSX attributes
+    const rest = []  // parts that need to be in {...rest} form
     for (let i = 1; i < children.length - 1; i++) {
       if (i > 1) parts.push(' ')
       const part = children[i]
@@ -3581,17 +3586,28 @@ JSXAttribute
           parts.push([part.name, '={', part.name, '}'])
           break
         case 'Property':
-          parts.push([part.name, '={', module.insertTrimmingSpace(part.value, ''), '}'])
+          if (part.name.type === 'ComputedPropertyName') {
+            rest.push(part)
+          } else {
+            parts.push([part.name, '={', module.insertTrimmingSpace(part.value, ''), '}'])
+          }
           break
         case 'SpreadProperty':
           parts.push(['{', part.value, '}'])
           break
         case 'MethodDefinition':
-          parts.push([part.name, '={', module.convertMethodToFunction(part), '}'])
+          try {
+            parts.push([part.name, '={', module.convertMethodToFunction(part), '}'])
+          } catch {  // get or set
+            rest.push(part)
+          }
           break
         default:
           throw new Error(`invalid object literal type in JSX attribute: ${part.type}`)
       }
+    }
+    if (rest.length) {
+      parts.push(['{...{', ...rest, '}}'])
     }
     return parts
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1517,10 +1517,13 @@ PropertyDefinitionList
 PropertyDefinition
   # NOTE: Added CoffeeScript {@id} -> {id: this.id} shorthand
   __:ws At:at IdentifierReference:id ->
+    const value = [{...at, token: "this."}, id]
     return {
       type: "Property",
-      children: [...ws, id, ": ", {...at, token: "this."}, id],
+      children: [...ws, id, ": ", ...value],
+      name: id,
       names: id.names,
+      value,
     }
   NamedProperty
   __:ws MethodDefinition:def ->
@@ -1533,6 +1536,7 @@ PropertyDefinition
       type: "SpreadProperty",
       children: [...ws, dots, exp],
       names: exp.names,
+      value: [dots, exp],
     }
   # NOTE: this needs to be at the bottom to prevent shadowing PropertyName
   __:ws IdentifierReference:id  ->
@@ -1541,11 +1545,13 @@ PropertyDefinition
 NamedProperty
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
-  __ PropertyName __ Colon ExtendedExpression:exp ->
+  __ PropertyName:name __ Colon ExtendedExpression:exp ->
     return {
       type: "Property",
       children: $0,
+      name: name,
       names: exp.names || [],
+      value: exp,
     }
 
 # Named property but doesn't allow any space between name and colon
@@ -1576,10 +1582,13 @@ Decorators
 # https://262.ecma-international.org/#prod-MethodDefinition
 MethodDefinition
   # NOTE: Not adding extra validation using PropertySetParameterList
-  Decorators? MethodSignature:signature BracedBlock:block ->
+  # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
+  Decorators?:decorators MethodSignature:signature BracedBlock:block ->
     return {
       type: "MethodDefinition",
       children: $0,
+      name: signature.name,
+      decorators,
       signature,
       block,
       parameters: signature.parameters,
@@ -1591,7 +1600,7 @@ MethodModifier
   # NOTE: Merged async and generator into MethodModifier
   ( Async __ ) ( Star __ )?
   Star __
-  Async __
+  #Async __
 
 # TypeScript method signature
 MethodSignature
@@ -1604,6 +1613,7 @@ MethodSignature
       parameters,
     }
 
+  # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
   MethodModifier? ClassElementName:name _* NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
     // Normalize name so we can check if it is `constructor`
     if (name.name) {
@@ -3225,7 +3235,7 @@ AtAt
 
 Async
   "async" ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, type: 'Async' }
 
 Await
   "await" NonIdContinue ->
@@ -3337,7 +3347,7 @@ Function
 
 GetOrSet
   ( "get" / "set" ) NonIdContinue ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, type: 'GetOrSet' }
 
 If
   # NOTE: Pull a single space into the 'if ' token so if it is replaced
@@ -3553,8 +3563,37 @@ JSXAttributes
 # NOTE: Merged SpreadAttribute and Attribute
 JSXAttribute
   # https://facebook.github.io/jsx/#prod-JSXSpreadAttribute
-  # NOTE: Using ExtendedExpression to allow If/Switch expressions
-  OpenBrace __ DotDotDot ExtendedExpression __ CloseBrace
+  # allows something like
+  #   OpenBrace __ DotDotDot ExtendedExpression __ CloseBrace
+  # (where ExtendedExpression additionally allows If/Switch expressions).
+  # More generally, we allow any braced object literal:
+  # {foo} is equivalent to foo={foo}, and
+  # {foo, bar: baz} is equivalent to foo={foo} and bar={baz}.
+  # {...foo} is a special case.
+  BracedObjectLiteral ->
+    const {children} = $1
+    const parts = []
+    for (let i = 1; i < children.length - 1; i++) {
+      if (i > 1) parts.push(' ')
+      const part = children[i]
+      switch (part.type) {
+        case 'Identifier':
+          parts.push([part.name, '={', part.name, '}'])
+          break
+        case 'Property':
+          parts.push([part.name, '={', module.insertTrimmingSpace(part.value, ''), '}'])
+          break
+        case 'SpreadProperty':
+          parts.push(['{', part.value, '}'])
+          break
+        case 'MethodDefinition':
+          parts.push([part.name, '={', module.convertMethodToFunction(part), '}'])
+          break
+        default:
+          throw new Error(`invalid object literal type in JSX attribute: ${part.type}`)
+      }
+    }
+    return parts
 
   # https://facebook.github.io/jsx/#prod-JSXAttribute
   JSXAttributeName JSXAttributeInitializer?
@@ -4379,6 +4418,7 @@ Init
 
     module.isWhitespaceOrEmpty = function(node) {
       if (!node) return true
+      if (node.token) return node.token.match(/^\s*$/)
       if (!node.length) return true
       if (typeof node === "string") return node.match(/^\s*$/)
       if (Array.isArray(node)) return node.every(module.isWhitespaceOrEmpty)
@@ -4921,6 +4961,35 @@ Init
           return clause
         default:
           throw new Error("Unknown postfix statement")
+      }
+    }
+
+    // Given a MethodDefinition, convert into a FunctionExpression
+    module.convertMethodToFunction = function(method) {
+      const {decorators, signature, block} = method
+      let opening = signature.children[0] // MethodModifier
+      if (opening) {
+        if (opening[0].type === 'GetOrSet') {
+          throw new Error('cannot convert get/set method to function')
+        } else if (opening[0][0]?.type === 'Async') {
+          // put function after async
+          opening = [opening[0][0], " function ", ...opening.slice(1)]
+        } else {
+          opening = ["function ", ...opening]
+        }
+      } else {
+        opening = "function ";
+      }
+      return {
+        ...signature,
+        id: signature.name,
+        type: "FunctionExpression",
+        children: [
+          decorators,
+          [opening, ...signature.children.slice(1)],
+          block,
+        ],
+        block,
       }
     }
 

--- a/test/jsx/objects.civet
+++ b/test/jsx/objects.civet
@@ -1,0 +1,120 @@
+{testCase, throws} from ../helper.civet
+
+describe "JSX object shorthand", ->
+  testCase """
+    identifier in braces
+    ---
+    <div {foo} />
+    ---
+    <div foo={foo} />
+  """
+
+  testCase """
+    separate identifiers in braces
+    ---
+    <div {foo} {bar} />
+    ---
+    <div foo={foo} bar={bar} />
+  """
+
+  testCase """
+    two identifiers in braces
+    ---
+    <div {foo, bar} />
+    ---
+    <div foo={foo} bar={bar} />
+  """
+
+  testCase """
+    property in braces
+    ---
+    <div {foo: bar} />
+    ---
+    <div foo={bar} />
+  """
+
+  testCase """
+    identifier and property in braces
+    ---
+    <div {foo, bar: baz} />
+    ---
+    <div foo={foo} bar={baz} />
+  """
+
+  testCase """
+    identifier and rest in braces
+    ---
+    <div {foo, ...props} />
+    ---
+    <div foo={foo} {...props} />
+  """
+
+  testCase """
+    identifier and property and rest in braces
+    ---
+    <div {foo, bar: baz, ...props} />
+    ---
+    <div foo={foo} bar={baz} {...props} />
+  """
+
+  testCase """
+    multiple rests in braces
+    ---
+    <div {...props1, ...props2} />
+    ---
+    <div {...props1} {...props2} />
+  """
+
+  testCase """
+    method in braces
+    ---
+    <div {method(x){x}} />
+    ---
+    <div method={function method(x){return x}} />
+  """
+
+  testCase """
+    async method in braces
+    ---
+    <div {async method(x){x}} />
+    ---
+    <div method={async function method(x){return x}} />
+  """
+
+  testCase """
+    generator method in braces
+    ---
+    <div {* method(x){x}} />
+    ---
+    <div method={function * method(x){return x}} />
+  """
+
+  testCase """
+    async generator method in braces
+    ---
+    <div {async* method(x){x}} />
+    ---
+    <div method={async function * method(x){return x}} />
+  """
+
+  testCase """
+    typed method in braces
+    ---
+    <div {method(x: number): number {x}} />
+    ---
+    <div method={function method(x: number): number {return x}} />
+  """
+
+  testCase """
+    identifier, property, and method in braces
+    ---
+    <div {foo, bar: baz, method(x){x}} />
+    ---
+    <div foo={foo} bar={baz} method={function method(x){return x}} />
+  """
+
+  throws """
+    get function in braces
+    ---
+    <div {get foo(){0}} />
+  """

--- a/test/jsx/objects.civet
+++ b/test/jsx/objects.civet
@@ -113,8 +113,42 @@ describe "JSX object shorthand", ->
     <div foo={foo} bar={baz} method={function method(x){return x}} />
   """
 
-  throws """
+  testCase """
+    computed property name in braces
+    ---
+    <div {[foo()]: bar} />
+    ---
+    <div {...{[foo()]: bar}} />
+  """
+
+  testCase """
+    mix of computed and regular property names in braces
+    ---
+    <div {[foo()]: bar, regular, [bar()]: baz} />
+    ---
+    <div  regular={regular} {...{[foo()]: bar, [bar()]: baz}} />
+  """
+
+  testCase """
     get function in braces
     ---
     <div {get foo(){0}} />
+    ---
+    <div {...{get foo(){return 0}}} />
+  """
+
+  testCase """
+    set function in braces
+    ---
+    <div {set foo(){0}} />
+    ---
+    <div {...{set foo(){0}}} />
+  """
+
+  testCase """
+    set function in braces
+    ---
+    <div {get foo(){0}, set foo(){0}} />
+    ---
+    <div  {...{get foo(){return 0}, set foo(){0}}} />
   """


### PR DESCRIPTION
Support any object literal as a JSX attribute:
* `{foo}` as shorthand for `foo={foo}`
* `{foo, bar}` is shorthand for `foo={foo} bar={bar}`
* `{foo: bar}` is shorthand for `foo={bar}`
* Multiple `...rest` supported
* Methods get converted into functions
* Computed property names and `get`/`set` methods supported via `{...rest}` JSX notation

~~Oops, `[foo]: bar` isn't supported yet.~~