### PR TITLE
Support content on same line as <>

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -81,7 +81,7 @@ makeCache = ->
             "AssignmentExpressionTail", "AssignmentExpression", "ExtendedExpression", "Expression", "MemberExpressionRest",\
             "ElseClause",\
             "CoffeeCommentEnabled", "SingleLineComment", "Debugger",\
-            "JSXElement", "JSXChild", "JSXChildren", "JSXFragment", "JSXNestedChildren"
+            "JSXElement", "JSXChild", "JSXChildren", "JSXFragment", "JSXNestedChildren", "JSXMixedChildren"
 
             break
           else

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3562,9 +3562,8 @@ JSXElement
     // Check that tags match
     if ($1[1] !== $4[2]) return $skip
     return $0
-  # NOTE: c1 matches "same-line" children, while c2 matches indented children
-  JSXOpeningElement:open (_ / JSXChild)*:c1 JSXNestedChildren:c2 InsertNewline InsertIndent ->
-    if (c1.length || c2.length) {
+  JSXOpeningElement:open JSXMixedChildren:children InsertNewline InsertIndent ->
+    if (children.length) {
       return [...$0, ["</", open[1], ">"]]
     } else {
       return [open.slice(0, -1), " />"]
@@ -3587,7 +3586,7 @@ JSXClosingElement
 # https://facebook.github.io/jsx/#prod-JSXFragment
 JSXFragment
   "<>" JSXChildren? "</>"
-  "<>" JSXNestedChildren InsertNewline InsertIndent ->
+  "<>" JSXMixedChildren InsertNewline InsertIndent ->
     return [...$0, "</>"]
 
 # https://facebook.github.io/jsx/#prod-JSXElementName
@@ -3674,6 +3673,12 @@ JSXAttributeValue
   OpenBrace ExtendedExpression __ CloseBrace
   JSXElement
   JSXFragment
+
+JSXMixedChildren
+  # NOTE: c1 matches "same-line" children, while c2 matches indented children
+  # Used in indentation-based JSX
+  (_ / JSXChild)*:c1 JSXNestedChildren:c2 ->
+    return c1.concat(c2)
 
 # https://facebook.github.io/jsx/#prod-JSXChildren
 JSXChildren

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -243,6 +243,27 @@ describe "Indentation-based JSX", ->
   """
 
   testCase """
+    content on same line as open tag
+    ---
+    <div>Hello
+      world
+      <b>Bold
+        text
+      <>Fragment
+        text
+    ---
+    <div>Hello
+      world
+      <b>Bold
+        text
+      </b>
+      <>Fragment
+        text
+      </>
+    </div>
+  """
+
+  testCase """
     array with indented closed tags
     ---
     [
@@ -296,4 +317,25 @@ describe "Indentation-based JSX", ->
         {svg}
       </>
     )
+  """
+
+  testCase """
+    indentation elements as attributes
+    ---
+    <Component sub=<div>
+      Hello
+    no-children=<div>
+    frag=<>...
+    >
+      child
+    ---
+    <Component sub=<div>
+      Hello
+    </div>
+    no-children=<div />
+    frag=<>...
+    </>
+    >
+      child
+    </Component>
   """

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -59,3 +59,11 @@ describe "JSX", ->
     throws """
       <h1>{text}</h2>
     """
+
+  testCase """
+    elements as attributes
+    ---
+    <Component sub=<div>Hello</div> self-close=<div/> frag=<>...</>/>
+    ---
+    <Component sub=<div>Hello</div> self-close=<div/> frag=<>...</>/>
+  """


### PR DESCRIPTION
Mirroring similar support for opening tags like `<foo>`. Also more tests.

(Noticed this bug when testing support for elements/fragments as attributes, which I didn't realize was even a thing in JSX, but it's there in the standard.)