### PR TITLE
Change `is in` operator to use `includes` method

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1959,14 +1959,23 @@ BinaryOpSymbol
       $loc,
       token: "instanceof",
       special: true,
+      negated: true,
     }
   ( !CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "not" NonIdContinue __ "of" NonIdContinue ) ->
     return {
       $loc,
       token: "in",
       special: true,
+      negated: true,
     }
-  ( "is" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "in" NonIdContinue ) ->
+  "is" NonIdContinue __ "in" NonIdContinue ->
+    return {
+      method: "includes",
+      relational: true,
+      reversed: true,
+      special: true,
+    }
+  CoffeeOfEnabled "in" NonIdContinue ->
     return {
       call: [module.getRef("indexOf"), ".call"],
       relational: true,
@@ -1974,7 +1983,15 @@ BinaryOpSymbol
       suffix: " >= 0",
       special: true,
     }
-  ( "is" NonIdContinue __ "not" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ) ->
+  "is" NonIdContinue __ "not" NonIdContinue __ "in" NonIdContinue ->
+    return {
+      method: "includes",
+      relational: true,
+      reversed: true,
+      special: true,
+      negated: true,
+    }
+  CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ->
     return {
       call: [module.getRef("indexOf"), ".call"],
       relational: true,
@@ -5477,11 +5494,20 @@ Init
             } else {
               children = [wsOp, op.call, "(", a, ",", wsB, b, ")", op.suffix]
             }
-          } else if (op.token === "instanceof" || op.token === "in") { // `not instanceof` / `not of`
-            children = ["!(", a, wsOp, op, wsB, b, ")"]
+          } else if (op.method) {
+            wsOp = module.insertTrimmingSpace(wsOp, "")
+            wsB = module.insertTrimmingSpace(wsB, "")
+            if (op.reversed) {
+              children = [wsB, b, wsOp, ".", op.method, "(", a, ")"]
+            } else {
+              children = [a, wsOp, ".", op.method, "(", wsB, b, ")"]
+            }
+          } else if (op.token) {
+            children = ["(", a, wsOp, op, wsB, b, ")"]
           } else {
             throw new Error("Unknown operator: " + JSON.stringify(op))
           }
+          if (op.negated) children.unshift("!")
 
           expandedOps.splice(i - 2, 5, {
             children

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -114,8 +114,7 @@ describe "binary operations", ->
     ---
     a is in b
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
-    indexOf.call(b, a) >= 0
+    b.includes(a)
   """
 
   testCase """
@@ -123,8 +122,7 @@ describe "binary operations", ->
     ---
     a is not in b
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
-    indexOf.call(b, a) < 0
+    !b.includes(a)
   """
 
   testCase """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -126,8 +126,7 @@ describe "&. function block shorthand", ->
     ---
     x.map & is in a
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
-    x.map($ => indexOf.call(a, $) >= 0)
+    x.map($ => a.includes($))
   """
 
   testCase """
@@ -135,8 +134,7 @@ describe "&. function block shorthand", ->
     ---
     x.map &.foo is in a
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
-    x.map($ => indexOf.call(a, $.foo) >= 0)
+    x.map($ => a.includes($.foo))
   """
 
   testCase """


### PR DESCRIPTION
As discussed in Discord a while back:

Unlike `coffeeCompat`'s `in` operator, `is in` is not restricted by CoffeeScript backwards compatibility.  By mapping `a is in b` to `b.includes(a)`, we enable the ability for the user to override this operator, while still maintaining compatibility with arrays and `NodeList` which already have `includes` methods. Also, `in` is a prefix of `includes` so it's intuitive.

Breaking change: For strings, `is in` now checks for substrings instead of individual characters.  This is in line with Python's `in` operator (and how it's currently documented in the cheatsheet), but different from CoffeeScript's `in` operator.