### PR TITLE
Support for labeling statements

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2554,6 +2554,10 @@ Statement
 
   EmptyStatement
 
+  # NOTE: LabelledStatment is before ExpressionStatement so that `$:` is
+  # treated as a label, not an implicit object literal, for Svelte compatibility
+  LabelledStatement
+
   # Wrap object literal with parens to disambiguate from block statements.
   # Also wrap nameless functions from `->` expressions with parens
   # as needed in JS.
@@ -2568,7 +2572,6 @@ Statement
   BlockStatement
 
   # NOTE: no WithStatement
-  # NOTE: no LabelledStatement
 
 # NOTE: EmptyStatement handled differently than spec, consuming inline whitespace and comments then asserting following semi-colon
 EmptyStatement
@@ -2578,6 +2581,21 @@ EmptyStatement
 BlockStatement
   # NOTE: Added lookahead for `=` to allow for destructuring assignment without parens
   ExplicitBlock !( __ "=" ) -> $1
+
+# https://262.ecma-international.org/#prod-LabelledStatement
+LabelledStatement
+  Label LabelledItem
+
+Label
+  # NOTE: `:label` instead of `label:` to not clash with implicit object literal
+  Colon:colon Identifier:id Whitespace:w ->
+    return [ id, colon, w ]
+  # NOTE: Make $: into label, not implicit object literal, for Svelte compat
+  "$:" Whitespace
+
+LabelledItem
+  Statement
+  FunctionDeclaration
 
 # https://262.ecma-international.org/#prod-IfStatement
 IfStatement


### PR DESCRIPTION
`:label` or `$:` for Svelte

This is enough for Svelte compatibility (#351).

But we should also add label support to `break` and `continue`. I just think we should discuss the other potential uses mentioned in  https://github.com/DanielXMoore/Civet/discussions/312#discussioncomment-4832062 first.