### PR TITLE
Fixes #205

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -16,7 +16,7 @@ uncacheable = new Set [
   "ActualAssignment"
   "ApplicationStart"
   "Arguments"
-  "ArgumentsWithTrailingCallExpressions"
+  "ArgumentsWithTrailingMemberExpressions"
   "ArrowFunction"
   "ArrowFunctionTail"
   "AssignmentExpression"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -79,8 +79,8 @@ IndentedApplicationAllowed
 
 ArgumentsWithTrailingMemberExpressions
   # Since this is recursive Arguments must consume input to avoid infinite recursion
-  # NOTE: Do not allow trailing template literals to match
-  Arguments ( Samedent MemberExpressionRest )*
+  # NOTE: Assert "." to not match "?" or "!" as a member expression on the following line
+  Arguments ( Samedent &"." MemberExpressionRest )*
 
 # https://262.ecma-international.org/#prod-ArgumentList
 ArgumentList

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -80,7 +80,7 @@ IndentedApplicationAllowed
 ArgumentsWithTrailingCallExpressions
   # Since this is recursive Arguments must consume input to avoid infinite recursion
   # NOTE: Do not allow trailing template literals to match
-  Arguments ( Samedent !Backtick CallExpressionRest )*
+  Arguments ( Samedent !Backtick !ArrowFunction CallExpressionRest )*
 
 # https://262.ecma-international.org/#prod-ArgumentList
 ArgumentList

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -77,10 +77,10 @@ IndentedApplicationAllowed
     if (module.suppressIndentedApplication) return $skip
     return
 
-ArgumentsWithTrailingCallExpressions
+ArgumentsWithTrailingMemberExpressions
   # Since this is recursive Arguments must consume input to avoid infinite recursion
   # NOTE: Do not allow trailing template literals to match
-  Arguments ( Samedent !Backtick !ArrowFunction CallExpressionRest )*
+  Arguments ( Samedent MemberExpressionRest )*
 
 # https://262.ecma-international.org/#prod-ArgumentList
 ArgumentList
@@ -512,11 +512,11 @@ LeftHandSideExpression
 # https://262.ecma-international.org/#prod-CallExpression
 CallExpression
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
-  "super" ArgumentsWithTrailingCallExpressions CallExpressionRest*
+  "super" ArgumentsWithTrailingMemberExpressions CallExpressionRest*
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
-  "import" ArgumentsWithTrailingCallExpressions CallExpressionRest* ->
+  "import" ArgumentsWithTrailingMemberExpressions CallExpressionRest* ->
     return {
       type: "CallExpression",
       children: $0,
@@ -534,7 +534,7 @@ CallExpressionRest
   MemberExpressionRest
   TemplateLiteral
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
-  ( OptionalShorthand / NonNullAssertion )? ArgumentsWithTrailingCallExpressions
+  ( OptionalShorthand / NonNullAssertion )? ArgumentsWithTrailingMemberExpressions
 
 # NOTE: Added shorthand x?(3) -> x?.(3)
 OptionalShorthand

--- a/test/function.civet
+++ b/test/function.civet
@@ -594,6 +594,19 @@ describe "function", ->
     }
   """
 
+  testCase """
+    nested block returning arrow function
+    ---
+    function test(a)
+      a = simplify a
+      (x) => x+a
+    ---
+    function test(a) {
+      a = simplify(a)
+      return (x) => x+a
+    }
+  """
+
   describe "implicit returns", ->
     testCase """
       basic

--- a/test/function.civet
+++ b/test/function.civet
@@ -607,6 +607,19 @@ describe "function", ->
     }
   """
 
+  testCase """
+    nested block returning negated identifier
+    ---
+    function test(a)
+      a = simplify a
+      !a
+    ---
+    function test(a) {
+      a = simplify(a)
+      return !a
+    }
+  """
+
   describe "implicit returns", ->
     testCase """
       basic


### PR DESCRIPTION
There may still be some caching related improvements but adding this negative lookahead prevents the parens of an arrow function on the following line from being interpreted as arguments in a call expression.

When I added no-cache to many rules the parser became too slow. Probably need to do some Hera and caching improvements in the future to really optimize.