### PR TITLE
Positive modulo operator %%

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Things Kept from CoffeeScript
 - `is` → `===`
 - `or`,  `or=`  → `||`, `||=`
 - `and`, `and=` → `&&`, `&&=`
+- `a %% b` → `(a % b + b) % b`
 - `loop` → `while(true)`
 - `unless exp` → `if(!exp)`
 - `until condition` → `while(!condition)`
@@ -131,7 +132,6 @@ Civet.
 - `a of b` (use `a in b` as in JS, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)
 - Backtick embedded JS (replaced by template literals)
 - Will add later
-  - `a %% b` → `(a % b + b) % b`
   - Conditional assignment `a?[x] = 3` → `a ? a[x] = 3 : undefined`
   - Multiple slice assignment `otherNumbers[0...] = numbers[3..6] = [-3, -4, -5, -6]`
 

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -611,6 +611,20 @@ obj.key ??= 'civet';
 
 :::
 
+::: code-group
+
+```coffee
+a %% b
+```
+
+```typescript
+const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+
+modulo(a, b);
+```
+
+:::
+
 ### Range literals
 
 ::: code-group

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1820,6 +1820,12 @@ BinaryOpSymbol
   "**"
   "*"
   "/"
+  "%%" ->
+    return {
+      call: module.getRef("modulo"),
+      special: true,
+    }
+  # NOTE: %% must be above %
   "%"
   "+"
   "-"
@@ -1872,13 +1878,17 @@ BinaryOpSymbol
     }
   CoffeeOfEnabled "in" NonIdContinue ->
     return {
-      ref: module.getRef("indexOf"),
+      call: [module.getRef("indexOf"), ".call"],
+      relational: true,
+      reversed: true,
       suffix: " >= 0",
       special: true,
     }
   CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ->
     return {
-      ref: module.getRef("indexOf"),
+      call: [module.getRef("indexOf"), ".call"],
+      relational: true,
+      reversed: true,
       suffix: " < 0",
       special: true,
     }
@@ -4587,6 +4597,14 @@ Reset
         // [indent, statement]
         module.prelude.push(["", ["const ", hasPropRef, typeSuffix, " = {}.hasOwnProperty", module.asAny, "\n"]])
       },
+      modulo(moduloRef) {
+        const typeSuffix = {
+          ts: true,
+          children: [": (a: number, b: number) => number"]
+        }
+        // [indent, statement]
+        module.prelude.push(["", ["const ", moduloRef, typeSuffix, " = (a, b) => (a % b + b) % b", "\n"]])
+      },
       JSX(jsxRef) {
         module.prelude.push({
           ts: true,
@@ -5101,11 +5119,15 @@ Init
           let [a, wsOp, op, wsB, b] = expandedOps.slice(i - 2, i + 3)
 
           let children
-          if (op.ref) {
+          if (op.call) {
             wsOp = module.insertTrimmingSpace(wsOp, "")
-            wsB = module.insertTrimmingSpace(wsB, "")
 
-            children = [wsOp, op.ref, ".call(", wsB, b, ", ", a, ")", op.suffix]
+            if (op.reversed) {
+              wsB = module.insertTrimmingSpace(wsB, "")
+              children = [wsOp, op.call, "(", wsB, b, ", ", a, ")", op.suffix]
+            } else {
+              children = [wsOp, op.call, "(", a, ",", wsB, b, ")", op.suffix]
+            }
           } else if (op.token === "instanceof" || op.token === "in") { // `not instanceof` / `not of`
             children = ["!(", a, wsOp, op, wsB, b, ")"]
           } else {
@@ -5151,8 +5173,8 @@ Init
       while (i < l) {
         const [, op] = binops[i]
 
-        // NOTE: coffee `in` and `not in` are ops that use a ref to indexOf. They are our only ref ops so far and they are both relational.
-        if (relationalOps.includes(op.token) || op.ref) {
+        // NOTE: Treat Coffee `in` and `not in` ops as relational.
+        if (relationalOps.includes(op.token) || op.relational) {
           chains.push(i)
         } else if (lowerPrecedenceOps.includes(op.token)) {
           // end of the chain

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -26,6 +26,24 @@ describe "binary operations", ->
   """
 
   testCase """
+    positive modulo
+    ---
+    a %% b
+    ---
+    const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b
+    modulo(a, b)
+  """
+
+  testCase """
+    positive modulo not relational
+    ---
+    a %% b %% c
+    ---
+    const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b
+    modulo(modulo(a, b), c)
+  """
+
+  testCase """
     additive
     ---
     a + b


### PR DESCRIPTION
Fixes #127

Restructured `special` ops to use `call` instead of `ref`, so that it can work with or without `.call`, and to have `relational` flag as `%%` isn't relational.