### PR TITLE
Wrap object expressions with parentheses at statement level

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1650,7 +1650,10 @@ NestedPropertyDefinition
 
 InlineObjectLiteral
   InsertInlineOpenBrace:open SnugNamedProperty ImplicitInlineObjectPropertyDelimiter ( ( Samedent / _* ) NamedProperty ImplicitInlineObjectPropertyDelimiter )* InsertCloseBrace:close ->
-    return [open, $2, $3, ...$4, close]
+    return {
+      type: "ObjectExpression",
+      children: [open, $2, $3, ...$4, close],
+    }
 
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
 # Instead we see if the next line matches a NamedProperty and if so we insert a comma
@@ -2030,8 +2033,16 @@ Statement
   TryStatement
 
   EmptyStatement
-  # TODO: wrap object literal output with parens to disambiguate from block statements in transpiled JS
-  ExpressionStatement
+
+  # Wrap object literal output with parens to disambiguate from block statements in transpiled JS
+  ExpressionStatement ->
+    if ($1.type === "ObjectExpression") {
+      return {
+        type: "ParenthesizedExpression",
+        children: ["(", $1, ")" ],
+      }
+    }
+    return $1
 
   # NOTE: Block statement is after expression statement because valid ObjectLiterals should take priority over blocks
   BlockStatement

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -67,7 +67,7 @@ describe "example code", ->
                                                         closingTagClosingBracketLocationData: $1.closingTagClosingBracketToken?[2]
       ]
     ---
-      {Identifier: [
+      ({Identifier: [
         o('IDENTIFIER',                             function() { return new IdentifierLiteral($1) }),
         o('JSX_TAG',                                function() { return new JSXTag($1.toString(), {
                                                         tagNameLocationData:                  $1.tagNameToken[2],
@@ -76,7 +76,7 @@ describe "example code", ->
                                                         closingTagNameLocationData:           $1.closingTagNameToken?.[2],
                                                         closingTagClosingBracketLocationData: $1.closingTagClosingBracketToken?.[2],
         }) })
-      ]}
+      ]})
   """
 
   testCase """
@@ -145,13 +145,13 @@ describe "example code", ->
         pattern, @flags, @delimiter
       }
     ---
-    {astProperties: function(o) {
+    ({astProperties: function(o) {
       [, pattern] = this.REGEX_REGEX.exec(this.value)
       return {
         value: undefined,
         pattern, flags: this.flags, delimiter: this.delimiter
       }
-    }}
+    }})
   """
 
   testCase """
@@ -211,7 +211,7 @@ describe "example code", ->
       @returnKeyword
     ---
     if ((this.expression) != null) {
-      {locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)}
+      ({locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)})
     }
     else {
       this.returnKeyword
@@ -252,14 +252,14 @@ describe "example code", ->
       finally
         delete @compileNode
     ---
-    {compileNode: function(o) {
+    ({compileNode: function(o) {
       try {
         return node.compileToFragments(o)
       }
       finally {
         delete this.compileNode
       }
-    }}
+    }})
   """
 
   testCase.skip """

--- a/test/function.civet
+++ b/test/function.civet
@@ -352,7 +352,7 @@ describe "function", ->
       a: 1
     ---
     function() {
-      return {a: 1}
+      return ({a: 1})
     }
   """
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -6,7 +6,7 @@ describe "object", ->
     ---
     {}
     ---
-    {}
+    ({})
   """
 
   testCase """
@@ -43,7 +43,7 @@ describe "object", ->
     ---
     a: b
     ---
-    {a: b}
+    ({a: b})
   """
 
   testCase """
@@ -51,7 +51,7 @@ describe "object", ->
     ---
     {x, func(){5}}
     ---
-    {x, func(){return 5}}
+    ({x, func(){return 5}})
   """
 
   testCase """
@@ -59,7 +59,7 @@ describe "object", ->
     ---
     {x, func(){}}
     ---
-    {x, func(){}}
+    ({x, func(){}})
   """
 
   testCase """
@@ -67,7 +67,7 @@ describe "object", ->
     ---
     {+x, -y, !z}
     ---
-    {x: true, y: false, z: false}
+    ({x: true, y: false, z: false})
   """
 
   testCase """
@@ -78,10 +78,10 @@ describe "object", ->
       -y
     }
     ---
-    {
+    ({
       x: true,
       y: false
-    }
+    })
   """
 
   testCase """
@@ -89,7 +89,7 @@ describe "object", ->
     ---
     { [x]: 5 }
     ---
-    { [x]: 5 }
+    ({ [x]: 5 })
   """
 
   testCase """
@@ -98,8 +98,8 @@ describe "object", ->
     a: b
     b: c
     ---
-    {a: b,
-    b: c}
+    ({a: b,
+    b: c})
   """
 
   testCase """
@@ -107,7 +107,7 @@ describe "object", ->
     ---
     { /**/ x}
     ---
-    { /**/ x}
+    ({ /**/ x})
   """
 
   testCase """
@@ -115,7 +115,7 @@ describe "object", ->
     ---
     { ...x }
     ---
-    { ...x }
+    ({ ...x })
   """
 
   // describe.only "", ->
@@ -357,7 +357,7 @@ describe "object", ->
     ---
     {@tokens, index: i}
     ---
-    {tokens: this.tokens, index: i}
+    ({tokens: this.tokens, index: i})
   """
 
   // TODO: Should this be wrapped in parens?
@@ -366,7 +366,7 @@ describe "object", ->
     ---
     a: 1
     ---
-    {a: 1}
+    ({a: 1})
   """
 
   testCase """
@@ -374,7 +374,7 @@ describe "object", ->
     ---
     a: 1, b: 2
     ---
-    {a: 1, b: 2}
+    ({a: 1, b: 2})
   """
 
   testCase """
@@ -383,8 +383,8 @@ describe "object", ->
     a: 1, b: 2
     c: 3, d: 4
     ---
-    {a: 1, b: 2,
-    c: 3, d: 4}
+    ({a: 1, b: 2,
+    c: 3, d: 4})
   """
 
   testCase """
@@ -394,8 +394,8 @@ describe "object", ->
       version: 3
     updateSourceMap: (outputStr, inputPos) -> outputStr
     ---
-    {json: function(srcFileName, outFileName) {
-      return {version: 3}
+    ({json: function(srcFileName, outFileName) {
+      return ({version: 3})
     },
-    updateSourceMap: function(outputStr, inputPos) { return outputStr }}
+    updateSourceMap: function(outputStr, inputPos) { return outputStr }})
   """


### PR DESCRIPTION
We now wrap `ObjectExpression` at the statement level with parentheses. Sometimes this results in an implicit `return` returning an unnecessarily wrapped object but we can optimize that further later.