### PR TITLE
Fixes #420 Decorate exported class

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5349,6 +5349,9 @@ TypeDeclaration
   ( Export _? )? ( Declare _? )  TypeLexicalDeclaration -> { ts: true, children: $0 }
   ( Export _? )? ( Declare _? )? TypeDeclarationRest    -> { ts: true, children: $0 }
 
+  # NOTE: TS Exported classes can have decorators before export but not after
+  Decorators ( Export _? ) !Decorators ClassDeclaration -> { ts: true, children: $0 }
+
 # NOTE: These are declarations even without a `declare` prefix
 TypeDeclarationRest
   # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
@@ -5459,7 +5462,7 @@ NestedDeclareElement
 
 # NOTE: Variation on TypeDeclaration where Declare already applied.
 DeclareElement
-  ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
+  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
   ( Export _? )? TypeDeclarationRest    -> { ts: true, children: $0 }
 
 EnumDeclaration

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -129,6 +129,8 @@ ForbiddenImplicitCalls
   /(as|of|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
   # NOTE: Don't allow non-heregex regexes that begin with a space as first argument without parens
   "/ "
+  # Don't treat @@decorator class ... as an implicit call
+  ForbidClassImplicitCall Class
   AtAt # experimentalDecorators
   Identifier "=" Whitespace
   Identifier !"(" ->
@@ -2312,7 +2314,9 @@ Decorator
   AtAt CallExpression
 
 Decorators
-  ( __ Decorator )+ __
+  ForbidClassImplicitCall ( __ Decorator )*:decorators __ RestoreClassImplicitCall ->
+    if (!decorators.length) return $skip
+    return $0
 
 # https://262.ecma-international.org/#prod-MethodDefinition
 MethodDefinition
@@ -3506,6 +3510,18 @@ ExpressionWithIndentedApplicationForbidden
     if (exp) return exp
     return $skip
 
+ForbidClassImplicitCall
+  "" ->
+    module.forbidIndentedApplication.push(true)
+
+AllowClassImplicitCall
+  "" ->
+    module.forbidIndentedApplication.push(false)
+
+RestoreClassImplicitCall
+  "" ->
+    module.forbidIndentedApplication.pop()
+
 ForbidIndentedApplication
   "" ->
     module.forbidIndentedApplication.push(true)
@@ -3565,10 +3581,10 @@ MultiLineImplicitObjectLiteralAllowed
     if (module.multiLineImplicitObjectLiteralForbidden) return $skip
 
 AllowAll
-  AllowTrailingMemberProperty AllowIndentedApplication AllowMultiLineImplicitObjectLiteral
+  AllowTrailingMemberProperty AllowIndentedApplication AllowMultiLineImplicitObjectLiteral AllowClassImplicitCall
 
 RestoreAll
-  RestoreTrailingMemberProperty RestoreIndentedApplication RestoreMultiLineImplicitObjectLiteral
+  RestoreTrailingMemberProperty RestoreIndentedApplication RestoreMultiLineImplicitObjectLiteral RestoreClassImplicitCall
 
 # https://262.ecma-international.org/#prod-ExpressionStatement
 ExpressionStatement
@@ -3821,8 +3837,9 @@ ExportDeclaration
     return { type: "ExportDeclaration", ts: $3.ts, children: $0 }
   # NOTE: Declaration and VariableStatement should come before NamedExports
   # so that NamedExports doesn't grab function, async, type, var, etc.
-  Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ) ->
-    return { type: "ExportDeclaration", ts: $3.ts, children: $0 }
+  # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
+  Decorators? Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):decl ->
+    return { type: "ExportDeclaration", ts: decl.ts, children: $0 }
 
 # CoffeeScript style `export x = 3` -> `export var x = 3`
 ExportVarDec
@@ -5349,9 +5366,6 @@ TypeDeclaration
   ( Export _? )? ( Declare _? )  TypeLexicalDeclaration -> { ts: true, children: $0 }
   ( Export _? )? ( Declare _? )? TypeDeclarationRest    -> { ts: true, children: $0 }
 
-  # NOTE: TS Exported classes can have decorators before export but not after
-  Decorators ( Export _? ) !Decorators ClassDeclaration -> { ts: true, children: $0 }
-
 # NOTE: These are declarations even without a `declare` prefix
 TypeDeclarationRest
   # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
@@ -5987,6 +6001,7 @@ Reset
       token: "",
     }]
 
+    module.forbidClassImplicitCall = [false]
     module.forbidIndentedApplication = [false]
     module.forbidTrailingMemberProperty = [false]
     module.forbidMultiLineImplicitObjectLiteral = [false]
@@ -6001,6 +6016,12 @@ Reset
           get() {
             const {indentLevels: l} = module
             return l[l.length-1]
+          },
+        },
+        classImplicitCallForbidden: {
+          get() {
+            const {forbidClassImplicitCall: s} = module
+            return s[s.length-1]
           },
         },
         indentedApplicationForbidden: {

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -233,3 +233,19 @@ describe "[TS] class", ->
       y: ()=>void
     }
   """
+
+  testCase """
+    decorate export class
+    ---
+    @@decorator
+    export class A {}
+    ---
+    @decorator
+    export class A {}
+  """
+
+  throws """
+    decorate export class
+    ---
+    export @@decorator class A {}
+  """

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -244,8 +244,20 @@ describe "[TS] class", ->
     export class A {}
   """
 
-  throws """
+  testCase """
     decorate export class
     ---
     export @@decorator class A {}
+    ---
+    export @decorator class A {}
+  """
+
+  testCase """
+    combo decorate
+    ---
+    @@decorator1
+    export @@decorator2 class A {}
+    ---
+    @decorator1
+    export @decorator2 class A {}
   """


### PR DESCRIPTION
This allows decorators in TS "before export" and TC39 "after export" positions and doesn't try to do anything smart about it yet.

I added another state flag for when we are inside `Decorators` to prevent `@@decorator class ...` from being treated as an implicit call passing a class expression to the decorator function. If someone really wants to do that they'll need to use parentheses and be explicit.