### PR TITLE
do expressions wrapping in iffe

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2797,6 +2797,8 @@ IterationStatement
   # NOTE: Added `loop` from CoffeeScript
   LoopStatement
   !CoffeeDoEnabled DoWhileStatement -> $2
+  # DoStatement must come after DoWhile statement
+  !CoffeeDoEnabled DoStatement -> $2
   WhileStatement
   ForStatement
 
@@ -2804,6 +2806,7 @@ IterationExpression
   IterationStatement ->
     return {
       type: "IterationExpression",
+      subtype: $1.type,
       children: [$1],
       block: $1.block,
     }
@@ -2832,6 +2835,15 @@ DoWhileStatement
     block: block
   }
 
+DoStatement
+  Do NoPostfixBracedBlock:block ->
+    block = module.insertTrimmingSpace(block, "")
+    return {
+      type: "DoStatement",
+      children: [block],
+      block,
+    }
+
 # https://262.ecma-international.org/#prod-WhileStatement
 WhileStatement
   # NOTE: Condition provides optional parens
@@ -2839,7 +2851,7 @@ WhileStatement
     return {
       type: "IterationStatement",
       children: [...clause.children, block],
-      block: block
+      block,
     }
 
 WhileClause
@@ -6284,37 +6296,53 @@ Init
     }
 
     function expressionizeIteration(exp) {
-      const resultsRef = {
-        type: "Ref",
-        base: "results",
-        id: "results",
-      }
+      const i = exp.children.indexOf(exp.block)
+      if (exp.subtype === "DoStatement") {
+        // Just wrap with IIFE
+        insertReturn(exp.block)
+        exp.children.splice(i, 1, "(()=>", ...exp.children, ")()")
+      } else {
+        const resultsRef = {
+          type: "Ref",
+          base: "results",
+          id: "results",
+        }
 
-      // insert `results.push` to gather results array
-      insertPush(exp.block, resultsRef)
-      // Wrap with IIFE
-      exp.children = ["(()=>{const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef, "})()"]
+        // insert `results.push` to gather results array
+        insertPush(exp.block, resultsRef)
+
+        // Wrap with IIFE
+        exp.children.splice(i, 1, "(()=>{const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef, "})()")
+      }
     }
 
     function wrapIterationReturningResults(statement, outerRef) {
-      const resultsRef = {
-        type: "Ref",
-        base: "results",
-        id: "results",
-      }
-
-      const declaration = {
-        type: "Declaration",
-        children: ["const ", resultsRef, "=[];"],
-      }
-
-      insertPush(statement.block, resultsRef)
-
-      statement.children.unshift(declaration)
-      if (outerRef) {
-        statement.children.push(";", outerRef, ".push(", resultsRef, ");")
+      if (statement.type === "DoStatement") {
+        if (outerRef) {
+          insertPush(statement.block, outerRef)
+        } else {
+          insertReturn(statement.block)
+        }
       } else {
-        statement.children.push(";return ", resultsRef, ";")
+        const resultsRef = {
+          type: "Ref",
+          base: "results",
+          id: "results",
+        }
+
+        const declaration = {
+          type: "Declaration",
+          children: ["const ", resultsRef, "=[];"],
+        }
+
+        insertPush(statement.block, resultsRef)
+
+        statement.children.unshift(declaration)
+        if (outerRef) {
+          statement.children.push(";", outerRef, ".push(", resultsRef, ");")
+        } else {
+          statement.children.push(";return ", resultsRef, ";")
+        }
       }
     }
 
@@ -6362,6 +6390,7 @@ Init
           return
         case "ForStatement":
         case "IterationStatement":
+        case "DoStatement":
           wrapIterationReturningResults(exp, ref)
           return
         case "BlockStatement":
@@ -6471,6 +6500,7 @@ Init
           return
         case "ForStatement":
         case "IterationStatement":
+        case "DoStatement":
           wrapIterationReturningResults(exp)
           return
         case "BlockStatement":
@@ -7406,8 +7436,9 @@ Init
     module.attachPostfixStatementAsExpression = function (exp, post) {
       let clause
       switch (post[1].type) {
-        case "IterationStatement":
         case "ForStatement":
+        case "IterationStatement":
+        case "DoStatement":
           clause = module.addPostfixStatement(exp, ...post)
           return {
             type: "IterationExpression",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6297,23 +6297,25 @@ Init
 
     function expressionizeIteration(exp) {
       const i = exp.children.indexOf(exp.block)
+
       if (exp.subtype === "DoStatement") {
         // Just wrap with IIFE
         insertReturn(exp.block)
         exp.children.splice(i, 1, "(()=>", ...exp.children, ")()")
-      } else {
-        const resultsRef = {
-          type: "Ref",
-          base: "results",
-          id: "results",
-        }
-
-        // insert `results.push` to gather results array
-        insertPush(exp.block, resultsRef)
-
-        // Wrap with IIFE
-        exp.children.splice(i, 1, "(()=>{const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef, "})()")
+        return
       }
+
+      const resultsRef = {
+        type: "Ref",
+        base: "results",
+        id: "results",
+      }
+
+      // insert `results.push` to gather results array
+      insertPush(exp.block, resultsRef)
+
+      // Wrap with IIFE
+      exp.children.splice(i, 1, "(()=>{const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef, "})()")
     }
 
     function wrapIterationReturningResults(statement, outerRef) {
@@ -6323,26 +6325,27 @@ Init
         } else {
           insertReturn(statement.block)
         }
+        return
+      }
+
+      const resultsRef = {
+        type: "Ref",
+        base: "results",
+        id: "results",
+      }
+
+      const declaration = {
+        type: "Declaration",
+        children: ["const ", resultsRef, "=[];"],
+      }
+
+      insertPush(statement.block, resultsRef)
+
+      statement.children.unshift(declaration)
+      if (outerRef) {
+        statement.children.push(";", outerRef, ".push(", resultsRef, ");")
       } else {
-        const resultsRef = {
-          type: "Ref",
-          base: "results",
-          id: "results",
-        }
-
-        const declaration = {
-          type: "Declaration",
-          children: ["const ", resultsRef, "=[];"],
-        }
-
-        insertPush(statement.block, resultsRef)
-
-        statement.children.unshift(declaration)
-        if (outerRef) {
-          statement.children.push(";", outerRef, ".push(", resultsRef, ");")
-        } else {
-          statement.children.push(";return ", resultsRef, ";")
-        }
+        statement.children.push(";return ", resultsRef, ";")
       }
     }
 

--- a/test/do.civet
+++ b/test/do.civet
@@ -1,6 +1,6 @@
 {testCase} from ./helper.civet
 
-describe "do", ->
+describe "do..while/until", ->
   testCase """
     basic
     ---
@@ -46,4 +46,105 @@ describe "do", ->
     do console.log(i++) while i < 10
     ---
     do { console.log(i++) } while (i < 10)
+  """
+
+describe "do", ->
+  testCase """
+    basic
+    ---
+    x := 1
+    do
+      y := x * x
+      console.log y * y
+    ---
+    const x = 1
+    {
+      const y = x * x
+      console.log(y * y)
+    }
+  """
+
+  testCase """
+    basic braced
+    ---
+    x := 1
+    do {
+      y := x * x
+      console.log y * y
+    }
+    ---
+    const x = 1
+    {
+      const y = x * x
+      console.log(y * y)
+    }
+  """
+
+  testCase """
+    expression
+    ---
+    x := 1
+    z := do
+      y := x * x
+      y * y
+    ---
+    const x = 1
+    const z = (()=> {
+      const y = x * x
+      return y * y
+    })()
+  """
+
+  testCase """
+    explicitly returned
+    ---
+    function f(x)
+      x = x * x
+      return do
+        y := x * x
+        y * y
+    ---
+    function f(x) {
+      x = x * x
+      return (()=> {
+        const y = x * x
+        return y * y
+      })()
+    }
+  """
+
+  testCase """
+    implicitly returned
+    ---
+    function f(x)
+      x = x * x
+      do
+        y := x * x
+        y * y
+    ---
+    function f(x) {
+      x = x * x
+      {
+        const y = x * x
+        return y * y
+      }
+    }
+  """
+
+  testCase """
+    pushed
+    ---
+    list :=
+      for x of items
+        do
+          y := x * x
+          y * y
+    ---
+    const list =
+      (()=>{const results=[];for (const x of items) {
+        {
+          const y = x * x
+          results.push(y * y)
+        }
+      }; return results})()
   """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -684,7 +684,7 @@ describe "switch", ->
           else
             4
       ---
-      const y =(()=>{const results=[]; for (const x in [1, 2, 3]) {
+      const y = (()=>{const results=[]; for (const x in [1, 2, 3]) {
         if(x === 1) {
             results.push(2)}
       else if(x === 2) {


### PR DESCRIPTION
Fixes #58, via the simpler approach. It's equivalent to wrapping in braces, unless it's used as an expression, in which case it gets an IFFE.

We can later explore the plan to remove IFFEs when possible, but this is nice for allowing declarations (even local `var`s) in the block. I think we also want to do this implicitly for `if` like CoffeeScript does, but that's (yet) another issue.

#202 tracks the issue that `return`s are forbidden within expressioned statements like this.