### PR TITLE
Fix identifier used only in coffee for loop

### DIFF
--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -139,7 +139,9 @@ repl = (options) ->
         when options.compile then '🐈> '
         else '🐱> '
     writer:
-      if options.compile and not options.ast
+      if options.ast
+        (obj) -> JSON.stringify obj, null, 2
+      else if options.compile
         (obj) -> obj?.replace /\n*$/, ''
     eval: (input, context, filename, callback) ->
       if input == '\n'  # blank input

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2355,7 +2355,7 @@ CoffeeForStatementParameters
           declaration = {
             type: "Declaration",
             children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", varRef, " = ", startRef, ...ascDec],
-            names: []
+            names: varRef.names,
           }
 
           blockPrefix./**/push(["", {
@@ -2467,14 +2467,12 @@ CoffeeForIndex
 CoffeeForDeclaration
   # NOTE: Coffee doesn't allow expression bindings like `for a.x in b`
   ( __ "own" NonIdContinue )?:own ForBinding:binding ->
-    if (own) {
-      binding.own = true
+    return {
+      type: "AssignmentExpression",
+      own: Boolean(own),
+      children: [$2],
+      names: $2.names,
     }
-
-    // Flag as assignment for auto-var
-    binding.type = "AssignmentExpression"
-
-    return binding
 
 ForStatementParameters
   # https://262.ecma-international.org/#prod-ForStatement

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -43,6 +43,19 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for i in range fixed
+    ---
+    "civet coffee-compat"
+    for i in [1..10]
+      c()
+    ---
+    var i
+    for (let i1 = i = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; i = asc ? ++i1 : --i1) {
+      c()
+    }
+  """
+
+  testCase """
     for in range variable end
     ---
     "civet coffee-compat"


### PR DESCRIPTION
Fixes #193

`CoffeeForDeclaration` was actually pretty broken: it modified the AST without duplicating the object! But it also removed the `Identifier` type.

Also fix a bug where CLI in `--ast` mode wasn't showing the full AST (just the first couple of levels like `console.log` does).