### PR TITLE
Support for many unbraced JSX attribute values

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3674,6 +3674,25 @@ JSXAttributeValue
   OpenBrace ExtendedExpression __ CloseBrace
   JSXElement
   JSXFragment
+  InsertInlineOpenBrace InlineJSXAttributeValue InsertCloseBrace
+
+# JSX shorthand to avoid explicit braces when unnecessary.
+# Subset of PrimaryExpression; omissions documented in comments below.
+InlineJSXAttributeValue
+  NullLiteral
+  BooleanLiteral
+  NumericLiteral
+  # omitting StringLiteral from LiteralContent which doesn't need braces
+  ThisLiteral
+  ArrayLiteral
+  # requiring braces on ObjectLiteral; this allows {a, b} even though `a, b` doesn't work as an inline object
+  BracedObjectLiteral
+  IdentifierReference
+  # omitting FunctionExpression and ClassExpression
+  RegularExpressionLiteral
+  TemplateLiteral
+  ParenthesizedExpression
+  # omitting JSXElement and JSXFragment which don't need braces
 
 # https://facebook.github.io/jsx/#prod-JSXChildren
 JSXChildren


### PR DESCRIPTION
The list of allowed types matches [this list](https://github.com/LXSMNSYC/ideas/discussions/11) pretty well.

We could consider adding more of `MemberExpression`, but I fear this may not leave as much room for future extension. For example, `foo=array[i]` might conflict (especially if we allow whitespace before `[`) with a future meaning for `[key]`, namely, set an attribute with key equal to the *variable* `key` (as opposed to the name `"key"`). Similarly, `foo=obj.name` might conflict with an attribute starting with `.` (though I'm not yet sure what this would mean... perhaps an automatic `class`).