### PR TITLE
#387. Improve thick pipe return; pipe after inline arrow expression

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -329,7 +329,7 @@ FatArrow
 # https://262.ecma-international.org/#prod-ConciseBody
 FatArrowBody
   # If same-line single expression, avoid wrapping in braces
-  !EOS PostfixedExpression:exp !SemicolonDelimiter -> exp
+  !EOS NonPipelinePostfixedExpression:exp !SemicolonDelimiter -> exp
   # Otherwise, wrap block body in braces and insert returns
   BracedOrEmptyBlock
 
@@ -2617,6 +2617,11 @@ PostfixedStatement
 
 PostfixedExpression
   ExtendedExpression:expression ( TrailingComment* PostfixStatement )?:post ->
+    if (post) return module.attachPostfixStatementAsExpression(expression, post)
+    return expression
+
+NonPipelinePostfixedExpression
+  NonPipelineExtendedExpression:expression ( TrailingComment* PostfixStatement )?:post ->
     if (post) return module.attachPostfixStatementAsExpression(expression, post)
     return expression
 
@@ -7921,8 +7926,18 @@ Init
           )
 
           if (result.type === "ReturnStatement") {
-            // TODO: Attach errors/warnings if there are more steps
+            // Attach errors/warnings if there are more steps
+            if (i < l - 1) {
+              result.children.push({
+                type: "Error",
+                message: "Can't continue a pipeline after returning",
+              })
+            }
             arg = result
+            if (children[children.length - 1] === ",") {
+              children.pop()
+              children.push(";")
+            }
             break
           }
 

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -142,6 +142,12 @@ describe "pipe", ->
       op4(op3(arg2)),)
   """
 
+  throws """
+    pipe after return is error
+    ---
+    a |> b |> return |> c
+  """
+
   describe "thicc", ->
     testCase """
       basic
@@ -170,6 +176,30 @@ describe "pipe", ->
       ||> g
       ---
       g(f(x)),f(x)
+    """
+
+    testCase """
+      return
+      ---
+      count |> &+1
+      ||> (c) => console.log c
+      |> return
+      ---
+      ((c) => console.log(c))(count+1);return count+1
+    """
+
+    testCase.skip """
+      complex return
+      ---
+      fetch url |> await
+      ||> ({status}) =>
+            console.log `Fetched ${url} with ${status}`
+      |> .json() |> await
+      ||> (json) =>
+            console.log `Parsed JSON ${json}`
+      |> return
+      ---
+      TODO
     """
 
     testCase """


### PR DESCRIPTION
Fixed some things still more to do before it's perfect.

Also note: pipelines that add a `return` can't be used in expression position. I think a big follow up will be to normalize all the block expressionization. Also related to hoisting ref decs that end up used inside expressions.