### PR TITLE
Fix semicolon method body

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -172,7 +172,7 @@ p := {
   name: 'Mary'
   say(msg)
     console.log @name, 'says', msg
-  setName(@name) {}
+  setName(@name);
   get NAME()
     @name.toUpperCase()
 }
@@ -182,7 +182,7 @@ p.say p.NAME
 ::: tip
 
 Methods need a body, or they get treated as literal shorthand.
-To keep the body blank, use `{}`.
+To specify a blank body, use `;` or `{}`.
 
 :::
 

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -89,6 +89,7 @@ uncacheable = new Set [
   "PushJSXOpeningFragment"
   "Samedent"
   "ShortCircuitExpression"
+  "SingleLineAssignmentExpression"
   "SingleLineComment"
   "SingleLineStatements"
   "SnugNamedProperty"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1291,7 +1291,7 @@ BracedBlock
 SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
-  ( ( _? !/\n/ ) Statement SemicolonDelimiter )*:stmts ( ( _? !/\n/ ) Statement SemicolonDelimiter? )?:last ->
+  ( ( _? !EOS ) Statement SemicolonDelimiter )*:stmts ( ( _? !EOS ) Statement SemicolonDelimiter? )?:last ->
     const children = [...stmts]
     if (last) children.push(last)
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -18,6 +18,10 @@ ExtendedExpression
   NonAssignmentExtendedExpression
   AssignmentExpression
 
+SingleLineExtendedExpression
+  NonAssignmentExtendedExpression
+  SingleLineAssignmentExpression
+
 NonPipelineExtendedExpression
   NonAssignmentExtendedExpression
   NonPipelineAssignmentExpression
@@ -191,20 +195,8 @@ AssignmentExpression
   # TODO If NonPipelineAssignmentExpression or SingleLineAssignmentExpression is used here then behavior changes
 
   # NOTE: Try to match a single line assignment expression before matching newline then assignment expression
-  TrailingComment*:ws AssignmentExpressionTail:tail ->
-    if (ws.length) {
-      // Glom whitespace into identifiers and literals to ease checking of "simple" refs
-      // NOTE: This can get weird if we depend on the specific location of children
-      if (tail.children && tail.type !== "IterationExpression") {
-        return {
-          ...tail,
-          children: [...ws, ...tail.children]
-        }
-      }
-      return $0
-    }
-    return tail
-
+  SingleLineAssignmentExpression
+  # TODO: Ideally this wouldn't be needed.
   __ AssignmentExpressionTail
   # NonPipelineAssignmentExpression
 
@@ -1297,7 +1289,9 @@ BracedBlock
 
 # NOTE: SingleLineStatements includes the empty case
 SingleLineStatements
-  ( _* Statement SemicolonDelimiter )*:stmts ( _* Statement SemicolonDelimiter? )?:last ->
+  # NOTE: Statement can start with __ via AssignmentExpression.
+  # Force staying on the same line via !/\n/ assertion.
+  ( ( _? !/\n/ ) Statement SemicolonDelimiter )*:stmts ( ( _? !/\n/ ) Statement SemicolonDelimiter? )?:last ->
     const children = [...stmts]
     if (last) children.push(last)
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -63,6 +63,20 @@ describe "object", ->
   """
 
   testCase """
+    object literal with semicolon method content
+    ---
+    {
+      a();
+      b();
+    }
+    ---
+    ({
+      a() {; },
+      b() {; }
+    })
+  """
+
+  testCase """
     flagging shorthand inline
     ---
     {+x, -y, !z}


### PR DESCRIPTION
Fix `SingleLineStatements` to stay on the same line.

Also cleanup some duplicated code in the grammar.