### PR TITLE
Implicit dynamic import()

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ Things Added that CoffeeScript didn't
   - Const assignment shorthand: `a := b` → `const a = b`, `{a, b} := c` → `const {a, b} = c`
   - `@#id` → `this.#id` shorthand for private identifiers
   - `import` shorthand: `x from ./x` → `import x from "./x"`
+  - Dynamic `import` shorthand: `import './x'` not at top level
+    (e.g. `await import './x'` or inside a function) →
+    `import('./x')`
   - `export` shorthand: `export x, y` → `export {x, y}`
   - Triple backtick Template Strings remove leading indentation for clarity
   - Class constructor shorthand `@( ... )`

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -72,7 +72,7 @@ makeCache = ->
           # Essentially anything that depends on mutable state in the parser like indents and the rules that depend on them
           # One day this will be better supported by Hera
           when "TrackIndented", "Samedent", "IndentedFurther", "PushIndent", "PopIndent", "Nested", "InsertIndent",\
-            "Arguments", "ImplicitArguments", "ArgumentsWithTrailingCallExpressions", "ApplicationStart",\
+            "Arguments", "ArgumentsWithTrailingCallExpressions", "ApplicationStart",\
             "CallExpression", "CallExpressionRest", "LeftHandSideExpression", "ActualAssignment", "UpdateExpression",\
             "UnaryExpression", "BinaryOpExpression", "BinaryOpRHS", "ConditionalExpression", "ShortCircuitExpression",\
             "ImplicitNestedBlock",\

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -72,7 +72,7 @@ makeCache = ->
           # Essentially anything that depends on mutable state in the parser like indents and the rules that depend on them
           # One day this will be better supported by Hera
           when "TrackIndented", "Samedent", "IndentedFurther", "PushIndent", "PopIndent", "Nested", "InsertIndent",\
-            "Arguments", "ArgumentsWithTrailingCallExpressions", "ApplicationStart",\
+            "Arguments", "ImplicitArguments", "ArgumentsWithTrailingCallExpressions", "ApplicationStart",\
             "CallExpression", "CallExpressionRest", "LeftHandSideExpression", "ActualAssignment", "UpdateExpression",\
             "UnaryExpression", "BinaryOpExpression", "BinaryOpRHS", "ConditionalExpression", "ShortCircuitExpression",\
             "ImplicitNestedBlock",\

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -60,6 +60,9 @@ Arguments
   # a b => a(b)
   # a b, c, d => a(b, c, d)
   # x y z => x(y(z))
+  ImplicitArguments
+
+ImplicitArguments
   ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
     return [open, module.insertTrimmingSpace(ws, ""), args, close]
 
@@ -80,6 +83,7 @@ ArgumentsWithTrailingCallExpressions
   # Since this is recursive Arguments must consume input to avoid infinite recursion
   # NOTE: Do not allow trailing template literals to match
   Arguments ( Samedent !Backtick CallExpressionRest )*
+  ExplicitArguments ( !Backtick CallExpressionRest )*
 
 # https://262.ecma-international.org/#prod-ArgumentList
 ArgumentList
@@ -489,8 +493,10 @@ LeftHandSideExpression
 CallExpression
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
   "super" ArgumentsWithTrailingCallExpressions
+  # Dynamic import(), with optional parentheses when not used at top level.
+  # (At top level, ImportDeclaration will match first.)
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
-  "import" __ OpenParen ExtendedExpression __ CloseParen
+  "import" ArgumentsWithTrailingCallExpressions
   MemberExpression CallExpressionRest* ->
     if ($2.length) return $0
     return $1

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -488,7 +488,7 @@ LeftHandSideExpression
 # https://262.ecma-international.org/#prod-CallExpression
 CallExpression
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
-  "super" ArgumentsWithTrailingCallExpressions
+  "super" ArgumentsWithTrailingCallExpressions CallExpressionRest*
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -60,9 +60,6 @@ Arguments
   # a b => a(b)
   # a b, c, d => a(b, c, d)
   # x y z => x(y(z))
-  ImplicitArguments
-
-ImplicitArguments
   ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
     return [open, module.insertTrimmingSpace(ws, ""), args, close]
 
@@ -83,7 +80,6 @@ ArgumentsWithTrailingCallExpressions
   # Since this is recursive Arguments must consume input to avoid infinite recursion
   # NOTE: Do not allow trailing template literals to match
   Arguments ( Samedent !Backtick CallExpressionRest )*
-  ExplicitArguments ( !Backtick CallExpressionRest )*
 
 # https://262.ecma-international.org/#prod-ArgumentList
 ArgumentList
@@ -496,7 +492,7 @@ CallExpression
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
-  "import" ArgumentsWithTrailingCallExpressions
+  "import" ArgumentsWithTrailingCallExpressions CallExpressionRest*
   MemberExpression CallExpressionRest* ->
     if ($2.length) return $0
     return $1

--- a/test/class.civet
+++ b/test/class.civet
@@ -446,6 +446,20 @@ describe "class", ->
     }
   """
 
+  testCase """
+    super with accessors
+    ---
+    class A
+      f()
+        super().foo() + super()(1)
+    ---
+    class A {
+      f() {
+        return super().foo() + super()(1)
+      }
+    }
+  """
+
   describe "decorators", ->
     testCase """
       method with decorators

--- a/test/import.civet
+++ b/test/import.civet
@@ -208,3 +208,29 @@ describe "import", ->
         ScriptTarget
       } from "typescript"
     """
+
+    testCase """
+      dynamic import
+      ---
+      import("./x.js")
+      ---
+      import("./x.js")
+    """
+
+    testCase """
+      dynamic import with member access
+      ---
+      import("./y.js").then((mod) => mod.default)
+      ---
+      import("./y.js").then((mod) => mod.default)
+    """
+
+    testCase """
+      implicit dynamic import
+      ---
+      await import "./x.js"
+      promise := import "./x.js"
+      ---
+      await import("./x.js")
+      const promise = import("./x.js")
+    """

--- a/test/import.civet
+++ b/test/import.civet
@@ -230,7 +230,9 @@ describe "import", ->
       ---
       await import "./x.js"
       promise := import "./x.js"
+      fetch = => import "./x.js"
       ---
       await import("./x.js")
       const promise = import("./x.js")
+      fetch = () => import("./x.js")
     """


### PR DESCRIPTION
With this PR, I believe `import foo` works as well as `import(foo)` currently does.

However, `import(foo).then(...)` doesn't currently work, and still doesn't work with this PR. Any ideas on how to fix? It doesn't seem to be a caching issue...