### PR TITLE
CLI support for running script with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ npm install -g @danielx/civet
 civet
 # Compile civet source file to typescript
 civet < source.civet > output.ts
+# Execute a simple civet script (no imports)
+civet source.civet ...args...
 # Execute a civet source file in node using ts-node
 node --loader ts-node/esm --loader @danielx/civet/esm source.civet
 ```

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -55,19 +55,19 @@ To use TypeScript for type checking, create a `tsconfig.json` file. For example:
 Simple execution of .civet source file without `import`s:
 
 ```sh
-civet source.civet
+civet source.civet ...args...
 ```
 
 Directly execute a .civet source file without `import`s in Node:
 
 ```sh
-node -r @danielx/civet/register.js source.civet
+node -r @danielx/civet/register.js source.civet ...args...
 ```
 
 Execute an ESM .civet source file with `import`s in Node using ts-node:
 
 ```sh
-node --loader ts-node/esm --loader @danielx/civet/esm source.civet
+node --loader ts-node/esm --loader @danielx/civet/esm source.civet ...args...
 ```
 
 ## Transpilation


### PR DESCRIPTION
Previously, `civet foo bar` would try to run two scripts, `foo` and `bar`. This is not how `node` or `coffee` work.

With this PR, `civet foo bar` runs script `foo` with argument `bar` (via `process.argv`). This is exactly how `node` and `coffee` work.

Note that `civet foo.civet -c` will no longer compile `foo.civet` (it will run it with an argument of `-c`).  Now `-c` needs to come first, as in `civet -c foo.civet`.  I think this is a worthwhile tradeoff.