### PR TITLE
Compilation and AST modes for REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ Quickstart Guide
 ```bash
 # Install
 npm install -g @danielx/civet
-# Run civet code directly in a REPL
+# Run Civet code directly in a REPL
 civet
-# Compile civet source file to typescript
+# Transpile typed Civet code into TypeScript in a REPL
+civet -c
+# Compile Civet source file to TypeScript
 civet < source.civet > output.ts
-# Execute a simple civet script (no imports)
+# Execute a simple .civet script (no imports)
 civet source.civet ...args...
-# Execute a civet source file in node using ts-node
+# Execute a .civet source file in node using ts-node
 node --loader ts-node/esm --loader @danielx/civet/esm source.civet
 ```
 

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -12,6 +12,12 @@ here is how to set up your environment to get productive right away and have a G
 Try out the transpiler interactively in the
 [Playground](https://civet-web.vercel.app/).
 
+Or transpile Civet code interactively in the command-line REPL:
+
+```sh
+npx @danielx/civet -c
+```
+
 Or run Civet code directly in the command-line REPL:
 
 ```sh

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -17,7 +17,9 @@ if process.argv.includes "--help"
 
     Usage:
 
-        civet [options]                              # REPL
+        civet                                        # REPL for executing code
+        civet -c                                     # REPL for transpiling code
+        civet --ast                                  # REPL for parsing code
         civet [options] -c input.civet               # -> input.civet.tsx
         civet [options] -c input.civet -o .ts        # -> input.ts
         civet [options] -c input.civet -o dir        # -> dir/input.civet.tsx
@@ -85,6 +87,8 @@ parseArgs = (args = process.argv[2..]) ->
       when '--'
         endOfArgs ++i  # remaining arguments are filename and/or arguments
       else
+        if arg.startsWith '-'
+          throw new Error "Invalid command-line argument #{arg}"
         if options.run
           endOfArgs i  # remaining arguments are arguments to the script
         else
@@ -117,12 +121,24 @@ readFiles = (filenames, options) ->
       yield {filename, error, stdin}
 
 repl = (options) ->
-  console.log "Civet #{version()} REPL.  Enter a blank line to execute code."
+  console.log "Civet #{version()} REPL.  Enter a blank line to #{
+    switch
+      when options.ast then 'parse'
+      when options.compile then 'transpile'
+      else 'execute'
+  } code."
   global.quit = global.exit = -> process.exit 0
   nodeRepl = require 'repl'
   vm = require 'vm'
   r = nodeRepl.start
-    prompt: '🐱> '
+    prompt:
+      switch
+        when options.ast then '🌲> '
+        when options.compile then '🐈> '
+        else '🐱> '
+    writer:
+      if options.compile and not options.ast
+        (obj) -> obj.replace /\n*$/, ''
     eval: (input, context, filename, callback) ->
       if input == '\n'  # blank input
         callback null
@@ -134,22 +150,25 @@ repl = (options) ->
         catch error
           #console.error "Failed to transpile Civet:"
           return callback error
-        try
-          result = vm.runInContext output, context, {filename}
-        catch error
-          return callback error
-        callback null, result
+        if options.compile or options.ast
+          callback null, output
+        else
+          try
+            result = vm.runInContext output, context, {filename}
+          catch error
+            return callback error
+          callback null, result
       else  # still reading
         callback new nodeRepl.Recoverable "Enter a blank line to execute code."
 
 cli = ->
   {filenames, scriptArgs, options} = parseArgs()
   unless filenames.length
-    options.compile = true
     if process.stdin.isTTY
       options.repl = true
     else
       # When piped, default to old behavior of transpiling stdin to stdout
+      options.compile = true
       filenames = ['-']
 
   # In run mode, compile to JS with source maps

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -138,7 +138,7 @@ repl = (options) ->
         else '🐱> '
     writer:
       if options.compile and not options.ast
-        (obj) -> obj.replace /\n*$/, ''
+        (obj) -> obj?.replace /\n*$/, ''
     eval: (input, context, filename, callback) ->
       if input == '\n'  # blank input
         callback null


### PR DESCRIPTION
* Previously, `civet -c` and `civet --ast` ran REPL but ignored options.
* Now `civet -c` runs an interactive transpiler (similar to Playground) and `civet --ast` runs an interactive AST parser.
* Initial message and prompt depend on mode.
* Also fail in case of invalid flag such as `--wrong`.

![image](https://user-images.githubusercontent.com/2218736/211155144-165400ed-ac2e-4125-9eac-1a8e40c7e65e.png)
