### PR TITLE
Insert semicolons between lines that JS would combine

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3575,6 +3575,10 @@ ExpressionDelimiter
 
 StatementDelimiter
   SemicolonDelimiter
+  # NOTE: Avoid automatic continuation onto lines that start with
+  # certain characters by adding an explicit semicolon.  See
+  # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion
+  &( Samedent [\(\[`\+\-\*\/] ) InsertSemicolon
   &EOS
 
 SemicolonDelimiter
@@ -4787,6 +4791,10 @@ Debugger
     debugger
 
 # Insertions
+
+InsertSemicolon
+  "" ->
+    return { $loc, token: ";" }
 
 InsertOpenParen
   "" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3578,7 +3578,10 @@ StatementDelimiter
   # NOTE: Avoid automatic continuation onto lines that start with
   # certain characters by adding an explicit semicolon.  See
   # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion
-  &( Samedent [\(\[`\+\-\*\/] ) InsertSemicolon
+  # TODO: Would be better to do this in a `processBlocks` postprocessing step,
+  # to avoid adding semicolons when they're not needed (e.g. `return` inserted
+  # before value, or parens not actually added around ObjectLiteral).
+  &( Samedent ( "(" / "[" / "`" / "+" / "-" / "*" / "/" / ObjectLiteral ) ) InsertSemicolon
   &EOS
 
 SemicolonDelimiter

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -130,7 +130,7 @@ describe "assignment", ->
     a := b
     {a, b} := c
     ---
-    const a = b
+    const a = b;
     const {a, b} = c
   """
 
@@ -140,7 +140,7 @@ describe "assignment", ->
     a .= b
     {a, b} .= c
     ---
-    let a = b
+    let a = b;
     let {a, b} = c
   """
 

--- a/test/autolet.civet
+++ b/test/autolet.civet
@@ -66,8 +66,8 @@ describe "auto let with multiple declaration", ->
         [a, b] = [1, 2]
         [c, d] = [3, 4]
         ---
-        let c = "str"
-        let [a, b] = [1, 2]
+        let c = "str";
+        let [a, b] = [1, 2];
         let d
         [c, d] = [3, 4]
     """

--- a/test/call-expression.civet
+++ b/test/call-expression.civet
@@ -147,3 +147,24 @@ describe "call-expression", ->
       data!
       .map((x) => x + 1)
     """
+
+  describe "insert semicolons to prevent accidental calls", ->
+    testCase """
+      parenthetical
+      ---
+      x
+      (z)
+      ---
+      x;
+      (z)
+    """
+
+    testCase """
+      arrow function
+      ---
+      x
+      (z) => z
+      ---
+      x;
+      (z) => z
+    """

--- a/test/chained-comparisons.civet
+++ b/test/chained-comparisons.civet
@@ -57,7 +57,7 @@ describe "chained comparisons", ->
     (a < b) < c
     (a + b) < (c + d) < (e + f)
     ---
-    (a < b) < c
+    (a < b) < c;
     (a + b) < (c + d) && (c + d) < (e + f)
   """
 

--- a/test/compat/auto-var.civet
+++ b/test/compat/auto-var.civet
@@ -279,7 +279,7 @@ describe "auto-var", ->
     {a, b} = c = d
     ---
     var b, c
-    let a = 1
+    let a = 1;
     ({a, b} = c = d)
   """
 

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -543,7 +543,7 @@ describe "examples (from real life)", ->
       debug: {
         module: serverModule,
       },
-    }
+    };
 
     const clientOptions: LanguageClientOptions = {
       documentSelector: 1,

--- a/test/function.civet
+++ b/test/function.civet
@@ -263,7 +263,7 @@ describe "function", ->
     () => x
     (x) => x
     ---
-    () => x
+    () => x;
     (x) => x
   """
 
@@ -617,7 +617,7 @@ describe "function", ->
       (x) => x+a
     ---
     function test(a) {
-      a = simplify(a)
+      a = simplify(a);
       return (x) => x+a
     }
   """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -472,7 +472,7 @@ describe "Unbraced function children in JSX", ->
       `[${priority}] ${item}`
     ---
     <For each={items}>{(item) => {
-      const {priority, text} = item
+      const {priority, text} = item;
       return `[${priority}] ${item}`
     }}
     </For>

--- a/test/parentheses.civet
+++ b/test/parentheses.civet
@@ -31,6 +31,6 @@ describe "parentheses", ->
     a
     /** @type Y */ (x)
     ---
-    a
+    a;
     /** @type Y */ (x)
   """

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -15,7 +15,7 @@ describe "[TS] class", ->
     }
     ---
     class UserAccount {
-      name: string
+      name: string;
       id: number
 
       constructor(name: string, id: number) {
@@ -51,7 +51,7 @@ describe "[TS] class", ->
         @id = id
     ---
     class UserAccount {
-      name: string
+      name: string;
       id: number
 
       constructor(name: string, id: number) {

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -18,7 +18,7 @@ describe "[TS] function", ->
     () : number => x
     (x) : number => x
     ---
-    () : number => x
+    () : number => x;
     (x) : number => x
   """
 


### PR DESCRIPTION
Fixes #272.  As discussed there, this quick fix adds some extra semicolons, as it is based on input instead of generated code.  But I think I covered most if not all cases, including a potential object literal on the next line that might get parenthesized.