### PR TITLE
Braceless type = and implicit inline braceless types

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4455,7 +4455,8 @@ TypeDeclaration
   ( Export _? )? ( Declare _? )? TypeDeclarationRest    -> { ts: true, children: $0 }
 
 TypeDeclarationRest
-  TypeKeyword TrailingComment* IdentifierName TypeParameters? __ Equals __ Type
+  # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
+  TypeKeyword TrailingComment* IdentifierName TypeParameters? __ Equals ( ( _? Type ) / ( __ Type ) )
   Interface   TrailingComment* IdentifierName TypeParameters? InterfaceExtendsClause? InterfaceBlock
   Namespace   TrailingComment* IdentifierName NamespaceBlock
   FunctionSignature
@@ -4497,9 +4498,12 @@ NestedInterfaceProperty
   Nested InterfaceProperty
 
 InterfaceProperty
-  ( TypeIndexSignature / PropertyName ) TypeSuffix InterfacePropertyDelimiter
+  BasicInterfaceProperty
   NonEmptyParameters TypeSuffix InterfacePropertyDelimiter
   MethodSignature InterfacePropertyDelimiter
+
+BasicInterfaceProperty
+  ( TypeIndexSignature / PropertyName ) TypeSuffix InterfacePropertyDelimiter
 
 InterfacePropertyDelimiter
   _* ( Semicolon / Comma )
@@ -4555,7 +4559,7 @@ Type
   TypeConditional
 
 TypeBinary
-  TypeUnary (__ TypeBinaryOp __ TypeUnary)* ->
+  TypeUnary ( __ TypeBinaryOp __ TypeUnary )* ->
     if ($2.length) return $0
     return $1
 
@@ -4578,12 +4582,15 @@ TypeIndexedAccess
 
 TypePrimary
   InterfaceBlock
-  __ OpenParen Type __ CloseParen
+  _? FunctionType
+  _? InlineInterfaceLiteral
   _? TypeTuple
   _? ImportType
-  _? FunctionType
   _? TypeLiteral
   _? IdentifierName (Dot IdentifierName)* TypeArguments?
+  # NOTE: Check FunctionType before parenthesized in order to distinguish between (a: T) => U and
+  # A parenthesized inline interface (a: T) ---> ({a: T})
+  __ OpenParen Type __ CloseParen
 
 ImportType
   "import" OpenParen __ BasicStringLiteral __ CloseParen ( Dot IdentifierName )? TypeArguments?
@@ -4618,6 +4625,18 @@ TypeLiteral
     return { $loc, token: "void" }
   "[]" ->
     return { $loc, token: "[]" }
+
+InlineInterfaceLiteral
+  InsertInlineOpenBrace InlineBasicInterfaceProperty ( ( IndentedFurther / _? ) InlineBasicInterfaceProperty )* InsertCloseBrace
+
+InlineBasicInterfaceProperty
+  ( TypeIndexSignature / PropertyName ) QuestionMark? Colon Type InlineInterfacePropertyDelimiter
+
+InlineInterfacePropertyDelimiter
+  ( _? Semicolon ) / CommaDelimiter
+  &( ( IndentedFurther / _? ) InlineBasicInterfaceProperty ) InsertComma -> $2
+  &( __  ( ":" / ")" / "]" / "}" ) )
+  &EOS
 
 TypeBinaryOp
   "|" ->

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -10,6 +10,62 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    nested braceless type
+    ---
+    type Point =
+      x: number
+      y: number
+    ---
+    type Point = {
+      x: number
+      y: number
+    }
+  """
+
+  testCase """
+    inline braceless type
+    ---
+    type Point = x: number, y: number
+    ---
+    type Point = {x: number, y: number}
+  """
+
+
+  testCase """
+    nested braceless type with inline braceless types
+    ---
+    type Point =
+      x: a: number, b: number
+      y: c: [string], d: =>
+    ---
+    type Point = {
+      x: {a: number, b: number}
+      y: {c: [string], d: ()=>void}
+    }
+  """
+
+  testCase """
+    nested braceless type with inline braceless types and trailing comma
+    ---
+    type Point =
+      x: a: number, b: number,
+      y: c: [string], d: =>
+    ---
+    type Point = {
+      x: {a: number, b: number,}
+      y: {c: [string], d: ()=>void}
+    }
+  """
+
+  testCase """
+    function type
+    ---
+    type X = (message: string) => void
+    ---
+    type X = (message: string) => void
+  """
+
+  testCase """
     type parameters
     ---
     type Z<X, Y> = Array<X>


### PR DESCRIPTION
Fixes #158 

Added support for:

```typescript
type Point =
  x: number
  y: number

type Point = x: number, y: number

type Point =
      x: a: number, b: number
      y: c: [string], d: =>
```