### PR TITLE
Inner assignments within assignment chains

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6880,7 +6880,7 @@ Init
     function processAssignments(statements) {
       gatherRecursiveAll(statements, n => n.type === "AssignmentExpression" && n.names === null)
       .forEach(exp => {
-        let {lhs: $1, exp: $2} = exp, tail = [], i = 0, len = $1.length
+        let {lhs: $1, exp: $2} = exp, pre = [], tail = [], i = 0, len = $1.length
 
         // identifier=
         if ($1.some((left) => left[left.length-1].special)) {
@@ -6894,6 +6894,20 @@ Init
           // Wrap right-hand side with call
           $2 = [ call, "(", lhs, ", ", $2, ")" ]
         }
+
+        // Move assignments within LHS to run earlier via comma operator
+        $1.forEach((lhsPart, i) => {
+          let expr = lhsPart[1]
+          while (expr.type === "ParenthesizedExpression") {
+            expr = expr.expression
+          }
+          if (expr.type === "AssignmentExpression") {
+            pre.push([lhsPart[1], ", "])
+            const newLhs = expr.lhs[0][1]
+            // TODO: use ref to avoid duplicating function calls
+            lhsPart[1] = newLhs
+          }
+        })
 
         // Force parens around destructuring object assignments
         // Walk from left to right the minimal number of parens are added and enclose all destructured assignments
@@ -6966,7 +6980,7 @@ Init
 
         // Gather all identifier names from the lhs array
         const names = $1.flatMap(([,l]) => l.names || [])
-        exp.children = [$1, $2, ...tail]
+        exp.children = [...pre, $1, $2, ...tail]
         exp.names = names
       })
     }

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -390,6 +390,39 @@ describe "assignment", ->
     a() = b
   """
 
+  describe "inner assignment operators", ->
+    testCase """
+      initialize and increment
+      ---
+      (x ?= 0) += 1
+      ---
+      (x ?= 0), x += 1
+    """
+
+    testCase """
+      double initialize and increment
+      ---
+      (x ?= 0) += (y ?= 0) + 1
+      ---
+      (x ??= 0), (y ??= 0), x += y += 1
+    """
+
+    testCase """
+      add and multiply
+      ---
+      (x += 1) *= 2
+      ---
+      (x += 1), x *= 2
+    """
+
+    testCase.skip """
+      initialize and ++
+      ---
+      (x ?= 0)++
+      ---
+      (x ?= 0), x++
+    """
+
   describe "function assignment operator", ->
     testCase """
       space on both sides

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -396,13 +396,13 @@ describe "assignment", ->
       ---
       (x ?= 0) += 1
       ---
-      (x ?= 0), x += 1
+      (x ??= 0), x += 1
     """
 
     testCase """
       double initialize and increment
       ---
-      (x ?= 0) += (y ?= 0) + 1
+      (x ?= 0) += (y ?= 0) += 1
       ---
       (x ??= 0), (y ??= 0), x += y += 1
     """
@@ -420,7 +420,7 @@ describe "assignment", ->
       ---
       (x ?= 0)++
       ---
-      (x ?= 0), x++
+      (x ??= 0), x++
     """
 
   describe "function assignment operator", ->


### PR DESCRIPTION
One idea from #317:

```js
(obj[key] ?= 0) += 1
---
(obj[key] ?= 0), obj[key] += 1
```

Now though I wonder whether assignment expressions is actually the right time to do this, because another natural example `(x ?= 0)++` does not work.  (Well, Civet is fine with it and leaves it as is, but JS is not fine with it, as `x ?= 0` is not a valid LHS, which is what this PR is trying to fix.)  I'd appreciate suggestions on *where* to do this transformation.  Currently the AST doesn't have the ability to go to the parent node, which makes it hard to look at all assignments and then replace itself.  I guess the `AssignmentExpression` node could rewrite its own contents (and even become a different type of node), but I don't know how (or even where) to add the assignment operation as a "pre" operation...

This might still be worth merging for now, as it does work, and is presumably useful. But also happy to rework it.