### PR TITLE
`<:` shorthand for implements

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -513,6 +513,13 @@ class Civet
 class Civet < Animal
 </Playground>
 
+### Implements
+
+<Playground>
+class Civet < Animal <: Named
+class Civet <: Animal, Named
+</Playground>
+
 ## Types
 
 ### Import

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -66,7 +66,7 @@ Arguments
     return $skip
 
 ImplicitArguments
-  ( TypeArguments !( __ ImplementsToken ) )?:ta ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
+  ( TypeArguments !ImplementsToken )?:ta ApplicationStart InsertOpenParen:open _*:ws ArgumentList:args InsertCloseParen:close ->
     return [ta?.[0], open, module.insertTrimmingSpace(ws, ""), args, close]
 
 ExplicitArguments
@@ -405,7 +405,6 @@ ExtendsClause
 ExtendsToken
   # NOTE: Added "<" extends shorthand
   Loc:l __:ws OpenAngleBracket:lt " "? ->
-
     const children = [
       ...ws,
       { ...lt, token: "extends " },
@@ -415,9 +414,7 @@ ExtendsToken
       children.unshift({ $loc: l.$loc, token: " " })
     }
 
-    return {
-      children,
-    }
+    return { children }
 
   __ Extends
 
@@ -430,15 +427,30 @@ ExtendsTarget
     return exp
 
 ImplementsClause
-  __ ImplementsToken ImplementsTarget ( Comma ImplementsTarget )* ->
+  ImplementsToken ImplementsTarget ( Comma ImplementsTarget )* ->
     return {
       ts: true,
       children: $0,
     }
 
 ImplementsToken
-  "implements" NonIdContinue ->
-    return { $loc, token: $1 }
+  # NOTE: Added "<:" implements shorthand
+  Loc:l __:ws ImplementsShorthand:token " "? ->
+    const children = [ ...ws, token ]
+
+    if (!ws.length) {
+      children.unshift({ $loc: l.$loc, token: " " })
+    }
+
+    return { children }
+
+  __ "implements" NonIdContinue ->
+    $2 = { $loc, token: $2 }
+    return [$1, $2]
+
+ImplementsShorthand
+  "<:" ->
+    return { $loc, token: "implements " }
 
 ImplementsTarget
   __ IdentifierName (Dot IdentifierName)* TypeArguments?

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -163,3 +163,35 @@ describe "[TS] class", ->
     ---
     class A extends B implements I, J {}
   """
+
+  testCase """
+    implements shorthand
+    ---
+    class A <: I {}
+    ---
+    class A implements I {}
+  """
+
+  testCase """
+    implements shorthand multiple
+    ---
+    class A <: I, J {}
+    ---
+    class A implements I, J {}
+  """
+
+  testCase """
+    extends and implements shorthand
+    ---
+    class A < B <: I {}
+    ---
+    class A extends B implements I {}
+  """
+
+  testCase """
+    extends and implements shorthand without spaces
+    ---
+    class A<B<:I {}
+    ---
+    class A extends B implements I {}
+  """


### PR DESCRIPTION
Here's my implementation of a shorthand for `implements`, as originally suggested in #254 and using the `<:` notation suggested in #274.

We might want to see if there are any better notations suggested before committing to `<:`.  Or we could merge this and change it later.