### PR TITLE
Trailing member properties in blocks

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1487,11 +1487,15 @@ ExplicitBlock
     })
 
 ImplicitNestedBlock
-  InsertOpenBrace NestedBlockStatements:block InsertNewline InsertIndent InsertCloseBrace ->
-    return Object.assign({}, block, {
-      children: [$1, ...block.children, $3, $4, $5],
+  # NOTE: Check &EOS needed by eventual PushIndent to skip work if not needed
+  &EOS InsertOpenBrace:open AllowAll ( NestedBlockStatements InsertNewline InsertIndent InsertCloseBrace )? RestoreAll ->
+    if (!$4) return $skip
+    const [block, ...tail] = $4
+    return {
+      ...block,
+      children: [open, ...block.children, ...tail],
       bare: false,
-    })
+    }
 
 # NOTE: This is the body of if/else/for/case etc.
 Block
@@ -1572,11 +1576,13 @@ NoPostfixBracedBlock
     }
 
 NonSingleBracedBlock
-  TrailingComment* OpenBrace BracedContent:block __ CloseBrace ->
+  TrailingComment*:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace )? RestoreAll ->
+    if (!$4) return $skip
+    const [block, ws2, close] = $4
     return {
       type: "BlockStatement",
       expressions: block.expressions,
-      children: [$1, $2, ...block.children, $4, $5],
+      children: [ws1, open, ...block.children, ws2, close],
       bare: false,
     }
     return block

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -57,6 +57,82 @@ describe "property access", ->
     super.foo.bar
   """
 
+  describe "trailing member access", ->
+    testCase """
+      simple
+      ---
+      foo
+      .bar
+      ---
+      foo
+      .bar
+    """
+
+    testCase """
+      pull outside implicit function call
+      ---
+      foo a, b
+      .bar
+      ---
+      foo(a, b)
+      .bar
+    """
+
+    testCase """
+      re-enable in nested block
+      ---
+      useEffect =>
+        foo
+        .bar
+      ---
+      useEffect(() => {
+        return foo
+        .bar
+      })
+    """
+
+    testCase """
+      re-enable in braced block
+      ---
+      useEffect => {
+        foo
+        .bar
+      }
+      ---
+      useEffect(() => {
+        return foo
+        .bar
+      })
+    """
+
+    testCase """
+      re-enable in parentheses
+      ---
+      func (
+        foo
+        .bar
+      )
+      ---
+      func((
+        foo
+        .bar
+      ))
+    """
+
+    testCase """
+      re-enable in arrays
+      ---
+      func [
+        foo
+        .bar
+      ]
+      ---
+      func([
+        foo
+        .bar
+      ])
+    """
+
   describe "string property access shorthand", ->
     testCase """
       double quoted


### PR DESCRIPTION
Fixes #367

* Explicit braces re-enable everything
* Indented block re-enables everything
* Add tests for trailing member properties on/off