### PR TITLE
Escape `*/` in `###...###`, document `###` and `coffeeBoolean`

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -594,6 +594,15 @@ numbers[1...-1] = []
 a + b = c
 </Playground>
 
+### Block Comments
+
+<Playground>
+###
+block comment
+/* nested comment */
+###
+</Playground>
+
 ### `Object.is`
 
 The `"civet objectIs"` directive changes the behavior of the `is` operator to
@@ -814,13 +823,23 @@ X::
 X::a
 </Playground>
 
+### CoffeeScript Booleans
+
+<Playground>
+"civet coffeeBooleans"
+on
+off
+yes
+no
+</Playground>
+
 ### CoffeeScript Comments
+
+If you don't need private fields, you can enable `#` for single-line comments:
 
 <Playground>
 "civet coffeeComment"
 # one-line comment
-###
-block
-comment
-###
 </Playground>
+
+[`###...###` block comments](#block-comments) are always available.

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -47,7 +47,8 @@ Things Kept from CoffeeScript
 - Prefix or postfix rest/splats `[...a]`, `x = [a...]`
 - RestProperty in any position `{a, ...b, c} = d` → `{a, c, ...b} = d`
 - RestElement/RestParameter in any position `(first, ...midle, last) ->` → `function(first, ...middle) { let [last] = middle.splice(-1)}`
-- `///` Heregexp (with some [changes](#things-changed-from-coffeescript))
+- `///` heregexp (with some [changes](#things-changed-from-coffeescript))
+- `###` block comments (but allowing nested `*/`)
 - JSX [with improved shorthands and an optional nested syntax](../README.md#jsx-enhancements)
   (with some [changes](#things-changed-from-coffeescript))
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3652,7 +3652,8 @@ CoffeeSingleLineComment
     return { $loc, token: `//${$1}` }
 
 CoffeeMultiLineComment
-  CoffeeHereCommentStart $( !(CoffeeHereCommentStart / "*/") . )* CoffeeHereCommentStart ->
+  CoffeeHereCommentStart $/[^]*?###/ ->
+    $2 = $2.slice(0, $2.length-3).replace(/\*\//g, "* /")
     return { $loc, token: `/*${$2}*/` }
 
 CoffeeHereCommentStart

--- a/test/comment.civet
+++ b/test/comment.civet
@@ -35,12 +35,17 @@ describe "comment", ->
 
   """
 
-  it "doesn't allow */ in ### block comments", ->
-    throws """
-      ###
-      hi */
-      ###
-    """
+  testCase """
+    escapes */ in ### block comments
+    ---
+    ###
+    hi */
+    ###
+    ---
+    /*
+    hi * /
+    */
+  """
 
   testCase """
     remains after empty statement in nested block


### PR DESCRIPTION
This started as a documentation commit, but I discovered that `###...###` didn't support `*/` inside. That matches CoffeeScript behavior but not the existing behavior of JSX `<!--...-->` comments, and it was an easy copy/paste to make it work in both.  I think it's nice to have a way to comment out a block of code that already has `/*...*/` comments.