### PR TITLE
Parent pointer cleanup

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7118,12 +7118,17 @@ Init
     function addParentPointers(node, parent) {
       if (node == null) return
       if (typeof node !== "object") return
-      node.parent = parent
+
+      // NOTE: Arrays are transparent and skipped when traversing via parent
       if (Array.isArray(node)) {
         for (const child of node) {
-          addParentPointers(child, node)
+          addParentPointers(child, parent)
         }
-      } else if (node.children) {
+        return
+      }
+
+      node.parent = parent
+      if (node.children) {
         for (const child of node.children) {
           addParentPointers(child, node)
         }
@@ -7897,6 +7902,8 @@ Init
 
         s.type = "PatternMatchingStatement"
         s.children = [root]
+        // Update parent pointers
+        addParentPointers(s, s.parent)
       })
     }
 
@@ -7965,6 +7972,8 @@ Init
 
         children.push(arg)
         s.children = children
+        // Update parent pointers
+        addParentPointers(s, s.parent)
       })
     }
 


### PR DESCRIPTION
- Don't add parent pointers to arrays
- Update parent pointers after adjusting subtrees in pipe and pattern matching