### PR TITLE
Don't deploy civet.dev website from forks

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,6 +23,8 @@ concurrency:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    # Don't attempt to deploy website from forks
+    if: github.repository == 'DanielXMoore/Civet'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
I can disable the action on my fork, but it seems more polite to new contributors to not have this action run whenever they sync their repo with upstream.

I haven't tested this, but it seems correct from https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution