### PR TITLE
Fixes #228. `this` type in function parameters.

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -508,13 +508,15 @@ FieldDefinition
 ThisLiteral
   This
   # NOTE: Added @identifier shorthand, also works for private identifiers
-  At:t $( "#"? IdentifierName ):id ->
-    // Extract children from 'Identifier' node because this won't interfere with refs
-    return [{...t, token: "this."}, id]
-  # NOTE: Added '@' as a 'this' shorthand from CoffeeScript
-  At ->
-    $1.token = "this"
-    return $1
+  # Converts 'IdentifierName' node to string so this won't interfere with refs
+  AtThis:at $( "#"? IdentifierName ):id ->
+    return [at, ".", id]
+  AtThis
+
+# NOTE: Added '@' as a 'this' shorthand from CoffeeScript
+AtThis
+  At:at ->
+    return { ...at, token: "this" }
 
 # https://262.ecma-international.org/#prod-LeftHandSideExpression
 LeftHandSideExpression
@@ -703,7 +705,7 @@ Parameters
 
 NonEmptyParameters
   # NOTE: BindingElement -> ParameterElement
-  TypeParameters?:tp OpenParen:open ParameterElement*:pes FunctionRestParameter?:rest ParameterElement*:after ( __ CloseParen ):close ->
+  TypeParameters?:tp OpenParen:open ThisType?:tt ParameterElement*:pes FunctionRestParameter?:rest ParameterElement*:after ( __ CloseParen ):close ->
     const names = pes.flatMap(p => p.names)
     if (rest) {
       let restIdentifier
@@ -729,6 +731,7 @@ NonEmptyParameters
         children: [
           tp,
           open,
+          tt,
           ...pes,
           // Remove delimiter
           {...rest, children: rest.children.slice(0, -1)},
@@ -742,7 +745,7 @@ NonEmptyParameters
 
     return {
       type: "Parameters",
-      children: [tp, open, ...pes, close],
+      children: [tp, open, tt, ...pes, close],
       names: pes.flatMap((p) => p.names),
       tp,
     }
@@ -4538,6 +4541,13 @@ TypeParameterDelimiter
   _* Comma
   &( __ ">" )
   &EOS InsertComma -> $2
+
+ThisType
+  ( This / AtThis ) Colon Type -> {
+    type: "ThisType",
+    ts: true,
+    children: $0
+  }
 
 ## Utility
 

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -3,10 +3,11 @@
 assert from assert
 cache := true
 
-compare := (src: string, result: string, filename: string) ->
+compare := (src: string, result: string, compilerOpts: any) ->
+  { filename } := compilerOpts
   compileResult := compile(src, {
     noCache: !cache
-    filename
+    ...compilerOpts
   })
 
   assert.equal compileResult, result, """
@@ -22,7 +23,7 @@ compare := (src: string, result: string, filename: string) ->
 
   """
 
-testCase := (text: string, opt?: "only" | "skip") ->
+testCase := (text: string, opt?: "only" | "skip", compilerOpts: any={}) ->
   [desc, src, result] := text.split("\n---\n")
 
   let fn
@@ -32,13 +33,21 @@ testCase := (text: string, opt?: "only" | "skip") ->
     fn = it
 
   fn desc, ->
-    compare src, result, desc
+    compare src, result, {
+      filename: desc
+      ...compilerOpts
+    }
 
 testCase.only = (text: string) ->
   testCase(text, "only")
 
 testCase.skip = (text: string) ->
   testCase(text, "skip")
+
+testCase.js = (text: string) ->
+  testCase(text, undefined, {
+    js: true
+  })
 
 throws := (text: string) ->
   assert.throws ->

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -209,3 +209,44 @@ describe "[TS] function", ->
       ---
       x<T>(y)
     """
+
+  describe "this type", ->
+    testCase """
+      interface method
+      ---
+      interface Object {
+          state<T>(this: T): T
+      }
+      ---
+      interface Object {
+          state<T>(this: T): T
+      }
+    """
+
+    testCase """
+      interface method @ shorthand
+      ---
+      interface Object {
+          state<T>(@: T): T
+      }
+      ---
+      interface Object {
+          state<T>(this: T): T
+      }
+    """
+
+    testCase """
+      plain function
+      ---
+      function (this: T) {}
+      ---
+      function (this: T) {}
+    """
+
+    testCase """
+      plain function with @ shorthand
+      ---
+      function (@: T) {}
+      ---
+      function (this: T) {}
+    """

--- a/test/types/js.civet
+++ b/test/types/js.civet
@@ -1,5 +1,6 @@
 assert from assert
-{compile} from ../../source/main.coffee
+{ compile } from ../../source/main.coffee
+{ testCase } from ../helper.civet
 
 describe "Types", ->
   describe "JS", ->
@@ -125,8 +126,8 @@ describe "Types", ->
       assert.equal js, """
       class A {
         foo = "str"
-        
-        
+      \u0020\u0020
+      \u0020\u0020
         bar() {
           return this.show(this.bar)
         }
@@ -173,4 +174,21 @@ describe "Types", ->
       """, js: true
       assert.equal js, """
       export { a, b, c, d } from "foo"
+      """
+
+    describe "this type is omitted in js", ->
+      testCase.js """
+        plain function
+        ---
+        function (this: T) {}
+        ---
+        function () {}
+      """
+
+      testCase.js """
+        plain function with @ shorthand
+        ---
+        function (@: T) {}
+        ---
+        function () {}
       """


### PR DESCRIPTION
Added support for `this: T` and `@: T` in function parameters. Also added a `js` mode option for `testCase`.
