### PR TITLE
Integer property access

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -85,6 +85,8 @@ Property access shorthand:
 <Playground>
 json.'long property'
 json.`${movie} name`
+matrix.0.0
+array.-1
 </Playground>
 
 ### Arrays

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -99,7 +99,7 @@ ArgumentsWithTrailingMemberExpressions
 
 TrailingMemberExpressions
   # NOTE: Assert "." to not match "?" or "!" as a member expression on the following line
-  MemberExpressionRest* ( ( Samedent / IndentedFurther ) &( "?"? "." ) MemberExpressionRest )* ->
+  MemberExpressionRest* ( ( Samedent / IndentedFurther ) &( "?"? "." ![0-9] ) MemberExpressionRest )* ->
     return $1.concat($2)
 
 NonSuppressedTrailingMemberExpressions
@@ -648,6 +648,23 @@ MemberBracketContent
       { token: "[", $loc: dot.$loc },
       str,
       "]",
+    ]
+
+  # NOTE: Added shorthand x.3 -> x[3]
+  Dot:dot !"." IntegerLiteral:num ->
+    return [
+      { token: "[", $loc: dot.$loc },
+      num,
+      "]",
+    ]
+
+  # NOTE: Added shorthand x.-1 -> x.at(-1)
+  Dot:dot "-":neg !"." IntegerLiteral:num ->
+    return [
+      { token: ".at(", $loc: dot.$loc },
+      neg,
+      num,
+      ")",
     ]
 
 SliceParameters
@@ -3323,6 +3340,7 @@ VariableDeclaration
     }
 
 # https://262.ecma-international.org/#prod-NumericLiteral
+# NOTE: No leading minus sign
 NumericLiteral
   NumericLiteralKind ->
     return { $loc, token: $1 }
@@ -3331,7 +3349,7 @@ NumericLiteralKind
   DecimalBigIntegerLiteral
   BinaryIntegerLiteral
   OctalIntegerLiteral
-  HexLiteral
+  HexIntegerLiteral
   DecimalLiteral
 
 # https://262.ecma-international.org/#prod-DecimalBigIntegerLiteral
@@ -3360,8 +3378,23 @@ OctalIntegerLiteral
   /0[oO][0-7](?:[0-7]|_[0-7])*n?/
 
 # https://262.ecma-international.org/#prod-HexIntegerLiteral
-HexLiteral
+HexIntegerLiteral
   /0[xX][0-9a-fA-F](?:[0-9a-fA-F]|_[0-9a-fA-F])*n?/
+
+# NOTE: Integer variation of NumericLiteral
+IntegerLiteral
+  IntegerLiteralKind ->
+    return { $loc, token: $1 }
+
+IntegerLiteralKind
+  DecimalBigIntegerLiteral
+  BinaryIntegerLiteral
+  OctalIntegerLiteral
+  HexIntegerLiteral
+  DecimalIntegerLiteral
+
+DecimalIntegerLiteral
+  /(?:0|[1-9](?:_[0-9]|[0-9])*)/
 
 # https://262.ecma-international.org/#prod-StringLiteral
 StringLiteral

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -83,3 +83,52 @@ describe "property access", ->
       ---
       x[`hello ${name}`]
     """
+
+  describe "integer property access shorthand", ->
+    testCase """
+      decimal
+      ---
+      x.1
+      ---
+      x[1]
+    """
+
+    testCase """
+      decimal with separators
+      ---
+      x.1_000_000
+      ---
+      x[1_000_000]
+    """
+
+    testCase """
+      octal
+      ---
+      x.0o777
+      ---
+      x[0o777]
+    """
+
+    testCase """
+      hex
+      ---
+      x.0xfff
+      ---
+      x[0xfff]
+    """
+
+    testCase """
+      multiple
+      ---
+      x.0.0
+      ---
+      x[0][0]
+    """
+
+    testCase """
+      negative
+      ---
+      x.-1
+      ---
+      x.at(-1)
+    """


### PR DESCRIPTION
* `x.0.0` -> `x[0][0]`
* `x.-1` -> `x.at(-1)`

There was some discussion on Discord about whether `.5` should become uniformly `[5]` or `.at(5)` for all integers `5`.  I went with a pragmatic approach: `[]` property access is usually what you want, it's probably faster, it matches `."string"` notation, and it works with more objects; while `.-1` is clearly asking for the last element. It also makes sense in the grammar, because `-` is already not part of the integer literal but rather an operator.

(Counterargument would be that `.at` is more overridable, so maybe mapping everything to `.at` is interesting... but I'm not sure who would really want to override this operator.)

I also wondered about a generic `x@y` shorthand for `x.at(y)`, but Oren pointed out that `-1` is *the* main use of `.at`, so instead the `.-1` notation is probably sufficient.