### PR TITLE
Avoid implicit return via trailing semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ Things Added that CoffeeScript didn't
 Things Changed from ES6
 ---
 
-- Implicit returns
+- Implicit returns, even for multi-statement functions
+  (avoid by adding a trailing `;`, an explicit `return`, or
+  via the directive `"civet -implicitReturns"`)
 - Disallow no parens on single argument arrow function. `x => ...` must become `(x) => ...`
   The reasoning is `x -> ...` => `x(function() ...)` in CoffeeScript and having `->` and `=>`
   behave more differently than they already do is bad. Passing an anonymous function to an

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1166,7 +1166,7 @@ BracedBlock
     }
 
 SingleLineStatements
-  ( TrailingComment* Statement ):first ( ( TrailingComment* Semicolon TrailingComment* ) Statement? )*:rest ->
+  ( TrailingComment* Statement ):first ( SemicolonDelimiter Statement? )*:rest ->
     if (rest.length) {
       return [first, ...rest]
     }
@@ -3338,12 +3338,15 @@ ExpressionDelimiter
   &EOS InsertComma -> $2
 
 StatementDelimiter
+  SemicolonDelimiter
+  &EOS
+
+SemicolonDelimiter
   TrailingComment* Semicolon TrailingComment* ->
     return {
-      type: "Semicolon",
+      type: "SemicolonDelimiter",
       children: $0
     }
-  &EOS
 
 NonIdContinue
   /(?!\p{ID_Continue})/
@@ -5058,7 +5061,7 @@ Init
       }
 
       // Don't add return if there's a trailing semicolon
-      if (node[node.length-1]?.type === "Semicolon") return
+      if (node[node.length-1]?.type === "SemicolonDelimiter") return
 
       // Insert return after indentation and before expression
       node.splice(1, 0, "return ")

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1166,7 +1166,7 @@ BracedBlock
     }
 
 SingleLineStatements
-  ( TrailingComment* Statement ):first ( ( TrailingComment* Semicolon TrailingComment* ) Statement )*:rest ->
+  ( TrailingComment* Statement ):first ( ( TrailingComment* Semicolon TrailingComment* ) Statement? )*:rest ->
     if (rest.length) {
       return [first, ...rest]
     }
@@ -3338,7 +3338,11 @@ ExpressionDelimiter
   &EOS InsertComma -> $2
 
 StatementDelimiter
-  TrailingComment* Semicolon TrailingComment*
+  TrailingComment* Semicolon TrailingComment* ->
+    return {
+      type: "Semicolon",
+      children: $0
+    }
   &EOS
 
 NonIdContinue
@@ -5053,7 +5057,10 @@ Init
           return
       }
 
-      // Insert return before expression
+      // Don't add return if there's a trailing semicolon
+      if (node[node.length-1]?.type === "Semicolon") return
+
+      // Insert return after indentation and before expression
       node.splice(1, 0, "return ")
     }
 

--- a/test/function.civet
+++ b/test/function.civet
@@ -616,6 +616,32 @@ describe "function", ->
     """
 
     testCase """
+      multiple statements with middle semicolon
+      ---
+      (x) ->
+        a;
+        b
+      ---
+      function(x) {
+        a;
+        return b
+      }
+    """
+
+    testCase """
+      multiple statements with final semicolon
+      ---
+      (x) ->
+        a
+        b;
+      ---
+      function(x) {
+        a
+        b;
+      }
+    """
+
+    testCase """
       loop
       ---
       (x) ->

--- a/test/function.civet
+++ b/test/function.civet
@@ -535,11 +535,38 @@ describe "function", ->
     """
 
     testCase """
+      semicolon
+      ---
+      (x) ->
+        x;
+      ---
+      function(x) {
+        x;
+      }
+    """
+
+    testCase """
+      one liner with semicolon
+      ---
+      (x) -> x;
+      ---
+      function(x) { x; }
+    """
+
+    testCase """
       inline multi-statement
       ---
       -> $2.implicit = $1.generated; $2
       ---
       function() { $2.implicit = $1.generated; return $2 }
+    """
+
+    testCase """
+      inline multi-statement with semicolon
+      ---
+      -> $2.implicit = $1.generated; $2;
+      ---
+      function() { $2.implicit = $1.generated; $2; }
     """
 
     describe.skip "TODO", ->


### PR DESCRIPTION
As suggested by @orenelbaum on Discord, this PR disables `implicitReturns` in functions that have a trailing semicolon.

I may not have dealt with all cases; I'm not sure what a trailing semicolon at the end of a `for` loop should mean, for example. But hopefully a useful enough start!