### PR TITLE
Fixes #51

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1073,29 +1073,55 @@ FunctionExpression
     }
 
   # Ruby/Crystal style block shorthand
-  Ampersand !_ CallExpressionRest+ ->
-    $1.token = "$ => $"
-    return {
-      type: "ArrowFunction",
-      children: [$1, $3],
+  AmpersandUnaryPrefix?:prefix Ampersand AmpersandBlockRHS?:rhs ->
+    if (!prefix && !rhs) return $skip
+
+    // Only unary ops
+    if (!rhs) {
+      const ref = {
+        type: "Ref",
+        base: "$",
+        id: "$"
+      }
+      return {
+        type: "ArrowFunction",
+        children: [ref, " => ", prefix, ref],
+      }
     }
 
-  # Binary ops
-  Ampersand ![&] BinaryOpRHS+ ->
-    $1.token = "$ => $"
-    const exp = module.processBinaryOpExpression([$1, $3])
+    const ref = rhs[0]
+
+    if (!prefix) {
+      return {
+        type: "ArrowFunction",
+        children: [ref, " => ", rhs],
+      }
+    }
 
     return {
       type: "ArrowFunction",
-      children: exp,
+      children: [ref, " => ", prefix, rhs],
     }
 
-  # Unary ops
-  [!~+-]+ Ampersand ->
-    return {
-      type: "ArrowFunction",
-      children: ["$ => ", $1, "$"],
+AmpersandBlockRHS
+  (!_ CallExpressionRest+ )?:callExpRest ( ![&] BinaryOpRHS+ )?:binopRHS ->
+    if (!callExpRest && !binopRHS) return $skip
+    const ref = {
+      type: "Ref",
+      base: "$",
+      id: "$"
     }
+
+    if (callExpRest && binopRHS) {
+      return module.processBinaryOpExpression([[ref, callExpRest[1]], binopRHS[1]])
+    }
+    if (binopRHS) {
+      return module.processBinaryOpExpression([[ref], binopRHS[1]])
+    }
+    return [ref, callExpRest[1]]
+
+AmpersandUnaryPrefix
+  [!~+-]+
 
 ThinArrowFunction
   Parameters:parameters ReturnTypeSuffix?:suffix _* Arrow:arrow BracedOrEmptyBlock:block ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1089,7 +1089,7 @@ FunctionExpression
       }
     }
 
-    const ref = rhs[0]
+    const { ref } = rhs
 
     if (!prefix) {
       return {
@@ -1112,13 +1112,25 @@ AmpersandBlockRHS
       id: "$"
     }
 
-    if (callExpRest && binopRHS) {
-      return module.processBinaryOpExpression([[ref, callExpRest[1]], binopRHS[1]])
+    const exp = {
+      type: "AmpersandRef",
+      children: [ref],
+      names: [],
+      ref,
     }
+
+    if (callExpRest) {
+      exp.children.push(...callExpRest[1])
+    }
+
     if (binopRHS) {
-      return module.processBinaryOpExpression([[ref], binopRHS[1]])
+      return {
+        children: module.processBinaryOpExpression([exp, binopRHS[1]]),
+        ref,
+      }
     }
-    return [ref, callExpRest[1]]
+
+    return exp
 
 AmpersandUnaryPrefix
   [!~+-]+

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -114,6 +114,32 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    access with chained comparisons
+    ---
+    x.map &.foo > a < b
+    ---
+    x.map($ => $.foo > a && a < b)
+  """
+
+  testCase """
+    special operator
+    ---
+    x.map & is in a
+    ---
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    x.map($ => indexOf.call(a, $) >= 0)
+  """
+
+  testCase """
+    access with special operator
+    ---
+    x.map &.foo is in a
+    ---
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    x.map($ => indexOf.call(a, $.foo) >= 0)
+  """
+
+  testCase """
     $ as local value
     ---
     x.map & < 3 && $ > 1

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -118,7 +118,7 @@ describe "&. function block shorthand", ->
     ---
     x.map & < 3 && $ > 1
     ---
-    x.map($ => $ < 3 && $ > 1)
+    x.map($1 => $1 < 3 && $ > 1)
   """
 
   testCase """


### PR DESCRIPTION
Fixes #51 

This also upgrades the ampersand block parameter to a ref so it can no longer be accessed inside the block. We can revisit adding a topic reference after we get further with pipes, etc.