### PR TITLE
Function with `then` body

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1148,7 +1148,7 @@ Block
     }
 
 ThenClause
-  Then TrailingComment*:ws Statement:s  ->
+  Then TrailingComment*:ws Statement:s ->
     const expressions = [[ws, s]]
     return {
       type: "BlockStatement",
@@ -1203,6 +1203,8 @@ BracedBlock
       // Remove !EOS assertion
       children: [o, s, ws, c],
     }
+  InsertOpenBrace:o ThenClause:then InsertSpace:ws InsertCloseBrace:c ->
+    return {...then, children: [o, ...then.children, ws, c]}
 
 SingleLineStatements
   ( TrailingComment* Statement ):first ( SemicolonDelimiter Statement? )*:rest ->
@@ -3332,7 +3334,7 @@ ReservedWord
   CoffeeNotEnabled /(?:not)(?!\p{ID_Continue})/
   "not" NonIdContinue __ "in" NonIdContinue
   # NOTE: Added `let`, Civet assumes strict mode
-  /(?:and|as|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|null|or|private|protected|public|return|satisfies|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
+  /(?:and|as|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|null|or|private|protected|public|return|satisfies|static|super|switch|then|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
 
 # https://262.ecma-international.org/#sec-comments
 Comment

--- a/test/function.civet
+++ b/test/function.civet
@@ -105,6 +105,30 @@ describe "function", ->
     """
 
     testCase """
+      then anonymous
+      ---
+      function then x
+      ---
+      function()  { return x }
+    """
+
+    testCase """
+      then assigned
+      ---
+      f := function then x
+      ---
+      function f ()  { return x }
+    """
+
+    testCase """
+      then
+      ---
+      function f then x
+      ---
+      function f()  { return x }
+    """
+
+    testCase """
       braced
       ---
       function f { 5 }


### PR DESCRIPTION
Following up on https://github.com/DanielXMoore/Civet/pull/159#issuecomment-1374862084, this PR extends `BracedBlock` to allow for a `ThenClause`. This seems symmetric and removes ambiguity for some one-line `function` definitions: `function f` looks like a named function, while `function then f` is clearly an anonymous function that evaluates to `f`.

I also added `then` to the list of keywords. Otherwise `function then` looked like a named function too!

As @STRd6 suggested, I could add a special `returns` but it might be overkill... And what if `returns` is an identifier and you're intending to call it?  Like `function f returns 5` could be construed as `function f { returns(5) }`.  Whereas `then` is consistent with `if`, `when`, etc., and I believe should already be treated as a keyword. (CoffeeScript does.)

I believe this change also allows `do then` and `try then` but that seems fine to (optionally) allow — arguably more symmetric?