### PR TITLE
Function declarations without parentheses

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -148,6 +148,11 @@ console.log x, f(x), (f g x), g f x
 ### Functions
 
 <Playground>
+function abort
+  process.exit 1
+</Playground>
+
+<Playground>
 (a: number, b: number) => a + b
 </Playground>
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -687,7 +687,8 @@ Parameters
     return {
       type: "Parameters",
       children: [{$loc, token: "()"}],
-      names: []
+      names: [],
+      implicit: true,
     }
 
 NonEmptyParameters
@@ -1037,15 +1038,17 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async __ )? Function Star? BindingIdentifier?:id __ NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async __ )?:async Function:func ( __ Star )?:star ( __ BindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
     return {
       type: "FunctionSignature",
-      id,
+      id: wid?.[1],
       parameters,
       returnType: suffix?.children?.[1]?.[0]?.[1]?.token,
       ts: false,
       block: null,
-      children: $0,
+      children: !parameters.implicit ? $0 :
+        [ async, func, star, wid, parameters, w, suffix ],
+        // move whitespace w to after implicit () in parameters
     }
 
 # https://262.ecma-international.org/#prod-FunctionExpression

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -766,18 +766,20 @@ ParameterElementDelimiter
 BindingIdentifier
   # NOTE: Added @param for binding identifiers
   # The parser will allow them in const/let/var declarations but JS/TS doesn't allow them there
-  __:ws At AtIdentifierRef:ref ->
+  __:ws NWBindingIdentifier:identifier ->
+    return { ...identifier, children: [...ws, ...identifier.children] }
+
+# Non-whitespace version of BindingIdentifier
+NWBindingIdentifier
+  # NOTE: Added @param for binding identifiers
+  # The parser will allow them in const/let/var declarations but JS/TS doesn't allow them there
+  At AtIdentifierRef:ref ->
     return {
       type: "AtBinding",
-      children: [...ws, ref],
+      children: [ref],
       ref,
     }
-
-  __:ws Identifier:id ->
-    return {
-      ...id,
-      children: [...ws, ...id.children],
-    }
+  Identifier:id
 
 AtIdentifierRef
   ReservedWord:r ->
@@ -1038,7 +1040,7 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async __ )?:async Function:func ( __ Star )?:star ( __ BindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async _? )?:async Function:func ( _? Star )?:star ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
     return {
       type: "FunctionSignature",
       id: wid?.[1],

--- a/test/function.civet
+++ b/test/function.civet
@@ -89,13 +89,71 @@ describe "function", ->
     """
 
     testCase """
-      separate lines
+      inline anonymous
+      ---
+      function 5
+      ---
+      function()  {return 5 }
+    """
+
+    testCase """
+      inline assigned
+      ---
+      f := function 5
+      ---
+      function f ()  {return 5 }
+    """
+
+    testCase """
+      braced
+      ---
+      function f { 5 }
+      ---
+      function f() { return 5 }
+    """
+
+    testCase """
+      anonymous braced
+      ---
+      function { 5 }
+      ---
+      function() { return 5 }
+    """
+
+    testCase """
+      implicit block
       ---
       function f
         x := 5
         x*x
       ---
       function f() {
+        const x = 5
+        return x*x
+      }
+    """
+
+    testCase """
+      implicit block anonymous
+      ---
+      function
+        x := 5
+        x*x
+      ---
+      function() {
+        const x = 5
+        return x*x
+      }
+    """
+
+    testCase """
+      separate lines assigned
+      ---
+      f := function
+        x := 5
+        x*x
+      ---
+      function f () {
         const x = 5
         return x*x
       }

--- a/test/function.civet
+++ b/test/function.civet
@@ -79,6 +79,28 @@ describe "function", ->
     async function defaultLoad () {}
   """
 
+  describe "argumentless without parens", ->
+    testCase """
+      inline
+      ---
+      function f 5
+      ---
+      function f()  {return 5 }
+    """
+
+    testCase """
+      separate lines
+      ---
+      function f
+        x := 5
+        x*x
+      ---
+      function f() {
+        const x = 5
+        return x*x
+      }
+    """
+
   describe "@params", ->
     testCase """
       empty function body

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -42,6 +42,17 @@ describe "[TS] function", ->
   """
 
   testCase """
+    argumentless without parens
+    ---
+    function f: void
+      console.log 'hi'
+    ---
+    function f(): void {
+      console.log('hi')
+    }
+  """
+
+  testCase """
     type parameters
     ---
     function add<T>(a: T, b: T) : T


### PR DESCRIPTION
Remove need for `()` in defining argumentless functions with `function`:

```coffee
function name
  data?.part[0]?.name
function abort: void
  process.exit 1
```

One catch is that I removed the ability to have newlines between the function name and the opening parenthesis of the arguments.  Otherwise we have issues with tracking indentation but also the following ambiguity:

```coffee
function f
  (x)
```

I'd say this is an argumentless function `f()` that returns `x`.  But currently it parses as the TS function declaration `function f(x)`.

Note that JS does allow

```js
function f
  (x)
{}
```

so this is technically an incompatibility with JS... Perhaps there should be a toggle?