### PR TITLE
New operators: is not, is in, is not in, not in

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,14 @@ Things Changed from CoffeeScript
 
 - `==` → `==` rather than `===` (unless you specify `"civet coffeeCompat"` or `"civet coffeeEq"`)
 - `!=` → `!=` rather than `!==` (unless you specify `"civet coffeeCompat"` or `"civet coffeeEq"`)
-- `is not` → `===`
+- `is not` → `!==`
   (unless you specify `"civet coffeeCompat"` or `"civet coffeeNot"`),
   instead of `isnt`
   (unless you specify `"civet coffeeCompat"` or `"civet coffeeIsnt"`)
 - `for in` and `for of` are no longer swapped and become their JS equivalents (unless you specify `"civet coffeeCompat"` or `"civet CoffeeOf"`)
 - `a is in b` → `b.indexOf(a) >= 0` and
   `a is not in b` → `b.indexOf(a) < 0` instead of `a in b` and `a not in b`;
-  `a in b` remains `a in b` as in JS
+  `a in b` remains `a in b` as in JS, and `a not in b` → `!(a in b)`
   (unless you specify `"civet coffeeCompat"` or `"civet coffeeOf"`)
 - `x?.y` now compiles to `x?.y` rather than the `if typeof x !== 'undefined' && x !== null` if check
 - Existential `x?` → `(x != null)` no longer checks for undeclared variables.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ Things Changed from CoffeeScript
 - `is not` → `===`, instead of `isnt` (but `isnt` is available if you specify
   `"civet coffeeCompat"`, or `"civet coffeeIsnt"`)
 - `for in` and `for of` are no longer swapped and become their JS equivalents (unless you specify `"civet coffeeCompat"` or `"civet CoffeeOf"`)
-- `a in b` now remains `a in b` rather than becoming `b.indexOf(a) >= 0` (unless you specify `"civet coffeeCompat"` or `"coffeeOf"`)
+- `a is in b` → `b.indexOf(a) >= 0` and
+  `a is not in b` → `b.indexOf(a) < 0` instead of `a in b` and `a not in b`;
+  `a in b` remains `a in b` as in JS
+  (unless you specify `"civet coffeeCompat"` or `"civet coffeeOf"`)
 - `x?.y` now compiles to `x?.y` rather than the `if typeof x !== 'undefined' && x !== null` if check
 - Existential `x?` → `(x != null)` no longer checks for undeclared variables.
 - `x?()` → `x?.()` instead of `if (typeof x === 'function') { x() }`

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ Things Changed from CoffeeScript
 
 - `==` → `==` rather than `===` (unless you specify `"civet coffeeCompat"` or `"civet coffeeEq"`)
 - `!=` → `!=` rather than `!==` (unless you specify `"civet coffeeCompat"` or `"civet coffeeEq"`)
-- `is not` → `===`, instead of `isnt` (but `isnt` is available if you specify
-  `"civet coffeeCompat"`, or `"civet coffeeIsnt"`)
+- `is not` → `===`
+  (unless you specify `"civet coffeeCompat"` or `"civet coffeeNot"`),
+  instead of `isnt`
+  (unless you specify `"civet coffeeCompat"` or `"civet coffeeIsnt"`)
 - `for in` and `for of` are no longer swapped and become their JS equivalents (unless you specify `"civet coffeeCompat"` or `"civet CoffeeOf"`)
 - `a is in b` → `b.indexOf(a) >= 0` and
   `a is not in b` → `b.indexOf(a) < 0` instead of `a in b` and `a not in b`;

--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Civet.
 
 - Implicit `var` declarations (use `"civet coffeeCompat"` or `"civet autoVar"`)
 - `on/yes/off/no` (use `true/false`, `"civet coffeeCompat"`, or `"civet coffeeBooleans"` to add them back)
-- `isnt` (use `!==`, `"civet coffeeCompat"`, or `"civet coffeeIsnt"`)
 - `not` (use `!`, `"civet coffeeCompat"`, or `"civet coffeeNot"`)
   - `not instanceof` (use `!(a instanceof b)`, `"civet coffeeCompat"`, or `"civet coffeeNot"`)
   - `not of` use (`"civet coffeeCompat"`, or `"civet coffeeNot"`)
@@ -140,6 +139,8 @@ Things Changed from CoffeeScript
 
 - `==` → `==` rather than `===` (unless you specify `"civet coffeeCompat"` or `"civet coffeeEq"`)
 - `!=` → `!=` rather than `!==` (unless you specify `"civet coffeeCompat"` or `"civet coffeeEq"`)
+- `is not` → `===`, instead of `isnt` (but `isnt` is available if you specify
+  `"civet coffeeCompat"`, or `"civet coffeeIsnt"`)
 - `for in` and `for of` are no longer swapped and become their JS equivalents (unless you specify `"civet coffeeCompat"` or `"civet CoffeeOf"`)
 - `a in b` now remains `a in b` rather than becoming `b.indexOf(a) >= 0` (unless you specify `"civet coffeeCompat"` or `"coffeeOf"`)
 - `x?.y` now compiles to `x?.y` rather than the `if typeof x !== 'undefined' && x !== null` if check

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -19,12 +19,14 @@ is almost always also valid Civet input.
 
 ```coffee
 a is b
+a is not b
 a or b
 a and b
 ```
 
 ```typescript
 a === b;
+a !== b;
 a || b;
 a && b;
 ```

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -33,6 +33,21 @@ a && b;
 
 :::
 
+::: code-group
+
+```coffee
+item is in array
+item is not in array
+```
+
+```typescript
+const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+indexOf.call(array, item) >= 0
+indexOf.call(array, item) < 0
+```
+
+:::
+
 ### Variables
 
 ::: code-group

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -22,6 +22,7 @@ a is b
 a is not b
 a or b
 a and b
+a not in b
 ```
 
 ```typescript
@@ -29,6 +30,7 @@ a === b;
 a !== b;
 a || b;
 a && b;
+!(a in b);
 ```
 
 :::

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1842,6 +1842,8 @@ BinaryOpSymbol
   "isnt" NonIdContinue ->
     if(module.config.coffeeIsnt) return "!=="
     return $skip
+  "is" NonIdContinue __ "not" NonIdContinue -> "!=="
+  # NOTE: "is" must come after "is not"
   "is" NonIdContinue -> "==="
   "==="
   # NOTE: CoffeeScript converts "==" -> "==="

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1842,9 +1842,6 @@ BinaryOpSymbol
   "isnt" NonIdContinue ->
     if(module.config.coffeeIsnt) return "!=="
     return $skip
-  "is" NonIdContinue __ "not" NonIdContinue -> "!=="
-  # NOTE: "is" must come after "is not"
-  "is" NonIdContinue -> "==="
   "==="
   # NOTE: CoffeeScript converts "==" -> "==="
   # Convert if CoffeeScript compat flag is set
@@ -1872,18 +1869,22 @@ BinaryOpSymbol
       token: "in",
       special: true,
     }
-  CoffeeOfEnabled "in" NonIdContinue ->
+  ( "is" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "in" NonIdContinue ) ->
     return {
       ref: module.getRef("indexOf"),
       suffix: " >= 0",
       special: true,
     }
-  CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ->
+  ( "is" NonIdContinue __ "not" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ) ->
     return {
       ref: module.getRef("indexOf"),
       suffix: " < 0",
       special: true,
     }
+  # NOTE: "is not" must come after "is not in"
+  "is" NonIdContinue __ "not" NonIdContinue -> "!=="
+  # NOTE: "is" must come after "is not" and "is in"
+  "is" NonIdContinue -> "==="
   "in" NonIdContinue ->
     return $1
   "&"
@@ -5097,7 +5098,9 @@ Init
       while (i < expandedOps.length) {
         const op = expandedOps[i]
         // a in b -> indexOf.call(b, a) >= 0
+        // a is in b -> indexOf.call(b, a) >= 0
         // a not in b -> indexOf.call(b, a) < 0
+        // a is not in b -> indexOf.call(b, a) < 0
         // a not instanceof b -> !(a instanceof b)
         if (op.special) {
           let [a, wsOp, op, wsB, b] = expandedOps.slice(i - 2, i + 3)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3265,6 +3265,8 @@ ReservedWord
   CoffeeIsntEnabled /(?:isnt)(?!\p{ID_Continue})/
   CoffeeForLoopsEnabled /(?:by)(?!\p{ID_Continue})/
   CoffeeOfEnabled /(?:of)(?!\p{ID_Continue})/
+  CoffeeNotEnabled /(?:not)(?!\p{ID_Continue})/
+  "not" NonIdContinue __ "in" NonIdContinue
   # NOTE: Added `let`, Civet assumes strict mode
   /(?:and|as|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|null|or|private|protected|public|return|satisfies|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1882,7 +1882,7 @@ BinaryOpSymbol
       special: true,
     }
   # NOTE: "is not" must come after "is not in"
-  "is" NonIdContinue __ "not" NonIdContinue -> "!=="
+  !CoffeeNotEnabled "is" NonIdContinue __ "not" NonIdContinue -> "!=="
   # NOTE: "is" must come after "is not" and "is in"
   "is" NonIdContinue -> "==="
   "in" NonIdContinue ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1859,13 +1859,13 @@ BinaryOpSymbol
     return $1
   CoffeeNotEnabled "not" NonIdContinue __ "instanceof" NonIdContinue ->
     return {
-      $loc: $loc,
+      $loc,
       token: "instanceof",
       special: true,
     }
-  CoffeeNotEnabled "not" NonIdContinue __ "of" NonIdContinue ->
+  ( !CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "not" NonIdContinue __ "of" NonIdContinue ) ->
     return {
-      $loc: $loc,
+      $loc,
       token: "in",
       special: true,
     }

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -66,6 +66,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    converts is not to !==
+    ---
+    a is not b
+    ---
+    a !== b
+  """
+
+  testCase """
     bitwise
     ---
     a | b

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -74,6 +74,24 @@ describe "binary operations", ->
   """
 
   testCase """
+    is in operator
+    ---
+    a is in b
+    ---
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    indexOf.call(b, a) >= 0
+  """
+
+  testCase """
+    is not in operator
+    ---
+    a is not in b
+    ---
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    indexOf.call(b, a) < 0
+  """
+
+  testCase """
     bitwise
     ---
     a | b

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -74,6 +74,22 @@ describe "binary operations", ->
   """
 
   testCase """
+    in operator
+    ---
+    a in b
+    ---
+    a in b
+  """
+
+  testCase """
+    not in operator
+    ---
+    a not in b
+    ---
+    !(a in b)
+  """
+
+  testCase """
     is in operator
     ---
     a is in b

--- a/test/compat/coffee-not.civet
+++ b/test/compat/coffee-not.civet
@@ -45,3 +45,12 @@ describe "coffeeNot", ->
     ---
     !(a instanceof b)
   """
+
+  testCase """
+    is not
+    ---
+    "civet coffee-compat"
+    a is not b
+    ---
+    a === !b
+  """


### PR DESCRIPTION
* `is not` &rarr; `!==`
* `a not in b` &rarr; `!(a in b)` (like CoffeeScript, but with `in` instead of `of`; disabled when `coffeeOf` is on)
* `is in` and `is not in` are like CoffeeScript's `in` and `not in` but for general use

Open questions:
* Should we allow implicit arrays like `role is in 'admin', 'editor'` and `char is in 'a'..'f'`?
* Or float ranges like `0..1`?
* Should we use `includes` instead of `indexOf` with the new Civet `is [not] in` operators? (Daniel says CoffeeScript operators should probably stay as-is for compatibility. I'm not totally convinced...)