### PR TITLE
Link to Vite, esbuild, ESM plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The CoffeeScript of TypeScript. Much closer to ES2015+ (for better or worse).
 - [Online Civet Playground](https://civet-web.vercel.app/)
 - [Civet VSCode Extension](https://marketplace.visualstudio.com/items?itemName=DanielX.civet)
 - [Discord Server](https://discord.gg/xkrW9GebBc)
+- Plugins for
+  [Vite](https://github.com/lorefnon/vite-plugin-civet),
+  [esbuild](source/esbuild-plugin.civet),
+  [ESM module resolution](source/esm.civet)
 - Starter templates for [Solid](https://github.com/orenelbaum/solid-civet-template) and [Solid Start](https://github.com/orenelbaum/solid-start-civet-template)
 
 Quickstart Guide


### PR DESCRIPTION
`source/esbuild-plugin.civet` could use some comments (like `source/esm.civet` does) about how to use the plugin, in particular from an NPM install (`@danielx/civet/...`). I don't know how to use it, though, so haven't attempted that here.