### PR TITLE
Fixes #192

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -61,8 +61,8 @@ Arguments
   # a b => a(b)
   # a b, c, d => a(b, c, d)
   # x y z => x(y(z))
-  ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
-    return [open, module.insertTrimmingSpace(ws, ""), args, close]
+  ( InlineTypeArguments !( __ ImplementsToken ) )?:ta ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
+    return [ta?.[0], open, module.insertTrimmingSpace(ws, ""), args, close]
 
 ExplicitArguments
   TypeArguments? OpenParen ArgumentList? ( __ Comma )? __ CloseParen
@@ -4461,6 +4461,17 @@ FunctionType
 TypeArguments
   __ "<" TypeArgument+ __ ">" ->
     return { ts: true, children: $0 }
+
+InlineTypeArguments
+  _* "<" InlineTypeArgument+ _* ">" ->
+    return { ts: true, children: $0 }
+
+InlineTypeArgument
+  _* Type InlineTypeArgumentDelimiter
+
+InlineTypeArgumentDelimiter
+  _* Comma
+  &( _* ">" )
 
 # TypeArguments without the leading whitespace
 CompactTypeArguments

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -190,3 +190,11 @@ describe "[TS] function", ->
       ---
       x<T>()
     """
+
+    testCase """
+      type arguments with implicit parens
+      ---
+      x<T> y
+      ---
+      x<T>(y)
+    """


### PR DESCRIPTION
This was fairly straightforward but had some nuance around the following situations:

```
a < b
a > b
---
a < b,
a >(b)
```

```
class A extends C<T> implements B {
  x := 3
}
---
class A extends C<T>(implements(B)) {
  x := 3
}
```

That's why I'm using `InlineTypeArguments` and added the `!"implements"` lookahead for implicit application.