### PR TITLE
#175 Added preliminary ':' -> 'as' improvement

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2852,7 +2852,7 @@ ImportClause
 
 # https://262.ecma-international.org/#prod-NameSpaceImport
 NameSpaceImport
-  Star __ As __ ImportedBinding:binding  ->
+  Star ImportAsToken __ ImportedBinding:binding  ->
     return {
       type: "Declaration",
       children: $0,
@@ -2882,7 +2882,7 @@ TypeAndImportSpecifier
 
 # https://262.ecma-international.org/#prod-ImportSpecifier
 ImportSpecifier
-  __ ModuleExportName __ As __ ImportedBinding:binding ObjectPropertyDelimiter ->
+  __ ModuleExportName ImportAsToken __ ImportedBinding:binding ObjectPropertyDelimiter ->
     return {
       binding: binding,
       children: $0,
@@ -2891,6 +2891,24 @@ ImportSpecifier
     return {
       binding: binding,
       children: $0,
+    }
+
+ImportAsToken
+  __ As
+  # NOTE: Allowing ':' in place of 'as', a preliminary step towards unifying
+  # imports and destructuring.
+  Loc:l __:ws Colon:c " "? ->
+    const children = [
+      ...ws,
+      { ...c, token: "as " },
+    ]
+
+    if (!ws.length) {
+      children.unshift({ $loc: l.$loc, token: " " })
+    }
+
+    return {
+      children,
     }
 
 # https://262.ecma-international.org/#prod-ModuleExportName

--- a/test/import.civet
+++ b/test/import.civet
@@ -42,6 +42,22 @@ describe "import", ->
   """
 
   testCase """
+    named imports with rename
+    ---
+    import {x as a, y as b} from "./y"
+    ---
+    import {x as a, y as b} from "./y"
+  """
+
+  testCase """
+    named imports with shorthand rename
+    ---
+    import {x: a, y: b} from "./y"
+    ---
+    import {x as a, y as b} from "./y"
+  """
+
+  testCase """
     multi-line import block
     ---
     import ts, {


### PR DESCRIPTION
This is the first step towards a unified `import` destructuring syntax.