### PR TITLE
JSX arrow functions don't need braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,14 @@ Things Added that CoffeeScript didn't
 - JSX enhancements (inspired by [solid-dsl discussions](https://github.com/solidjs-community/solid-dsl/discussions)):
   - Indentation: instead of explicitly closing `<tag>`s or `<>`s,
     you can indent the children and Civet will close your tags for you
+  - Arrow function children do not need to be wrapped in braces
+    (assuming they are not preceded by text); this is unambiguous because
+    `>` isn't valid JSX text. For example, `<For> (item) => ...`
+    (where function body can be indented).
   - Any braced object literal can be used as an attribute:
     `{foo}` → `foo={foo}`, `{foo: bar}` → `foo={bar}`,
     `{...foo}` remains as is; methods and getters/setters work too.
-  - `...foo` shorthand for `{...foo}`
+  - Attribute `...foo` shorthand for `{...foo}`
   - Attribute values without whitespace or suitably wrapped
     (parenthesized expressions, strings and template strings,
     regular expressions, array literals, braced object literals)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3963,7 +3963,6 @@ JSXNestedChildren
 
 # https://facebook.github.io/jsx/#prod-JSXChild
 JSXChild
-  JSXText
   JSXElement
   JSXFragment
   OpenBrace JSXChildExpression?:expression __ CloseBrace ->
@@ -3972,6 +3971,14 @@ JSXChild
       children: $0,
       expression,
     }
+  InsertInlineOpenBrace ArrowFunction:expression InsertCloseBrace ->
+    return {
+      type: "JSXChildExpression",
+      children: $0,
+      expression,
+    }
+  # NOTE: JSXText must come after attempt to match ArrowFunction
+  JSXText
 
 # https://facebook.github.io/jsx/#prod-JSXText
 JSXText

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -113,6 +113,19 @@ describe "braced JSX attributes", ->
     <Component {...foo} {...bar} />
   """
 
+  testCase """
+    value with whitespace / on its own line
+    ---
+    <Show keyed = true fallback =
+      <div>Loading...
+    >
+    ---
+    <Show keyed = {true} fallback =
+      <div>Loading...
+    </div>
+     />
+  """
+
 describe "JSX computed attribute names", ->
   testCase """
     name and value

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -432,3 +432,21 @@ describe "Unbraced function children in JSX", ->
     }}
     </For>
   """
+
+  testCase """
+    line after text
+    ---
+    <For each={items}>
+      Hello
+      (item) => <li>{item}
+    ---
+    <For each={items}>
+      Hello
+      {(item) => <li>{item}
+    </li>}
+    </For>
+  """
+  it "doesn't work on same line as text", ->
+    throws """
+      <For each={items}> Hello (item) => <li>{item}
+    """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -339,3 +339,96 @@ describe "Indentation-based JSX", ->
       child
     </Component>
   """
+
+describe "Unbraced function children in JSX", ->
+  testCase """
+    same line, thin, no arguments
+    ---
+    <For each={items}>-> 'item'
+    ---
+    <For each={items}>{function() { return 'item' }}
+    </For>
+  """
+
+  testCase """
+    same line, thick, no arguments
+    ---
+    <For each={items}>=> 'item'
+    ---
+    <For each={items}>{() => 'item'}
+    </For>
+  """
+
+  testCase """
+    same line, thick, whitespace, no arguments
+    ---
+    <For each={items}> => 'item'
+    ---
+    <For each={items}>{() => 'item'}
+    </For>
+  """
+
+  testCase """
+    same line, indent, thick, no arguments
+    ---
+    <For each={items}>=>
+      'item'
+    ---
+    <For each={items}>{() => {
+      return 'item'
+    }}
+    </For>
+  """
+
+  testCase """
+    same line, indent, thick, whitespace, no arguments
+    ---
+    <For each={items}> =>
+      'item'
+    ---
+    <For each={items}>{() => {
+      return 'item'
+    }}
+    </For>
+  """
+
+  testCase """
+    multi-line, thick, argument
+    ---
+    <For each={items}>(item) =>
+      {priority, text} := item
+      `[${priority}] ${item}`
+    ---
+    <For each={items}>{(item) => {
+      const {priority, text} = item
+      return `[${priority}] ${item}`
+    }}
+    </For>
+  """
+
+  testCase """
+    next line, thick, argument, JSX
+    ---
+    <For each={items}>
+      (item) => <li>{item}
+    ---
+    <For each={items}>
+      {(item) => <li>{item}
+    </li>}
+    </For>
+  """
+
+  testCase """
+    next line, indent, thick, argument, JSX
+    ---
+    <For each={items}>
+      (item) =>
+        <li>{item}
+    ---
+    <For each={items}>
+      {(item) => {
+        return <li>{item}
+        </li>
+    }}
+    </For>
+  """


### PR DESCRIPTION
Given that `<For each=items()>(item) => ...` isn't valid JSX because `>` isn't valid JSX text, I added support for automatically wrapping arrow functions like this in braces. This is convenient for SolidJS in particular which often uses function children.