### PR TITLE
Confirm that docs build in CI for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
-on: ["push", "pull_request"]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: Build
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,22 @@ jobs:
       with:
         name: browser.js
         path: dist/browser.js
+
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Setup Node.js 18.x
+      uses: actions/setup-node@v3
+      with:
+        cache: yarn
+        node-version: 18.x
+
+    - name: Install and Test
+      # `yarn docs:build` includes `yarn build`
+      run: |
+        yarn
+        yarn docs:build


### PR DESCRIPTION
Add a job that tests that the docs build in a PR, *before* we merge and the docs fail to build/deploy.  Should be in parallel to running tests (though both jobs are redundantly running `build`).

I also noticed that the jobs were running twice on a PR, because they also counted as a `push` (at least for local branches). Now the `push` tests only run on `master`.