### PR TITLE
Re-order docs to ease people into the Civet mindset

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -18,24 +18,113 @@ The TypeScript code on
 
 [[toc]]
 
+## TC39 Left a Lot on the Table
+
+### Default to `const` for Iteration Items
+
+<Playground>
+for (item of [1, 2, 3, 4, 5]) {
+  console.log(item * item);
+}
+</Playground>
+
+### Block Strings / Templates
+
+[TC39 Proposal: String Dedent](https://github.com/tc39/proposal-string-dedent)
+
+<Playground>
+text = """
+  This text is a string that doesn't include the leading
+  whitespace.
+"""
+</Playground>
+
+<Playground>
+text = ```
+  Also works for
+  templates!
+```
+</Playground>
+
+### Modulo Operator
+
+<Playground>
+let a = -3
+let b = 5
+let rem = a % b
+let mod = a %% b
+console.log rem, mod
+</Playground>
+
+### Spread in Any Position
+
+Spreads in first or middle position:
+
+<Playground>
+[...head, last] = [1, 2, 3, 4, 5]
+</Playground>
+
+<Playground>
+{a, ...rest, b} = {a: 7, b: 8, x: 0, y: 1}
+</Playground>
+
+<Playground>
+function justDoIt(a, ...args, cb) {
+  cb.apply(a, args)
+}
+</Playground>
+
+### Import Syntax Matches Destructuring
+
+<Playground>
+import {X: LocalX, Y: LocalY} from "./util"
+</Playground>
+
+### Single-Argument Function Shorthand
+
+<Playground>
+x.map &.name
+x.map &.profile?.name[0...3]
+x.map &.callback a, b
+x.map +&
+</Playground>
+
+::: info
+Short function block syntax like [Ruby symbol to proc](https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-to_proc),
+[Crystal](https://crystal-lang.org/reference/1.6/syntax_and_semantics/blocks_and_procs.html#short-one-parameter-syntax),
+or [Elm record access](https://elm-lang.org/docs/records#access)
+:::
+
+### Pipelines
+
+[TC39 Proposal: Pipe Operator](https://github.com/tc39/proposal-pipeline-operator)
+
+<Playground>
+data
+  |> Object.keys
+  |> console.log
+</Playground>
+
+Pipe expression with shorthand functions:
+
+<Playground>
+a |> & + 1 |> bar
+</Playground>
+
+### Export Convenience
+
+<Playground>
+export a, b, c from "./cool.js"
+export x = 3
+</Playground>
+
+### Throw Expression
+
+<Playground>
+x == null ? throw "x is null" : x.fn()
+</Playground>
+
 ## Basics
-
-### Humanize Operators
-
-<Playground>
-a is b
-a is not b
-a and b
-a or b
-a not in b
-a?
-</Playground>
-
-<Playground>
-item is in array
-item is not in array
-substring is in string
-</Playground>
 
 ### Variable Declaration
 
@@ -57,12 +146,6 @@ obj :=
   c:
     x: 'pretty'
     y: 'cool'
-</Playground>
-
-Spreads anywhere:
-
-<Playground>
-{a, ...rest, b} = {a: 7, b: 8, x: 0, y: 1}
 </Playground>
 
 Flagging shorthand inspired by [LiveScript](https://livescript.net/#literals-objects):
@@ -136,6 +219,23 @@ console.log """
 """
 </Playground>
 
+### Humanized Operators
+
+<Playground>
+a is b
+a is not b
+a and b
+a or b
+a not in b
+a?
+</Playground>
+
+<Playground>
+item is in array
+item is not in array
+substring is in string
+</Playground>
+
 ## Functions
 
 ### Function Calls
@@ -199,19 +299,6 @@ circle := (degrees: number): {x: number, y: number} =>
   x: Math.cos theta
   y: Math.sin theta
 </Playground>
-
-### Single-Argument Shorthand
-
-<Playground>
-x.map &.name
-x.map &.profile?.name[0...3]
-x.map &.callback a, b
-x.map +&
-</Playground>
-
-::: info
-Short function block syntax like [Ruby symbol to proc](https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-to_proc), [Crystal](https://crystal-lang.org/reference/1.6/syntax_and_semantics/blocks_and_procs.html#short-one-parameter-syntax) or [Elm record access](https://elm-lang.org/docs/records#access)
-:::
 
 ## Conditions
 
@@ -459,10 +546,6 @@ a ?= b
 obj.key ?= 'civet'
 </Playground>
 
-<Playground>
-a %% b
-</Playground>
-
 ### Chained Comparisons
 
 <Playground>
@@ -519,20 +602,6 @@ numbers[1...-1] = []
 
 <Playground>
 a + b = c
-</Playground>
-
-### Pipelines
-
-<Playground>
-data
-  |> Object.keys
-  |> console.log
-</Playground>
-      
-Pipe expression with shorthand functions:
-      
-<Playground>
-a |> & + 1 |> bar
 </Playground>
 
 ## Automatic Variable Declaration


### PR DESCRIPTION
Emphasizing the "better ES" features first. The goal is to ease
people into the language concepts by first presenting things that
most people feel are obvious, if minor improvements. Then as they
read further present more cool/powerful ideas. They might not
notice the shorthand until it is too late... and then down comes
the net.
