### PR TITLE
ESM build and refactoring

### DIFF
--- a/build/coffee-esm.mjs
+++ b/build/coffee-esm.mjs
@@ -34,9 +34,10 @@ export async function load(url, context, next) {
       inlineMap: true,
       noHeader: true,
     })
+    const isESM = /^\s*(import(?!\()|export)\b/m.test(jsSource);
 
-    return next(url + ".cjs", {
-      format: "commonjs",
+    return next(url + (isESM ? ".mjs" : ".cjs"), {
+      format: isESM ? "module" : "commonjs",
       source: jsSource
     });
   }

--- a/build/esbuild.coffee
+++ b/build/esbuild.coffee
@@ -17,7 +17,7 @@ exists = (p) ->
 extensionResolverPlugin = (extensions) ->
   name: "extension-resolve"
   setup: (build) ->
-    # For relatiev requires that don't contain a '.'
+    # For relative requires that don't contain a '.'
     build.onResolve { filter: /\/[^.]*$/ }, (r) ->
       for extension in extensions
         {path: resolvePath, resolveDir} = r
@@ -39,6 +39,7 @@ esbuild.build({
   minify
   watch
   platform: 'node'
+  format: 'cjs'
   outfile: 'dist/cli.js'
   plugins: [
     resolveExtensions
@@ -49,20 +50,22 @@ esbuild.build({
   ]
 }).catch -> process.exit 1
 
-esbuild.build({
-  entryPoints: ['source/main.coffee']
-  bundle: true
-  watch
-  platform: 'node'
-  outfile: 'dist/main.js'
-  plugins: [
-    resolveExtensions
-    coffeeScriptPlugin
-      bare: true
-      inlineMap: sourcemap
-    heraPlugin
-  ]
-}).catch -> process.exit 1
+for esm in [false, true]
+  esbuild.build({
+    entryPoints: ['source/main.coffee']
+    bundle: true
+    watch
+    platform: 'node'
+    format: if esm then 'esm' else 'cjs'
+    outfile: "dist/main.#{if esm then 'mjs' else 'js'}"
+    plugins: [
+      resolveExtensions
+      coffeeScriptPlugin
+        bare: true
+        inlineMap: sourcemap
+      heraPlugin
+    ]
+  }).catch -> process.exit 1
 
 esbuild.build({
   entryPoints: ['source/main.coffee']

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/main.js",
   "module": "dist/main.mjs",
   "exports": {
-    ".": "./dist/main.js",
+    ".": {
+      "import": "./dist/main.mjs",
+      "require": "./dist/main.js"
+    },
     "./esm": "./dist/esm.mjs",
     "./esbuild-plugin": "./dist/esbuild-plugin.js"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.24",
   "description": "CoffeeScript style syntax for TypeScript",
   "main": "dist/main.js",
+  "module": "dist/main.mjs",
   "exports": {
     ".": "./dist/main.js",
     "./esm": "./dist/esm.mjs",

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -1,3 +1,6 @@
+import {parse, compile, generate} from "./main"
+{prune} = generate
+
 version = -> require("../package.json").version
 if process.argv.includes "--version"
   console.log version()
@@ -36,9 +39,6 @@ if process.argv.includes "--help"
 
   """
   process.exit(0)
-
-{parse, compile, generate} = require "./main"
-{prune} = generate
 
 encoding = "utf8"
 

--- a/source/generate.coffee
+++ b/source/generate.coffee
@@ -5,7 +5,7 @@
 #   - map src string into position / line char lookup
 # construct source mapping data
 
-gen = (node, options) ->
+export default gen = (node, options) ->
   if node is null or node is undefined
     return ""
 
@@ -40,11 +40,9 @@ gen = (node, options) ->
   debugger
   throw new Error("Unknown node", JSON.stringify(node))
 
-module.exports = gen
-
 # Remove empty arrays, empty string, null, undefined from node tree
 # Useful for debugging so I don't need to step though tons of empty nodes
-prune = (node) ->
+export prune = (node) ->
   if node is null or node is undefined
     return
 
@@ -67,5 +65,3 @@ prune = (node) ->
     return node
 
   return node
-
-gen.prune = prune

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -1,8 +1,11 @@
 "civet coffeeCompat"
 
-{ parse } = require "./parser"
-{ prune } = gen = require "./generate"
-{ SourceMap, base64Encode } = util = require "./util.coffee"
+import parser from "./parser.hera"
+{ parse } = parser
+import generate, { prune } from "./generate.coffee"
+import * as util from "./util.coffee"
+{ SourceMap, base64Encode } = util
+export { parse, generate, util }
 
 defaultOptions = {}
 
@@ -34,45 +37,41 @@ uncacheable = new Set [
   "JSXChild", "JSXChildren", "JSXNestedChildren", "JSXMixedChildren"
 ]
 
-module.exports =
-  parse: parse
-  compile: (src, options=defaultOptions) ->
-    filename = options.filename or "unknown"
+export compile = (src, options=defaultOptions) ->
+  filename = options.filename or "unknown"
 
-    # TODO: This makes source maps slightly off in the first line.
-    if filename.endsWith('.coffee') and not
-       /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
-      src = "\"civet coffeeCompat\"; #{src}"
+  # TODO: This makes source maps slightly off in the first line.
+  if filename.endsWith('.coffee') and not
+     /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
+    src = "\"civet coffeeCompat\"; #{src}"
 
-    if !options.noCache
-      events = makeCache()
+  if !options.noCache
+    events = makeCache()
 
-    ast = prune parse(src, {
-      filename
-      events
-    })
+  ast = prune parse(src, {
+    filename
+    events
+  })
 
-    if options.ast
-      return ast
+  if options.ast
+    return ast
 
-    if options.sourceMap or options.inlineMap
-      sm = SourceMap(src)
-      options.updateSourceMap = sm.updateSourceMap
-      code = gen ast, options
+  if options.sourceMap or options.inlineMap
+    sm = SourceMap(src)
+    options.updateSourceMap = sm.updateSourceMap
+    code = generate ast, options
 
-      if options.inlineMap
-        srcMapJSON = sm.json(filename, "")
-        # NOTE: separate comment to prevent this string getting picked up as actual sourceMappingURL in tools
-        return "#{code}\n#{"//#"} sourceMappingURL=data:application/json;base64,#{base64Encode JSON.stringify(srcMapJSON)}\n"
-      else
-        return {
-          code,
-          sourceMap: sm
-        }
+    if options.inlineMap
+      srcMapJSON = sm.json(filename, "")
+      # NOTE: separate comment to prevent this string getting picked up as actual sourceMappingURL in tools
+      return "#{code}\n#{"//#"} sourceMappingURL=data:application/json;base64,#{base64Encode JSON.stringify(srcMapJSON)}\n"
+    else
+      return {
+        code,
+        sourceMap: sm
+      }
 
-    gen ast, options
-  generate: gen
-  util: util
+  generate ast, options
 
 # logs = []
 makeCache = ->

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -116,3 +116,5 @@ makeCache = ->
       return
 
   return events
+
+export default { parse, generate, util, compile }

--- a/source/util.coffee
+++ b/source/util.coffee
@@ -1,7 +1,7 @@
 "civet coffeeCompat"
 
 # Utility function to create a line/column lookup table for an input string
-locationTable = (input) ->
+export locationTable = (input) ->
   linesRe = /([^\r\n]*)(\r\n|\r|\n|$)/y
   lines = []
   line = 0
@@ -15,7 +15,7 @@ locationTable = (input) ->
 
   return lines
 
-lookupLineColumn = (table, pos) ->
+export lookupLineColumn = (table, pos) ->
   l = 0
   prevEnd = 0
 
@@ -25,7 +25,7 @@ lookupLineColumn = (table, pos) ->
   # [line, column]; zero based
   return [l, pos - prevEnd]
 
-SourceMap = (sourceString) ->
+export SourceMap = (sourceString) ->
   srcTable = locationTable sourceString
 
   sm = {
@@ -218,15 +218,8 @@ encodeBase64 = (value) ->
   BASE64_CHARS[value] or throw new Error "Cannot Base64 encode value: #{value}"
 
 # Note: currently only works in node
-base64Encode = (src) ->
+export base64Encode = (src) ->
   return Buffer.from(src).toString('base64')
-
-module.exports = {
-  base64Encode
-  locationTable
-  lookupLineColumn
-  SourceMap
-}
 
 # Accelerate VLQ decoding with a lookup table
 vlqTable = new Uint8Array(128)

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -1,6 +1,4 @@
-{ default as Civet } from ../source/main.coffee
-
-{ compile } := Civet
+{ compile } from ../source/main.coffee
 
 assert from assert
 cache := true

--- a/test/infra/esbuild.civet
+++ b/test/infra/esbuild.civet
@@ -1,5 +1,5 @@
 import { createRequire } from 'module'
-require := createRequire(import.meta.url)
+require := createRequire import.meta.url
 esbuildPlugin := require "../../source/esbuild-plugin.civet"
 
 assert from assert

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -1,6 +1,6 @@
 fs from fs
 
-Civet from ../source/main.coffee
+{compile as civetCompile} from ../source/main.coffee
 
 Hera from ../source/parser.hera
 {parse} := Hera
@@ -25,7 +25,7 @@ describe "integration", ->
   it "should sourcemap complex civet files", ->
     src := fs.readFileSync("integration/example/compiler.civet", "utf8")
 
-    assert Civet.compile(src, { sourceMap: true, filename: "integration/example/compiler.civet" })
+    assert civetCompile(src, { sourceMap: true, filename: "integration/example/compiler.civet" })
 
 describe "convert coffee ast to civet", ->
   it.skip "converts", ->

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -1,9 +1,7 @@
-main from ../source/main.coffee
-{compile} := main
+{compile} from ../source/main.coffee
 assert from assert
 
-util from ../source/util.coffee
-{SourceMap} := util
+{SourceMap} from ../source/util.coffee
 
 describe "source map", ->
   it "should generate a source mapping", ->

--- a/test/types/js.civet
+++ b/test/types/js.civet
@@ -1,6 +1,5 @@
 assert from assert
-main from ../../source/main.coffee
-{compile} := main
+{compile} from ../../source/main.coffee
 
 describe "Types", ->
   describe "JS", ->

--- a/test/util/locations.civet
+++ b/test/util/locations.civet
@@ -1,6 +1,5 @@
 assert from assert
-util from ../../source/util.coffee
-{locationTable, lookupLineColumn} := util
+{locationTable, lookupLineColumn} from ../../source/util.coffee
 
 describe "util", ->
   describe "locationTable", ->


### PR DESCRIPTION
* Add support for ESM `.coffee` files in `coffee-esm.mjs` (autodetection)
* Build new ESM version `dist/main.mjs`, which Vite seems to need in #125 (I've tested this in code I haven't yet pushed). (If I just told esbuild to convert the CJS code to ESM, you wouldn't be able to do `import {compile} from '@danielx/civet'`; only the default export gets preserved.)
* CoffeeScript code refactored to use ESM (but some things like Hera parser are still CJS)
* Note that default exports no longer have everything; need to `import *`