### PR TITLE
autoWithType / Implicit Let

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2941,6 +2941,28 @@ LexicalDeclaration
       children,
     }
 
+  InsertAutoWithType:l (BindingPattern / BindingIdentifier):id TypeSuffix:suffix __:ws Equals:eq ExtendedExpression:e ->
+    l = {
+      ...l,
+      $loc: {
+        pos: eq.$loc.pos - 1,
+        length: eq.$loc.length + 1,
+      }
+    }
+
+    let [splices, thisAssignments] = module.gatherBindingCode(id)
+
+    splices = splices.map(s => [", ", s])
+    thisAssignments = thisAssignments.map(a => [";", a])
+
+    const children = [l, id, suffix, ...ws, eq, e, ...splices, ...thisAssignments]
+
+    return {
+      type: "Declaration",
+      names: id.names,
+      children,
+    }
+
 ConstAssignment
   ":=" ->
     return { $loc, token: "=" }
@@ -4400,6 +4422,16 @@ InsertConst
 InsertLet
   "" ->
     return { $loc, token: "let " }
+  
+InsertAutoWithType
+  "" ->
+    if (module.config.autoWithType) {
+      if (module.config.autoLet)
+        return { $loc, token: "let " }
+      else if (module.config.autoVar)
+        return { $loc, token: "var " }
+    }
+    return $skip
 
 InsertReadonly
   # NOTE: Includes a trailing space
@@ -4508,6 +4540,7 @@ Reset
     module.config = parse.config = {
       autoVar: false,
       autoLet: false,
+      autoWithType: false,
       coffeeBinaryExistential: false,
       coffeeBooleans: false,
       coffeeClasses: false,

--- a/test/autolet.civet
+++ b/test/autolet.civet
@@ -82,3 +82,42 @@ describe "auto let inner assignment expression", ->
         return [a, b]
     }(a)
     """
+
+describe "auto let with type", ->
+    testCase """
+    auto let with type
+    ---
+    "civet autoLet autoWithType"
+    foo := () =>
+        number = 3
+        v1: number = 3
+        v2: (number = 3)
+        v3: (number = 3)
+    ---
+    const foo = () => {
+        let number = 3
+        let v1: number = 3
+        return {v2: (number = 3),
+        v3: (number = 3)}
+    }
+    """
+
+describe "auto var with type", ->
+    testCase """
+    auto var with type
+    ---
+    "civet autoVar autoWithType"
+    foo := () =>
+        number = 3
+        v1: number = 3
+        v2: (number = 3)
+        v3: (number = 3)
+    ---
+    var number
+    const foo = () => {
+        number = 3
+        var v1: number = 3
+        return {v2: (number = 3),
+        v3: (number = 3)}
+    }
+    """


### PR DESCRIPTION
# Warning
+ This flag will influence coffeescript compability.
+ This flag is not property named, may be named like `Implicit let/var`

# Summary
When `autoLet` or `autoVar` is enabled, and `autoWithType` enabled, the sentence
```
a: number = 3
```
will compile to 
```
let a: number = 3
```

While in coffeescript, it compile to
```
var number;

({
  a: number = 3
})
```
in civet, it compile to
```
{a:number = 3}
```
with coffeeCompat it compile to
```
var number
{a:number = 3}
```

This let/var only trigger when there is an assignment with strict `=`, the pattern `a: number` still compile to `{a: number}`, the pattern `a: (number = 3)` still compile to `a: {let number = 3}`.

Breaking down example, this actually is from difference between coffee and civet:
```
"civet autoLet autoWithType"
foo := () =>
    number = 3
    v = v0: number
    v1: number = 3
    v2: (number = 3)
    v3: (number = 3)
```
compile to 
```
const foo = () => {
    let number = 3
    return let v = {v0: number,
    v1:number = 3,
    v2: (number = 3),
    v3: (number = 3)}
}
```
In Coffeescript
```
(() => {
  var number, v;
  number = 3;
  v = {
    v0: number
  };
  return {
    v1: number = 3,
    v2: (number = 3),
    v3: (number = 3)
  };
});
```