### PR TITLE
Fix singleton TypeParameters compatibility with TSX

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -564,7 +564,7 @@ Parameters
   "" ->
     return {
       type: "Parameters",
-      children:[{$loc, token: "()"}],
+      children: [{$loc, token: "()"}],
       names: [],
     }
 
@@ -601,6 +601,7 @@ NonEmptyParameters
           {...rest, children: rest.children.slice(0, -1)},
           close,
         ],
+        tp,
         names,
         blockPrefix,
       }
@@ -610,6 +611,7 @@ NonEmptyParameters
       type: "Parameters",
       children: [tp, open, ...pes, close],
       names: pes.flatMap((p) => p.names),
+      tp,
     }
 
 # https://262.ecma-international.org/#prod-FunctionRestParameter
@@ -3991,8 +3993,13 @@ TypeArguments
     return { ts: true, children: $0 }
 
 TypeParameters
-  __ "<" TypeParameter+ __ ">" ->
-    return { ts: true, children: $0 }
+  __ "<" TypeParameter+:parameters __ ">" ->
+    return {
+      type: "TypeParameters",
+      parameters,
+      ts: true,
+      children: $0
+    }
 
 TypeParameter
   __ Identifier TypeConstraint? TypeParameterDelimiter
@@ -4979,7 +4986,13 @@ Init
     }
 
     function processParams(f) {
-      const { parameters, block } = f
+      const { type, parameters, block } = f
+      // Check for singleton TypeParameters <Foo> before arrow function,
+      // which TypeScript (in tsx mode) treats like JSX; replace with <Foo,>
+      if (type === "ArrowFunction" && parameters && parameters.tp && parameters.tp.parameters.length === 1) {
+        parameters.tp.parameters.push(",")
+      }
+
       if (!block) return
       const { expressions } = block
       if (!expressions) return

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -53,6 +53,22 @@ describe "[TS] function", ->
   """
 
   testCase """
+    arrow function type parameter
+    ---
+    const add = <T>(a: T, b: T) : T => a + b
+    ---
+    const add = <T,>(a: T, b: T) : T => a + b
+  """
+
+  testCase """
+    arrow function type parameters
+    ---
+    const ignore = <T, U>(a: T, b: U) : void => null
+    ---
+    const ignore = <T, U>(a: T, b: U) : void => null
+  """
+
+  testCase """
     optional parameter
     ---
     const x = (a: number, b?: number) : number ->


### PR DESCRIPTION
As discussed in discord, `<T>(x) => x` is not valid TSX (but is valid TS).  Convert to `<T,>(x) => x` for safety.