### PR TITLE
async do, async for

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -792,6 +792,22 @@ you cannot use `return` inside such a loop,
 nor can you `break` or `continue` any outer loop.
 :::
 
+Loops that use `await` automatically get `await`ed.
+If you'd rather obtain the promise for the results so you can `await` them
+yourself, use `async for`.
+
+<Playground>
+results :=
+  for url of urls
+    await fetch url
+</Playground>
+
+<Playground>
+promise :=
+  async for url of urls
+    await fetch url
+</Playground>
+
 ### Infinite Loop
 
 <Playground>
@@ -845,6 +861,16 @@ Because `do` expressions wrap in an
 [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE),
 you cannot use `return`, `break`, or `continue` within them.
 :::
+
+### Async Do Blocks
+
+You can create a promise using `await` notation with `async do`:
+
+<Playground>
+promise := async do
+  result := await fetch url
+  await result.json()
+</Playground>
 
 ### Labels
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -13,7 +13,7 @@ Program
 TopLevelStatement
   EOS? ModuleItem StatementDelimiter
 
-# Expressions with If and Switch
+# Expressions with If and Switch, but no comma operator
 ExtendedExpression
   NonAssignmentExtendedExpression
   AssignmentExpression
@@ -3514,9 +3514,12 @@ RestoreAll
 ExpressionStatement
   # NOTE: semi-colons are being handled elsewhere
   # NOTE: Shouldn't need negative lookahead if shadowed in the proper order
-  # NOTE: Using ExtendedExpression instead of Expression to allow for
-  # e.g. await forms of IterationExpressions that can't be IterationStatement
-  ExtendedExpression
+  # NOTE: Allow for e.g. await forms of IterationExpression that weren't
+  # already parsed as IterationStatement. Must be before Expression to avoid
+  # treated `async do ...` like a function call `async(do ...)`.
+  IterationExpression
+  # NOTE: Expression enables , operator
+  Expression
 
 KeywordStatement
   # https://262.ecma-international.org/#prod-BreakStatement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2816,12 +2816,13 @@ IterationStatement
   ForStatement
 
 IterationExpression
-  IterationStatement ->
+  ( Async __ )?:async IterationStatement:statement ->
     return {
       type: "IterationExpression",
-      subtype: $1.type,
-      children: [$1],
-      block: $1.block,
+      subtype: statement.type,
+      children: [statement],
+      block: statement.block,
+      async,
     }
 
 # NOTE: Added from CoffeeScript
@@ -3513,7 +3514,9 @@ RestoreAll
 ExpressionStatement
   # NOTE: semi-colons are being handled elsewhere
   # NOTE: Shouldn't need negative lookahead if shadowed in the proper order
-  Expression
+  # NOTE: Using ExtendedExpression instead of Expression to allow for
+  # e.g. await forms of IterationExpressions that can't be IterationStatement
+  ExtendedExpression
 
 KeywordStatement
   # https://262.ecma-international.org/#prod-BreakStatement
@@ -6351,7 +6354,7 @@ Init
       if (exp.subtype === "DoStatement") {
         // Just wrap with IIFE
         insertReturn(exp.block)
-        exp.children.splice(i, 1, ...module.wrapIIFE(exp.children))
+        exp.children.splice(i, 1, ...module.wrapIIFE(exp.children, exp.async))
         return
       }
 
@@ -6365,9 +6368,11 @@ Init
       insertPush(exp.block, resultsRef)
 
       // Wrap with IIFE
-      exp.children.splice(i, 1, module.wrapIIFE(
-        ["const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef]
-      ))
+      exp.children.splice(i, 1,
+        module.wrapIIFE([
+          "const ", resultsRef, "=[];", ...exp.children, "; return ", resultsRef
+        ], exp.async)
+      )
     }
 
     // Does this expression have an `await` in it and thus needs to be `async`?
@@ -6376,10 +6381,14 @@ Init
     }
 
     // Wrap an expression in an IIFE, adding async/await if expression
-    // uses await.  Returns an Array suitable for `children`.
-    module.wrapIIFE = (exp) => {
+    // uses await, or just adding async if specified.
+    // Returns an Array suitable for `children`.
+    module.wrapIIFE = (exp, async) => {
       let prefix, suffix
-      if (module.hasAwait(exp)) {
+      if (async) {
+        prefix = "(async ()=>{"
+        suffix = "})()"
+      } else if (module.hasAwait(exp)) {
         prefix = "(await (async ()=>{"
         suffix = "})())"
       } else {
@@ -7115,7 +7124,7 @@ Init
       if (node == null) return []
 
       if (Array.isArray(node)) {
-        return node.flatMap((n) => gatherRecursive(n, predicate))
+        return node.flatMap((n) => gatherRecursive(n, predicate, skipPredicate))
       }
 
       if (skipPredicate?.(node)) return []
@@ -7124,7 +7133,7 @@ Init
         return [node]
       }
 
-      return gatherRecursive(node.children, predicate)
+      return gatherRecursive(node.children, predicate, skipPredicate)
     }
 
     function gatherRecursiveAll(node, predicate) {
@@ -7142,9 +7151,11 @@ Init
       return nodes
     }
 
-    function isFunction({type}) {
+    function isFunction(node) {
+      const {type} = node
       return type === "FunctionExpression" || type === "ArrowFunction" ||
-             type === "MethodDefinition"
+             type === "MethodDefinition" || node.async
+      // do blocks can be marked async to prevent automatic await
     }
     function gatherRecursiveWithinFunction(node, predicate) {
       return gatherRecursive(node, predicate, isFunction)

--- a/test/do.civet
+++ b/test/do.civet
@@ -150,7 +150,7 @@ describe "do", ->
   """
 
   testCase """
-    async
+    auto async
     ---
     async function f(x)
       return do
@@ -163,4 +163,43 @@ describe "do", ->
         return y * y
       }})())
     }
+  """
+
+  testCase """
+    async do one-line
+    ---
+    async do (await getList()).length
+    ---
+    (async ()=>{{ return (await getList()).length }})()
+  """
+
+  testCase """
+    async do
+    ---
+    async do
+      (await getList()).length
+    ---
+    (async ()=>{{
+      return (await getList()).length
+    }})()
+  """
+
+  testCase """
+    async do example
+    ---
+    await Promise.all(
+      for item of array
+        async do
+          data = await op1(item)
+          await op2(item, data)
+    )
+    ---
+    await Promise.all(
+      (()=>{const results=[];for (const item of array) {
+        results.push((async ()=>{{
+          data = await op1(item)
+          return await op2(item, data)
+        }})())
+      }; return results})()
+    )
   """

--- a/test/for.civet
+++ b/test/for.civet
@@ -243,3 +243,14 @@ describe "for", ->
         }
       }; return results})()
     """
+
+    testCase """
+      async for
+      ---
+      async for x of y
+        await x
+      ---
+      (async ()=>{const results=[];for (const x of y) {
+        results.push(await x)
+      }; return results})()
+    """


### PR DESCRIPTION
`async` variation of iteration expressions, including simple `do`, which build a promise for the results by making the IIFE wrapper `async`.

For example, `async do` lets you build a Promise easily using `await` syntax:

```coffee
promise := async do
  await f1()
  await f2()
---
const promise = (async ()=>{ {
  await f1()
  return await f2()
}})()
```

Fixes #292 which shows a nice example of using this in a `for` loop to do `await Promise.all` in parallel.

Similarly, `async for` returns a promise that resolves to the returned array, once all `await`s are complete (in sequence):

```coffee
promise := async for x of y
  await f(x)
---
const promise = (async ()=>{const results=[];for (const x of y) {
  results.push(await f(x))
}; return results})()
```

Having this as an option is essentially what @gustavopch was asking for in #355.  I think it makes sense to `await` by default, because there isn't obviously a function involved here.  But it *also* makes sense to allow the user to ask that a task be done `async` and get that promise.  An `async` prefix seems to reasonably naturally mirror `async function`, and given that I had previously come up with the same idea in #292 (and then promptly forgotten) it seems pretty natural. 🙂 