### PR TITLE
Spreads in object globs

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -58,6 +58,8 @@ point = data{x,y}
 point = data.{x,y};
 point.{x,y} = data
 complex := obj.{x:a, b.c()?.y}
+merged := data.{...global, ...user};
+data.{a, b, ...rest} = result
 </Playground>
 
 Flagging shorthand inspired by [LiveScript](https://livescript.net/#literals-objects):

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2001,6 +2001,7 @@ PropertyDefinitionList
     return $0.map(([prop, delim]) => {
       return {
         ...prop,
+        delim,
         children: [...prop.children, delim],
       }
     })
@@ -2047,7 +2048,8 @@ PropertyDefinition
       type: "SpreadProperty",
       children: [ws, dots, exp],
       names: exp.names,
-      value: [dots, exp],
+      dots,
+      value: exp,
     }
   # NOTE: Added `{x.y?.z()}` shorthand for `{z: x.y?.z()}`
   # NOTE: this needs to be at the bottom to prevent shadowing NamedProperty
@@ -4738,7 +4740,7 @@ JSXAttribute
           }
           break
         case 'SpreadProperty':
-          parts.push(['{', part.value, '}'])
+          parts.push(['{', part.dots, part.value, '}'])
           break
         case 'MethodDefinition':
           try {
@@ -5829,35 +5831,43 @@ Init
           .concat(glob.children[0]) // dot
           const parts = []
           for (const part of glob.object.content) {
-            // TODO: could maybe support ...spread via ref assignment
-            if (part.type === "SpreadProperty") {
-              throw new Error("Glob pattern cannot have ...spread property")
-            }
             if (part.type === "MethodDefinition") {
               throw new Error("Glob pattern cannot have method definition")
             }
             if (part.value && !["CallExpression", "MemberExpression", "Identifier"].includes(part.value.type)) {
               throw new Error("Glob pattern must have call or member expression value")
             }
-            const {name} = part
             let value = part.value ?? part.name
             const wValue = module.getTrimmingSpace(part.value)
             value = prefix.concat(module.insertTrimmingSpace(value, ""))
             if (wValue) value.unshift(wValue)
-            parts.push({
-              type: "Property",
-              name,
-              value,
-              names: part.names,
-              children: [
-                module.isWhitespaceOrEmpty(part.children[0]) && part.children[0],
-                name,
-                module.isWhitespaceOrEmpty(part.children[2]) && part.children[2],
-                part.children[3]?.token === ":" ? part.children[3] : ":",
+            if (part.type === "SpreadProperty") {
+              parts.push({
+                type: part.type,
                 value,
-                part.children[part.children.length-1], // comma delimiter
-              ]
-            })
+                dots: part.dots,
+                delim: part.delim,
+                names: part.names,
+                children: part.children.slice(0, 2) // whitespace, ...
+                          .concat(value, part.delim)
+              })
+            } else {
+              parts.push({
+                type: part.type,
+                name: part.name,
+                value,
+                delim: part.delim,
+                names: part.names,
+                children: [
+                  module.isWhitespaceOrEmpty(part.children[0]) && part.children[0],
+                  part.name,
+                  module.isWhitespaceOrEmpty(part.children[2]) && part.children[2],
+                  part.children[3]?.token === ":" ? part.children[3] : ":",
+                  value,
+                  part.delim, // comma delimiter
+                ]
+              })
+            }
           }
           const object = {
             type: "ObjectExpression",

--- a/test/object.civet
+++ b/test/object.civet
@@ -698,17 +698,28 @@ describe "object", ->
       ({ a:obj.a, b: obj.c, d : obj.e } = x)
     """
 
-    describe "no initializer", ->
+    testCase """
+      ...spread
+      ---
+      obj.{...a, ... b}
+      ---
+      ({...obj.a, ... obj.b})
+    """
+
+    testCase """
+      ...spread assignment
+      ---
+      obj.{a, b, ...rest} = x
+      ---
+      ({a:obj.a, b:obj.b, ...obj.rest} = x)
+    """
+
+    it "no initializer", ->
       throws """
         obj.{a, b=5}
       """
 
-    describe "no ...spread", ->
-      throws """
-        obj.{...spread}
-      """
-
-    describe "no +/- flags", ->
+    it "no +/- flags", ->
       throws """
         obj.{+x}
       """
@@ -719,7 +730,7 @@ describe "object", ->
         obj.{!x}
       """
 
-    describe "no general expressions", ->
+    it "no general expressions", ->
       throws """
         obj.{x: a+b}
       """


### PR DESCRIPTION
(More of part 4 of #238.)

### Assignment form:
`obj.{a, b, ...rest} = data` → `{a:obj.a, b:obj.b, ...obj.rest} = data`
* This is clearly the right thing.

### Object literal form:
`obj.{a, b, ...c}` → `{a:obj.a, b:obj.b, ...obj.c}`
* This is useful e.g. to merge subobjects: `obj.{...defaults, ...globals, ...user}` → `{...obj.defaults, ...obj.globals, ...obj.users}`
* Also clearly mirrors the assignment form.
* Originally I thought that `obj.{a, b, ...c}` should mean something like `{a, b, ...c} = obj, {a, b, c}`, i.e., extract the "rest" into `c` and make it into an attribute. But I think this is a little too magical, restricted to a single `...spread`, and isn't actually the intuitive thing for a non-assignment. The fact that the implemented syntax does this for actual assignments suggests it's the right thing in both cases.