### PR TITLE
Prevent indented application in Coffee for loops

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2917,11 +2917,11 @@ ForStatementControl
     return $2
 
 WhenCondition
-  __ When ExtendedExpression:exp -> exp
+  __ When ExpressionWithIndentedApplicationForbidden:exp -> exp
 
 CoffeeForStatementParameters
   # NOTE: Coffee for loops can't have parens
-  ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExtendedExpression:exp ( __ By ExtendedExpression )?:step InsertCloseParen:close ->
+  ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExpressionWithIndentedApplicationForbidden:exp ( __ By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
     let blockPrefix = []
     const indent = module.currentIndent.token + "  "
     exp = module.insertTrimmingSpace(exp, "")

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -16,6 +16,20 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for in with object literal
+    ---
+    "civet coffee-compat"
+    for a in b
+      x: a
+    ---
+    var a
+    for (let i = 0, len = b.length; i < len; i++) {
+      a = b[i]
+      ({x: a})
+    }
+  """
+
+  testCase """
     for in i in scope
     ---
     "civet coffee-compat"
@@ -176,6 +190,21 @@ describe "coffeeForLoops", ->
       a = b[i]
       if (!(a > 0)) continue
       a.x
+    }
+  """
+
+  testCase """
+    for in when object literal
+    ---
+    "civet coffee-compat"
+    for a in b when a > 0
+      x: a
+    ---
+    var a
+    for (let i = 0, len = b.length; i < len; i++) {
+      a = b[i]
+      if (!(a > 0)) continue
+      ({x: a})
     }
   """
 


### PR DESCRIPTION
Matches behavior of regular `for..of` loops, as well as CoffeeScript behavior: [example 1](https://coffeescript.org/#try:for%20x%20in%20y%0A%20%20z%3A%20w), [example 2](https://coffeescript.org/#try:for%20x%20in%20y%20by%20z%0A%20%20z%3A%20w), [example 3](https://coffeescript.org/#try:for%20x%20in%20y%20when%20z%0A%20%20z%3A%20w)