### PR TITLE
enum support

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1715,6 +1715,7 @@ Literal
   LiteralContent ->
     return {
       type: "Literal",
+      subtype: $1.type,
       children: $0,
       raw: $1.token,
     }
@@ -3806,6 +3807,7 @@ Declaration
   ClassDeclaration
   LexicalDeclaration
   TypeDeclaration
+  EnumDeclaration
   OperatorDeclaration
 
 # https://262.ecma-international.org/#prod-HoistableDeclaration
@@ -4532,6 +4534,10 @@ In
 # https://262.ecma-international.org/#prod-LetOrConst
 LetOrConst
   ( "let" / "const" ) NonIdContinue ->
+    return { $loc, token: $1 }
+
+Const
+  "const" NonIdContinue ->
     return { $loc, token: $1 }
 
 LetOrConstOrVar
@@ -5315,6 +5321,10 @@ TypeKeyword
   "type" NonIdContinue ->
     return { $loc, token: $1 }
 
+Enum
+  "enum" NonIdContinue ->
+    return { $loc, token: $1 }
+
 Interface
   "interface" NonIdContinue ->
     return { $loc, token: $1 }
@@ -5355,7 +5365,7 @@ BasicInterfaceProperty
   ( TypeIndexSignature / PropertyName ) TypeSuffix InterfacePropertyDelimiter
 
 InterfacePropertyDelimiter
-  _* ( Semicolon / Comma )
+  _? ( Semicolon / Comma )
   &( __ CloseBrace )
   &EOS
 
@@ -5392,6 +5402,98 @@ NestedDeclareElement
 DeclareElement
   ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
   ( Export _? )? TypeDeclarationRest    -> { ts: true, children: $0 }
+
+EnumDeclaration
+  ( Const _ )?:isConst Enum TrailingComment* IdentifierName:id EnumBlock:block ->
+    const ts = {
+      ts: true,
+      children: $0,
+    }
+    // const enums do not generate any JavaScript code
+    if (isConst) return ts
+    // Generate JS output for enum similar to how TypeScript does
+    const names = new Set(block.properties.map(p => p.name.name))
+    return [ts,
+      {
+        js: true,
+        children: [
+          ["let ", id, " = {};\n"],
+          ...block.properties.map((property, i) => {
+            let init, isString
+            if (property.init) {
+              // Replace references to other enum members.
+              // TS further restricts this to past enum members,
+              // but we don't need to enforce that here.
+              init = module.replaceNodes(structuredClone(property.init),
+                n => n.type === "Identifier" && names.has(n.name),
+                n => [id, '["', n.name, '"]'])
+              const value = init[init.length - 1]
+              isString = value.type === "TemplateLiteral" ||
+                (value.type === "Literal" && value.subtype === "StringLiteral")
+            } else {
+              // Default initializer is previous property + 1, or 0 if first.
+              // TS further restricts this to when previous property is
+              // constant, but we don't need to enforce that here.
+              init = i === 0 ? " = 0" :
+                [" = ", id, '["', block.properties[i-1].name, '"] + 1']
+            }
+            // String enums do not get back references
+            if (isString) {
+              return [
+                id, '["', property.name, '"]', init, ";\n",
+              ]
+            } else {
+              return [
+                id, "[", id, '["', property.name, '"]', init,
+                '] = "', property.name, '";\n',
+              ]
+            }
+          }),
+        ],
+      }
+    ]
+
+EnumBlock
+  __ OpenBrace NestedEnumProperties:props __ CloseBrace ->
+    return {
+      properties: props.properties,
+      children: $0,
+    }
+  __ OpenBrace ( __ EnumProperty )*:props __ CloseBrace ->
+    return {
+      properties: props.map(p => p[1]),
+      children: $0,
+    }
+  # NOTE: Added indentation based implied braces
+  InsertOpenBrace NestedEnumProperties:props InsertNewline InsertIndent InsertCloseBrace ->
+    return {
+      properties: props.properties,
+      children: $0,
+    }
+
+NestedEnumProperties
+  PushIndent NestedEnumProperty*:props PopIndent ->
+    if (!props.length) return $skip
+    return {
+      properties: props.map((p) => p.property),
+      children: $0,
+    }
+
+NestedEnumProperty
+  Nested EnumProperty ->
+    return {
+      property: $2,
+      children: $0,
+    }
+
+EnumProperty
+  Identifier:name ( __ Equals ExtendedExpression )?:init ObjectPropertyDelimiter ->
+    return {
+      type: "EnumProperty",
+      name,
+      init,
+      children: $0,
+    }
 
 TypeIndexSignature
   ( [+-]? "readonly" __ )? OpenBracket TypeIndex CloseBracket ( __ [+-] QuestionMark )?
@@ -7241,6 +7343,22 @@ Init
         if (predicate(node)) return node
         node = node.parent
       }
+    }
+
+    // Replace all nodes that match predicate with replacer(node)
+    module.replaceNodes = (root, predicate, replacer) => {
+      if (root == null) return root
+      const array = Array.isArray(root) ? root : root.children
+      if (!array) return root
+      array.forEach((node, i) => {
+        if (node == null) return
+        if (predicate(node)) {
+          array[i] = replacer(node, root)
+        } else {
+          module.replaceNodes(node, predicate, replacer)
+        }
+      })
+      return root
     }
 
     function processParams(f) {

--- a/test/types/enum.civet
+++ b/test/types/enum.civet
@@ -1,0 +1,107 @@
+{testCase} from ../helper.civet
+
+describe "[TS] enum", ->
+  // Examples from https://www.typescriptlang.org/docs/handbook/enums.html#computed-and-constant-members
+
+  testCase """
+    braced
+    ---
+    enum Direction {
+      Up,
+      Down,
+      Left,
+      Right,
+    }
+    ---
+    enum Direction {
+      Up,
+      Down,
+      Left,
+      Right,
+    }
+  """
+
+  testCase """
+    indented
+    ---
+    enum Direction
+      Up
+      Down
+      Left
+      Right
+    ---
+    enum Direction {
+      Up,
+      Down,
+      Left,
+      Right,
+    }
+  """
+
+  testCase.js """
+    no initializers
+    ---
+    enum Direction
+      Up
+      Down
+      Left
+      Right
+    ---
+    let Direction = {};
+    Direction[Direction["Up"] = 0] = "Up";
+    Direction[Direction["Down"] = Direction["Up"] + 1] = "Down";
+    Direction[Direction["Left"] = Direction["Down"] + 1] = "Left";
+    Direction[Direction["Right"] = Direction["Left"] + 1] = "Right";
+
+  """
+
+  testCase.js """
+    initializers
+    ---
+    enum Direction
+      Up
+      Down = 1 + 2
+      Left
+      Right = foo()
+    ---
+    let Direction = {};
+    Direction[Direction["Up"] = 0] = "Up";
+    Direction[Direction["Down"] = 1 + 2] = "Down";
+    Direction[Direction["Left"] = Direction["Down"] + 1] = "Left";
+    Direction[Direction["Right"] = foo()] = "Right";
+
+  """
+
+  testCase.js """
+    initializers referring to other members
+    ---
+    enum Direction
+      Up
+      Down = Up + 1
+      Left = Up + Down
+      Right = Other.Up + Other.Down
+    ---
+    let Direction = {};
+    Direction[Direction["Up"] = 0] = "Up";
+    Direction[Direction["Down"] = Direction["Up"] + 1] = "Down";
+    Direction[Direction["Left"] = Direction["Up"] + Direction["Down"]] = "Left";
+    Direction[Direction["Right"] = Other.Up + Other.Down] = "Right";
+
+  """
+
+  testCase.js """
+    string initializers
+    ---
+    enum Direction
+      Up = "up"
+      Down = `down`
+      Left = 'left'
+      Right = 4
+    ---
+    let Direction = {};
+    Direction["Up"] = "up";
+    Direction["Down"] = `down`;
+    Direction["Left"] = 'left';
+    Direction[Direction["Right"] = 4] = "Right";
+
+  """


### PR DESCRIPTION
Fixes #227.

The fun part here is the JavaScript code generation.  I tried to (roughly) follow the rules in [the documentation](https://www.typescriptlang.org/docs/handbook/enums.html#computed-and-constant-members), but I didn't enforce as many rules because I believe these simple rules work whenever TS considers the enum valid, and we can rely on TS checking for validity.

Note that TS [doesn't generate back references for string values](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEEQBd4A8Bc8CuA7A1rgPYDuuANPAJ5Z6GkXwBmRRWUuVAsAFC8i5sAW3gARAJZwwycUVzwA3r3jwAqgAd4AXngAibOt3llYhtvgADYAwvGeKgDIgmqHQEY7KgEriA5gAtXPRg-QKNeAF9eIA) (and it doesn't support mixing strings with "computed" types, so we don't need to detect e.g. a variable of type `string`).

TS also puts all of this inside a function wrapper, but I don't see the point of that. There can't be any declarations, this can't be an expression, and this code always goes right after the declaration.