### PR TITLE
Fix multi-line JSX fragments

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3580,7 +3580,7 @@ JSXClosingElement
 
 # https://facebook.github.io/jsx/#prod-JSXFragment
 JSXFragment
-  "<>" JSXChildren? "</>"
+  "<>" JSXChildren? __ "</>"
   "<>" JSXMixedChildren InsertNewline InsertIndent ->
     return [...$0, "</>"]
 
@@ -3814,9 +3814,9 @@ JSXChild
 # https://facebook.github.io/jsx/#prod-JSXText
 JSXText
   # NOTE: not currently excluding https://facebook.github.io/jsx/#prod-HTMLCharacterReference
-  # NOTE: Additionally forbidding leading whitespace, so it can be used for
-  # indentation (by JSXNestedChildren) or ignored by JSXChildren,
-  # and newlines which we leave for the next indentation.
+  # NOTE: additionally excluding newlines to leave the next indentation;
+  # leading whitespace will actually be consumed by JSXChildren or
+  # JSXNestedChildren (where it's used for indentation).
   [^{}<>\r\n]+
 
 # https://facebook.github.io/jsx/#prod-JSXChildExpression

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -40,6 +40,20 @@ describe "JSX", ->
   """
 
   testCase """
+    multi-line fragment
+    ---
+    <>
+      Hi {name}
+      how are you?
+    </>
+    ---
+    <>
+      Hi {name}
+      how are you?
+    </>
+  """
+
+  testCase """
     expression
     ---
     <h1>{text}</h1>


### PR DESCRIPTION
Whitespace before `</>` accidentally wasn't allowed.