### PR TITLE
xor/^^ and xnor/!^ operators

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -226,7 +226,21 @@ a instanceof "number"
 a not instanceof "number"
 </Playground>
 
+### Logical XOR Operator
+
+<Playground>
+a ^^ b
+a xor b
+</Playground>
+
+<Playground>
+a !^ b
+a xnor b
+</Playground>
+
 ### Modulo Operator
+
+`%` can return negative values, while `%%` is always between 0 and the divisor.
 
 <Playground>
 let a = -3

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5558,7 +5558,7 @@ Reset
           children: [": <T>(this: T[], searchElement: T) => boolean"]
         }
         // [indent, statement]
-        module.prelude.push(["", ["const ", indexOfRef, typeSuffix, " = [].indexOf", module.asAny, "\n"]])
+        module.prelude.push(["", ["const ", indexOfRef, typeSuffix, " = [].indexOf", module.asAny, ";\n"]])
       },
       hasProp(hasPropRef) {
         const typeSuffix = {
@@ -5566,7 +5566,7 @@ Reset
           children: [": <T>(this: T, prop: keyof T) => boolean"]
         }
         // [indent, statement]
-        module.prelude.push(["", ["const ", hasPropRef, typeSuffix, " = {}.hasOwnProperty", module.asAny, "\n"]])
+        module.prelude.push(["", ["const ", hasPropRef, typeSuffix, " = {}.hasOwnProperty", module.asAny, ";\n"]])
       },
       is(isRef) {
         // Thanks to @thetarnav for help with this TypeScript magic.
@@ -5581,7 +5581,7 @@ Reset
           children: [": { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B }"]
         }
         // [indent, statement]
-        module.prelude.push(["", ["const ", isRef, typeSuffix, " = Object.is", module.asAny, "\n"]])
+        module.prelude.push(["", ["const ", isRef, typeSuffix, " = Object.is", module.asAny, ";\n"]])
       },
       modulo(moduloRef) {
         const typeSuffix = {
@@ -5589,7 +5589,7 @@ Reset
           children: [": (a: number, b: number) => number"]
         }
         // [indent, statement]
-        module.prelude.push(["", ["const ", moduloRef, typeSuffix, " = (a, b) => (a % b + b) % b", "\n"]])
+        module.prelude.push(["", ["const ", moduloRef, typeSuffix, " = (a, b) => (a % b + b) % b;", "\n"]])
       },
       returnSymbol(ref) {
         module.prelude.push({

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -84,7 +84,7 @@ ApplicationStart
 ForbiddenImplicitCalls
   # Reserved words that prevent spaced implicit function application
   # ie: the 'of' in 'for x of ...'
-  /(as|for|while|until|of|satisfies|then|when|implements)(?!\p{ID_Continue}|[\u200C\u200D$])/
+  /(as|for|while|until|of|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
   # NOTE: Don't allow non-heregex regexes that begin with a space as first argument without parens
   "/ "
   AtAt # experimentalDecorators
@@ -615,7 +615,8 @@ OptionalDot
   ( Dot / InsertDot )
 
 NonNullAssertion
-  "!" -> { type: "NonNullAssertion", ts: true, children: $1 }
+  # NOTE: Prevent shadowing !^ xnor operator
+  "!" !"^" -> { type: "NonNullAssertion", ts: true, children: $1 }
 
 # https://262.ecma-international.org/#prod-MemberExpression
 MemberExpression
@@ -2400,6 +2401,17 @@ BinaryOpSymbol
   CoffeeOfEnabled "of" NonIdContinue -> "in"
   "or" NonIdContinue -> "||"
   "||"
+  # NOTE: ^^ must be above ^
+  "^^" / ( "xor" NonIdContinue ) ->
+    return {
+      call: module.getRef("xor"),
+      special: true,
+    }
+  /!\^\^?/ / ( "xnor" NonIdContinue ) ->
+    return {
+      call: module.getRef("xnor"),
+      special: true,
+    }
   "??"
   CoffeeBinaryExistentialEnabled "?" -> "??"
   "instanceof" NonIdContinue ->
@@ -5590,6 +5602,22 @@ Reset
         }
         // [indent, statement]
         module.prelude.push(["", ["const ", moduloRef, typeSuffix, " = (a, b) => (a % b + b) % b;", "\n"]])
+      },
+      xor(xorRef) {
+        const typeSuffix = {
+          ts: true,
+          children: [": (a: unknown, b: unknown) => boolean"]
+        }
+        // [indent, statement]
+        module.prelude.push(["", ["const ", xorRef, typeSuffix, " = (a, b) => a && b ? false : a || b;", "\n"]])
+      },
+      xnor(xnorRef) {
+        const typeSuffix = {
+          ts: true,
+          children: [": (a: unknown, b: unknown) => boolean"]
+        }
+        // [indent, statement]
+        module.prelude.push(["", ["const ", xnorRef, typeSuffix, " = (a, b) => a || b ? a && b : true;", "\n"]])
       },
       returnSymbol(ref) {
         module.prelude.push({

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2291,6 +2291,18 @@ AssignmentOp
 # This is separate from AssignmentOp because it only works in certain contexts
 # (in particular, not at the beginning of a line).
 OperatorAssignmentOp
+  Xor "=" &Whitespace TrailingComment* ->
+    return {
+      special: true,
+      call: module.getRef("xor"),
+      children: [$2, ...$4]
+    }
+  Xnor "=" &Whitespace TrailingComment* ->
+    return {
+      special: true,
+      call: module.getRef("xnor"),
+      children: [$2, ...$4]
+    }
   Identifier "=" &Whitespace TrailingComment* ->
     return {
       special: true,
@@ -2495,6 +2507,11 @@ BinaryOpSymbol
   "&"
   "^"
   "|"
+
+Xor
+  "^^" / ( "xor" NonIdContinue )
+Xnor
+  /!\^\^?/ / "xnor"
 
 UnaryOp
   # Lookahead to prevent unary operators from overriding block unary operator shorthand

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -347,6 +347,40 @@ describe "assignment", ->
     a = b
   """
 
+  testCase """
+    word assignment operators
+    ---
+    a and= b
+    a or= b
+    ---
+    a &&= b
+    a ||= b
+  """
+
+  testCase """
+    xor assignment
+    ---
+    a xor= b
+    a ^^= b
+    ---
+    const xor: (a: unknown, b: unknown) => boolean = (a, b) => a && b ? false : a || b;
+    a = xor(a, b)
+    a = xor(a, b)
+  """
+
+  testCase """
+    xnor assignment
+    ---
+    a xnor= b
+    a !^= b
+    a !^^= b
+    ---
+    const xnor: (a: unknown, b: unknown) => boolean = (a, b) => a || b ? a && b : true;
+    a = xnor(a, b)
+    a = xnor(a, b)
+    a = xnor(a, b)
+  """
+
   // TOMAYBE: Static semantics https://262.ecma-international.org/#sec-static-semantics-assignmenttargettype
   testCase """
     illegal assignment with function call

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -245,6 +245,36 @@ describe "binary operations", ->
   """
 
   testCase """
+    xor
+    ---
+    a^^b
+    a ^^ b
+    a xor b
+    ---
+    const xor: (a: unknown, b: unknown) => boolean = (a, b) => a && b ? false : a || b;
+    xor(a,b)
+    xor(a, b)
+    xor(a, b)
+  """
+
+  testCase """
+    xnor
+    ---
+    a!^b
+    a!^^b
+    a !^ b
+    a !^^ b
+    a xnor b
+    ---
+    const xnor: (a: unknown, b: unknown) => boolean = (a, b) => a || b ? a && b : true;
+    xnor(a,b)
+    xnor(a,b)
+    xnor(a, b)
+    xnor(a, b)
+    xnor(a, b)
+  """
+
+  testCase """
     weird spacing
     ---
     a

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -30,7 +30,7 @@ describe "binary operations", ->
     ---
     a %% b
     ---
-    const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b
+    const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
     modulo(a, b)
   """
 
@@ -39,7 +39,7 @@ describe "binary operations", ->
     ---
     a %% b %% c
     ---
-    const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b
+    const modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
     modulo(modulo(a, b), c)
   """
 
@@ -116,7 +116,7 @@ describe "binary operations", ->
       "civet objectIs"
       a is b
       ---
-      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any
+      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
       is(a, b)
     """
 
@@ -126,7 +126,7 @@ describe "binary operations", ->
       "civet objectIs"
       a is not b
       ---
-      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any
+      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
       !is(a, b)
     """
 
@@ -136,7 +136,7 @@ describe "binary operations", ->
       "civet objectIs"
       a is true
       ---
-      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any
+      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
       is(a, true as const)
     """
 
@@ -146,7 +146,7 @@ describe "binary operations", ->
       "civet objectIs"
       a is 0
       ---
-      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any
+      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
       is(a, 0 as const)
     """
 
@@ -156,7 +156,7 @@ describe "binary operations", ->
       "civet objectIs"
       a is "hello"
       ---
-      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any
+      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
       is(a, "hello" as const)
     """
 
@@ -166,7 +166,7 @@ describe "binary operations", ->
       "civet objectIs"
       a is null is undefined
       ---
-      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any
+      const is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
       is(a, null) && is(null, undefined)
     """
 

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -128,7 +128,7 @@ describe "coffeeForLoops", ->
     coffees = (s for s in scripts when s.type in coffeetypes)
     ---
     var coffees, s
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     coffees = (()=>{const results=[];for (let i = 0, len = scripts.length; i < len; i++) {
       s = scripts[i]
       if (!(indexOf.call(coffeetypes, s.type) >= 0)) continue
@@ -254,7 +254,7 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a
-    const hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any
+    const hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
     for (a in b) {
       if (!hasProp.call(b, a)) continue
       console.log(a)
@@ -268,7 +268,7 @@ describe "coffeeForLoops", ->
     log(a) for own a of b when a != "y"
     ---
     var a
-    const hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any
+    const hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
     for (a in b) {
       if (!hasProp.call(b, a)) continue
       if (!(a !== "y")) continue

--- a/test/compat/coffee-not.civet
+++ b/test/compat/coffee-not.civet
@@ -25,7 +25,7 @@ describe "coffeeNot", ->
     "civet coffee-compat"
     a not in b
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     indexOf.call(b, a) < 0
   """
 

--- a/test/compat/coffee-of.civet
+++ b/test/compat/coffee-of.civet
@@ -7,7 +7,7 @@ describe "coffeeOf", ->
     "civet coffee-compat"
     a in b
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     indexOf.call(b, a) >= 0
   """
 
@@ -17,7 +17,7 @@ describe "coffeeOf", ->
     "civet coffeeCompat"
     s.type in coffeetypes
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     indexOf.call(coffeetypes, s.type) >= 0
   """
 
@@ -27,7 +27,7 @@ describe "coffeeOf", ->
     "civet coffee-compat"
     a not in b
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     indexOf.call(b, a) < 0
   """
 
@@ -38,7 +38,7 @@ describe "coffeeOf", ->
     import {indexOf} from 'lodash'
     a in b
     ---
-    const indexOf1: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf1: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     import {indexOf} from 'lodash'
     indexOf1.call(b, a) >= 0
   """
@@ -49,7 +49,7 @@ describe "coffeeOf", ->
     "civet coffee-compat"
     a in b or c
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     indexOf.call(b, a) >= 0 || c
   """
 
@@ -59,7 +59,7 @@ describe "coffeeOf", ->
     "civet coffee-compat"
     a in b in d
     ---
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     indexOf.call(b, a) >= 0 && indexOf.call(d, b) >= 0
   """
 
@@ -71,7 +71,7 @@ describe "coffeeOf", ->
     a in b
     ---
     var a
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     a = 3
     indexOf.call(b, a) >= 0
   """

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -44,7 +44,7 @@ describe "example code", ->
         'IDENTIFIER'
     ---
     var tag
-    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any
+    const indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     tag =
       (colon || prev != null &&
          (indexOf.call(['.', '?.', '::', '?::'], prev[0]) >= 0 ||


### PR DESCRIPTION
As suggested by @samualtnorman:
* `^^` and `xor` are logical XOR operators (but `xor` is not a reserved word), to `^` as `||` is to `|`.
* `!^` and `!^^` and `xnor` are logical XNOR operators (logical equality), by analogy to `!=`/`!==`. (Should I add `not xor` too?)
* Assignment versions of all of the above, e.g., `xor=`

Normally I'd write these as `Boolean(a) !== Boolean(b)` and `Boolean(a) === Boolean(b)`, respectively. But `xor` has a much more clear meaning, and these should shortcut properly and use `a` or `b` as values instead of `true` and `false` whenever possible, similar to `&&` and `||`.

In a separate commit, added semicolons to prelude ref declarations; otherwise a `(` on the next line will prevent automatic semicolon insertion. For example, [`(x %% y)` in the first line compiles incorrectly](https://civet.dev/playground?code=KHggJSUgeSk%3D).  (We may need to do this for `autoVar` too.)