### PR TITLE
Add simple export tests for require/import of package

### DIFF
--- a/test/infra/import.civet
+++ b/test/infra/import.civet
@@ -14,7 +14,9 @@ describe "build importable", ->
     Civet := require "../.."
     assert Civet.compile
 
-  it "dynamic ESM file", async ->
+  it.skip "dynamic ESM file", async ->
+    @timeout 10000
+    // TODO: Why does this take 3s?
     Civet := await import "../../dist/main.mjs"
     assert Civet.compile
     assert Civet.default.compile

--- a/test/infra/import.civet
+++ b/test/infra/import.civet
@@ -1,0 +1,20 @@
+// NOTE: These test the final built version, not the current code
+
+{ createRequire } from module
+require := createRequire import.meta.url
+
+assert from assert
+
+describe "build importable", ->
+  it "CommonJS file", ->
+    Civet := require "../../dist/main.js"
+    assert Civet.compile
+
+  it "CommonJS directory", ->
+    Civet := require "../.."
+    assert Civet.compile
+
+  it "dynamic ESM file", async ->
+    Civet := await import "../../dist/main.mjs"
+    assert Civet.compile
+    assert Civet.default.compile


### PR DESCRIPTION
I realize I never `git add`ed these... Oops.

They do add something like 20% to the test execution time (on my machine, 8.5 seconds vs. 7.2 seconds or so).  Alternatively, we could add them with `.skip`...