### PR TITLE
Improve super property support

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -619,16 +619,14 @@ NonNullAssertion
 MemberExpression
   # NOTE: "new" MemberExpression Arguments seems to be handled fine by other rules already
   # NOTE: Eliminated left recursion
-  PrimaryExpression MemberExpressionRest*:rest ->
-    if (rest.length) {
+  ( PrimaryExpression / SuperProperty / MetaProperty ) MemberExpressionRest*:rest ->
+    if (rest.length || Array.isArray($1)) {
       return {
         type: "MemberExpression",
-        children: [$1].concat(rest.flat()),
+        children: [$1, ...rest].flat(),
       }
     }
     return $1
-  SuperProperty
-  MetaProperty
 
 MemberExpressionRest
   # NOTE: Added shorthand x?[3] -> x?.[3]
@@ -767,7 +765,7 @@ PropertyAccess
     return p
 
 SuperProperty
-  "super[" PostfixedExpression __ CloseBracket
+  "super" MemberBracketContent
   "super" !( QuestionMark / NonNullAssertion ) PropertyAccess
 
 MetaProperty

--- a/test/class.civet
+++ b/test/class.civet
@@ -534,6 +534,34 @@ describe "class", ->
     }
   """
 
+  testCase """
+    super properties
+    ---
+    class A
+      f()
+        super.id
+    ---
+    class A {
+      f() {
+        return super.id
+      }
+    }
+  """
+
+  testCase """
+    super splice
+    ---
+    class A
+      f()
+        super[i...j]
+    ---
+    class A {
+      f() {
+        return super.slice(i, j)
+      }
+    }
+  """
+
   describe "anonymous", ->
     testCase """
       anonymous with static

--- a/test/object.civet
+++ b/test/object.civet
@@ -590,3 +590,28 @@ describe "object", ->
       ---
       ({[y]: x[y]})
     """
+
+    testCase """
+      super access
+      ---
+      {super.x}
+      ---
+      ({x: super.x})
+    """
+
+    testCase """
+      super member access
+      ---
+      {super[x]}
+      ---
+      ({[x]: super[x]})
+    """
+
+    describe "no meta properties", ->
+      throws """
+        {new.target}
+      """
+
+      throws """
+        {import.meta}
+      """


### PR DESCRIPTION
* Make `super` property access more like general property access
* `super[i...j]` and other splice forms (calls `super.splice`)
* `{super.foo}` and `{super[foo]}` object literal shorthand