### PR TITLE
Support computed JSX attribute names

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Things Added that CoffeeScript didn't
   - Many attribute values (basic literals, array literals, braced object
     literals, regular expressions, template strings, and parenthesized
     expressions) do not need braces.  `foo=bar` -> `foo={bar}`
+  - Attributes can use computed property names:
+    `[expr]={value}` -> `{...{[expr]: value}}`
 - CoffeeScript improvements
   - Postfix loop `run() loop` -> `while(true) run()`
   - Character range literals `["a".."z"]`, `['f'..'a']`, `['0'..'9']`

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1608,6 +1608,9 @@ PropertyName
   NumericLiteral
   StringLiteral
   IdentifierName
+  ComputedPropertyName
+
+ComputedPropertyName
   # https://262.ecma-international.org/#prod-ComputedPropertyName
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
   OpenBracket ExtendedExpression __ CloseBracket ->
@@ -3652,12 +3655,31 @@ JSXAttribute
     return parts
 
   # https://facebook.github.io/jsx/#prod-JSXAttribute
-  JSXAttributeName JSXAttributeInitializer?
+  JSXAttributeName:name JSXAttributeInitializer?:value ->
+    if (name.type === "ComputedPropertyName") {
+      if (value) {
+        // Strip off equals sign and whitespace from JSXAttributeInitializer
+        value = value[value.length-1]
+        // Strip off braces if present
+        if (value[0]?.token === "{" &&
+            value[value.length-1]?.token === "}") {
+          value = value.slice(1, -1)
+        }
+      } else {
+        // React and SolidJS define a bare attribute to mean setting it to true.
+        // We need to specify a value here, so this seems a reasonable choice.
+        value = "true"
+      }
+      return ["{...{", name, ": ", value, "}}"]
+    } else {
+      return $0
+    }
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeName
 JSXAttributeName
   # NOTE: Merged JSXIdentifier and JSXNamespacedName
   JSXIdentifierName ( Colon JSXIdentifierName )?
+  ComputedPropertyName
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeInitializer
 JSXAttributeInitializer
@@ -3989,7 +4011,7 @@ InsertOpenBrace
 
 InsertInlineOpenBrace
   "" ->
-    return [{ $loc, token: "{" } ]
+    return { $loc, token: "{" }
 
 InsertCloseBrace
   "" ->


### PR DESCRIPTION
`[name]=value` translates into `{...{[name]: value}}`

This PR is relative to #38, because it also touches the file `test/jsx/attr.civet`; I can rebase once #38 is merged.