### PR TITLE
x[..] slice

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -776,7 +776,7 @@ SliceParameters
       children: [start, [...ws, {...sep, token: ", "}], [end, ...inc]]
     }
 
-  Loc:l __:ws DotDot ->
+  Loc:l __:ws ( DotDot / DotDotDot ) &( __ CloseBracket ) ->
     const start = {
       $loc: l.$loc,
       token: "0",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -776,6 +776,19 @@ SliceParameters
       children: [start, [...ws, {...sep, token: ", "}], [end, ...inc]]
     }
 
+  Loc:l __:ws DotDot ->
+    const start = {
+      $loc: l.$loc,
+      token: "0",
+    }
+
+    return {
+      type: "SliceParameters",
+      start,
+      end: undefined,
+      children: [start, ws],
+    }
+
 PropertyAccess
   ( QuestionMark / NonNullAssertion )? Dot ( IdentifierName / PrivateIdentifier ):id ->
     const children = [$2, ...id.children]
@@ -4372,7 +4385,7 @@ Dot
     return { $loc, token: $1 }
 
 DotDot
-  ".." ->
+  ".." !"." ->
     return { $loc, token: $1 }
 
 DotDotDot

--- a/test/slice.civet
+++ b/test/slice.civet
@@ -29,7 +29,9 @@ describe "slice", ->
     slice both omitted
     ---
     x[..]
+    x[...]
     ---
+    x.slice(0)
     x.slice(0)
   """
 
@@ -70,7 +72,9 @@ describe "slice", ->
       everything
       ---
       x[..] = [a, b, c]
+      x[...] = [a, b, c]
       ---
+      x.splice(0, 1/0, ...[a, b, c])
       x.splice(0, 1/0, ...[a, b, c])
     """
 

--- a/test/slice.civet
+++ b/test/slice.civet
@@ -26,6 +26,14 @@ describe "slice", ->
   """
 
   testCase """
+    slice both omitted
+    ---
+    x[..]
+    ---
+    x.slice(0)
+  """
+
+  testCase """
     slice inclusive number end
     ---
     x[0..10]
@@ -58,6 +66,14 @@ describe "slice", ->
   """
 
   describe "assignment", ->
+    testCase """
+      everything
+      ---
+      x[..] = [a, b, c]
+      ---
+      x.splice(0, 1/0, ...[a, b, c])
+    """
+
     testCase """
       no upper bound
       ---


### PR DESCRIPTION
Fixes #365

I went with the CoffeeScript approach of just allowing `..`, not `...`, to avoid conflict with spreads, though we could add both...