### PR TITLE
Add missing NonIdContinue after keywords

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -387,7 +387,7 @@ ExtendsToken
   # NOTE: Added "<" extends shorthand
   "<" ->
     return { $loc, token: "extends" }
-  "extends" ->
+  "extends" NonIdContinue ->
     return { $loc, token: $1 }
 
 ExtendsTarget
@@ -401,7 +401,7 @@ ImplementsClause
     }
 
 ImplementsToken
-  "implements" ->
+  "implements" NonIdContinue ->
     return { $loc, token: $1 }
 
 ImplementsTarget
@@ -645,7 +645,7 @@ SuperProperty
 
 MetaProperty
   New Dot Target
-  "import.meta" ->
+  "import.meta" NonIdContinue ->
     return { $loc, token: $1 }
 
 # https://262.ecma-international.org/#prod-FormalParameters
@@ -2374,7 +2374,7 @@ CoffeeForIndex
 
 CoffeeForDeclaration
   # NOTE: Coffee doesn't allow expression bindings like `for a.x in b`
-  ( __ "own" )?:own ForBinding:binding ->
+  ( __ "own" NonIdContinue )?:own ForBinding:binding ->
     if (own) {
       binding.own = true
     }
@@ -2616,7 +2616,7 @@ CatchBind
 
 # https://262.ecma-international.org/#prod-Finally
 Finally
-  __ "finally" BracedBlock
+  __ "finally" NonIdContinue BracedBlock
 
 # https://262.ecma-international.org/#prod-CatchParameter
 CatchParameter
@@ -3383,7 +3383,7 @@ AtAt
     return { $loc, token: "@" }
 
 Async
-  "async" ->
+  "async" NonIdContinue ->
     return { $loc, token: $1, type: 'Async' }
 
 Await
@@ -3403,11 +3403,11 @@ Case
     return { $loc, token: $1 }
 
 Catch
-  "catch" ->
+  "catch" NonIdContinue ->
     return { $loc, token: $1 }
 
 Class
-  "class" ->
+  "class" NonIdContinue ->
     return { $loc, token: $1 }
 
 CloseBrace
@@ -3471,7 +3471,7 @@ DoubleQuote
     return { $loc, token: $1 }
 
 Else
-  "else" ->
+  "else" NonIdContinue ->
     return { $loc, token: $1 }
 
 Equals
@@ -3491,7 +3491,7 @@ From
     return { $loc, token: $1 }
 
 Function
-  "function" ->
+  "function" NonIdContinue ->
     return { $loc, token: $1 }
 
 GetOrSet
@@ -3501,7 +3501,7 @@ GetOrSet
 If
   # NOTE: Pull a single space into the 'if ' token so if it is replaced
   # with a ternary in expressions it doesn't add an extra space
-  $("if" " "?) ->
+  $("if" NonIdContinue " "?) ->
     return { $loc, token: $1 }
 
 Import
@@ -3510,7 +3510,7 @@ Import
     return { $loc, token: $1 }
 
 In
-  "in" ->
+  "in" NonIdContinue ->
     return { $loc, token: $1 }
 
 # https://262.ecma-international.org/#prod-LetOrConst
@@ -3533,7 +3533,7 @@ Not
     return { $loc, token: "!" }
 
 Of
-  "of" ->
+  "of" NonIdContinue ->
     return { $loc, token: $1 }
 
 OpenBrace
@@ -3593,7 +3593,7 @@ Star
     return { $loc, token: $1 }
 
 Static
-  "static" ->
+  "static" NonIdContinue ->
     return { $loc, token: $1 }
   # NOTE: In ClassElements @ is a shorthand for 'static'
   # NOTE: added negative assertion to prevent overlapping constructor shorthand and `@@` decorator syntax
@@ -4254,10 +4254,10 @@ TypeUnarySuffix
   QuestionMark
 
 TypeUnaryOp
-  "keyof"
-  "typeof"
-  "infer"
-  "readonly"
+  "keyof" NonIdContinue
+  "typeof" NonIdContinue
+  "infer" NonIdContinue
+  "readonly" NonIdContinue
 
 TypeIndexedAccess
   __ OpenBracket Type? __ CloseBracket
@@ -4287,14 +4287,14 @@ NestedType
   Nested Type ArrayElementDelimiter
 
 TypeConditional
-  TypeBinary ( __ "extends" Type ( __ QuestionMark Type __ Colon Type )? )? ->
+  TypeBinary ( __ "extends" NonIdContinue Type ( __ QuestionMark Type __ Colon Type )? )? ->
     if ($2) return $0
     return $1
 
 TypeLiteral
   Literal
   TemplateLiteral
-  "void" ->
+  "void" NonIdContinue ->
     return { $loc, token: "void" }
   "[]" ->
     return { $loc, token: "[]" }
@@ -4336,7 +4336,7 @@ TypeParameter
   __ Identifier TypeConstraint? TypeParameterDelimiter
 
 TypeConstraint
-  __ "extends" Type
+  __ "extends" NonIdContinue Type
 
 TypeParameterDelimiter
   _* Comma
@@ -4353,7 +4353,7 @@ CivetPrologue
   [\t ]* SingleQuote CivetPrologueContent:content SingleQuote $StatementDelimiter EOS? -> content
 
 CivetPrologueContent
-  "civet" CivetOption*:options [\s]* ->
+  "civet" NonIdContinue CivetOption*:options [\s]* ->
     return {
       type: "CivetPrologue",
       children: [],


### PR DESCRIPTION
I searched for `[a-z]"(?!\s+NonIdContinue)(?![,:)\]])(?!$)` and found a bunch of missing `NonIdContinue`s.

I think the rest are OK, though there are some tricky ones like in `CallExpression` and `SuperProperty` where you need to think about it.