### PR TITLE
Support whitespace-free JSX attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,12 @@ Things Added that CoffeeScript didn't
   - Any braced object literal can be used as an attribute:
     `{foo}` → `foo={foo}`, `{foo: bar}` → `foo={bar}`,
     `{...foo}` remains as is; methods and getters/setters work too.
-  - Many attribute values (basic literals, array literals, braced object
-    literals, regular expressions, template strings, and parenthesized
-    expressions) do not need braces.  `foo=bar` → `foo={bar}`
+  - Attribute values without whitespace or suitably wrapped
+    (parenthesized expressions, strings and template strings,
+    regular expressions, array literals, braced object literals)
+    do not need braces:
+    `foo=bar` → `foo={bar}`, `count=count()` → `count={count()}`,
+    `sum=x+1` → `sum={x+1}`, `list=[1, 2, 3]` → `list={[1, 2, 3]}`
   - Attributes can use computed property names:
     `[expr]={value}` → `{...{[expr]: value}}`
 - CoffeeScript improvements

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -44,7 +44,8 @@ Expression
 
 # https://262.ecma-international.org/#prod-Arguments
 Arguments
-  OpenParen ArgumentList? ( __ Comma )? __ CloseParen
+  ExplicitArguments ->
+    return $1
   # NOTE: Added spacing based implicit function application
   # Trailing (__ MemberExpressionRest)* is to capture trailing .someMethod and bind them at the right place
 
@@ -55,6 +56,9 @@ Arguments
   # x y z => x(y(z))
   ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
     return [open, module.insertTrimmingSpace(ws, ""), args, close]
+
+ExplicitArguments
+  OpenParen ArgumentList? ( __ Comma )? __ CloseParen
 
 # Start of function application, inserts an open parenthesis, maintains spacing and comments when possible
 ApplicationStart
@@ -106,10 +110,8 @@ ArgumentPart
 
 BinaryOpExpression
   UnaryExpression BinaryOpRHS* ->
-    if ($2.length) {
+    if ($2.length)
       return module.processBinaryOpExpression($0)
-    }
-
     return $1
 
 BinaryOpRHS
@@ -124,54 +126,7 @@ UnaryExpression
   # https://262.ecma-international.org/#prod-AwaitExpression
   # NOTE: Eliminated left recursion
   UnaryOp*:pre UpdateExpression:exp UnaryPostfix?:post ->
-    // Handle "?" postfix
-    if (post?.token === "?") {
-      post = {
-        $loc: post.$loc,
-        token: " != null",
-      }
-
-      switch (exp.type) {
-        case "Identifier":
-        case "Literal":
-          return {...exp,
-            children: [...pre, ...exp.children, post]
-          }
-        default:
-          return {
-            type: "ParenthesizedExpression",
-            children: ["(", ...pre, "(", exp, ")", post, ")"]
-          }
-      }
-    }
-
-    // Combine unary - to create negative numeric literals
-    if (exp.type === "Literal") {
-      if (pre.length === 1 && pre[0].token === "-") {
-        const children = [pre[0], ...exp.children]
-        if (post) exp.children./**/push(post)
-
-        return {
-          type: "Literal",
-          children,
-          raw: `-${exp.raw}`
-        }
-      }
-    }
-
-    if (exp.children) {
-      const children = [...pre, ...exp.children]
-      if (post) children./**/push(post)
-      return Object.assign({}, exp, { children })
-    } else if (Array.isArray(exp)) {
-      const children = [...pre, ...exp]
-      if (post) children./**/push(post)
-      return { children }
-    } else {
-      const children = [...pre, exp]
-      if (post) children./**/push(post)
-      return { children }
-    }
+    return module.processUnaryExpression(pre, exp, post)
 
   # NOTE: This is a little hacky to match CoffeeScript's behavior
   # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
@@ -3274,6 +3229,11 @@ Whitespace
   [\s]+ ->
     return { $loc, token: $0 }
 
+# Alternative to __ for when whitespace is forbidden
+Nothing
+  "" ->
+    return []
+
 # Fake a blocklike form for single expressions
 ExpressionDelimiter
   TrailingComment* Semicolon InsertComma TrailingComment* ->
@@ -3720,9 +3680,14 @@ JSXAttributeInitializer
 # https://facebook.github.io/jsx/#prod-JSXAttributeValue
 JSXAttributeValue
   # https://facebook.github.io/jsx/#prod-JSXDoubleStringCharacters
-  /"[^"]*"/
   # https://facebook.github.io/jsx/#prod-JSXSingleStringCharacters
-  /'[^']*'/
+  # But double-quoted strings may turn into interpolation,
+  # and some triple-quoted strings may not use interpolation.
+  # So try to match but skip here if we find interpolation,
+  # and add parens in InlineJSXAttributeValue otherwise.
+  StringLiteral ->
+    if (module.isTemplateLiteral($1)) return $skip
+    return $1
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
   OpenBrace ExtendedExpression __ CloseBrace
   JSXElement
@@ -3730,22 +3695,78 @@ JSXAttributeValue
   InsertInlineOpenBrace InlineJSXAttributeValue InsertCloseBrace
 
 # JSX shorthand to avoid explicit braces when unnecessary.
-# Subset of PrimaryExpression; omissions documented in comments below.
 InlineJSXAttributeValue
+  InlineJSXUnaryExpression InlineJSXBinaryOpRHS* ->
+    if ($2.length)
+      return module.processBinaryOpExpression($0)
+    return $1
+
+# BinaryOpRHS without whitespace and without ExpressionizedStatement
+InlineJSXBinaryOpRHS
+  Nothing BinaryOp Nothing ( ParenthesizedAssignment / InlineJSXUnaryExpression )
+
+# JSXUnaryExpression, with InlineJSX prefixes and no Do (which has whitespace)
+InlineJSXUnaryExpression
+  InlineJSXUnaryOp*:pre InlineJSXUpdateExpression:exp InlineJSXUnaryPostfix?:post ->
+    return module.processUnaryExpression(pre, exp, post)
+
+# UnaryOp, restricted to whitespace-free symbol operators
+InlineJSXUnaryOp
+  /[!~+-](?!\s|[!~+-]*&)/ ->
+    return { $loc, token: $0 }
+
+# UnaryPostfix, restricted to whitespace-free symbol operators
+InlineJSXUnaryPostfix
+  QuestionMark
+
+# UpdateExpression, with LeftHandSideExpression -> InlineJSXCallExpression
+InlineJSXUpdateExpression
+  UpdateExpressionSymbol UnaryExpression
+  InlineJSXCallExpression UpdateExpressionSymbol? ->
+    if ($2) return $0
+    return $1
+
+# CallExpression, with only explicit function calls.
+# This also acts as a replacement for LeftHandSideExpression
+# (we don't allow New because that has whitespace).
+InlineJSXCallExpression
+  "super" ExplicitArguments
+  "import" OpenParen ExtendedExpression __ CloseParen
+  InlineJSXMemberExpression InlineJSXCallExpressionRest* ->
+    if ($2.length) return $0
+    return $1
+
+# CallExpressionRest, with only explicit function calls.
+InlineJSXCallExpressionRest
+  MemberExpressionRest
+  TemplateLiteral
+  ( OptionalShorthand / NonNullAssertion )? ExplicitArguments
+
+# MemberExpression, with PrimaryExpression -> InlineJSXPrimaryExpression
+InlineJSXMemberExpression
+  InlineJSXPrimaryExpression MemberExpressionRest* ->
+    if ($2.length) return $0
+    return $1
+  SuperProperty
+  MetaProperty
+
+# Subset of PrimaryExpression; omissions documented below.
+InlineJSXPrimaryExpression
   NullLiteral
   BooleanLiteral
   NumericLiteral
-  # omitting StringLiteral from LiteralContent which doesn't need braces
+  # StringLiteral that doesn't need braces already matched in JSXAttributeValue
+  StringLiteral
   ThisLiteral
   ArrayLiteral
-  # requiring braces on ObjectLiteral; this allows {a, b} even though `a, b` doesn't work as an inline object
+  # Requiring braces on ObjectLiteral; this allows {a, b} even though `a, b` doesn't work as an inline object
   BracedObjectLiteral
   IdentifierReference
-  # omitting FunctionExpression and ClassExpression
+  # Omitting FunctionExpression and ClassExpression which have whitespace
   RegularExpressionLiteral
   TemplateLiteral
   ParenthesizedExpression
-  # omitting JSXElement and JSXFragment which don't need braces
+  # Omitting JSXElement and JSXFragment which don't need braces
 
 JSXMixedChildren
   # NOTE: c1 matches "same-line" children, while c2 matches indented children
@@ -4294,6 +4315,57 @@ Init
       }
     })
 
+    module.processUnaryExpression = (pre, exp, post) => {
+      // Handle "?" postfix
+      if (post?.token === "?") {
+        post = {
+          $loc: post.$loc,
+          token: " != null",
+        }
+
+        switch (exp.type) {
+          case "Identifier":
+          case "Literal":
+            return {...exp,
+              children: [...pre, ...exp.children, post]
+            }
+          default:
+            return {
+              type: "ParenthesizedExpression",
+              children: ["(", ...pre, "(", exp, ")", post, ")"]
+            }
+        }
+      }
+
+      // Combine unary - to create negative numeric literals
+      if (exp.type === "Literal") {
+        if (pre.length === 1 && pre[0].token === "-") {
+          const children = [pre[0], ...exp.children]
+          if (post) exp.children./**/push(post)
+
+          return {
+            type: "Literal",
+            children,
+            raw: `-${exp.raw}`
+          }
+        }
+      }
+
+      if (exp.children) {
+        const children = [...pre, ...exp.children]
+        if (post) children./**/push(post)
+        return Object.assign({}, exp, { children })
+      } else if (Array.isArray(exp)) {
+        const children = [...pre, ...exp]
+        if (post) children./**/push(post)
+        return { children }
+      } else {
+        const children = [...pre, exp]
+        if (post) children./**/push(post)
+        return { children }
+      }
+    }
+
     module.expressionizeIfClause = function(clause, b, e) {
       const children = clause.children.slice(1) // Remove 'if'
       children./**/push("?", b) // Add ternary
@@ -4563,6 +4635,13 @@ Init
       if (!node.length) return true
       if (typeof node === "string") return node.match(/^\s*$/)
       if (Array.isArray(node)) return node.every(module.isWhitespaceOrEmpty)
+    }
+
+    // Test whether a given StringLiteral is a
+    module.isTemplateLiteral = function(node) {
+      let s = node
+      while (s && s[0] && !s.token) s = s[0]
+      return s.token?.startsWith?.('`')
     }
 
     module.processBinaryOpExpression = function($0) {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -44,8 +44,7 @@ Expression
 
 # https://262.ecma-international.org/#prod-Arguments
 Arguments
-  ExplicitArguments ->
-    return $1
+  ExplicitArguments
   # NOTE: Added spacing based implicit function application
   # Trailing (__ MemberExpressionRest)* is to capture trailing .someMethod and bind them at the right place
 
@@ -110,8 +109,7 @@ ArgumentPart
 
 BinaryOpExpression
   UnaryExpression BinaryOpRHS* ->
-    if ($2.length)
-      return module.processBinaryOpExpression($0)
+    if ($2.length) return module.processBinaryOpExpression($0)
     return $1
 
 BinaryOpRHS
@@ -3229,11 +3227,6 @@ Whitespace
   [\s]+ ->
     return { $loc, token: $0 }
 
-# Alternative to __ for when whitespace is forbidden
-Nothing
-  "" ->
-    return []
-
 # Fake a blocklike form for single expressions
 ExpressionDelimiter
   TrailingComment* Semicolon InsertComma TrailingComment* ->
@@ -3697,13 +3690,14 @@ JSXAttributeValue
 # JSX shorthand to avoid explicit braces when unnecessary.
 InlineJSXAttributeValue
   InlineJSXUnaryExpression InlineJSXBinaryOpRHS* ->
-    if ($2.length)
-      return module.processBinaryOpExpression($0)
+    if ($2.length) return module.processBinaryOpExpression($0)
     return $1
 
 # BinaryOpRHS without whitespace and without ExpressionizedStatement
 InlineJSXBinaryOpRHS
-  Nothing BinaryOp Nothing ( ParenthesizedAssignment / InlineJSXUnaryExpression )
+  BinaryOp ( ParenthesizedAssignment / InlineJSXUnaryExpression ) ->
+    // NOTE: Inserting empty whitespace arrays to be compatible with BinaryOpRHS and `processBinaryOpExpression`
+    return [[], $1, [], $2]
 
 # JSXUnaryExpression, with InlineJSX prefixes and no Do (which has whitespace)
 InlineJSXUnaryExpression
@@ -3744,11 +3738,26 @@ InlineJSXCallExpressionRest
 
 # MemberExpression, with PrimaryExpression -> InlineJSXPrimaryExpression
 InlineJSXMemberExpression
-  InlineJSXPrimaryExpression MemberExpressionRest* ->
+  InlineJSXPrimaryExpression InlineJSXMemberExpressionRest* ->
     if ($2.length) return $0
     return $1
   SuperProperty
   MetaProperty
+
+# MemberExpressionRest without optional IndentFurther before PropertyAccess
+InlineJSXMemberExpressionRest
+  ( OptionalShorthand / NonNullAssertion )? MemberBracketContent ->
+    if ($1) {
+      // Optional followed by a slice expression
+      if ($1.length === 2 && $2.type === "SliceExpression") {
+        // Remove '.' from optional since it is present in '.slice'
+        return [$1[0], $2]
+      }
+      return $0
+    }
+    return $2
+  PropertyAccess
+  NonNullAssertion
 
 # Subset of PrimaryExpression; omissions documented below.
 InlineJSXPrimaryExpression

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3054,10 +3054,10 @@ CoffeeStringSubstitution
 
 CoffeeInterpolatedDoubleQuotedString
   CoffeeInterpolationEnabled DoubleQuote:s ( CoffeeDoubleQuotedStringCharacters / CoffeeStringSubstitution )*:parts DoubleQuote:e ->
-    const noInterpolations = parts.length === 1 && parts[0].token != null
-    if (noInterpolations) {
+    // Check for no interpolations
+    if (parts.length === 0 || (parts.length === 1 && parts[0].token != null)) {
       return {
-        token: `"${module.modifyString(parts[0].token)}"`,
+        token: parts.length ? `"${module.modifyString(parts[0].token)}"` : '""',
         $loc,
       }
     }
@@ -3531,12 +3531,13 @@ Throw
   "throw" NonIdContinue ->
     return { $loc, token: $1 }
 
-# NOTE: These become a single backtick
+# NOTE: These become a single backtick, to properly escape "s and newlines
+# and in case there are interpolations
 TripleDoubleQuote
   "\"\"\"" ->
     return { $loc, token: "`" }
 
-# NOTE: These become a single backtick
+# NOTE: These become a single backtick, to properly escape 's and newlines
 TripleSingleQuote
   "'''" ->
     return { $loc, token: "`" }

--- a/test/block-strings.civet
+++ b/test/block-strings.civet
@@ -11,6 +11,13 @@ describe "block strings", ->
     x = `hello`
   '''
 
+  testCase '''
+    single line
+    ---
+    x = """hello "world"."""
+    ---
+    x = `hello "world".`
+  '''
 
   testCase '''
     multi-line indented

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -1,0 +1,44 @@
+{testCase, throws} from ../helper.civet
+
+describe "braced JSX attributes", ->
+  testCase """
+    string interpolation
+    ---
+    <div class=`foo ${bar}` />
+    ---
+    <div class={`foo ${bar}`} />
+  """
+
+  testCase """
+    all PrimaryExpression types
+    ---
+    <Component n=null u=undefined t=true f=false i=100 bi=1_000_000n
+     a=[1, 2, 3] o={a, b} id=foo r=/[a-zA-Z]+/
+     t={`string ${interpolation}`} p=(if cond then 1 else 2) />
+    ---
+    <Component n={null} u={undefined} t={true} f={false} i={100} bi={1_000_000n}
+     a={[1, 2, 3]} o={{a, b}} id={foo} r={/[a-zA-Z]+/}
+     t={`string ${interpolation}`} p={((cond)? 1 : 2)} />
+  """
+
+  it "if expressions", ->
+    throws """
+      <Component c=if cond then 1 else 2 />
+    """
+
+describe "JSX computed attribute names", ->
+  testCase """
+    name and value
+    ---
+    <Component [x+y]=bar />
+    ---
+    <Component {...{[x+y]: bar}} />
+  """
+
+  testCase """
+    just name
+    ---
+    <Component [x+y] />
+    ---
+    <Component {...{[x+y]: true}} />
+  """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -2,7 +2,41 @@
 
 describe "braced JSX attributes", ->
   testCase """
-    string interpolation
+    regular strings are not braced
+    ---
+    <div class='foo bar' />
+    ---
+    <div class='foo bar' />
+  """
+
+  testCase """
+    non-interpolated strings are not braced
+    ---
+    "civet coffeeInterpolation"
+    <div class="foo bar" />
+    ---
+    <div class="foo bar" />
+  """
+
+  testCase '''
+    interpolated strings are braced
+    ---
+    "civet coffeeInterpolation"
+    <div class="foo #{bar}" />
+    ---
+    <div class={`foo ${bar}`} />
+  '''
+
+  testCase """
+    triple-quoted strings are braced
+    ---
+    <div class='''hello 'world'.''' />
+    ---
+    <div class={`hello 'world'.`} />
+  """
+
+  testCase """
+    backtick string interpolation is braced
     ---
     <div class=`foo ${bar}` />
     ---
@@ -24,6 +58,51 @@ describe "braced JSX attributes", ->
   it "if expressions", ->
     throws """
       <Component c=if cond then 1 else 2 />
+    """
+
+  testCase """
+    function calls
+    ---
+    <Component count=count() result=f(a, b, c) />
+    ---
+    <Component count={count()} result={f(a, b, c)} />
+  """
+
+  testCase """
+    attribute access
+    ---
+    <Component x=a.b.c()?.d[e]?() />
+    ---
+    <Component x={a.b.c()?.d[e]?.()} />
+  """
+
+  testCase """
+    ++ and --
+    ---
+    <Component post=foo++ pre=++foo />
+    ---
+    <Component post={foo++} pre={++foo} />
+  """
+
+  testCase """
+    unary expressions
+    ---
+    <Component pos=+1 neg=-1 not=!true />
+    ---
+    <Component pos={+1} neg={-1} not={!true} />
+  """
+
+  testCase """
+    binary expressions
+    ---
+    <Component sum=1+2+x calls=f()+g() />
+    ---
+    <Component sum={1+2+x} calls={f()+g()} />
+  """
+
+  it "binary expressions with spaces", ->
+    throws """
+      <Component sum=1 + 2 />
     """
 
 describe "JSX computed attribute names", ->

--- a/test/strings.civet
+++ b/test/strings.civet
@@ -11,6 +11,15 @@ describe "strings", ->
   """
 
   testCase """
+    CoffeeScript interpolation empty
+    ---
+    "civet coffeeInterpolation"
+    x = ""
+    ---
+    x = ""
+  """
+
+  testCase """
     a
     ---
     x = "a"


### PR DESCRIPTION
* Fix output of `""` in `coffeeCompat` mode (previously was ``` `` ```)
* Oops, I never added `test/jsx/attr.civet` which had been testing past features
* Add support for whitespace-free JSX attributes, including unary, binary, call, attribute expressions. This involved refactoring unary processing to avoid duplicating that code.
* Fix support for strings in JSX attributes (previously, `coffeeInterpolation` would have broken things)