### PR TITLE
Indentation in middle of arrays

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1312,7 +1312,14 @@ RangeExpression
 ArrayLiteralContent
   RangeExpression
   NestedElementList
-  ElementList
+  ElementList NestedElementList? ->
+    if ($2) {
+      // ElementList never ends in comma; otherwise, the next line of elements
+      // would be absorbed into the ElementList.
+      return [...$1, ",", ...$2]
+    } else {
+      return $1
+    }
 
 NestedElementList
   PushIndent NestedElement*:elements PopIndent ->

--- a/test/array.civet
+++ b/test/array.civet
@@ -26,6 +26,22 @@ describe "array", ->
   """
 
   testCase """
+    indentation mid-array
+    ---
+    [a
+     b
+     c,
+     d
+    ]
+    ---
+    [a,
+     b,
+     c,
+     d
+    ]
+  """
+
+  testCase """
     compact rows
     ---
     bitlist := [
@@ -39,6 +55,20 @@ describe "array", ->
       0, 0, 1,
       1, 1, 0
     ]
+  """
+
+  testCase """
+    compact rows with indentation mid-array
+    ---
+    bitlist :=
+      [1, 0, 1
+       0, 0, 1
+       1, 1, 0]
+    ---
+    const bitlist =
+      [1, 0, 1,
+       0, 0, 1,
+       1, 1, 0]
   """
 
   testCase """


### PR DESCRIPTION
Support for indentation after the first line of items in an array, e.g.:

```coffee
[1, 2, 3
 4, 5, 6
 7, 8, 9]
```

Fixes #27 (at least for arrays — maybe there are other cases of indentation-in-the-middle that we need to find).

This is still a lot more strict than CoffeeScript, which allows some weird things:

```coffee
[x
   y
     z
] → [x, y, z]

[x
    y
 z
   w
] → [x, y, z, w]

[x
   y: z
] → [x, {y: z}] (!)

[x
   y
     z: w
] → [x, y({z: w})]
```