### PR TITLE
XML comment support within JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Things Added that CoffeeScript didn't
     `"civet solid server"` for server-only code (SSR only), or
     `"civet solid client server"` for isomorphic code that runs on
     client and server (SSR + hydration).
+  - XML comments: `<!-- ... -->` → `{/* ... */}`
 - CoffeeScript improvements
   - Postfix loop `run() loop` → `while(true) run()`
   - Character range literals `["a".."z"]`, `['f'..'a']`, `['0'..'9']`

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4064,12 +4064,15 @@ JSXNestedChildren
 JSXChild
   JSXElement
   JSXFragment
+  # NOTE: Adding support for XML comments
+  JSXComment
   OpenBrace JSXChildExpression?:expression __ CloseBrace ->
     return {
       type: "JSXChildExpression",
       children: $0,
       expression,
     }
+  # NOTE: Adding support for arrow functions without wrapping braces
   InsertInlineOpenBrace ArrowFunction:expression InsertCloseBrace ->
     return {
       type: "JSXChildExpression",
@@ -4078,6 +4081,15 @@ JSXChild
     }
   # NOTE: JSXText must come after attempt to match ArrowFunction
   JSXText
+
+# XML comments: https://www.w3.org/TR/xml/#sec-comments
+JSXComment
+  "<!--" JSXCommentContent "-->" ->
+    return [ "{/*", $2, "*/}" ]
+
+JSXCommentContent
+  /(?:-[^-]|[^-]*)*/ ->
+    return { $loc, token: $0.replace(/\*\//g, "* /") }
 
 # https://facebook.github.io/jsx/#prod-JSXText
 JSXText

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -117,3 +117,28 @@ describe "JSX", ->
       /* This is a comment
       // </div>
     """
+
+describe "JSX XML comments", ->
+  testCase """
+    basic usage
+    ---
+    <div>
+      <!-- This is a comment -->
+    </div>
+    ---
+    <div>
+      {/* This is a comment */}
+    </div>
+  """
+
+  testCase """
+    escaping
+    ---
+    <div>
+      <!-- This is a /* comment */ -->
+    </div>
+    ---
+    <div>
+      {/* This is a /* comment * / */}
+    </div>
+  """


### PR DESCRIPTION
Mentioned as idea 7 on https://github.com/lxsmnsyc/ideas/discussions/11
I've wanted this myself in the past, though partly because CoffeeScript's equivalent (`{### ... ###}`) is so verbose.

One use-case for `<!-- ... -->` comments is that they let you comment out a block of JSX that itself has `/*...*/` comments (similar to single vs. double quotes and their tripled forms).

(Of course this only works one level deep... you can't use `<!-- ... -->` to comment out a block that has other `<!-- ... -->` comments.)