### PR TITLE
Fixes #387

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -91,6 +91,7 @@ uncacheable = new Set [
   "NestedObject"
   "NestedPropertyDefinitions"
   "NonSingleBracedBlock"
+  "NotDedented"
   "ObjectLiteral"
   "PopIndent"
   "PopJSXStack"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -179,7 +179,7 @@ BinaryOpRHS
   # Does not match
   # a
   # +b
-  __ BinaryOp ( _ / ( EOS __ ) ) RHS
+  NotDedented BinaryOp ( _ / ( EOS __ ) ) RHS
 
 RHS
   ParenthesizedAssignment
@@ -359,7 +359,7 @@ ShortCircuitExpression
   BinaryOpExpression
 
 PipelineExpression
-  _?:ws PipelineHeadItem:head ( __ Pipe __ PipelineTailItem )+:body ->
+  _?:ws PipelineHeadItem:head ( NotDedented Pipe __ PipelineTailItem )+:body ->
     return {
       type: "PipelineExpression",
       children: [ws, head, body]
@@ -6795,10 +6795,12 @@ Init
       if (Array.isArray(target)) {
         if (target.length === 1) {
           return module.skipIfOnlyWS(target[0])
+        } else if (target.every(e => (module.skipIfOnlyWS(e) === undefined))) {
+          return undefined
         }
         return target
       }
-      if (target.token && target.token.trim() === '') {
+      if (target.token != null && target.token.trim() === '') {
         return undefined
       }
       return target
@@ -8379,6 +8381,13 @@ IndentedFurther
       return $0
     }
     return $skip
+
+NotDedented
+  ( Samedent / IndentedFurther )? _? ->
+    const ws = []
+    if ($1) ws.push(...$1)
+    if ($2) ws.push(...$2)
+    return ws.flat(Infinity).filter(Boolean)
 
 # Indents one level deeper
 # Must be matched with PopIndent

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -188,7 +188,7 @@ describe "pipe", ->
       ((c) => console.log(c))(count+1);return count+1
     """
 
-    testCase.skip """
+    testCase """
       complex return
       ---
       fetch url |> await
@@ -199,7 +199,11 @@ describe "pipe", ->
             console.log `Parsed JSON ${json}`
       |> return
       ---
-      TODO
+      (({status}) => {
+            return console.log(`Fetched ${url} with ${status}`)
+      })(await fetch(url)),((json) => {
+            return console.log(`Parsed JSON ${json}`)
+      })(await (await fetch(url)).json());return await (await fetch(url)).json()
     """
 
     testCase """


### PR DESCRIPTION
Better dedent handling for binary ops and pipes.

The BinarOpRHS dedent change is unnecessary for this fix but it doesn't break any tests so far and it gets us closer to having the same rules for dedenting everywhere.