### PR TITLE
Fixes #416: Fix handling of backslash escapes inside strings that convert to template strings

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7153,8 +7153,13 @@ Init
         .replace(/(\r?\n|\n)[ \t]*$/, "")
       }
 
-      // escape backtick, $
-      str = str.replace(/(`|\$\{)/g, "\\$1")
+      // escape unescaped backticks and `${`
+      str = str.replace(/(\\.|`|\$\{)/g, s => {
+        if (s[0] === "\\") {
+          return s
+        }
+        return `\\${s}`
+      })
 
       return {
         $loc,

--- a/test/block-strings.civet
+++ b/test/block-strings.civet
@@ -161,3 +161,17 @@ describe "block strings", ->
       ---
       x = `\n\nhello`
     '''
+
+    testCase """
+      doesn't escape dollar signs that are already escaped
+      ---
+      '''
+        <div>
+          \\${3 + 4}
+        </div>
+      '''
+      ---
+      `<div>
+        \\${3 + 4}
+      </div>`
+    """

--- a/test/template-literal.civet
+++ b/test/template-literal.civet
@@ -73,6 +73,38 @@ describe "template literal", ->
     x`yo`
   """
 
+  // NOTE: backslashes are extra escaped because the test is inside a string
+  testCase """
+    triple single-quote substitutions
+    ---
+    x'''yo${x}'''
+    ---
+    x`yo\\${x}`
+  """
+
+  // NOTE: backslashes are extra escaped because the test is inside a string
+  testCase """
+    tagged triple single-quote escapes
+    ---
+    x'''yo\\\\${x}'''
+    ---
+    x`yo\\\\\\${x}`
+  """
+
+  testCase """
+    escaped $ in block template
+    ---
+    ```
+      <div>
+        \\${3 + 4}
+      </div>
+    ```
+    ---
+    `<div>
+      \\${3 + 4}
+    </div>`
+  """
+
   testCase '''
     tagged triple double-quote
     ---


### PR DESCRIPTION
In the string processing we weren't pulling the backslash escaped characters with the backslash so they ended up double escaping.