### PR TITLE
Add type guard function for compile errors

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -122,4 +122,9 @@ makeCache = ->
 
   return events
 
-export default { parse, generate, util, compile }
+# TODO: Import ParseError class from Hera
+export isCompileError = (err) ->
+  err instanceof Error and
+  [err.message, err.name, err.filename, err.line, err.column, err.offset].every (value) -> value isnt undefined
+
+export default { parse, generate, util, compile, isCompileError }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -16,6 +16,17 @@ declare module "@danielx/civet" {
     }
   }
 
+  // TODO: Import ParseError class from Hera
+  export type ParseError = {
+    message: string
+    name: string
+    filename: string
+    line: number
+    column: number
+    offset: number
+  }
+  export function isCompileError(err: any): err is ParseError
+
   export function compile<T extends CompileOptions>(source: string, options?: T): T extends { sourceMap: true } ? {
     code: string,
     sourceMap: SourceMap,
@@ -25,6 +36,7 @@ declare module "@danielx/civet" {
 
   const Civet: {
     compile: typeof compile
+    isCompileError: typeof isCompileError
     parse: typeof parse
     generate: typeof generate
     util: {


### PR DESCRIPTION
Utility function to provide a civet error typing

![image](https://user-images.githubusercontent.com/13007891/211479928-34b724b1-6819-492a-a180-a38272bb6b3d.png)
