### PR TITLE
Filter combined JSX classes

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3770,9 +3770,11 @@ JSXAttributes
         }
         return true
       })
-      let classValue
-      function braced(c) {
+      function isBraced(c) {
         return c[0] === "{" || c[0]?.token === "{"
+      }
+      function unbrace(c) {
+        return c.slice(1, -1)
       }
       function parseClass(c) {
         c = c.token || c
@@ -3784,19 +3786,25 @@ JSXAttributes
         }
         return JSON.parse(c)
       }
-      if (classes.some(braced)) {
-        classValue = ["{`"]
-        classes.forEach((c, i) => {
-          if (i > 0) classValue.push(" ")
-          if (braced(c)) {
-            classValue.push("$", c)
-          } else {
-            classValue.push(parseClass(c))
-          }
-        })
-        classValue.push("`}")
-      } else { // all strings
-        classValue = JSON.stringify(classes.map(parseClass).join(" "))
+      const strings = [], exprs = []
+      classes.forEach((c) => {
+        if (isBraced(c)) {
+          exprs.push(unbrace(c))
+          exprs.push(", ")
+        } else {
+          strings.push(parseClass(c))
+        }
+      })
+      const stringPart = strings.filter(Boolean).join(" ")
+      let classValue
+      if (exprs.length) { // some expressions
+        exprs.pop()  // remove trailing comma
+        if (stringPart) { // some strings too
+          exprs.unshift(JSON.stringify(stringPart), ", ")
+        }
+        classValue = ["{[", ...exprs, "].filter(Boolean).join(\" \")}"]
+      } else { // strings only
+        classValue = JSON.stringify(stringPart)
       }
       attrs.splice(0, 0, [" ", [className, ["=", classValue]]])
     }

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -246,7 +246,7 @@ describe "JSX class shorthand", ->
     ---
     <div .foo class={bar()} />
     ---
-    <div class={`foo ${bar()}`} />
+    <div class={["foo", bar()].filter(Boolean).join(" ")} />
   """
 
   testCase """
@@ -254,7 +254,7 @@ describe "JSX class shorthand", ->
     ---
     <div .foo className={bar()} />
     ---
-    <div className={`foo ${bar()}`} />
+    <div className={["foo", bar()].filter(Boolean).join(" ")} />
   """
 
   testCase """
@@ -279,5 +279,5 @@ describe "JSX class shorthand", ->
     ---
     <div#id.class1.class2.t-[5px].{myClass()} class={anotherClass}/>
     ---
-    <div class={`class1 class2 t-[5px] ${myClass()} ${anotherClass}`} id="id"/>
+    <div class={["class1 class2 t-[5px]", myClass(), anotherClass].filter(Boolean).join(" ")} id="id"/>
   """


### PR DESCRIPTION
Currently, JSX attributes `.class1 .class2 class={foo()}` compile to ``class={`class1 class2 ${foo()}`}``. This isn't what people expect when `foo()` returns `undefined` or `false`.

This PR instead compiles `.class1 .class2 class={foo()}` to `class={["class1 class2", foo()].filter(Boolean).join(" ")}`.