### PR TITLE
Interface fixes

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4494,7 +4494,7 @@ TypeDeclarationBinding
   ( BindingPattern / BindingIdentifier ) TypeSuffix?
 
 InterfaceExtendsClause
-  ExtendsToken InterfaceExtendsTarget
+  ExtendsToken InterfaceExtendsTarget ( Comma InterfaceExtendsTarget )*
 
 InterfaceExtendsTarget
   ImplementsTarget

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -80,7 +80,7 @@ ApplicationStart
 ForbiddenImplicitCalls
   # Reserved words that prevent spaced implicit function application
   # ie: the 'of' in 'for x of ...'
-  /(as|for|of|satisfies|then|when)(?!\p{ID_Continue}|[\u200C\u200D$])/
+  /(as|for|of|satisfies|then|when|implements)(?!\p{ID_Continue}|[\u200C\u200D$])/
   # NOTE: Don't allow non-heregex regexes that begin with a space as first argument without parens
   "/ "
   AtAt # experimentalDecorators

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -131,3 +131,35 @@ describe "[TS] class", ->
       ) {}
     }
   """
+
+  testCase """
+    implements
+    ---
+    class A implements I {}
+    ---
+    class A implements I {}
+  """
+
+  testCase """
+    implements multiple
+    ---
+    class A implements I, J {}
+    ---
+    class A implements I, J {}
+  """
+
+  testCase """
+    extends and implements
+    ---
+    class A extends B implements I, J {}
+    ---
+    class A extends B implements I, J {}
+  """
+
+  testCase """
+    extends shorthand and implements
+    ---
+    class A < B implements I, J {}
+    ---
+    class A extends B implements I, J {}
+  """

--- a/test/types/interface.civet
+++ b/test/types/interface.civet
@@ -174,6 +174,28 @@ describe "[TS] interface", ->
   """
 
   testCase """
+    interface extends multiple
+    ---
+    interface X extends Y, Z
+      id: number
+    ---
+    interface X extends Y, Z {
+      id: number
+    }
+  """
+
+  testCase """
+    interface extends shorthand multiple
+    ---
+    interface X extends Y, Z, W
+      id: number
+    ---
+    interface X extends Y, Z, W {
+      id: number
+    }
+  """
+
+  testCase """
     multiple computed properties
     ---
     interface A {


### PR DESCRIPTION
Fixes #254:
* `interface` support for multiple `extends`
* Fix `class` with `extends` and `implements`

I tried adding a `<<` shorthand for `implements`, but `class A < B << C` is currently treated as `class A extends (B << C)` and it seems a bit difficult to bypass (and maybe once we have operator overloading, we wouldn't want to?).  Let me know if you have thoughts on this.