### PR TITLE
Declare and update return.value

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -412,6 +412,14 @@ function search(list)
   list.destroy()
 </Playground>
 
+<Playground>
+function search<T>(list: T[], pred: (T) => boolean)
+  let return: number | undefined
+  if list
+    return = list.findIndex pred
+    list.splice return.value, 1
+</Playground>
+
 ### Single-Argument Function Shorthand
 
 <Playground>

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -395,6 +395,23 @@ circle := (degrees: number): {x: number, y: number} =>
   y: Math.sin theta
 </Playground>
 
+### `return.value`
+
+Instead of specifying a function's return value when it returns,
+you can prepare it ahead of time using `return.value`
+(or its shorthand, assigning to `return`).
+Using this feature disables implicit `return` for that function.
+
+<Playground>
+function search(list)
+  return unless list
+  for item of list
+    if match item
+      return = item
+  return++ if return.value
+  list.destroy()
+</Playground>
+
 ### Single-Argument Function Shorthand
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -594,7 +594,7 @@ CallExpression
     })
   # NOTE: Special `return.value` (and `return =` shorthand)
   # for changing the automatic return value of function
-  ( "return.value" NonIdContinue ) / ( "return" &WAssignmentOp ) ->
+  ( "return.value" NonIdContinue ) / ( Return &( WAssignmentOp / UpdateExpressionSymbol ) ) ->
     return { type: "ReturnValue", children: $0 }
 
   MemberExpression:member AllowedTrailingMemberExpressions:trailing CallExpressionRest*:rest ->
@@ -3441,7 +3441,7 @@ KeywordStatement
 
   # https://262.ecma-international.org/#prod-ReturnStatement
   # NOTE: Modified to leave room for `return.value` and `return =`
-  Return !("." / WAssignmentOp) MaybeNestedExpression?:expression -> {
+  Return !("." / WAssignmentOp / UpdateExpressionSymbol) MaybeNestedExpression?:expression -> {
     type: "ReturnStatement",
     expression,
     children: $0,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -592,10 +592,7 @@ CallExpression
       type: "CallExpression",
       children: [$1, ...$2, ...rest.flat()],
     })
-  # NOTE: Special `return.value` (and `return =` shorthand)
-  # for changing the automatic return value of function
-  ( "return.value" NonIdContinue ) / ( Return &( WAssignmentOp / UpdateExpressionSymbol ) ) ->
-    return { type: "ReturnValue", children: $0 }
+  ReturnValue
 
   MemberExpression:member AllowedTrailingMemberExpressions:trailing CallExpressionRest*:rest ->
     if (rest.length || trailing.length) {
@@ -607,6 +604,19 @@ CallExpression
     }
 
     return member
+
+# NOTE: Special `return.value` (and `return =` shorthand)
+# for changing the automatic return value of function
+ReturnValue
+  ( "return.value" NonIdContinue ) / ( Return &AfterReturnShorthand ) ->
+    return { type: "ReturnValue", children: [$1[0]] }
+
+AfterReturnShorthand
+  WAssignmentOp
+  UpdateExpressionSymbol
+  __ Colon
+  __ LetAssignment
+  __ ConstAssignment
 
 CallExpressionRest
   MemberExpressionRest
@@ -905,6 +915,9 @@ NWBindingIdentifier
       ref,
     }
   Identifier:id
+  # NOTE: Support for return := 1 and let return: number
+  ReturnValue ->
+    return { children: [$1], names: [] }
 
 AtIdentifierRef
   ReservedWord:r ->
@@ -3441,7 +3454,7 @@ KeywordStatement
 
   # https://262.ecma-international.org/#prod-ReturnStatement
   # NOTE: Modified to leave room for `return.value` and `return =`
-  Return !("." / WAssignmentOp / UpdateExpressionSymbol) MaybeNestedExpression?:expression -> {
+  Return !("." / AfterReturnShorthand) MaybeNestedExpression?:expression -> {
     type: "ReturnStatement",
     expression,
     children: $0,

--- a/test/function.civet
+++ b/test/function.civet
@@ -1344,6 +1344,21 @@ describe "function", ->
     """
 
     testCase """
+      return++
+      ---
+      function f
+        return = 5
+        return++
+      ---
+      function f() {
+        let ret;
+        ret = 5
+        ret++
+        return ret
+      }
+    """
+
+    testCase """
       return.value =
       ---
       function f

--- a/test/function.civet
+++ b/test/function.civet
@@ -1404,6 +1404,65 @@ describe "function", ->
     """
 
     testCase """
+      return .=
+      ---
+      function f
+        return .= 0
+      ---
+      function f() {
+        let ret = 0
+        return ret
+      }
+    """
+
+    testCase """
+      return.value .=
+      ---
+      function f
+        return.value .= 0
+      ---
+      function f() {
+        let ret = 0
+        return ret
+      }
+    """
+
+    testCase """
+      let return
+      ---
+      function f
+        let return: number
+      ---
+      function f() {
+        let ret: number
+        return ret
+      }
+    """
+
+    testCase """
+      let return.value
+      ---
+      function f
+        let return.value: number
+      ---
+      function f() {
+        let ret: number
+        return ret
+      }
+    """
+
+    testCase.skip """
+      return.value parameter
+      ---
+      function f(return.value)
+        console.log 'hi'
+      ---
+      function f(ret)
+        console.log('hi')
+        return ret
+    """
+
+    testCase """
       big example
       ---
       function f(list)


### PR DESCRIPTION
Sequel to #364. I started writing documentation and then added a few intended features:
* `let return: T`
* `return .= init`
* `return++`

Also cleans up the code in a single `ReturnValue` rule.