### PR TITLE
`not instanceof`, `!<?`, reserve `not`

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -146,6 +146,7 @@ a is not b
 a and b
 a or b
 a not in b
+a not instanceof b
 a?
 </Playground>
 
@@ -513,13 +514,21 @@ obj.key ?= 'civet'
 <Playground>
 a < b <= c
 a is b is not c
-a instanceof b instanceof c
+a instanceof b not instanceof c
+</Playground>
+
+### `instanceof` shorthand
+
+<Playground>
+a <? b
+a !<? b
+a <? b !<? c
 </Playground>
 
 ### Rest
 
 Rest properties/parameters/elements are no longer limited to the final position.
-You may use them in ther first or middle positions as well.
+You may use them in their first or middle positions as well.
 
 <Playground>
 [...head, last] = [1, 2, 3, 4, 5]

--- a/civet.dev/index.md
+++ b/civet.dev/index.md
@@ -56,7 +56,7 @@ text = ```
 <Playground>
 a < b <= c
 a is b is not c
-a instanceof b instanceof c
+a instanceof b not instanceof c
 </Playground>
 
 ### Default to `const` for Iteration Items

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -159,8 +159,8 @@ Civet provides a compatibility prologue directive that aims to be 97+% compatibl
 | coffeeForLoops      | for in, of, from loops behave like they do in CoffeeScript |
 | coffeeInterpolation | `"a string with #{myVar}"` |
 | coffeeIsnt          | `isnt` → `!==` |
-| coffeeNot           | `not` → `!`, `a not instanceof b` → `!(a instanceof b)`, `a not of b` → `!(a in b)`    |
-| coffeeOf            | `a of b` → `a in b`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
+| coffeeNot           | `not` → `!`    |
+| coffeeOf            | `a of b` → `a in b`, `a not of b` → `!(a in b)`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
 | coffeePrototype     | enables `x::` -> `x.prototype` and `x::y` -> `x.prototype.y` shorthand.
 
 You can use these with `"civet coffeeCompat"` to opt in to all or use them bit by bit with `"civet coffeeComment coffeeEq coffeeInterpolation"`.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -79,7 +79,7 @@ ExplicitArguments
 # Start of function application, inserts an open parenthesis, maintains spacing and comments when possible
 ApplicationStart
   IndentedApplicationAllowed &NestedImplicitObjectLiteral
-  !EOS &( _+ !ForbiddenImplicitCalls )
+  !EOS &( _ !ForbiddenImplicitCalls )
 
 ForbiddenImplicitCalls
   # Reserved words that prevent spaced implicit function application
@@ -2042,6 +2042,14 @@ BinaryOpSymbol
       relational: true,
       special: true,
     }
+  "!<?" ->
+    return {
+      $loc,
+      token: "instanceof",
+      relational: true,
+      special: true,
+      negated: true,
+    }
   "<<"
   # NOTE: Avoid matching JSX opening tag by requiring non-identifier character
   # (e.g. whitespace) after "<".  This does forbid 1<2 or x<y.
@@ -2074,7 +2082,7 @@ BinaryOpSymbol
   CoffeeBinaryExistentialEnabled "?" -> "??"
   "instanceof" NonIdContinue ->
     return $1
-  CoffeeNotEnabled "not" NonIdContinue __ "instanceof" NonIdContinue ->
+  "not" NonIdContinue __ "instanceof" NonIdContinue ->
     return {
       $loc,
       token: "instanceof",
@@ -3611,10 +3619,8 @@ ReservedWord
   CoffeeIsntEnabled /(?:isnt)(?!\p{ID_Continue})/
   CoffeeForLoopsEnabled /(?:by)(?!\p{ID_Continue})/
   CoffeeOfEnabled /(?:of)(?!\p{ID_Continue})/
-  CoffeeNotEnabled /(?:not)(?!\p{ID_Continue})/
-  "not" NonIdContinue __ "in" NonIdContinue
   # NOTE: Added `let`, Civet assumes strict mode
-  /(?:and|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|null|or|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
+  /(?:and|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|not|null|or|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
 
 # https://262.ecma-international.org/#sec-comments
 Comment
@@ -5745,7 +5751,8 @@ Init
               children = [a, wsOp, ".", op.method, "(", wsB, b, ")"]
             }
           } else if (op.token) {
-            children = ["(", a, wsOp, op, wsB, b, ")"]
+            children = [a, wsOp, op, wsB, b]
+            if (op.negated) children = ["(", ...children, ")"]
           } else {
             throw new Error("Unknown operator: " + JSON.stringify(op))
           }

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -65,6 +65,7 @@ describe "binary operations", ->
     a != b
     a !== b
     a <? b
+    a !<? b
     ---
     a < b
     a > b
@@ -74,7 +75,8 @@ describe "binary operations", ->
     a === b
     a != b
     a !== b
-    (a instanceof b)
+    a instanceof b
+    !(a instanceof b)
   """
 
   testCase """
@@ -266,6 +268,14 @@ describe "binary operations", ->
     a instanceof b
     ---
     a instanceof b
+  """
+
+  testCase """
+    not instanceof
+    ---
+    a not instanceof b
+    ---
+    !(a instanceof b)
   """
 
   testCase """

--- a/test/chained-comparisons.civet
+++ b/test/chained-comparisons.civet
@@ -64,11 +64,11 @@ describe "chained comparisons", ->
   testCase """
     instanceof shorthand is relational
     ---
-    a <? b <? c
+    a <? b !<? c
     a <? b === c
     ---
-    (a instanceof b) && (b instanceof c)
-    (a instanceof b) && b === c
+    a instanceof b && !(b instanceof c)
+    a instanceof b && b === c
   """
 
   testCase """

--- a/test/compat/coffee-not.civet
+++ b/test/compat/coffee-not.civet
@@ -20,14 +20,6 @@ describe "coffeeNot", ->
   """
 
   testCase """
-    non-compat
-    ---
-    not a
-    ---
-    not(a)
-  """
-
-  testCase """
     not in
     ---
     "civet coffee-compat"

--- a/test/unary-expression.civet
+++ b/test/unary-expression.civet
@@ -24,3 +24,11 @@ describe "unary expression", ->
     ---
     typeof x
   """
+
+  testCase.skip """
+    not
+    ---
+    not a
+    ---
+    !a
+  """


### PR DESCRIPTION
* Make `not instanceof` always work, not just in `coffeeNot` mode. This mirrors existing `not in`, `is not`, etc.
* `!<?` shorthand for `not instanceof`
* Remove unneeded parens around `x <? y` expansion, which otherwise broke automatic semicolon insertion.
* Make `not` a reserved word, as we plan to add it in some form (paralleling `and` and `or` but maybe with different precedence than `coffeeNot`).