### PR TITLE
Create directory in `-o` option if it doesn't exist

### DIFF
--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -224,6 +224,7 @@ cli = ->
             # (don't use this with multiple input files)
             outputPath = optionsPath
         outputFilename = path.format outputPath
+        os.mkdir outputPath.dir { recursive: true }
         try
           await fs.writeFile outputFilename, output
         catch error

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -211,7 +211,8 @@ cli = ->
             stat = await fs.stat options.output
           catch
             stat = null
-          if stat?.isDirectory()
+          if stat?.isDirectory() or options.output.endsWith(path.sep) or
+                                    options.output.endsWith('/')
             # -o dir writes outputs into that directory with default name
             outputPath.dir = options.output
           else if /^(\.[^.]+)+$/.test optionsPath.base
@@ -223,8 +224,9 @@ cli = ->
             # -o filename fully specifies the output filename
             # (don't use this with multiple input files)
             outputPath = optionsPath
+        # Make output directory in case it doesn't already exist
+        fs.mkdir outputPath.dir, recursive: true if outputPath.dir
         outputFilename = path.format outputPath
-        os.mkdir outputPath.dir { recursive: true }
         try
           await fs.writeFile outputFilename, output
         catch error


### PR DESCRIPTION
For example, if `civet ... -o dist/.ts` was used and the `dist` directory didn't exist, this PR makes it so that Civet automatically creates it.
