### PR TITLE
Add civet config

### DIFF
--- a/build/esbuild.coffee
+++ b/build/esbuild.coffee
@@ -33,6 +33,23 @@ extensionResolverPlugin = (extensions) ->
 resolveExtensions = extensionResolverPlugin(["hera", "coffee"])
 
 esbuild.build({
+  entryPoints: ['source/config.coffee']
+  bundle: false
+  sourcemap
+  minify
+  watch
+  platform: 'node'
+  outfile: 'dist/config.js'
+  plugins: [
+    resolveExtensions
+    coffeeScriptPlugin
+      bare: true
+      inlineMap: sourcemap
+    heraPlugin
+  ]
+}).catch -> process.exit 1
+
+esbuild.build({
   entryPoints: ['source/cli.coffee']
   bundle: false
   sourcemap

--- a/source/config.coffee
+++ b/source/config.coffee
@@ -1,0 +1,42 @@
+fs = require 'fs/promises'
+path = require 'path'
+
+searchConfig = (fromFile) ->
+  # It should not be useful, but just an insurance not falling into loop
+  maxSearchLevel = 30
+  configNames = [
+    'civet-config.json',
+    'civetConfig.json',
+    'civet_config.json'
+  ]
+  exists = (path) => 
+    fs.access(path)
+      .then => true
+      .catch => false
+  #console.log "Starting with #{fromFile}"
+  checkingPath = path.dirname fromFile
+  basename = path.basename fromFile
+  for _ in [0...maxSearchLevel]
+    packagePath = path.resolve checkingPath, "package.json"
+    #console.log("Checking #{packagePath}")
+    if await exists packagePath
+      for configName from configNames
+        configPath = path.resolve checkingPath, configName
+        if await exists configPath
+          return await loadConfig configPath 
+    nextPath = path.resolve checkingPath, "../"
+    break if checkingPath == nextPath
+    checkingPath = nextPath
+  {}
+
+loadConfig = (file) ->
+  try
+    config = await fs.readFile file
+    return JSON.parse config
+  catch err
+    console.error "Fail to parse civet config. Will fallback to default options. \n#{}"
+    return {}
+
+module.exports =
+  searchConfig: searchConfig
+  loadConfig: loadConfig

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -44,10 +44,11 @@ uncacheable = new Set [
 export compile = (src, options=defaultOptions) ->
   filename = options.filename or "unknown"
 
-  # TODO: This makes source maps slightly off in the first line.
+  parse.config = options.compilerOptions || {}
   if filename.endsWith('.coffee') and not
-     /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
-    src = "\"civet coffeeCompat\"; #{src}"
+      /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
+    parse.config.coffeeCompat = true
+
 
   if !options.noCache
     events = makeCache()

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4603,7 +4603,7 @@ Reset
       })
     }
 
-    module.config = parse.config = {
+    module.config = {
       autoVar: false,
       autoLet: false,
       coffeeBinaryExistential: false,
@@ -4804,6 +4804,11 @@ Reset
         }
       }
     })
+
+    if (parse.config != null) {
+      Object.assign(module.config, parse.config)
+    }
+    parse.config = module.config
 
     // TODO: this is only here because directive prologues depend on it
     // eventually all these `module.*` variables should be handled better in Hera


### PR DESCRIPTION
This pull request try to add a civet-config.json reader.

```
{
    "compilerOptions": {
        “coffeeCompat”: true
    }
}
```

Now it works by:
+ For first file passed to civet, search its directory for a `package.json`, if it not exists, then its upper directory.
+ Try to load `civet-config.json`(or other 2 alias) under that directory.

Limits:
+ Reading file from stdin, cannot locate where file from, so cannot load config.
+ REPL don’t have a filename, cannot load config.
 
Tested on Mac, Not tested for Windows. 
   
Is there some way to test cli features?