### PR TITLE
Auto let Fix

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5851,6 +5851,7 @@ Init
           }
         }
         else if (node.type == "Declaration") {
+            if (node.children && node.children.length) createLetDecs(node.children, scopes)
             node.names.forEach((name) => currentScope.add(name))
         }
         else {

--- a/test/autolet.civet
+++ b/test/autolet.civet
@@ -31,6 +31,7 @@ describe "auto let", ->
     """
 
 describe "auto let with function", ->
+    // TODO: We should fix the return let here, this is invalid.
     testCase """
         auto let with function
         ---
@@ -41,6 +42,9 @@ describe "auto let with function", ->
             var b = 2
         }
         a = 2
+        let c = (b) => {
+            c = 1
+        }
         ---
         let b = 1
         function b(a) {
@@ -48,6 +52,9 @@ describe "auto let with function", ->
             var b = 2
         }
         let a = 2
+        let c = (b) => {
+            return let c = 1
+        }
     """
 
 describe "auto let with multiple declaration", ->


### PR DESCRIPTION
Fix missing let decs inner declaration.    
I'm not sure if it's needed to fix that breaking `return let` which won't happen on `auto Var` as autovar move all variables to top. 