### PR TITLE
Call with unparenthesized iteration expression argument

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -69,6 +69,12 @@ Arguments
 
 ImplicitArguments
   ( TypeArguments !ImplementsToken )?:ta ApplicationStart InsertOpenParen:open _*:ws NonPipelineArgumentList:args InsertCloseParen:close ->
+    // Don't treat as call if this is a postfix for/while/until/if/unless
+    if (args.length === 1 && args[0].type === "IterationExpression" &&
+        args[0].subtype !== "DoStatement" && !args[0].async &&
+        module.isEmptyBareBlock(args[0].block)) {
+      return $skip
+    }
     return [ta?.[0], open, module.insertTrimmingSpace(ws, ""), args, close]
 
 ExplicitArguments
@@ -82,7 +88,7 @@ ApplicationStart
 ForbiddenImplicitCalls
   # Reserved words that prevent spaced implicit function application
   # ie: the 'of' in 'for x of ...'
-  /(as|for|while|until|of|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
+  /(as|of|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
   # NOTE: Don't allow non-heregex regexes that begin with a space as first argument without parens
   "/ "
   AtAt # experimentalDecorators
@@ -1550,8 +1556,9 @@ Block
   ImplicitNestedBlock
 
   ThenClause
-  TrailingComment*:ws Statement:s ->
-    const expressions = [$0]
+  # NOTE: !EOS prevents capturing a following unindented Statement
+  TrailingComment*:ws !EOS Statement:s ->
+    const expressions = [[ws, s]]
     return {
       type: "BlockStatement",
       expressions,
@@ -6797,6 +6804,15 @@ Init
       let s = node
       while (s && s[0] && !s.token) s = s[0]
       return s.token?.startsWith?.('`')
+    }
+
+    module.isEmptyBareBlock = function(node) {
+      if (node?.type !== "BlockStatement") return false
+      const {bare, expressions} = node
+      return bare &&
+        (expressions.length === 0 ||
+         (expressions.length === 1 &&
+          expressions[0][1]?.type === "EmptyStatement"))
     }
 
     module.processBinaryOpExpression = function($0) {

--- a/test/for.civet
+++ b/test/for.civet
@@ -181,24 +181,30 @@ describe "for", ->
     postfix
     ---
     console.log(i) for let i = 0; i < 10; i++
+    nextLine
     ---
     for (let i = 0; i < 10; i++) { console.log(i) }
+    nextLine
   """
 
   testCase """
     postfix for in
     ---
     console.log(i) for i in x
+    nextLine
     ---
     for (const i in x) { console.log(i) }
+    nextLine
   """
 
   testCase """
     postfix for of
     ---
     console.log(i) for i of x
+    nextLine
     ---
     for (const i of x) { console.log(i) }
+    nextLine
   """
 
   describe "expression", ->

--- a/test/for.civet
+++ b/test/for.civet
@@ -181,29 +181,46 @@ describe "for", ->
     postfix
     ---
     console.log(i) for let i = 0; i < 10; i++
-    nextLine
     ---
     for (let i = 0; i < 10; i++) { console.log(i) }
-    nextLine
   """
 
   testCase """
     postfix for in
     ---
     console.log(i) for i in x
-    nextLine
     ---
     for (const i in x) { console.log(i) }
-    nextLine
   """
 
   testCase """
     postfix for of
     ---
     console.log(i) for i of x
+    ---
+    for (const i of x) { console.log(i) }
+  """
+
+  testCase """
+    postfix for of with unindented next line
+    ---
+    console.log(i) for i of x
     nextLine
     ---
     for (const i of x) { console.log(i) }
+    nextLine
+  """
+
+  testCase """
+    postfix for of with dedented next line
+    ---
+    for x of y
+      console.log(i) for i of x
+    nextLine
+    ---
+    for (const x of y) {
+      for (const i of x) { console.log(i) }
+    }
     nextLine
   """
 

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -394,6 +394,37 @@ describe "function application", ->
       c)
   """
 
+  // Beyond CoffeeScript
+  testCase """
+    apply to a for loop
+    ---
+    x for y of z
+      y ** 2
+    ---
+    x((()=>{const results=[];for (const y of z) {
+      results.push(y ** 2)
+    }; return results})())
+  """
+
+  testCase """
+    apply to a one-line for loop
+    ---
+    x for y of z then y ** 2
+    ---
+    x((()=>{const results=[];for (const y of z) results.push(y ** 2); return results})())
+  """
+
+  testCase """
+    apply to a while loop
+    ---
+    x while y
+      y--
+    ---
+    x((()=>{const results=[];while (y) {
+      results.push(y--)
+    }; return results})())
+  """
+
   testCase """
     CoffeeScript style splat
     ---


### PR DESCRIPTION
I've long wanted to be able to do this (CoffeeScript doesn't allow it):

```coffee
func for x of y
  x * 2
```

As @STRd6 suggested, this checks for `IterationExpression`s without any body (e.g. a single semicolon) and skips in that case to enable a postfix iteration. Seems relatively easy!

I am a little worried about weird interaction with caching if we end up parsing the iteration body multiple times and getting the indentation wrong the second time (which happened in #398)... but so far it seems to work in all cases. (And this would hopefully be fixed by #341.) A workaround if it ever happens would be to add an explicit semicolon after a postfix iteration.