### PR TITLE
Fix Init being called too late

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3645,6 +3645,10 @@ ExpressionDelimiter
     return [$1, $3, $4]
   &EOS InsertComma -> $2
 
+SimpleStatementDelimiter
+  SemicolonDelimiter
+  &EOS
+
 StatementDelimiter
   SemicolonDelimiter
   # NOTE: Avoid automatic continuation onto lines that start with
@@ -4815,8 +4819,8 @@ Shebang
   /#![^\r\n]*/ EOL
 
 CivetPrologue
-  [\t ]* DoubleQuote CivetPrologueContent:content DoubleQuote $StatementDelimiter EOS? -> content
-  [\t ]* SingleQuote CivetPrologueContent:content SingleQuote $StatementDelimiter EOS? -> content
+  [\t ]* DoubleQuote CivetPrologueContent:content DoubleQuote $SimpleStatementDelimiter EOS? -> content
+  [\t ]* SingleQuote CivetPrologueContent:content SingleQuote $SimpleStatementDelimiter EOS? -> content
 
 CivetPrologueContent
   "civet" NonIdContinue CivetOption*:options [\s]* ->
@@ -4848,7 +4852,7 @@ CivetOption
 UnknownPrologue
   # NOTE: $ is to keep source verbatim and not insert a semicolon if one was omitted
   # Can't use $EOS because it will prevent re-writing of coffee style comments
-  [\t ]* BasicStringLiteral:s $StatementDelimiter EOS
+  [\t ]* BasicStringLiteral:s $SimpleStatementDelimiter EOS
 
 DirectivePrologue
   CivetPrologue


### PR DESCRIPTION
Fix #279 by adding a `SimpleStatementDelimiter` that does not attempt automatic semicolon insertion, used just for prologues.