### PR TITLE
Leave plain JSX strings alone, including newlines

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5070,12 +5070,15 @@ JSXAttributeValue
     // Check for string literal resulting from CoffeeScript interpolated
     // double-quoted string that didn't end up actually interpolating.
     if ($2.children?.length === 1 && $2.children[0].type === "StringLiteral") {
-      return $2.children[0]
+      // Instead parse using the following string literal rule,
+      // which avoids e.g. converting newlines into \n.
+      return $skip
     }
     return $0
   # NOTE: InlineJSXAttributeValue which contains TemplateLiteral must be before
   # StringLiteral, so that CoffeeScript interpolated strings get checked first.
-  StringLiteral
+  # NOTE: JSX strings allow newlines, and they get passed through as-is.
+  /"[^"]*"|'[^']*'/
 
 # JSX shorthand to avoid explicit braces when unnecessary (no whitespace)
 InlineJSXAttributeValue
@@ -6130,6 +6133,11 @@ Reset
       // Replace non-escaped newlines with escaped newlines
       // taking into account the possibility of a preceding escaped backslash
       return str.replace(/(^.?|[^\\]{2})(\\\\)*\n/g, '$1$2\\n')
+    }
+
+    // Turn the \n's (e.g. added by modifyString) back into actual newlines
+    module.unmodifyString = function(str) {
+      return str.replace(/\\n/g, '\n')
     }
 
     // Add quotes around a string to make it a valid JavaScript string,

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -10,6 +10,18 @@ describe "braced JSX attributes", ->
   """
 
   testCase """
+    newlines in strings are preserved
+    ---
+    <div class='foo
+    
+    bar' />
+    ---
+    <div class='foo
+    
+    bar' />
+  """
+
+  testCase """
     non-interpolated strings are not braced
     ---
     "civet coffeeInterpolation"


### PR DESCRIPTION
Fixes #405 by not processing plain JSX strings at all.

> Another option would be to convert the `\n` to ` ` in JSX.

Interestingly, this is what [CoffeeScript does](https://coffeescript.org/#try:%3Cdiv%20class%3D%22hello%0A%0A%0Aworld%5Cn%5Ct%22%2F%3E). (It even seems to convert multiple newlines into a single space.)  I guess it's fine with `class`, but I like better the approach of just leaving the string alone in this case.

One inconsistency I noticed is that `\t` and other escape characters are normally ignored (the backslash remains a backslash) in JSX strings.  But if you use an interpolated string (CoffeeScript's `"#{foo}"` or Civet's always-available `"""#{foo}"""`), which turn into a braced template string, then the backslashes are processed.  This is [consistent with CoffeeScript](https://coffeescript.org/#try:%3Cdiv%20class%3D%22hello%0A%0A%0A%23%7Bfoo%7D%0A%0Aworld%5Cn%5Ct%22%2F%3E) so I think it's OK.  Just a bit weird.