### PR TITLE
Import assertions

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -476,6 +476,7 @@ a instanceof b instanceof c
 <Playground>
 fs from fs
 {basename, dirname} from path
+metadata from ./package.json assert type: 'json'
 </Playground>
 
 ### Dynamic Import

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2902,7 +2902,7 @@ FromClause
 # https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#import-assertions
 # NOTE: Forbid newline before `assert` which could mean a function call
 ImportAssertion
-  _? "assert" NonIdContinue __ ObjectLiteral
+  _? "assert" NonIdContinue _? ObjectLiteral
 
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2834,20 +2834,20 @@ MaybeNestedExpression
 
 # https://262.ecma-international.org/#prod-ImportDeclaration
 ImportDeclaration
-  Import __ TypeKeyword __ ImportClause __ FromClause -> { ts: true, children: $0 }
-  Import __ ImportClause __ FromClause
-  Import __ ModuleSpecifier
+  Import __ TypeKeyword __ ImportClause __ FromClause ImportAssertion? -> { ts: true, children: $0 }
+  Import __ ImportClause __ FromClause ImportAssertion?
+  Import __ ModuleSpecifier ImportAssertion?
   # NOTE: Added import shorthand
   # NOTE: Not adding $loc to source map here yet because it will point to the start of the identifier
   # the proper place may be to use the From location
-  ImpliedImport:i ( TypeKeyword __ )?:t ImportClause:c __:w FromClause:f ->
+  ImpliedImport:i ( TypeKeyword __ )?:t ImportClause:c __:w FromClause:f ImportAssertion?:a ->
     // Map implied import location to `from`
     // The pos and length adjustment better match how tsc outputs to include the space before `from` with the `from` token
     i.$loc = {
       pos: f[0].$loc.pos-1,
       length: f[0].$loc.length+1,
     }
-    const children = [i, t, c, w, f]
+    const children = [i, t, c, w, f, a]
     if (!t) return children
     return { ts: true, children }
 
@@ -2897,6 +2897,12 @@ NamedImports
 # https://262.ecma-international.org/#prod-FromClause
 FromClause
   From __ ModuleSpecifier
+
+# https://github.com/tc39/proposal-import-assertions
+# https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#import-assertions
+# NOTE: Forbid newline before `assert` which could mean a function call
+ImportAssertion
+  _? "assert" NonIdContinue __ ObjectLiteral
 
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier

--- a/test/import.civet
+++ b/test/import.civet
@@ -252,3 +252,62 @@ describe "import", ->
       const promise = import("./x.js")
       fetch = () => import("./x.js")
     """
+
+  describe "import assertions", ->
+    testCase """
+      standard style
+      ---
+      import json from "./foo.json" assert { type: "json" }
+      ---
+      import json from "./foo.json" assert { type: "json" }
+    """
+
+    testCase """
+      shorthand object literal
+      ---
+      import json from "./foo.json" assert type: "json"
+      ---
+      import json from "./foo.json" assert {type: "json"}
+    """
+
+    testCase """
+      from shorthand
+      ---
+      json from ./foo.json assert type: "json"
+      ---
+      import json from "./foo.json" assert {type: "json"}
+    """
+
+    testCase """
+      side-effect import
+      ---
+      import "./foo.json" assert type: "json"
+      ---
+      import "./foo.json" assert {type: "json"}
+    """
+
+    testCase """
+      dynamic import
+      ---
+      import("./foo.json", { assert: { type: "json" }})
+      ---
+      import("./foo.json", { assert: { type: "json" }})
+    """
+
+    testCase """
+      dynamic import shorthand
+      ---
+      foo := import "./foo.json", assert: type: "json"
+      ---
+      const foo = import("./foo.json", {assert: {type: "json"}})
+    """
+
+    testCase """
+      assert function call
+      ---
+      import "./foo.json"
+      assert type: "json"
+      ---
+      import "./foo.json"
+      assert({type: "json"})
+    """

--- a/test/import.civet
+++ b/test/import.civet
@@ -271,6 +271,17 @@ describe "import", ->
     """
 
     testCase """
+      nested implicit object literal
+      ---
+      import json from "./foo.json" assert
+        type: "json"
+      ---
+      import json from "./foo.json" assert {
+        type: "json",
+      }
+    """
+
+    testCase """
       from shorthand
       ---
       json from ./foo.json assert type: "json"


### PR DESCRIPTION
Fixes #243

* Add support for static `import` with assertions, including object literal shorthand.
* Dynamic import assertions already worked; add tests.