### PR TITLE
Civet loader for Bun (integration needs fixing)

### DIFF
--- a/build/esbuild.coffee
+++ b/build/esbuild.coffee
@@ -83,3 +83,22 @@ esbuild.build({
     heraPlugin
   ]
 }).catch -> process.exit 1
+
+esbuild.build({
+  entryPoints: ['source/bun-civet.coffee']
+  bundle: true
+  sourcemap
+  minify
+  watch
+  platform: 'node'
+  format: 'esm'
+  outfile: 'dist/bun-civet.mjs'
+  external: ['bun']
+  plugins: [
+    resolveExtensions
+    coffeeScriptPlugin
+      bare: true
+      inlineMap: sourcemap
+    heraPlugin
+  ]
+}).catch -> process.exit 1

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "./esm": "./dist/esm.mjs",
     "./esbuild-plugin": "./dist/esbuild-plugin.js",
+    "./bun-civet": "./dist/bun-civet.mjs",
     "./register": "./register.js",
     "./*": "./*",
     "./dist/*": "./dist/*"

--- a/source/bun-civet.coffee
+++ b/source/bun-civet.coffee
@@ -1,0 +1,15 @@
+import { plugin } from 'bun'
+
+await plugin(
+  name: 'Civet loader'
+  setup: (builder) ->
+    { compile } = await import('@danielx/civet')
+    { readFileSync } = await import('fs')
+    
+    builder.onLoad filter: /\.civet$/, ({path}) ->
+      source = readFileSync path, 'utf8'
+      contents = compile source
+
+      return
+          contents: contents
+          loader: 'js')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
     /* Language and Environment */
-    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": [
       "ES2020",
       "DOM"


### PR DESCRIPTION
@STRd6 

I spent a lot time with it, but couldn't get the integration working. I feel like I'm out of my depth. I have very little xp with npm packages and bundlers and I think the crux of the issue is in that area.

The loader itself works 100% (I tested it separately), but when I try to import it from the Civet repo, `bun` gets stuck on some code in that repo. But when I use the loader as-is, as just a file in my own project (albeit a TS version), it works no problem.

I wager you guys can see what the problem is more apparently. Feel free to give pointers and reject the PR, or try the integration yourself.

Alternatively, you can just copy the loader out of the PR, convert it to TS and try it as is. Just create a TS file like `test.ts`, write some code like:

_test.ts_
```
import "./bun-civet.ts"
import * as file from './file.civet'
console.log(file.animal)
```

_file.civet_
```
export let animal
let a = ->
    animal = '🐈'
a()
```

then just do `bun test.ts` (plus install Civet in that project ofc)

You can even import other civet files in your civet files, bun applies the loader to every imported `.civet`.