### PR TITLE
New CLI including REPL

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,10 +11,10 @@ chmod +x "$BIN"
 rm dist/cli.js
 
 # esbuild-plugin
-./dist/civet --js -c source/esbuild-plugin.civet -o dist/.js
+./dist/civet --js -c source/esbuild-plugin.civet -o dist/esbuild-plugin.js
 
 # esm loader
-./dist/civet --js -c source/esm.civet -o dist/.mjs
+./dist/civet --js -c source/esm.civet -o dist/esm.mjs
 
 # types
 cp types/types.d.ts dist/types.d.ts

--- a/build/build.sh
+++ b/build/build.sh
@@ -11,10 +11,10 @@ chmod +x "$BIN"
 rm dist/cli.js
 
 # esbuild-plugin
-./dist/civet --js < source/esbuild-plugin.civet > dist/esbuild-plugin.js
+./dist/civet --js -c source/esbuild-plugin.civet -o dist/.js
 
 # esm loader
-./dist/civet --js < source/esm.civet > dist/esm.mjs
+./dist/civet --js -c source/esm.civet -o dist/.mjs
 
 # types
 cp types/types.d.ts dist/types.d.ts

--- a/build/test-compat.coffee
+++ b/build/test-compat.coffee
@@ -21,21 +21,19 @@ for filename in process.argv[2..]
   console.log '*', filename
   input = fs.readFileSync filename, encoding: 'utf8'
 
-  if filename.endsWith('.coffee') and not input.startsWith('"civet')
-    input = """
-      "civet coffeeCompat"
-      #{input}
-    """
-
   lines = input.split '\n'
   origCount = countLines lines
 
   loop
     try
-      civet.compile input
+      civet.compile input, {filename}
       break
     catch e
-      match = e.message.match /^\s*unknown:(\d+)/
+      match = e.message.match ///
+        ^\s*
+        #{filename.replace /[\.*+?|\[\](){}\\]/g, "\\$&"}
+        :(\d+)
+      ///
       unless match?
         console.error "Unrecognized error message #{JSON.stringify e.message}; counts will be inaccurate"
         break

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -117,9 +117,9 @@ repl = (options) ->
         process.exit 0
       else if input.endsWith '\n\n'  # finished input with blank line
         try
-          output = compile input, options
+          output = compile input, {...options, filename}
         catch error
-          console.error "Failed to transpile Civet:"
+          #console.error "Failed to transpile Civet:"
           return callback error
         try
           result = vm.runInContext output, context, {filename}
@@ -153,9 +153,9 @@ cli = ->
 
     # Transpile
     try
-      output = compile content, options
+      output = compile content, {...options, filename}
     catch error
-      console.error "#{filename} failed to transpile:"
+      #console.error "#{filename} failed to transpile:"
       console.error error
       continue
 

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -30,46 +30,113 @@ if process.argv.includes "--help"
 {prune} = generate
 
 encoding = "utf8"
-process.stdin.setEncoding encoding
 
-fs = require "fs"
-readline = try
-  require 'node:readline'
-catch
-  require 'readline'
+fs = require "fs/promises"
+path = require "path"
 
-readLines = (rl) ->
-  new Promise (resolve, reject) ->
-    parts = []
-    rl.on 'line', (buffer) -> parts.push buffer + '\n'
-    rl.on 'SIGINT', ->
-      reject '^C'
-    rl.on 'close', ->
-      resolve parts.join ''
+parseArgs = (args = process.argv[2..]) ->
+  options = {}
+  filenames = []
+  i = 0
+  while i < args.length
+    arg = args[i]
+    # Split -ab into -a -b
+    if /^-\w{2,}$/.test arg
+      args[i..i] =
+        for char in arg[1..]
+          "-#{char}"
+      continue
+    # Main argument handling
+    switch arg
+      when '-c', '--compile'
+        options.compile = true
+      when '--ast'
+        options.ast = true
+      when '--no-cache'
+        options.noCache = true
+      when '--inline-map'
+        options.inlineMap = true
+      when '--js'
+        options.js = true
+      when '--'
+        filenames.push ...args[++i..]
+        i = args.length
+      else
+        filenames.push arg
+    i++
 
-readLines readline.createInterface process.stdin, process.stdout
-.then (input) ->
-  ast =       process.argv.includes "--ast"
-  noCache =   process.argv.includes "--no-cache"
-  inlineMap = process.argv.includes "--inline-map"
-  js =        process.argv.includes "--js"
+  options.run = not (options.ast or options.compile)
+  # In run mode, compile to JS
+  options.js = true if options.run
 
-  filename = "unknown"
-  try
-    filename = fs.realpathSync '/dev/stdin'
+  {filenames, options}
 
-  output = compile input, {
-    ast,
-    noCache,
-    filename,
-    inlineMap,
-    js,
-  }
+readFiles = (filenames, options) ->
+  for filename in filenames
+    stdin = filename == '-'
+    try
+      if stdin
+        process.stdin.setEncoding encoding
+        filename = "<stdin>"
+        try
+          filename = await fs.realpath '/dev/stdin'
+        lines = []
+        rl = require('readline').createInterface process.stdin, process.stdout
+        rl.on 'line', (buffer) -> lines.push buffer + '\n'
+        content = await new Promise (resolve, reject) ->
+          rl.on 'SIGINT', ->
+            reject '^C'
+          rl.on 'close', ->
+            resolve lines.join ''
+      else
+        content = await fs.readFile filename, {encoding}
+      yield {filename, content, stdin}
+    catch error
+      yield {filename, error, stdin}
 
-  if ast
-    output = JSON.stringify(output, null, 2)
+cli = ->
+  {filenames, options} = parseArgs()
+  unless filenames.length
+    # When piped, default to old behavior of transpiling stdin to stdout
+    filenames = ['-']
+    options.compile = true
 
-  process.stdout.write output
-.catch (e) ->
-  console.error e
-  process.exit 1
+  for await {filename, error, content, stdin} from readFiles filenames, options
+    if error
+      console.error "#{filename} failed to load:"
+      console.error error
+      continue
+
+    # Transpile
+    try
+      output = compile content, options
+    catch error
+      console.error "#{filename} failed to transpile:"
+      console.error error
+      continue
+
+    if options.ast
+      process.stdout.write JSON.stringify(output, null, 2)
+    else if options.compile
+      if stdin
+        process.stdout.write output
+      else
+        outputFilename = filename
+        if options.js
+          outputFilename += ".jsx"
+        else
+          outputFilename += ".tsx"
+        try
+          await fs.writeFile outputFilename, output
+        catch error
+          console.error "#{outputFilename} failed to write:"
+          console.error error
+    else # run
+      try
+        vm = require 'vm'
+        require.main._compile output, filename
+      catch error
+        console.error "#{filename} crashed while running:"
+        console.error error
+
+cli() if require.main == module

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -140,8 +140,10 @@ cli = ->
       filenames = ['-']
 
   options.run = not (options.ast or options.compile)
-  # In run mode, compile to JS
-  options.js = true if options.run
+  # In run mode, compile to JS with source maps
+  if options.run
+    options.js = true
+    options.inlineMap = true
 
   return repl options if options.repl
 

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -37,13 +37,10 @@ module.exports =
   compile: (src, options=defaultOptions) ->
     filename = options.filename or "unknown"
 
-    # TODO: This incorrectly shifts line numbers by 1
+    # TODO: This makes source maps slightly off in the first line.
     if filename.endsWith('.coffee') and not
        /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
-      src = """
-        "civet coffeeCompat"
-        #{src}
-      """
+      src = "\"civet coffeeCompat\"; #{src}"
 
     if !options.noCache
       events = makeCache()

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -37,6 +37,14 @@ module.exports =
   compile: (src, options=defaultOptions) ->
     filename = options.filename or "unknown"
 
+    # TODO: This incorrectly shifts line numbers by 1
+    if filename.endsWith('.coffee') and not
+       /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
+      src = """
+        "civet coffeeCompat"
+        #{src}
+      """
+
     if !options.noCache
       events = makeCache()
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4294,8 +4294,8 @@ Shebang
   /#![^\r\n]*/ EOL
 
 CivetPrologue
-  [\t ]* DoubleQuote CivetPrologueContent:content DoubleQuote $StatementDelimiter EOS -> content
-  [\t ]* SingleQuote CivetPrologueContent:content SingleQuote $StatementDelimiter EOS -> content
+  [\t ]* DoubleQuote CivetPrologueContent:content DoubleQuote $StatementDelimiter EOS? -> content
+  [\t ]* SingleQuote CivetPrologueContent:content SingleQuote $StatementDelimiter EOS? -> content
 
 CivetPrologueContent
   "civet" CivetOption*:options [\s]* ->

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -55,7 +55,7 @@ describe "example code", ->
   """
 
   testCase """
-    grammar.coffee
+    grammar.coffee snippet
     ---
       Identifier: [
         o 'IDENTIFIER',                             -> new IdentifierLiteral $1

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -428,7 +428,7 @@ describe "examples (from real life)", ->
   """
 
   testCase """
-    lexer.coffee
+    lexer.coffee snippet
     ---
     tag = switch id
       when '!'                 then 'UNARY'


### PR DESCRIPTION
* `-c`/`--compile` to compile specified `.civet` files to `.civet.tsx` or `.civet.jsx` files (according to `--js` flag)
* `-o`/`--output` lets you override the output directory/extension/filename
* Without `-c`, runs files directly (like `coffee`)
* `-` to run or compile stdin; `-o -` to output to stdout
* `civet <input >output` still works
* `civet` alone runs simple REPL with cute prompt: `🐱> `

I also made the main `compile` function turn on `coffeeCompat` by default (when no other `civet` directive) for filenames ending with `.coffee`. This currently messes up line numbers by 1 though... Ideally we'd have a way to send information to the parser, but I don't know how.

Builds on #96

TODO: `require` registration, so `require`s work (this is generally missing in Civet I think)

TODO: `civet foo.civet` in ESM mode?