### PR TITLE
Improve ligature toggles

### DIFF
--- a/civet.dev/.vitepress/components/Playground.vue
+++ b/civet.dev/.vitepress/components/Playground.vue
@@ -2,7 +2,7 @@
 import { onMounted, ref, watch, nextTick, computed } from 'vue';
 import { compileCivetToHtml } from '../utils/compileCivetToHtml';
 import { b64 } from '../utils/b64';
-import { ligatures } from '../utils/ligatures';
+import { ligatures } from '../store/ligatures.store';
 
 const emit = defineEmits(['input']);
 const props = defineProps<{
@@ -114,10 +114,10 @@ const playgroundUrl = computed(() => {
         <div v-if="outputHtml" v-html="outputHtml" />
         <slot v-else name="output" />
       </div>
-      <div class="compilation-info">
+      <label class="compilation-info">
         <input type="checkbox" v-model="ligatures"/>
-        <label>Ligatures</label>
-      </div>
+        Ligatures
+      </label>
     </div>
   </div>
 </template>

--- a/civet.dev/.vitepress/store/ligatures.store.ts
+++ b/civet.dev/.vitepress/store/ligatures.store.ts
@@ -1,0 +1,17 @@
+import { ref, watch } from 'vue';
+
+// Read initial value from localStorage
+let init = false;
+try {
+  init = JSON.parse(localStorage.getItem('ligatures') ?? 'false')
+} catch (e) {}
+
+// Shared state for ligatures toggle
+export const ligatures = ref(init);
+
+// Keep localStorage up-to-date
+watch(ligatures, () => {
+  try {
+    localStorage.setItem('ligatures', JSON.stringify(ligatures.value));
+  } catch (e) {}
+})

--- a/civet.dev/.vitepress/theme/custom.css
+++ b/civet.dev/.vitepress/theme/custom.css
@@ -11,6 +11,7 @@
   src: url("/fonts/FiraCode-Regular.woff2") format('woff2'), url("/fonts/FiraCode-Regular.woff") format('woff');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -18,13 +19,15 @@
   src: url('/fonts/FiraMono-Regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
+/* Each font falls back to the other for smoother switching */
 :root {
-  --vp-font-family-mono: 'Fira Mono', monospace;
+  --vp-font-family-mono: 'Fira Mono', 'Fira Code', monospace;
 }
 .ligatures {
-  --vp-font-family-mono: 'Fira Code', monospace;
+  --vp-font-family-mono: 'Fira Code', 'Fira Mono', monospace;
 }
 
 textarea {

--- a/civet.dev/.vitepress/utils/ligatures.ts
+++ b/civet.dev/.vitepress/utils/ligatures.ts
@@ -1,3 +1,0 @@
-// Shared state for ligatures toggle
-import { ref } from 'vue';
-export const ligatures = ref(false);


### PR DESCRIPTION
* Implement argeento's comments
* Put shared state in `civet.dev/.vitepress/store`
* Ligature toggle state remembered in localStorage (when possible)
* Clicking on "Ligatures" label toggles the checkbox
* No more blinking when toggling for the first time (while font loads)