### PR TITLE
Automatically await/async expressionized statements with await

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1409,10 +1409,14 @@ FunctionExpression
     }
 
     const { ref } = rhs
+    const children = [ref, " => ", prefix, rhs]
+    if (module.hasAwait(rhs)) {
+      children.unshift("async ")
+    }
 
     return {
       type: "ArrowFunction",
-      children: [ref, " => ", prefix, rhs],
+      children,
       ampersandBlock: true,
     }
 
@@ -6365,11 +6369,16 @@ Init
       ))
     }
 
+    // Does this expression have an `await` in it and thus needs to be `async`?
+    module.hasAwait = (exp) => {
+      return gatherRecursiveWithinFunction(exp, ({type}) => type === "Await").length > 0
+    }
+
     // Wrap an expression in an IIFE, adding async/await if expression
     // uses await.  Returns an Array suitable for `children`.
     module.wrapIIFE = (exp) => {
       let prefix, suffix
-      if (gatherRecursiveWithinFunction(exp, ({type}) => type === "Await").length) {
+      if (module.hasAwait(exp)) {
         prefix = "(await (async ()=>{"
         suffix = "})())"
       } else {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3264,7 +3264,7 @@ SwitchExpression
     return {
       type: "SwitchExpression",
       // wrap with IIFE
-      children: ["(()=>{", e.children, "})()"],
+      children: module.wrapIIFE(e.children),
       expression: e.expression,
       caseBlock: e.caseBlock,
     }
@@ -3396,7 +3396,7 @@ TryExpression
     return {
       type: "TryExpression",
       blocks: t.blocks,
-      children: ["(()=>{", t, "})()"]
+      children: module.wrapIIFE(t)
     }
 
 # https://262.ecma-international.org/#prod-Catch
@@ -3565,14 +3565,14 @@ DebuggerExpression
   Debugger ->
     return {
       type: "DebuggerExpression",
-      children: ["(()=>{", $1, "})()"],
+      children: module.wrapIIFE($1),
     }
 
 ThrowExpression
   Throw ExtendedExpression ->
     return {
       type: "ThrowExpression",
-      children: ["(()=>{", $0, "})()"],
+      children: module.wrapIIFE($0),
     }
 
 MaybeNestedExpression
@@ -4381,7 +4381,7 @@ Async
 
 Await
   "await" NonIdContinue ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, type: 'Await' }
 
 Backtick
   "`" ->
@@ -6346,7 +6346,7 @@ Init
       if (exp.subtype === "DoStatement") {
         // Just wrap with IIFE
         insertReturn(exp.block)
-        exp.children.splice(i, 1, "(()=>", ...exp.children, ")()")
+        exp.children.splice(i, 1, ...module.wrapIIFE(exp.children))
         return
       }
 
@@ -6360,7 +6360,27 @@ Init
       insertPush(exp.block, resultsRef)
 
       // Wrap with IIFE
-      exp.children.splice(i, 1, "(()=>{const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef, "})()")
+      exp.children.splice(i, 1, module.wrapIIFE(
+        ["const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef]
+      ))
+    }
+
+    // Wrap an expression in an IIFE, adding async/await if expression
+    // uses await.  Returns an Array suitable for `children`.
+    module.wrapIIFE = (exp) => {
+      let prefix, suffix
+      if (gatherRecursiveWithinFunction(exp, ({type}) => type === "Await").length) {
+        prefix = "(await (async ()=>{"
+        suffix = "})())"
+      } else {
+        prefix = "(()=>{"
+        suffix = "})()"
+      }
+      if (Array.isArray(exp)) {
+        return [prefix, ...exp, suffix]
+      } else {
+        return [prefix, exp, suffix]
+      }
     }
 
     function wrapIterationReturningResults(statement, outerRef) {
@@ -7901,8 +7921,7 @@ Init
 
         if (module.config.implicitReturns && s.type === "SwitchExpression") {
           insertReturn(root[0])
-          root.unshift("(()=>{")
-          root.push("})()")
+          root.splice(0, 1, module.wrapIIFE(root[0]))
         }
 
         s.type = "PatternMatchingStatement"

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -333,6 +333,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    await in throw expression
+    ---
+    a or throw await makeError()
+    ---
+    a || (await (async ()=>{throw await makeError()})())
+  """
+
+  testCase """
     late assignments
     ---
     x = 3 + y = 2 + z = 1

--- a/test/do.civet
+++ b/test/do.civet
@@ -89,10 +89,10 @@ describe "do", ->
       y * y
     ---
     const x = 1
-    const z = (()=> {
+    const z = (()=>{ {
       const y = x * x
       return y * y
-    })()
+    }})()
   """
 
   testCase """
@@ -106,10 +106,10 @@ describe "do", ->
     ---
     function f(x) {
       x = x * x
-      return (()=> {
+      return (()=>{ {
         const y = x * x
         return y * y
-      })()
+      }})()
     }
   """
 
@@ -147,4 +147,20 @@ describe "do", ->
           results.push(y * y)
         }
       }; return results})()
+  """
+
+  testCase """
+    async
+    ---
+    async function f(x)
+      return do
+        y := await x
+        y * y
+    ---
+    async function f(x) {
+      return (await (async ()=>{ {
+        const y = await x
+        return y * y
+      }})())
+    }
   """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -264,3 +264,11 @@ describe "&. function block shorthand", ->
     ---
     const x = $ => $.foo
   """
+
+  testCase """
+    await
+    ---
+    x.map & + await f()
+    ---
+    x.map(async $ => $ + await f())
+  """

--- a/test/try.civet
+++ b/test/try.civet
@@ -131,6 +131,7 @@ describe "try", ->
       ---
       thing = (()=>{try { return foo() } catch(e) {return}})()
     """
+
     testCase """
       with catch and finally
       ---
@@ -156,4 +157,12 @@ describe "try", ->
       const y = (()=>{const results=[]; for (const x of xs) {
         try { results.push(foo()) } catch(e) {results.push(void 0);}
       }; return results})()
+    """
+
+    testCase """
+      async
+      ---
+      thing = try await foo()
+      ---
+      thing = (await (async ()=>{try { return await foo() } catch(e) {return}})())
     """


### PR DESCRIPTION
Fixes #355 by replacing all IIFE code (that I could find anyway) with a new `module.wrapIIFE` helper that checks for `await` in the wrapped expression (without crossing a function boundary) and wraps accordingly.

One thing: I'm not sure what was meant by "Fix `catch { c }`" in #355. Is this about whether `catch` should return a value? Should we split that off into a separate issue?