### PR TITLE
Forbid indented application in first line of array literal

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -35,6 +35,7 @@ uncacheable = new Set [
   "ConditionalExpression"
   "Declaration"
   "Debugger"
+  "ElementListWithIndentedApplicationForbidden"
   "ElseClause"
   "Expression"
   "ExpressionStatement"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1867,7 +1867,7 @@ ArrayLiteralContent
   RangeExpression
   NestedImplicitObjectLiteral ( __ Comma NestedImplicitObjectLiteral )*
   NestedElementList
-  ElementList:list InsertComma:comma NestedElementList?:nested ->
+  ElementListWithIndentedApplicationForbidden:list InsertComma:comma NestedElementList?:nested ->
     if (nested) {
       // ElementList never ends in comma; otherwise, the next line of elements
       // would be absorbed into the ElementList.
@@ -1909,6 +1909,11 @@ ArrayElementDelimiter
   # verbatim.
   &( __ "]" )
   &EOS InsertComma -> $2
+
+ElementListWithIndentedApplicationForbidden
+  ForbidIndentedApplication ElementList? RestoreIndentedApplication ->
+    if ($2) return $2
+    return $skip
 
 # https://262.ecma-international.org/#prod-ElementList
 # NOTE: Modified and simplified from the spec

--- a/test/array.civet
+++ b/test/array.civet
@@ -42,6 +42,20 @@ describe "array", ->
   """
 
   testCase """
+    indentation mid-array with object literal
+    ---
+    [a
+     b: c
+     d: e
+    ]
+    ---
+    [a,
+     {b: c,
+     d: e}
+    ]
+  """
+
+  testCase """
     compact rows
     ---
     bitlist := [

--- a/test/if.civet
+++ b/test/if.civet
@@ -312,13 +312,15 @@ describe "if", ->
     testCase """
       allowed in array literal
       ---
-      if [foo
-        a: 1
+      if [
+        foo
+          a: 1
       ]
         hi
       ---
-      if ([foo({
-        a: 1,
+      if ([
+        foo({
+          a: 1,
       })
       ]) {
         hi


### PR DESCRIPTION
Matches [CoffeeScript behavior](https://coffeescript.org/#try:%5Ba%0A%20b%3A%20c%0A%5D%0A%0Aif%20%5Bfoo%0A%20%20a%3A%201%0A%5D%0A%20%20x%0A%20%20%0Aif%20%5B%0A%20%20foo%0A%20%20%20%20a%3A%201%0A%5D%0A%20%20x)