### PR TITLE
Aggregate duplicate pattern matching bindings

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7579,18 +7579,18 @@ Init
       const props = gatherRecursiveAll(bindings, n => n.type === "BindingMatchProperty")
       const declarations = []
 
-      const propsGroupedByName = props.reduce((acc, p) => {
+      const propsGroupedByName = new Map
+
+      for(const p of props) {
         const { name } = p
 
         const key = name.name
-        if (acc.has(key)) {
-          acc.get(key).push(p)
+        if (propsGroupedByName.has(key)) {
+          propsGroupedByName.get(key).push(p)
         } else {
-          acc.set(key, [p])
+          propsGroupedByName.set(key, [p])
         }
-
-        return acc
-      }, new Map())
+      }
 
       propsGroupedByName.forEach((shared, key) => {
         if (shared.length === 1) return

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7575,6 +7575,48 @@ Init
       }
     }
 
+    function aggregateDuplicateBindings(bindings) {
+      const props = gatherRecursiveAll(bindings, n => n.type === "BindingMatchProperty")
+      const declarations = []
+
+      const propsGroupedByName = props.reduce((acc, p) => {
+        const { name } = p
+
+        const key = name.name
+        if (acc.has(key)) {
+          acc.get(key).push(p)
+        } else {
+          acc.set(key, [p])
+        }
+
+        return acc
+      }, new Map())
+
+      propsGroupedByName.forEach((shared, key) => {
+        if (shared.length === 1) return
+
+        // Create a ref alias for each duplicate binding
+        const refs = shared.map((p) => {
+          const ref = {
+            type: "Ref",
+            base: key,
+            id: key,
+          }
+
+          p.children.push(": ", ref)
+
+          return ref
+        })
+
+        // Gather duplicates in an array
+        declarations.push(["const ", key, " = [", ...refs.map((r, i) => {
+          return i === 0 ? r : [", ", r]
+        }), "]"])
+      })
+
+      return declarations
+    }
+
     function processPatternMatching(statements) {
       gatherRecursiveAll(statements, n => n.type === "SwitchStatement" || n.type === "SwitchExpression")
       .forEach((s) => {
@@ -7660,12 +7702,16 @@ Init
 
               // Gather bindings
               let [splices, thisAssignments] = gatherBindingCode(pattern)
+              const patternBindings = nonMatcherBindings(pattern)
+
+              const duplicateDeclarations = aggregateDuplicateBindings(patternBindings)
 
               splices = splices.map(s => [", ", nonMatcherBindings(s)])
               thisAssignments = thisAssignments.map(a => [indent, a, ";\n"])
 
-              prefix.push([indent, "const ", nonMatcherBindings(pattern), " = ", ref, splices, ";\n"])
+              prefix.push([indent, "const ", patternBindings, " = ", ref, splices, ";\n"])
               prefix.push(...thisAssignments)
+              prefix.push(...duplicateDeclarations.map(d => [indent, d, ";\n"]))
 
               break
             }

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -714,3 +714,16 @@ describe "switch", ->
           return 4
         }})()
     """
+
+    testCase """
+      duplicate bindings
+      ---
+      switch x
+        [{type: "text"}, {type: "image"}]
+          x
+      ---
+      if(Array.isArray(x) && x.length === 2 && typeof x[0] === 'object' && x[0] != null && 'type' in x[0] && x[0].type === "text" && typeof x[1] === 'object' && x[1] != null && 'type' in x[1] && x[1].type === "image") {
+          const [{type: type1}, {type: type2}] = x;
+          const type = [type1, type2];
+          x}
+    """


### PR DESCRIPTION
This aggregates duplicate bindings with the same identifier in pattern matching. Since there can only ever be one identifier with the same name in a scope merging more than one bindings into an array makes a lot of sense to me. Adding an implicit suffix seems like it would be hard to discover when adding or removing identifiers. TS should provide decent support and highlighting if you weren't expecting an array.

There are probably some other cases where this doesn't work but I'll fix those at a later time.

Part of #335