### PR TITLE
Replace TrailingComment* with _? except after statement delimiters.

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4346,6 +4346,8 @@ Comment
   MultiLineComment
   SingleLineComment
 
+# https://262.ecma-international.org/#prod-SingleLineComment
+# This is more accurately called "RestOfLineComment"
 SingleLineComment
   JSSingleLineComment
   CoffeeCommentEnabled CoffeeSingleLineComment
@@ -4387,7 +4389,7 @@ RestOfLine
   (NonNewlineWhitespace / SingleLineComment / MultiLineComment)* EOL
 
 TrailingComment
-  (NonNewlineWhitespace / InlineComment / SingleLineComment)
+  _? SingleLineComment
 
 # Non-newline "white space" (includes inline comments)
 # TODO: Allow for inline Coffee comments when enabled
@@ -4417,7 +4419,7 @@ Whitespace
 
 # Fake a blocklike form for single expressions
 ExpressionDelimiter
-  _? Semicolon InsertComma TrailingComment* ->
+  _? Semicolon InsertComma TrailingComment? ->
     // Replace semicolon with comma
     return [$1, $3, $4]
   &EOS InsertComma -> $2
@@ -4438,7 +4440,7 @@ StatementDelimiter
   &EOS
 
 SemicolonDelimiter
-  _? Semicolon TrailingComment* ->
+  _? Semicolon TrailingComment? ->
     return {
       type: "SemicolonDelimiter",
       children: $0

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -176,8 +176,8 @@ ArgumentList
     return module.insertTrimmingSpace($1, '')
   NestedArgumentList
   # NOTE: Eliminated left recursion
-  TrailingComment* ArgumentPart ( CommaDelimiter TrailingComment* ArgumentPart )* ->
-    return [...$1, $2, ...$3]
+  _? ArgumentPart ( CommaDelimiter _? ArgumentPart )* ->
+    return [...($1 || []), $2, ...$3]
 
 # NOTE: ArgumentList variant that forbids top-level pipeline operators
 NonPipelineArgumentList
@@ -187,8 +187,8 @@ NonPipelineArgumentList
     return module.insertTrimmingSpace($1, '')
   NestedArgumentList
   # NOTE: Eliminated left recursion
-  TrailingComment* NonPipelineArgumentPart ( CommaDelimiter TrailingComment* NonPipelineArgumentPart )* ->
-    return [...$1, $2, ...$3]
+  _? NonPipelineArgumentPart ( CommaDelimiter _? NonPipelineArgumentPart )* ->
+    return [...($1 || []), $2, ...$3]
 
 NestedArgumentList
   PushIndent NestedArgument*:args PopIndent ->
@@ -199,7 +199,7 @@ NestedArgument
   Nested SingleLineArgumentExpressions ParameterElementDelimiter
 
 SingleLineArgumentExpressions
-  TrailingComment* ArgumentPart ( TrailingComment* Comma TrailingComment* ArgumentPart )*
+  _? ArgumentPart ( _? Comma _? ArgumentPart )*
 
 ArgumentPart
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
@@ -306,8 +306,8 @@ NonPipelineAssignmentExpression
   __ AssignmentExpressionTail
 
 SingleLineAssignmentExpression
-  TrailingComment*:ws AssignmentExpressionTail:tail ->
-    if (ws.length) {
+  _?:ws AssignmentExpressionTail:tail ->
+    if (ws?.length) {
       // Glom whitespace into identifiers and literals to ease checking of "simple" refs
       // NOTE: This can get weird if we depend on the specific location of children
       if (tail.children && tail.type !== "IterationExpression") {
@@ -353,7 +353,7 @@ YieldExpression
 YieldTail
   &EOS
   # NOTE: Merged optional star
-  ( TrailingComment* Star )? AssignmentExpression
+  ( _? Star )? AssignmentExpression
 
 # https://262.ecma-international.org/#prod-ArrowFunction
 ArrowFunction
@@ -402,7 +402,7 @@ ConditionalExpression
 TernaryRest
   NestedTernaryRest
   # NOTE: Ternary `a ? b : c` is disabled if CoffeeScript binary existential `a ? b` is enabled
-  !CoffeeBinaryExistentialEnabled &" " TrailingComment* QuestionMark ExtendedExpression __ Colon ExtendedExpression ->
+  !CoffeeBinaryExistentialEnabled &" " _? QuestionMark ExtendedExpression __ Colon ExtendedExpression ->
     return $0.slice(2)
 
 NestedTernaryRest
@@ -559,7 +559,7 @@ NestedClassElement
 # https://262.ecma-international.org/#prod-ClassElement
 ClassElement
   # NOTE: Combined optional static and Method/Field definition
-  Decorators? AccessModifier? ( Static TrailingComment* )? ClassElementDefinition
+  Decorators? AccessModifier? ( Static _? )? ClassElementDefinition
   # ClassStaticBlock
   Static BracedBlock
 
@@ -584,7 +584,7 @@ NestedClassSignatureElement
 
 ClassSignatureElement
   # NOTE: MethodSignature instead of MethodDefinition
-  Decorators? AccessModifier? ( Static TrailingComment* )? ( MethodSignature / FieldDefinition )
+  Decorators? AccessModifier? ( Static _? )? ( MethodSignature / FieldDefinition )
   Static ClassSignatureBody
 
 AccessModifier
@@ -623,7 +623,7 @@ FieldDefinition
     }
     return $0
 
-  ( Abstract TrailingComment* )? ( Readonly TrailingComment* )? ClassElementName TypeSuffix? Initializer? ->
+  ( Abstract _? )? ( Readonly _? )? ClassElementName TypeSuffix? Initializer? ->
     if ($1) return { children: $0, ts: true }
     return $0
 
@@ -1681,7 +1681,7 @@ NoPostfixBracedBlock
     }
 
 NonSingleBracedBlock
-  TrailingComment*:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace )? RestoreAll ->
+  _?:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace )? RestoreAll ->
     if (!$4) return $skip
     const [block, ws2, close] = $4
     return {
@@ -1733,7 +1733,7 @@ PostfixedSingleLineStatements
 
 BracedContent
   NestedBlockStatements
-  TrailingComment* Statement ->
+  _? Statement ->
     const expressions = [["", $2]]
     return {
       type: "BlockStatement",
@@ -2137,7 +2137,7 @@ InlineObjectLiteral
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
 # Instead we see if the next line matches a NamedProperty and if so we insert a comma
 ImplicitInlineObjectPropertyDelimiter
-  TrailingComment* Comma
+  _? Comma
   &( ( Samedent / _* ) NamedProperty ) InsertComma -> $2
   # NOTE: This is hacky but used when an inline object is inside a ternary conditional
   # Also if inline object is in an argument list or subexpression
@@ -2354,7 +2354,7 @@ MethodDefinition
 
 MethodModifier
   # NOTE: Merged get/set definitions
-  GetOrSet TrailingComment*
+  GetOrSet _?
   # NOTE: Merged async and generator into MethodModifier
   ( Async __ ) ( Star __ )?
   Star __
@@ -2434,8 +2434,8 @@ WAssignmentOp
 
 # https://262.ecma-international.org/#prod-AssignmentOperator
 AssignmentOp
-  AssignmentOpSymbol TrailingComment* ->
-    if ($2.length) {
+  AssignmentOpSymbol _? ->
+    if ($2?.length) {
       return {
         token: $1,
         children: [$1, ...$2]
@@ -2448,19 +2448,19 @@ AssignmentOp
 # This is separate from AssignmentOp because it only works in certain contexts
 # (in particular, not at the beginning of a line).
 OperatorAssignmentOp
-  Xor "=" &Whitespace TrailingComment* ->
+  Xor "=" &Whitespace _? ->
     return {
       special: true,
       call: module.getRef("xor"),
       children: [$2, ...$4]
     }
-  Xnor "=" &Whitespace TrailingComment* ->
+  Xnor "=" &Whitespace _? ->
     return {
       special: true,
       call: module.getRef("xnor"),
       children: [$2, ...$4]
     }
-  Identifier "=" &Whitespace TrailingComment* ->
+  Identifier "=" &Whitespace _? ->
     return {
       special: true,
       call: $1,
@@ -2691,17 +2691,17 @@ StatementListItem
   PostfixedStatement
 
 PostfixedStatement
-  Statement:statement ( TrailingComment* PostfixStatement )?:post ->
+  Statement:statement ( _? PostfixStatement )?:post ->
     if (post) return module.addPostfixStatement(statement, ...post)
     return statement
 
 PostfixedExpression
-  ExtendedExpression:expression ( TrailingComment* PostfixStatement )?:post ->
+  ExtendedExpression:expression ( _? PostfixStatement )?:post ->
     if (post) return module.attachPostfixStatementAsExpression(expression, post)
     return expression
 
 NonPipelinePostfixedExpression
-  NonPipelineExtendedExpression:expression ( TrailingComment* PostfixStatement )?:post ->
+  NonPipelineExtendedExpression:expression ( _? PostfixStatement )?:post ->
     if (post) return module.attachPostfixStatementAsExpression(expression, post)
     return expression
 
@@ -2744,7 +2744,8 @@ Statement
 
 # NOTE: EmptyStatement handled differently than spec, consuming inline whitespace and comments then asserting following semi-colon
 EmptyStatement
-  TrailingComment* &";" -> { type: "EmptyStatement", children: $1 }
+  _? &";" ->
+    return { type: "EmptyStatement", children: $1 || [] }
 
 # https://262.ecma-international.org/#prod-BlockStatement
 BlockStatement
@@ -2783,7 +2784,7 @@ IfStatement
 
 ElseClause
   Samedent Else Block
-  TrailingComment* Else Block
+  _? Else Block
 
 IfClause
   If Condition -> { type: "IfStatement", children: $0 }
@@ -2809,7 +2810,7 @@ UnlessExpression
     return module.expressionizeIfClause(clause, b, e)
 
 ElseExpressionClause
-  ( ( Samedent Else ) / ( TrailingComment* Else ) ) ElseExpressionBlock ->
+  ( ( Samedent Else ) / ( _? Else ) ) ElseExpressionBlock ->
     return [...$1, $2]
 
 # Block of expressions that can't include pure statements
@@ -2939,7 +2940,7 @@ WhileStatement
     }
 
 WhileClause
-  ( While / Until ):kind TrailingComment*:ws Condition:cond ->
+  ( While / Until ):kind _?:ws Condition:cond ->
     if (kind.token === "until") {
       kind.token = "while"
 
@@ -3505,7 +3506,7 @@ CatchParameter
 
 # An expression with explicit or implied parentheses, for use in if/while/switch
 Condition
-  ParenthesizedExpression !( TrailingComment* ( BinaryOp / AssignmentOp / Dot / QuestionMark ) ) !( _ OperatorAssignmentOp ) -> $1
+  ParenthesizedExpression !( _? ( BinaryOp / AssignmentOp / Dot / QuestionMark ) ) !( _ OperatorAssignmentOp ) -> $1
   InsertOpenParen:open ExpressionWithIndentedApplicationForbidden:expression InsertCloseParen:close ->
     // Don't double wrap parethesized expressions
     if (expression.type === "ParenthesizedExpression") return expression
@@ -4416,7 +4417,7 @@ Whitespace
 
 # Fake a blocklike form for single expressions
 ExpressionDelimiter
-  TrailingComment* Semicolon InsertComma TrailingComment* ->
+  _? Semicolon InsertComma TrailingComment* ->
     // Replace semicolon with comma
     return [$1, $3, $4]
   &EOS InsertComma -> $2
@@ -4437,7 +4438,7 @@ StatementDelimiter
   &EOS
 
 SemicolonDelimiter
-  TrailingComment* Semicolon TrailingComment* ->
+  _? Semicolon TrailingComment* ->
     return {
       type: "SemicolonDelimiter",
       children: $0
@@ -5380,9 +5381,9 @@ TypeDeclaration
 # NOTE: These are declarations even without a `declare` prefix
 TypeDeclarationRest
   # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
-  TypeKeyword TrailingComment* IdentifierName TypeParameters? __ Equals ( ( _? Type ) / ( __ Type ) )
-  Interface   TrailingComment* IdentifierName TypeParameters? InterfaceExtendsClause? InterfaceBlock
-  Namespace   TrailingComment* IdentifierName ModuleBlock
+  TypeKeyword _? IdentifierName TypeParameters? __ Equals ( ( _? Type ) / ( __ Type ) )
+  Interface   _? IdentifierName TypeParameters? InterfaceExtendsClause? InterfaceBlock
+  Namespace   _? IdentifierName ModuleBlock
   FunctionSignature
 
 # NOTE: These are all guaranteed to be preceded by a `declare` keyword
@@ -5390,7 +5391,7 @@ TypeLexicalDeclaration
   __ LetOrConstOrVar TypeDeclarationBinding ( CommaDelimiter __ TypeDeclarationBinding )*
   __ EnumDeclaration
   ClassSignature
-  Namespace TrailingComment* IdentifierName DeclareBlock
+  Namespace _? IdentifierName DeclareBlock
   Module _ StringLiteral DeclareBlock?
   Global DeclareBlock?
 
@@ -5491,7 +5492,7 @@ DeclareElement
   ( Export _? )? TypeDeclarationRest    -> { ts: true, children: $0 }
 
 EnumDeclaration
-  ( Const _ )?:isConst Enum TrailingComment* IdentifierName:id EnumBlock:block ->
+  ( Const _ )?:isConst Enum _? IdentifierName:id EnumBlock:block ->
     const ts = {
       ts: true,
       children: $0,


### PR DESCRIPTION
TrailingComment includes // comments and those can't appear in the middle of a single line statement (it would comment out the rest of the line). So now we only check for inline comments in most places except statement delimiters which should have the rest of line trailing comments attached to them so they don't get attached to enclosing blocks.