### PR TITLE
JSX #id and .class shorthands

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ Things Added that CoffeeScript didn't
     `>` isn't valid JSX text. For example, `<For> (item) => ...`
     (where function body can be indented).
   - `#foo` shorthand for `id="foo"`;
-    also `#"foo bar"` or `` #`foo ${bar}` `` or `#{expr}`
+    also `#"foo bar"`, `` #`foo ${bar}` ``, `#{expr}`
+  - `.foo` shorthand for `class="foo"` (but must be at least one space after
+    tag name); also `.foo.bar`, `."foo bar"`, `` .`foo ${bar}` ``, `.{expr}`
+    - `"civet react"` flag uses `className` instead of `class`
   - Any braced object literal can be used as an attribute:
     `{foo}` → `foo={foo}`, `{foo: bar}` → `foo={bar}`,
     `{...foo}` remains as is; methods and getters/setters work too.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Things Added that CoffeeScript didn't
     (assuming they are not preceded by text); this is unambiguous because
     `>` isn't valid JSX text. For example, `<For> (item) => ...`
     (where function body can be indented).
+  - `#foo` shorthand for `id="foo"`;
+    also `#"foo bar"` or `` #`foo ${bar}` `` or `#{expr}`
   - Any braced object literal can be used as an attribute:
     `{foo}` → `foo={foo}`, `{foo: bar}` → `foo={bar}`,
     `{...foo}` remains as is; methods and getters/setters work too.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3680,7 +3680,7 @@ TypedJSXElement
 # https://facebook.github.io/jsx/#prod-JSXElement
 JSXElement
   JSXSelfClosingElement
-  JSXOpeningElement JSXChildren? __ JSXClosingElement ->
+  JSXOpeningElement JSXChildren? Whitespace? JSXClosingElement ->
     // Check that tags match
     if ($1[1] !== $4[2]) return $skip
     return { type: "JSXElement", children: $0 }
@@ -3696,16 +3696,16 @@ JSXElement
 
 # https://facebook.github.io/jsx/#prod-JSXSelfClosingElement
 JSXSelfClosingElement
-  "<" $JSXElementName CompactTypeArguments? JSXAttributes? __ "/>" ->
+  "<" $JSXElementName CompactTypeArguments? JSXAttributes? Whitespace? "/>" ->
     return { type: "JSXElement", children: $0 }
 
 # https://facebook.github.io/jsx/#prod-JSXOpeningElement
 JSXOpeningElement
-  "<" $JSXElementName CompactTypeArguments? JSXAttributes? __ ">"
+  "<" $JSXElementName CompactTypeArguments? JSXAttributes? Whitespace? ">"
 
 # https://facebook.github.io/jsx/#prod-JSXClosingElement
 JSXClosingElement
-  "</" __ $JSXElementName __ ">"
+  "</" Whitespace? $JSXElementName Whitespace? ">"
 
 TypedJSXFragment
   JSXFragment ->
@@ -3718,7 +3718,7 @@ TypedJSXFragment
 
 # https://facebook.github.io/jsx/#prod-JSXFragment
 JSXFragment
-  "<>" JSXChildren? __ "</>" ->
+  "<>" JSXChildren? Whitespace? "</>" ->
     if ($2) {
       return { type: "JSXFragment", children: $0, jsxChildren: $2.jsxChildren }
     } else {
@@ -3741,7 +3741,7 @@ JSXIdentifierName
 
 # https://facebook.github.io/jsx/#prod-JSXAttributes
 JSXAttributes
-  ( __ JSXAttribute )*
+  ( Whitespace? JSXAttribute )*
 
 # NOTE: Merged SpreadAttribute and Attribute
 JSXAttribute
@@ -3822,7 +3822,7 @@ JSXAttributeName
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeInitializer
 JSXAttributeInitializer
-  __ Equals __ JSXAttributeValue
+  Whitespace? Equals Whitespace? JSXAttributeValue
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeValue
 JSXAttributeValue
@@ -3836,7 +3836,7 @@ JSXAttributeValue
     if (module.isTemplateLiteral($1)) return $skip
     return $1
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
-  OpenBrace ExtendedExpression __ CloseBrace
+  OpenBrace ExtendedExpression Whitespace? CloseBrace
   JSXElement
   JSXFragment
   InsertInlineOpenBrace InlineJSXAttributeValue InsertCloseBrace
@@ -3998,7 +3998,7 @@ JSXText
 # https://facebook.github.io/jsx/#prod-JSXChildExpression
 JSXChildExpression
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
-  __ ( DotDotDot __ )? ExtendedExpression
+  Whitespace? ( DotDotDot Whitespace? )? ExtendedExpression
 
 ## Type Stuff
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3819,6 +3819,23 @@ JSXAttribute
   # NOTE: Adding ...foo shorthand for {...foo}
   InsertInlineOpenBrace DotDotDot InlineJSXAttributeValue InsertCloseBrace
 
+  # NOTE: #id shorthand
+  "#" JSXShorthandString ->
+    return [ " ", "id=", $2 ]
+
+JSXShorthandString
+  /(?:[\w\-:]+|\([^()]*\)|\[[^\[\]]*\])+/ ->
+    return module.quoteString($0)
+  StringLiteral ->
+    if (module.isTemplateLiteral($1)) {
+      return [ "{", $1, "}" ]
+    } else {
+      return $1
+    }
+  TemplateLiteral ->
+    return [ "{", $1, "}" ]
+  OpenBrace ExtendedExpression Whitespace? CloseBrace
+
 # https://facebook.github.io/jsx/#prod-JSXAttributeName
 JSXAttributeName
   # NOTE: Merged JSXIdentifier and JSXNamespacedName
@@ -4592,6 +4609,17 @@ Reset
       // Replace non-escaped newlines with escaped newlines
       // taking into account the possibility of a preceding escaped backslash
       return str.replace(/(^.?|[^\\]{2})(\\\\)*\n/g, '$1$2\\n')
+    }
+
+    // Add quotes around a string to make it a valid JavaScript string,
+    // escaping any \s
+    module.quoteString = function(str) {
+      str = str.replace(/\\/g, '\\\\')
+      if (str.includes('"') && !str.includes("'")) {
+        return "'" + str.replace(/'/g, "\\'") + "'"
+      } else {
+        return '"' + str.replace(/"/g, '\\"') + '"'
+      }
     }
 
 Init

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3742,11 +3742,68 @@ JSXIdentifierName
 # https://facebook.github.io/jsx/#prod-JSXAttributes
 JSXAttributes
   ( Whitespace? JSXAttribute )* ->
-    // Sometimes JSXAttribute adds a leading space to separate from previous.
-    // Remove that space if there's already whitespace here.
-    return $0.map((attr) =>
-      attr[0] && attr[1][0] === " " ? [attr[0], attr[1].slice(1)] : attr
-    )
+    // Extract all .class shorthands into `classes` array
+    const classes = []
+    let attrs = $0.filter((pair) => {
+      const [, attr] = pair
+      if (attr.type === "JSXClass") {
+        classes.push(attr.class)
+        return false
+      }
+      return true
+    })
+    if (classes.length) {
+      // Check for non-shorthand class or className attribute
+      let className = module.config.react ? "className" : "class"
+      attrs = attrs.filter((pair) => {
+        const [, attr] = pair
+        if ((attr[0][0] === "class" || attr[0][0] === "className") &&
+            !attr[0][1]) {
+          className = attr[0][0]
+          classes.push(attr[1][attr[1].length-1])
+          return false
+        }
+        return true
+      })
+      let classValue
+      function braced(c) {
+        return c[0] === "{" || c[0]?.token === "{"
+      }
+      function parseClass(c) {
+        c = c.token || c
+        if (c.startsWith("'")) {
+          c = '"' +
+            c.slice(1, -1)
+            .replace(/\\*"/g, (m) => m.length % 2 == 0 ? m : "\\"+m) +
+            '"'
+        }
+        return JSON.parse(c)
+      }
+      if (classes.some(braced)) {
+        classValue = ["{`"]
+        classes.forEach((c, i) => {
+          if (i > 0) classValue.push(" ")
+          if (braced(c)) {
+            classValue.push("$", c)
+          } else {
+            classValue.push(parseClass(c))
+          }
+        })
+        classValue.push("`}")
+      } else { // all strings
+        classValue = JSON.stringify(classes.map(parseClass).join(" "))
+      }
+      attrs.splice(0, 0, [" ", [className, ["=", classValue]]])
+    }
+    return attrs.map((pair) => {
+      const [space, attr] = pair
+      // Sometimes JSXAttribute adds a leading space to separate from previous.
+      // Remove that space if there's already whitespace here.
+      if (space && attr[0] === " ") {
+        pair = [space, attr.slice(1)]
+      }
+      return pair
+    })
 
 # NOTE: Merged SpreadAttribute and Attribute
 JSXAttribute
@@ -3822,6 +3879,11 @@ JSXAttribute
   # NOTE: #id shorthand
   "#" JSXShorthandString ->
     return [ " ", "id=", $2 ]
+  Dot JSXShorthandString ->
+    return {
+      type: "JSXClass",
+      class: $2,
+    }
 
 JSXShorthandString
   /(?:[\w\-:]+|\([^()]*\)|\[[^\[\]]*\])+/ ->
@@ -4434,6 +4496,7 @@ Reset
       coffeeNot: false,
       coffeeOf: false,
       implicitReturns: true,
+      react: false,
       solid: false,
       client: false, // default behavior: client only
       server: false,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3741,7 +3741,12 @@ JSXIdentifierName
 
 # https://facebook.github.io/jsx/#prod-JSXAttributes
 JSXAttributes
-  ( Whitespace? JSXAttribute )*
+  ( Whitespace? JSXAttribute )* ->
+    // Sometimes JSXAttribute adds a leading space to separate from previous.
+    // Remove that space if there's already whitespace here.
+    return $0.map((attr) =>
+      attr[0] && attr[1][0] === " " ? [attr[0], attr[1].slice(1)] : attr
+    )
 
 # NOTE: Merged SpreadAttribute and Attribute
 JSXAttribute

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -273,3 +273,11 @@ describe "JSX class shorthand", ->
     ---
     <div class="foo" id="id"/>
   """
+
+  testCase """
+    big example
+    ---
+    <div#id.class1.class2.t-[5px].{myClass()} class={anotherClass}/>
+    ---
+    <div class={`class1 class2 t-[5px] ${myClass()} ${anotherClass}`} id="id"/>
+  """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -142,3 +142,52 @@ describe "JSX computed attribute names", ->
     ---
     <Component {...{[x+y]: true}} />
   """
+
+describe "JSX id shorthand", ->
+  testCase """
+    without space
+    ---
+    <div#foo/>
+    ---
+    <div id="foo"/>
+  """
+
+  testCase """
+    with space
+    ---
+    <div #foo />
+    ---
+    <div id="foo" />
+  """
+
+  testCase """
+    quoted string
+    ---
+    <div #'foo bar' />
+    ---
+    <div id='foo bar' />
+  """
+
+  testCase """
+    triple quoted string
+    ---
+    <div #'''foo bar''' />
+    ---
+    <div id={`foo bar`} />
+  """
+
+  testCase """
+    template literal
+    ---
+    <div #`foo ${bar}` />
+    ---
+    <div id={`foo ${bar}`} />
+  """
+
+  testCase '''
+    braced expression
+    ---
+    <div #{foo bar} />
+    ---
+    <div id={foo(bar)} />
+  '''

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -191,3 +191,85 @@ describe "JSX id shorthand", ->
     ---
     <div id={foo(bar)} />
   '''
+
+describe "JSX class shorthand", ->
+  testCase """
+    without space
+    ---
+    <div.foo/>
+    ---
+    <div.foo/>
+  """
+
+  testCase """
+    with space
+    ---
+    <div .foo/>
+    ---
+    <div class="foo"/>
+  """
+
+  testCase """
+    two classes without space
+    ---
+    <div .foo.bar/>
+    ---
+    <div class="foo bar"/>
+  """
+
+  testCase """
+    two classes with space
+    ---
+    <div .foo .bar/>
+    ---
+    <div class="foo bar"/>
+  """
+
+  testCase """
+    two classes, one single quoted
+    ---
+    <div .foo .'b"r'/>
+    ---
+    <div class="foo b\\"r"/>
+  """
+
+  testCase """
+    two classes, both quoted
+    ---
+    <div ."f'o" .'b"r'/>
+    ---
+    <div class="f'o b\\"r"/>
+  """
+
+  testCase """
+    short and long class
+    ---
+    <div .foo class={bar()} />
+    ---
+    <div class={`foo ${bar()}`} />
+  """
+
+  testCase """
+    short and long className
+    ---
+    <div .foo className={bar()} />
+    ---
+    <div className={`foo ${bar()}`} />
+  """
+
+  testCase """
+    react
+    ---
+    "civet react"
+    <div .foo/>
+    ---
+    <div className="foo"/>
+  """
+
+  testCase """
+    mix #id and .class
+    ---
+    <div#id.foo/>
+    ---
+    <div class="foo" id="id"/>
+  """

--- a/test/jsx/objects.civet
+++ b/test/jsx/objects.civet
@@ -126,7 +126,7 @@ describe "JSX object shorthand", ->
     ---
     <div {[foo()]: bar, regular, [bar()]: baz} />
     ---
-    <div  regular={regular} {...{[foo()]: bar, [bar()]: baz}} />
+    <div regular={regular} {...{[foo()]: bar, [bar()]: baz}} />
   """
 
   testCase """
@@ -150,5 +150,5 @@ describe "JSX object shorthand", ->
     ---
     <div {get foo(){0}, set foo(){0}} />
     ---
-    <div  {...{get foo(){return 0}, set foo(){0}}} />
+    <div {...{get foo(){return 0}, set foo(){0}}} />
   """

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -89,3 +89,31 @@ describe "JSX", ->
     ---
     <Component<number>><Child<string>/></Component>
   """
+
+  testCase """
+    JS comments in braces
+    ---
+    <div>
+      {/* This is a comment */}
+      {// Another comment
+      }
+    </div>
+    ---
+    <div>
+      {/* This is a comment */}
+      {// Another comment
+      }
+    </div>
+  """
+
+  testCase """
+    JS comments ignored outside braces
+    ---
+    <div>
+      /* This is a comment
+      // </div>
+    ---
+    <div>
+      /* This is a comment
+      // </div>
+    """


### PR DESCRIPTION
* JSX `.class` shorthand, which stack together and with `class`/`className`
* JSX `#id` shorthand
* Improve JSX attribute space generation (fewer double spaces)
* Forbid JS comments in JSX (outside braces) — this never should have been allowed
