### PR TITLE
Fix function application with implicit object

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -85,6 +85,8 @@ ArgumentsWithTrailingCallExpressions
 ArgumentList
   ArgumentPart ( __ Comma ( NestedImplicitObjectLiteral / NestedArgumentList ) )+
   # NOTE: Added nested arguments on separate new lines
+  InsertNewline InsertIndent NestedImplicitObjectLiteral ->
+    return [$1, $2, module.insertTrimmingSpace($3, '')]
   NestedArgumentList
   InlineArgumentExpressions
 

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -227,11 +227,36 @@ describe "function application", ->
     ---
     f(
       a: 1
+      b: 2
     )
     ---
     f(
-      {a: 1}
+    {
+      a: 1,
+      b: 2,
+    }
     )
+  """
+
+  testCase """
+    single nested object with nested members with implied parens and braces as argument
+    ---
+    f // Deeply nested object follows:
+      a: 1
+      b:
+        e: "hello"
+        f: // Numeric value
+          10
+    ---
+    f(// Deeply nested object follows:
+    {
+      a: 1,
+      b: {
+        e: "hello",
+        f: // Numeric value
+          10,
+      },
+    })
   """
 
   testCase """
@@ -259,7 +284,9 @@ describe "function application", ->
       environment: 'node'
     ---
     sourceMapSupport(
-      {environment: 'node'},)
+    {
+      environment: 'node',
+    })
   """
 
   testCase """


### PR DESCRIPTION
Passing implicit (not brace delimited) object to a function as first parameter has some oddities currently. 

Something like this appears to work in basic example: 

```
foo
 a: 10
```
```js
foo(
 {a: 10},)
```

But if one more property is added things get weird: 

```
foo
 a: 10
 b: 20
```
```js
foo(
 {a: 10(
 {b: 20},)},)
```

Making the function invocation explicit through parens doesn't help: 

```
foo(
 a: 10
 b: 20
)
```
```js
foo(
 {a: 10(
 {b: 20})}
)
```

But interestingly if I add a space, then it is parsed as an implicit function application whose argument is a parenthesized implicit object expression, which works: 

```
foo (
 a: 10
 b: 20
) 
```
```js
foo(( {
 a: 10,
 b: 20,
}
))
```

This PR adds an additional rule so the first two scenarios also behave as expected.