### PR TITLE
Test helper `throws` supports description and ---

### DIFF
--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -399,10 +399,11 @@ describe "assignment", ->
       x.y = min(x.y, z())
     """
 
-    it "need space on left", ->
-      throws """
-        {x}min= y
-      """
+    throws """
+      need space on left
+      ---
+      {x}min= y
+    """
 
     testCase """
       need space on right
@@ -422,7 +423,8 @@ describe "assignment", ->
       min=y
     """
 
-    it "not form doesn't work", ->
-      throws """
-        x not min= y
-      """
+    throws """
+      not form doesn't work
+      ---
+      x not min= y
+    """

--- a/test/conditional.civet
+++ b/test/conditional.civet
@@ -17,7 +17,8 @@ describe "conditional", ->
     x ? {a: b} : {c: d}
   """
 
-  it "needs space before ?", ->
-    throws """
-      x? y : z
-    """
+  throws """
+    needs space before ?
+    ---
+    x? y : z
+  """

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -403,8 +403,11 @@ describe "function application", ->
   """
 
   // TODO: Maybe this could be allowed eventually
-  it "x of then", ->
-    throws "x then"
+  throws """
+    x of then
+    ---
+    x then
+  """
 
   testCase """
     function application with implicit object key name starts with null keyword

--- a/test/function.civet
+++ b/test/function.civet
@@ -267,11 +267,12 @@ describe "function", ->
     })
   """
 
-  it "doesn't allow import inside of function ", ->
-    throws """
-      (x) ->
-        import * from 'x'
-    """
+  throws """
+    doesn't allow import inside of function
+    ---
+    (x) ->
+      import * from 'x'
+  """
 
   testCase """
     fat arrow

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -44,14 +44,9 @@ testCase.js = (text: string) ->
 
 throws := (text: string, opt?: "only" | "skip") ->
   let [desc, src] = text.split("\n---\n")
+  throw new Error "Missing code block" unless src
 
-  let fn
-  if src?
-    fn = opt ? it[opt] : it
-  else
-    // Backward compatibility mode: just code, no description
-    src = desc
-    fn = (_desc: string, x: () => void) => x()
+  fn := opt ? it[opt] : it
 
   fn desc, ->
     let e: unknown, result: string

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -26,11 +26,7 @@ compare := (src: string, result: string, compilerOpts: any) ->
 testCase := (text: string, opt?: "only" | "skip", compilerOpts: any={}) ->
   [desc, src, result] := text.split("\n---\n")
 
-  let fn
-  if opt
-    fn = it[opt]
-  else
-    fn = it
+  fn := opt ? it[opt] : it
 
   fn desc, ->
     compare src, result, {
@@ -38,34 +34,45 @@ testCase := (text: string, opt?: "only" | "skip", compilerOpts: any={}) ->
       ...compilerOpts
     }
 
-testCase.only = (text: string) ->
-  testCase(text, "only")
-
-testCase.skip = (text: string) ->
-  testCase(text, "skip")
+testCase.only = (text: string) -> testCase text, "only"
+testCase.skip = (text: string) -> testCase text, "skip"
 
 testCase.js = (text: string) ->
   testCase(text, undefined, {
     js: true
   })
 
-throws := (src: string) ->
-  let e: unknown, result: string
-  try
-    result = compile src, {
-      cache
-    }
-  catch caught
-    e = caught
-  assert.throws => e && throw e, (undefined as any), """
+throws := (text: string, opt?: "only" | "skip") ->
+  let [desc, src] = text.split("\n---\n")
 
-    --- Source   ---
-    #{src}
+  let fn
+  if src?
+    fn = opt ? it[opt] : it
+  else
+    // Backward compatibility mode: just code, no description
+    src = desc
+    fn = (_desc: string, x: () => void) => x()
 
-    --- Got      ---
-    #{result!}
+  fn desc, ->
+    let e: unknown, result: string
+    try
+      result = compile src, {
+        cache
+      }
+    catch caught
+      e = caught
+    assert.throws => e && throw e, (undefined as any), """
 
-  """
+      --- Source   ---
+      #{src}
+
+      --- Got      ---
+      #{result!}
+
+    """
+
+throws.only = (text: string) -> testCase text, "only"
+throws.skip = (text: string) -> testCase text, "skip"
 
 evalsTo := (src: string, value: any) ->
   result := eval compile src, {

--- a/test/if.civet
+++ b/test/if.civet
@@ -59,15 +59,16 @@ describe "if", ->
     }
   """
 
-  it "invalid indentation", ->
-    throws """
-      ->
-        if x
-          if y
-            a
-      else
-        c
-    """
+  throws """
+    invalid indentation
+    ---
+    ->
+      if x
+        if y
+          a
+    else
+      c
+  """
 
   testCase """
     if inline

--- a/test/indent.civet
+++ b/test/indent.civet
@@ -136,12 +136,13 @@ describe "indent", ->
     }
   """
 
-  it "mismatched custom tabs and spaces", ->
-    throws """
-      "civet tab=3"
-      if true
-        if false
-          return true
-      \telse
-      \t\treturn false
-    """
+  throws """
+    mismatched custom tabs and spaces
+    ---
+    "civet tab=3"
+    if true
+      if false
+        return true
+    \telse
+    \t\treturn false
+  """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -55,10 +55,11 @@ describe "braced JSX attributes", ->
      t={`string ${interpolation}`} p={((cond)? 1 : 2)} />
   """
 
-  it "if expressions", ->
-    throws """
-      <Component c=if cond then 1 else 2 />
-    """
+  throws """
+    if expressions
+    ---
+    <Component c=if cond then 1 else 2 />
+  """
 
   testCase """
     function calls
@@ -100,10 +101,11 @@ describe "braced JSX attributes", ->
     <Component sum={1+2+x} calls={f()+g()} />
   """
 
-  it "binary expressions with spaces", ->
-    throws """
-      <Component sum=1 + 2 />
-    """
+  throws """
+    binary expressions with spaces
+    ---
+    <Component sum=1 + 2 />
+  """
 
   testCase """
     ...foo shorthand
@@ -330,10 +332,11 @@ describe "JSX class shorthand", ->
     <div class="y" x />
   """
 
-  it "requires space between attribute and class shorthand", ->
-    throws """
-      <div x.y>
-    """
+  throws """
+    requires space between attribute and class shorthand
+    ---
+    <div x.y>
+  """
 
 describe "JSX LiveScript-like toggles", ->
   testCase """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -106,13 +106,14 @@ describe "Indentation-based JSX", ->
     )
   """
 
-  it "improperly indented children fails", ->
-    throws """
-      return
-        <div>
-      console.log 'unreachable'
-        </div>
-    """
+  throws """
+    improperly indented children fails
+    ---
+    return
+      <div>
+    console.log 'unreachable'
+      </div>
+  """
 
   testCase """
     indented fragments
@@ -546,10 +547,11 @@ describe "Unbraced function children in JSX", ->
     </For>
   """
 
-  it "doesn't work on same line as text", ->
-    throws """
-      <For each={items}> Hello (item) => <li>{item}
-    """
+  throws """
+    doesn't work on same line as text
+    ---
+    <For each={items}> Hello (item) => <li>{item}
+  """
 
   testCase """
     with if expression

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -101,10 +101,11 @@ describe "JSX", ->
     <h1 title={(x < 10)?"Hello":void 0}/>
   """
 
-  it "throws with mismatched tags", ->
-    throws """
-      <h1>{text}</h2>
-    """
+  throws """
+    throws with mismatched tags
+    ---
+    <h1>{text}</h2>
+  """
 
   testCase """
     elements as attributes

--- a/test/numbers.civet
+++ b/test/numbers.civet
@@ -73,10 +73,11 @@ describe "numbers", ->
     hello2.toString()
   """
 
-  it "throws when double dotting", ->
-    throws """
-      1..toString()
-    """
+  throws """
+    throws when double dotting
+    ---
+    1..toString()
+  """
 
   testCase """
     method calls using optional accessor

--- a/test/object.civet
+++ b/test/object.civet
@@ -189,22 +189,29 @@ describe "object", ->
     }
   """
 
-  it "doesn't allow bare assignments inside", ->
-    throws """
-      {x=y}
-    """
+  throws """
+    doesn't allow bare assignments inside
+    ---
+    {x=y}
+  """
 
-    throws """
-      {x+=y}
-    """
+  throws """
+    doesn't allow update assignments inside
+    ---
+    {x+=y}
+  """
 
-    throws """
-      {x-=y}
-    """
+  throws """
+    doesn't allow update assignments inside
+    ---
+    {x-=y}
+  """
 
-    throws """
-      {x<=y}
-    """
+  throws """
+    doesn't allow comparisons inside
+    ---
+    {x<=y}
+  """
 
   testCase """
     allows for extra newlines and whitespace with braces

--- a/test/object.civet
+++ b/test/object.civet
@@ -623,14 +623,17 @@ describe "object", ->
       ({[x]: super[x]})
     """
 
-    it "no meta properties", ->
-      throws """
-        {new.target}
-      """
+    throws """
+      no new properties
+      ---
+      {new.target}
+    """
 
-      throws """
-        {import.meta}
-      """
+    throws """
+      no meta properties
+      ---
+      {import.meta}
+    """
 
   describe "object globs", ->
     testCase """
@@ -714,23 +717,30 @@ describe "object", ->
       ({a:obj.a, b:obj.b, ...obj.rest} = x)
     """
 
-    it "no initializer", ->
-      throws """
-        obj.{a, b=5}
-      """
+    throws """
+      no initializer
+      ---
+      obj.{a, b=5}
+    """
 
-    it "no +/- flags", ->
-      throws """
-        obj.{+x}
-      """
-      throws """
-        obj.{-x}
-      """
-      throws """
-        obj.{!x}
-      """
+    throws """
+      no + flags
+      ---
+      obj.{+x}
+    """
+    throws """
+      no - flags
+      ---
+      obj.{-x}
+    """
+    throws """
+      no ! flags
+      ---
+      obj.{!x}
+    """
 
-    it "no general expressions", ->
-      throws """
-        obj.{x: a+b}
-      """
+    throws """
+      no general expressions
+      ---
+      obj.{x: a+b}
+    """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -219,11 +219,14 @@ describe "pipe", ->
     """
 
   describe "assignment outside of first position", ->
-    it "doesn't allow assignment outside of first position", ->
-      throws """
-        a |> b |>= c
-      """
+    throws """
+      pipe then assign
+      ---
+      a |> b |>= c
+    """
 
-      throws """
-        a |>= b |>= c |>= d |>= e
-      """
+    throws """
+      multiple assigns
+      ---
+      a |>= b |>= c |>= d |>= e
+    """

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -57,10 +57,11 @@ describe "regexp", ->
     /(?:\\p{ID_Continue}|[\\u200C\\u200D$])*/
   """
 
-  it "throws when regexp is actually unclosed comment", ->
-    throws """
-      /*/
-    """
+  throws """
+    throws when regexp is actually unclosed comment
+    ---
+    /*/
+  """
 
   describe "don't parse as implicit function arguments", ->
     testCase """


### PR DESCRIPTION
While still offering backward-compatible mode of just code (still used in some batch tests)