### PR TITLE
`type ... from ...` import shorthand

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -411,7 +411,7 @@ type ID = number | string
 ### Import
 
 <Playground>
-import type { Civet, Cat } from animals
+type { Civet, Cat } from animals
 </Playground>
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2840,14 +2840,16 @@ ImportDeclaration
   # NOTE: Added import shorthand
   # NOTE: Not adding $loc to source map here yet because it will point to the start of the identifier
   # the proper place may be to use the From location
-  ImpliedImport:i ImportClause:c __:w FromClause:f ->
+  ImpliedImport:i ( TypeKeyword __ )?:t ImportClause:c __:w FromClause:f ->
     // Map implied import location to `from`
     // The pos and length adjustment better match how tsc outputs to include the space before `from` with the `from` token
     i.$loc = {
       pos: f[0].$loc.pos-1,
       length: f[0].$loc.length+1,
     }
-    return [i, c, w, f]
+    const children = [i, t, c, w, f]
+    if (!t) return children
+    return { ts: true, children }
 
 ImpliedImport
   "" ->

--- a/test/types/import.civet
+++ b/test/types/import.civet
@@ -24,9 +24,25 @@ describe "[TS] import", ->
   """
 
   testCase """
+    import type shorthand
+    ---
+    type { CompilerOptions, LanguageServiceHost } from "typescript"
+    ---
+    import type { CompilerOptions, LanguageServiceHost } from "typescript"
+  """
+
+  testCase """
     import some types and some not
     ---
     import { a, b, type S, type T, c, d } from "foo"
+    ---
+    import { a, b, type S, type T, c, d } from "foo"
+  """
+
+  testCase """
+    import shorthand
+    ---
+    { a, b, type S, type T, c, d } from "foo"
     ---
     import { a, b, type S, type T, c, d } from "foo"
   """


### PR DESCRIPTION
For consistency with regular `import` shorthand

(Noticed this while adding to docs.)