### PR TITLE
Indented application

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -70,6 +70,7 @@ uncacheable = new Set [
   "MemberExpression"
   "MemberExpressionRest"
   "Nested"
+  "NestedArgumentList"
   "NestedBindingElement"
   "NestedBindingElements"
   "NestedBlockExpression"
@@ -91,12 +92,19 @@ uncacheable = new Set [
   "NestedModuleItems"
   "NestedObject"
   "NestedPropertyDefinitions"
+  "NonAssignmentExtendedExpression"
+  "NonPipelineArgumentPart"
+  "NonPipelineArgumentList"
+  "NonPipelineAssignmentExpression"
+  "NonPipelineExtendedExpression"
+  "NonPipelinePostfixedExpression"
   "NonSingleBracedBlock"
   "NotDedented"
   "ObjectLiteral"
   "PopIndent"
   "PopJSXStack"
   "PostfixedExpression"
+  "PostfixedSingleLineStatements"
   "PostfixedStatement"
   "PrimaryExpression"
   "PushIndent"
@@ -199,6 +207,9 @@ makeCache = ->
       cache = caches.get(ruleName)
 
       if !cache and !uncacheable.has(ruleName)
+        #if /Line[S]/.test(ruleName)
+        #  console.log ruleName
+        #  return
         cache = new Map
         caches.set(ruleName, cache)
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -76,7 +76,7 @@ ExplicitArguments
 
 # Start of function application, inserts an open parenthesis, maintains spacing and comments when possible
 ApplicationStart
-  IndentedApplicationAllowed &NestedImplicitObjectLiteral
+  IndentedApplicationAllowed &( IndentedFurther !Dot )
   !EOS &( _ !ForbiddenImplicitCalls )
 
 ForbiddenImplicitCalls
@@ -1867,7 +1867,7 @@ ArrayLiteralContent
   RangeExpression
   NestedImplicitObjectLiteral ( __ Comma NestedImplicitObjectLiteral )*
   NestedElementList
-  ElementListWithIndentedApplicationForbidden:list InsertComma:comma NestedElementList?:nested ->
+  !EOS ElementListWithIndentedApplicationForbidden:list InsertComma:comma NestedElementList?:nested ->
     if (nested) {
       // ElementList never ends in comma; otherwise, the next line of elements
       // would be absorbed into the ElementList.
@@ -1875,6 +1875,7 @@ ArrayLiteralContent
     } else {
       return list
     }
+  &EOS ElementListWithIndentedApplicationForbidden:list -> list
 
 NestedElementList
   PushIndent NestedElement*:elements PopIndent ->

--- a/test/array.civet
+++ b/test/array.civet
@@ -26,6 +26,34 @@ describe "array", ->
   """
 
   testCase """
+    functions
+    ---
+    [
+      => a
+      => b
+    ]
+    ---
+    [
+      () => a,
+      () => b
+    ]
+  """
+
+  testCase """
+    functions within calls
+    ---
+    [
+      o a, => x
+      o b, => y
+    ]
+    ---
+    [
+      o(a, () => x),
+      o(b, () => y)
+    ]
+  """
+
+  testCase """
     indentation mid-array
     ---
     [a

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -379,6 +379,36 @@ describe "function application", ->
       true,)
   """
 
+  testCase """
+    nested arguments
+    ---
+    f
+      a
+      b
+    ---
+    f(
+      a,
+      b,)
+  """
+
+  testCase """
+    multiple nested arguments
+    ---
+    f
+      a
+      b
+      g
+        c
+        d
+    ---
+    f(
+      a,
+      b,
+      g(
+        c,
+        d,),)
+  """
+
   // https://coffeescript.org/#try:x%20if%203%0A%20%20b%0Aelse%0A%20%20c
   testCase """
     apply to a conditional expression

--- a/test/if.civet
+++ b/test/if.civet
@@ -321,7 +321,7 @@ describe "if", ->
       if ([
         foo({
           a: 1,
-      })
+        })
       ]) {
         hi
       }


### PR DESCRIPTION
At this point, this PR is more of a proof-of-concept, but it does seem possible to unambiguously enable

```coffee
f
  a
  b
  g
    c
    d
---
f(
  a,
  b,
  g(
    c,
    d,))
```

Unfortunately, the number of rules added to the no-cache set is probably too big; tests get substantially slower, and there's one test that needs >2 seconds, so Mocha times out unless you specify `yarn test --timeout 5000`.

My guess is that there's something too repetitive in the way that arguments are parsed (e.g. in `NonPipelineArgumentList`) that requires too much revisiting of the same code.  The challenge here seems to be keeping the indentation around long enough; if we end up parsing the innards again after popping the indentation, we mistakenly treat something as indented.  An example that was hard to get working:

```coffee
f [
  o a, -> x
  p b, -> y
]
```

If `x` gets parsed a second time after the array indentation has been lost, it treats `p` as an argument.

Maybe this is worth revisiting after #341 gets fixed?