### PR TITLE
move beyond tc39 to home page, slight reorder

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -18,112 +18,6 @@ The TypeScript code on
 
 [[toc]]
 
-## Beyond TC39
-
-### Default to `const` for Iteration Items
-
-<Playground>
-for (item of [1, 2, 3, 4, 5]) {
-  console.log(item * item);
-}
-</Playground>
-
-### Block Strings / Templates
-
-[TC39 Proposal: String Dedent](https://github.com/tc39/proposal-string-dedent)
-
-<Playground>
-text = """
-  This text is a string that doesn't include the leading
-  whitespace.
-"""
-</Playground>
-
-<Playground>
-text = ```
-  Also works for
-  templates!
-```
-</Playground>
-
-### Modulo Operator
-
-<Playground>
-let a = -3
-let b = 5
-let rem = a % b
-let mod = a %% b
-console.log rem, mod
-</Playground>
-
-### Spread in Any Position
-
-Spreads in first or middle position:
-
-<Playground>
-[...head, last] = [1, 2, 3, 4, 5]
-</Playground>
-
-<Playground>
-{a, ...rest, b} = {a: 7, b: 8, x: 0, y: 1}
-</Playground>
-
-<Playground>
-function justDoIt(a, ...args, cb) {
-  cb.apply(a, args)
-}
-</Playground>
-
-### Import Syntax Matches Destructuring
-
-<Playground>
-import {X: LocalX, Y: LocalY} from "./util"
-</Playground>
-
-### Single-Argument Function Shorthand
-
-<Playground>
-x.map &.name
-x.map &.profile?.name[0...3]
-x.map &.callback a, b
-x.map +&
-</Playground>
-
-::: info
-Short function block syntax like [Ruby symbol to proc](https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-to_proc),
-[Crystal](https://crystal-lang.org/reference/1.6/syntax_and_semantics/blocks_and_procs.html#short-one-parameter-syntax),
-or [Elm record access](https://elm-lang.org/docs/records#access)
-:::
-
-### Pipelines
-
-[TC39 Proposal: Pipe Operator](https://github.com/tc39/proposal-pipeline-operator)
-
-<Playground>
-data
-  |> Object.keys
-  |> console.log
-</Playground>
-
-Pipe expression with shorthand functions:
-
-<Playground>
-a |> & + 1 |> bar
-</Playground>
-
-### Export Convenience
-
-<Playground>
-export a, b, c from "./cool.js"
-export x = 3
-</Playground>
-
-### Throw Expression
-
-<Playground>
-x == null ? throw "x is null" : x.fn()
-</Playground>
-
 ## Basics
 
 ### Variable Declaration
@@ -617,6 +511,25 @@ obj.key ?= 'civet'
 a < b <= c
 a is b is not c
 a instanceof b instanceof c
+</Playground>
+
+### Rest
+
+Rest properties/parameters/elements are no longer limited to the final position.
+You may use them in ther first or middle positions as well.
+
+<Playground>
+[...head, last] = [1, 2, 3, 4, 5]
+</Playground>
+
+<Playground>
+{a, ...rest, b} = {a: 7, b: 8, x: 0, y: 1}
+</Playground>
+
+<Playground>
+function justDoIt(a, ...args, cb) {
+  cb.apply(a, args)
+}
 </Playground>
 
 ### ESM Import

--- a/civet.dev/index.md
+++ b/civet.dev/index.md
@@ -15,19 +15,121 @@ Civet on <span class="wide">the left</span><span class="narrow">top</span>,
 compiled TypeScript output on
 <span class="wide">the right</span><span class="narrow">bottom</span>:
 
+## Beyond TC39
+
+### Pipelines
+
+[TC39 Proposal: Pipe Operator](https://github.com/tc39/proposal-pipeline-operator)
+
 <Playground>
-i .= 0
-loop
-  i++
-  break if i > 5
+data
+  |> Object.keys
+  |> console.log
+</Playground>
+
+Pipe expression with shorthand functions:
+
+<Playground>
+a |> & + 1 |> bar
+</Playground>
+
+### Dedented Strings and Templates
+
+[TC39 Proposal: String Dedent](https://github.com/tc39/proposal-string-dedent)
+
+<Playground>
+text = """
+  This text is a string that doesn't include the leading
+  whitespace.
+"""
+</Playground>
+
+<Playground>
+text = ```
+  Also works for
+  templates!
+```
+</Playground>
+
+### Chained Comparisons
+
+<Playground>
+a < b <= c
+a is b is not c
+a instanceof b instanceof c
+</Playground>
+
+### Default to `const` for Iteration Items
+
+<Playground>
+for (item of [1, 2, 3, 4, 5]) {
+  console.log(item * item);
+}
+</Playground>
+
+### Modulo Operator
+
+<Playground>
+let a = -3
+let b = 5
+let rem = a % b
+let mod = a %% b
+console.log rem, mod
+</Playground>
+
+### Spread in Any Position
+
+Spreads in first or middle position:
+
+<Playground>
+[...head, last] = [1, 2, 3, 4, 5]
+</Playground>
+
+<Playground>
+{a, ...rest, b} = {a: 7, b: 8, x: 0, y: 1}
+</Playground>
+
+<Playground>
+function justDoIt(a, ...args, cb) {
+  cb.apply(a, args)
+}
+</Playground>
+
+### Import Syntax Matches Destructuring
+
+<Playground>
+import {X: LocalX, Y: LocalY} from "./util"
+</Playground>
+
+### Single-Argument Function Shorthand
+
+<Playground>
+x.map &.name
+x.map &.profile?.name[0...3]
+x.map &.callback a, b
+x.map +&
+</Playground>
+
+::: info
+Short function block syntax like [Ruby symbol to proc](https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-to_proc),
+[Crystal](https://crystal-lang.org/reference/1.6/syntax_and_semantics/blocks_and_procs.html#short-one-parameter-syntax),
+or [Elm record access](https://elm-lang.org/docs/records#access)
+:::
+
+### Export Convenience
+
+<Playground>
+export a, b, c from "./cool.js"
+export x = 3
+</Playground>
+
+### Throw Expression
+
+<Playground>
+x == null ? throw "x is null" : x.fn()
 </Playground>
 
 [JSX](/cheatsheet#jsx)? No problem!
-
-<Playground>
-ListItem := (props: Props) =>
-  <li .item>{props.value}
-</Playground>
 
 <Sponsors />
 


### PR DESCRIPTION
In line with some of @tomByrer's suggestions. Keeping cheatsheet simpler, moving "why Civet?" type features to the home page.