### PR TITLE
Class shorthand optimizations

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3803,7 +3803,11 @@ JSXAttributes
         if (stringPart) { // some strings too
           exprs.unshift(JSON.stringify(stringPart), ", ")
         }
-        classValue = ["{[", ...exprs, "].filter(Boolean).join(\" \")}"]
+        if (exprs.length === 1) {
+          classValue = ["{(", ...exprs, ") || \"\"}"]
+        } else {
+          classValue = ["{[", ...exprs, "].filter(Boolean).join(\" \")}"]
+        }
       } else { // strings only
         classValue = JSON.stringify(stringPart)
       }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3775,6 +3775,7 @@ JSXAttributes
         return c[0] === "{" || c[0]?.token === "{"
       }
       function unbrace(c) {
+        // Remove leading "{" and trailing "}" tokens
         return c.slice(1, -1)
       }
       function parseClass(c) {
@@ -3804,8 +3805,27 @@ JSXAttributes
           exprs.unshift(JSON.stringify(stringPart), ", ")
         }
         if (exprs.length === 1) {
-          classValue = ["{(", ...exprs, ") || \"\"}"]
+          // Single expression doesn't need array, filter, or join.
+          let root = exprs[0]
+          // Remove trailing whitespace, e.g. in JSXShorthandString rule
+          while (root.length &&
+                 module.isWhitespaceOrEmpty(root[root.length-1])) {
+            root = root.slice(0, -1)
+          }
+          // Unwrap possibly resulting singleton arrays
+          while (root?.length === 1) root = root[0]
+          // processUnaryExpression wraps in {children: [...]}
+          if (root?.children) root = root.children
+          if (root?.[0]?.token === "`") {
+            // Template literals work just as-is.
+            classValue = ["{", ...exprs, "}"]
+          } else {
+            // Other expressions get `|| ""` to avoid e.g. `undefined` class.
+            classValue = ["{(", ...exprs, ") || \"\"}"]
+          }
         } else {
+          // In general, wrap expressions in array and filter out falsy values,
+          // to avoid accidental e.g. `undefined` classes.
           classValue = ["{[", ...exprs, "].filter(Boolean).join(\" \")}"]
         }
       } else { // strings only
@@ -5040,6 +5060,7 @@ Init
     module.isWhitespaceOrEmpty = function(node) {
       if (!node) return true
       if (node.token) return node.token.match(/^\s*$/)
+      if (node.children) node = node.children
       if (!node.length) return true
       if (typeof node === "string") return node.match(/^\s*$/)
       if (Array.isArray(node)) return node.every(module.isWhitespaceOrEmpty)

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -267,6 +267,14 @@ describe "JSX class shorthand", ->
   """
 
   testCase """
+    single dynamic class doesn't get wrapped in array
+    ---
+    <div .{myClass()} />
+    ---
+    <div class={(myClass()) || ""} />
+  """
+
+  testCase """
     mix #id and .class
     ---
     <div#id.foo/>

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -275,6 +275,22 @@ describe "JSX class shorthand", ->
   """
 
   testCase """
+    single template class doesn't get ||
+    ---
+    <div .`w-${width}` />
+    ---
+    <div class={`w-${width}`} />
+  """
+
+  testCase """
+    single braced template class doesn't get ||
+    ---
+    <div .{`w-${width}`} />
+    ---
+    <div class={`w-${width}`} />
+  """
+
+  testCase """
     mix #id and .class
     ---
     <div#id.foo/>


### PR DESCRIPTION
* Single class doesn't get array/filter/join; instead use `|| ""`
* Single template literal class doesn't need `|| ""`