### PR TITLE
Implicit `async` and `*` for functions and methods

### DIFF
--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -26,7 +26,7 @@ module.exports = {
   setup(build)
     build.onLoad {
       filter: /\.civet$/
-    }, async (args) ->
+    }, (args) ->
       try
         source := await readFile args.path, 'utf8'
         filename := path.relative(process.cwd(), args.path)

--- a/source/lib.js
+++ b/source/lib.js
@@ -118,11 +118,32 @@ function gatherRecursiveAll(node, predicate) {
   return nodes
 }
 
+/**
+ * Does this expression have an `await` in it and thus needs to be `async`?
+ */
+function hasAwait(exp) {
+  return gatherRecursiveWithinFunction(exp, ({ type }) => type === "Await").length > 0
+}
+
+function isFunction(node) {
+  const { type } = node
+  return type === "FunctionExpression" || type === "ArrowFunction" ||
+    type === "MethodDefinition" || node.async
+  // do blocks can be marked async to prevent automatic await
+}
+
+function gatherRecursiveWithinFunction(node, predicate) {
+  return gatherRecursive(node, predicate, isFunction)
+}
+
 module.exports = {
   clone,
   deepCopy,
   gatherNodes,
   gatherRecursive,
   gatherRecursiveAll,
+  gatherRecursiveWithinFunction,
+  hasAwait,
+  isFunction,
   removeParentPointers,
 }

--- a/source/lib.js
+++ b/source/lib.js
@@ -125,6 +125,10 @@ function hasAwait(exp) {
   return gatherRecursiveWithinFunction(exp, ({ type }) => type === "Await").length > 0
 }
 
+function hasYield(exp) {
+  return gatherRecursiveWithinFunction(exp, ({ type }) => type === "Yield").length > 0
+}
+
 function isFunction(node) {
   const { type } = node
   return type === "FunctionExpression" || type === "ArrowFunction" ||
@@ -144,6 +148,7 @@ module.exports = {
   gatherRecursiveAll,
   gatherRecursiveWithinFunction,
   hasAwait,
+  hasYield,
   isFunction,
   removeParentPointers,
 }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -11,6 +11,9 @@ const {
   gatherNodes,
   gatherRecursive,
   gatherRecursiveAll,
+  gatherRecursiveWithinFunction,
+  hasAwait,
+  isFunction,
   removeParentPointers,
 } = require("./lib.js")
 ```
@@ -357,22 +360,21 @@ YieldTail
 
 # https://262.ecma-international.org/#prod-ArrowFunction
 ArrowFunction
-  ( Async __ )? ArrowFunctionTail:tail ->
-    return {
-      ...tail,
-      children: [...($1 || []), ...tail.children]
+  ThinArrowFunction
+  ( Async _ )?:async Parameters:parameters ReturnTypeSuffix?:suffix FatArrow FatArrowBody:expOrBlock ->
+    if (!async) async = []
+    if (hasAwait(expOrBlock)) {
+      async.push("async ")
     }
 
-ArrowFunctionTail
-  ThinArrowFunction
-  Parameters:parameters ReturnTypeSuffix?:suffix FatArrow FatArrowBody:expOrBlock ->
     return {
       type: "ArrowFunction",
       parameters,
       returnType: suffix,
       ts: false,
+      async,
       block: expOrBlock,
-      children: $0,
+      children: [async, $0.slice(1)],
     }
 
 FatArrow
@@ -626,10 +628,14 @@ FieldDefinition
     switch (exp.type) {
       // TODO: => functions
       case "FunctionExpression":
+        const fnTokenIndex = exp.children.findIndex(c => c.token === "function")
+        // copy
+        const children = exp.children.slice()
+        // replace "function" token with id
+        children.splice(fnTokenIndex, 1, id)
         return {
           ...exp,
-          // Remove "function" token
-          children: [id, ...exp.children.slice(1)]
+          children,
         }
       default:
         return [id, " = ", exp]
@@ -1436,13 +1442,16 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async _? )?:async Function:func ( _? Star )?:star ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async _ )?:async Function:func ( _? Star )?:star ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
+    if (!async) async = []
+
     return {
       type: "FunctionSignature",
       id: wid?.[1],
       parameters,
       returnType: suffix,
       ts: false,
+      async,
       block: null,
       children: !parameters.implicit ? $0 :
         [ async, func, star, wid, parameters, w, suffix ],
@@ -1457,6 +1466,10 @@ FunctionExpression
     if (!block) {
       signature.ts = true
       return signature
+    }
+
+    if (hasAwait(block) && !signature.async.length) {
+      signature.async.push("async ")
     }
 
     // Attach the block
@@ -1490,7 +1503,7 @@ AmpersandFunctionExpression
     }
 
     const children = [ ref, " => ", ...body ]
-    if (module.hasAwait(body)) {
+    if (hasAwait(body)) {
       children.unshift("async ")
     }
 
@@ -1577,15 +1590,22 @@ AmpersandUnaryPrefix
   [!~+-]+
 
 ThinArrowFunction
-  Parameters:parameters ReturnTypeSuffix?:suffix _* Arrow:arrow BracedOrEmptyBlock:block ->
+  ( Async _ )?:async Parameters:parameters ReturnTypeSuffix?:suffix _* Arrow:arrow BracedOrEmptyBlock:block ->
+    if (!async) async = []
+    if (hasAwait(block)) {
+      async.push("async ")
+    }
+
     return {
       type: "FunctionExpression",
       id: undefined,
       parameters,
       returnType: suffix,
       ts: false,
+      async,
       block: block,
       children: [
+        async,
         { $loc: arrow.$loc, token: "function" },
         parameters,
         suffix,
@@ -2367,9 +2387,29 @@ MethodDefinition
   # NOTE: Not adding extra validation using PropertySetParameterList
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
   MethodSignature:signature !PropertyAccess BracedOrEmptyBlock:block ->
+    let children = $0
+
+    debugger
+
+    if (hasAwait(block)) {
+      children = children.slice()
+      // get or set
+      if (signature.modifier) {
+        children.push({
+          type: "Error",
+          message: "Getters and setters cannot be async",
+        })
+      } else if(gatherRecursive(signature.modifier, (n) => n.type === "Async").length) {
+        // Do nothing, alread async
+      } else {
+        // Insert implicit async
+        children.unshift("async ")
+      }
+    }
+
     return {
       type: "MethodDefinition",
-      children: $0,
+      children,
       name: signature.name,
       signature,
       block,
@@ -2382,7 +2422,6 @@ MethodModifier
   # NOTE: Merged async and generator into MethodModifier
   ( Async __ ) ( Star __ )?
   Star __
-  #Async __
 
 # TypeScript method signature
 MethodSignature
@@ -2396,7 +2435,7 @@ MethodSignature
     }
 
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
-  MethodModifier? ClassElementName:name _* NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
+  MethodModifier? ClassElementName:name _? NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
     // Normalize name so we can check if it is `constructor`
     if (name.name) {
       name = name.name
@@ -2409,7 +2448,6 @@ MethodSignature
       children: $0,
       name: name,
       modifier: $1?.[0]?.token, // get/set
-      // TODO: get return type from type annotation
       returnType: suffix,
       parameters,
     }
@@ -6624,11 +6662,6 @@ Init
       )
     }
 
-    // Does this expression have an `await` in it and thus needs to be `async`?
-    module.hasAwait = (exp) => {
-      return gatherRecursiveWithinFunction(exp, ({type}) => type === "Await").length > 0
-    }
-
     // Wrap an expression in an IIFE, adding async/await if expression
     // uses await, or just adding async if specified.
     // Returns an Array suitable for `children`.
@@ -6637,7 +6670,7 @@ Init
       if (async) {
         prefix = "(async ()=>{"
         suffix = "})()"
-      } else if (module.hasAwait(exp)) {
+      } else if (hasAwait(exp)) {
         prefix = "(await (async ()=>{"
         suffix = "})())"
       } else {
@@ -7346,16 +7379,6 @@ Init
           message: "Multiple rest properties in object pattern",
         }, props]
       }
-    }
-
-    function isFunction(node) {
-      const {type} = node
-      return type === "FunctionExpression" || type === "ArrowFunction" ||
-             type === "MethodDefinition" || node.async
-      // do blocks can be marked async to prevent automatic await
-    }
-    function gatherRecursiveWithinFunction(node, predicate) {
-      return gatherRecursive(node, predicate, isFunction)
     }
 
     function addParentPointers(node, parent) {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2398,7 +2398,7 @@ MethodDefinition
           message: "Getters and setters cannot be async",
         })
       } else if(gatherRecursive(signature.modifier, (n) => n.type === "Async").length) {
-        // Do nothing, alread async
+        // Do nothing, already async
       } else {
         // Insert implicit async
         children.unshift("async ")

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7863,25 +7863,25 @@ Init
     // Given a MethodDefinition, convert into a FunctionExpression
     module.convertMethodToFunction = function(method) {
       const {signature, block} = method
-      let opening = signature.modifier // MethodModifier
-      if (opening) {
-        if (opening.get || opening.set) {
+      let { modifier } = signature
+      if (modifier) {
+        if (modifier.get || modifier.set) {
           throw new Error('cannot convert get/set method to function')
-        } else if (opening.async) {
+        } else if (modifier.async) {
           // put function after async
-          opening = [opening[0][0], " function ", ...opening.slice(1)]
+          modifier = [modifier.children[0][0], " function ", ...modifier.children.slice(1)]
         } else {
-          opening = ["function ", ...opening]
+          modifier = ["function ", ...modifier.children]
         }
       } else {
-        opening = "function ";
+        modifier = "function ";
       }
       return {
         ...signature,
         id: signature.name,
         type: "FunctionExpression",
         children: [
-          [opening, ...signature.children.slice(1)],
+          [modifier, ...signature.children.slice(1)],
           block,
         ],
         block,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -13,6 +13,7 @@ const {
   gatherRecursiveAll,
   gatherRecursiveWithinFunction,
   hasAwait,
+  hasYield,
   isFunction,
   removeParentPointers,
 } = require("./lib.js")
@@ -366,6 +367,14 @@ ArrowFunction
       async = "async "
     }
 
+    let error
+    if (hasYield(expOrBlock)) {
+      error = {
+        type: "Error",
+        message: "Can't use yield inside of => arrow function",
+      }
+    }
+
     return {
       type: "ArrowFunction",
       parameters,
@@ -373,7 +382,7 @@ ArrowFunction
       ts: false,
       async,
       block: expOrBlock,
-      children: [async, $0.slice(1)],
+      children: [async, $0.slice(1), error],
     }
 
 FatArrow
@@ -627,11 +636,16 @@ FieldDefinition
     switch (exp.type) {
       // TODO: => functions
       case "FunctionExpression":
-        const fnTokenIndex = exp.children.findIndex(c => c?.token === "function")
+        const fnTokenIndex = exp.children.findIndex(c => c?.token?.startsWith("function"))
         // copy
         const children = exp.children.slice()
-        // replace "function" token with id
-        children.splice(fnTokenIndex, 1, id)
+        if (exp.generator) {
+          // replace "function" and move generator ahead of id
+          children.splice(fnTokenIndex, 2, children[fnTokenIndex+1], id)
+        } else {
+          // replace "function" token with id
+          children.splice(fnTokenIndex, 1, id)
+        }
         return {
           ...exp,
           children,
@@ -1441,8 +1455,9 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async _ )?:async Function:func ( _? Star )?:star ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
     if (!async) async = []
+    if (!generator) generator = []
 
     return {
       type: "FunctionSignature",
@@ -1451,9 +1466,10 @@ FunctionSignature
       returnType: suffix,
       ts: false,
       async,
+      generator,
       block: null,
       children: !parameters.implicit ? $0 :
-        [ async, func, star, wid, parameters, w, suffix ],
+        [ async, func, generator, wid, parameters, w, suffix ],
         // move whitespace w to after implicit () in parameters
     }
 
@@ -1469,6 +1485,10 @@ FunctionExpression
 
     if (hasAwait(block) && !signature.async.length) {
       signature.async.push("async ")
+    }
+
+    if (hasYield(block) && !signature.generator.length) {
+      signature.generator.push("*")
     }
 
     // Attach the block
@@ -1594,6 +1614,11 @@ ThinArrowFunction
       async = "async "
     }
 
+    let generator = ""
+    if (hasYield(block)) {
+      generator = "*"
+    }
+
     return {
       type: "FunctionExpression",
       id: undefined,
@@ -1601,10 +1626,12 @@ ThinArrowFunction
       returnType: suffix,
       ts: false,
       async,
+      generator,
       block: block,
       children: [
         async,
         { $loc: arrow.$loc, token: "function" },
+        generator,
         parameters,
         suffix,
         block
@@ -2386,20 +2413,40 @@ MethodDefinition
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
   MethodSignature:signature !PropertyAccess BracedOrEmptyBlock:block ->
     let children = $0
+    let generatorPos = 0
+    const { modifier } = signature
 
     if (hasAwait(block)) {
+      generatorPos++
       children = children.slice()
       // get or set
-      if (signature.modifier) {
+      if (modifier?.get || modifier?.set) {
         children.push({
           type: "Error",
           message: "Getters and setters cannot be async",
         })
-      } else if(gatherRecursive(signature.modifier, (n) => n.type === "Async").length) {
+      } else if(modifier?.async) {
         // Do nothing, already async
       } else {
         // Insert implicit async
         children.unshift("async ")
+      }
+    }
+
+    if (hasYield(block)) {
+      if (children === $0) children = children.slice()
+
+      // get or set
+      if (modifier?.get || modifier?.set) {
+        children.push({
+          type: "Error",
+          message: "Getters and setters cannot be generators",
+        })
+      } else if(modifier?.generator) {
+        // Do nothing, already generator
+      } else {
+        // Insert implicit generator
+        children.splice(generatorPos, 0, "*")
       }
     }
 
@@ -2414,10 +2461,34 @@ MethodDefinition
 
 MethodModifier
   # NOTE: Merged get/set definitions
-  GetOrSet _?
+  GetOrSet:kind _? ->
+    return {
+      type: "MethodModifier",
+      async: false,
+      generator: false,
+      get: kind.token === "get",
+      set: kind.token === "set",
+      children: $0,
+    }
   # NOTE: Merged async and generator into MethodModifier
-  ( Async __ ) ( Star __ )?
-  Star __
+  ( Async __ ) ( Star __ )? ->
+    return {
+      type: "MethodModifier",
+      async: true,
+      get: false,
+      set: false,
+      generator: !!$1,
+      children: $0,
+    }
+  Star __ ->
+    return {
+      type: "MethodModifier",
+      async: false,
+      get: false,
+      set: false,
+      generator: true,
+      children: $0,
+    }
 
 # TypeScript method signature
 MethodSignature
@@ -2430,8 +2501,8 @@ MethodSignature
       parameters,
     }
 
-  # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
-  MethodModifier? ClassElementName:name _? NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
+  # NOTE: If this node layout changes, be sure to update `convertMethodToFunction`
+  MethodModifier?:modifier ClassElementName:name _? NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
     // Normalize name so we can check if it is `constructor`
     if (name.name) {
       name = name.name
@@ -2443,7 +2514,7 @@ MethodSignature
       type: "MethodSignature",
       children: $0,
       name: name,
-      modifier: $1?.[0]?.token, // get/set
+      modifier, // get/set/async/generator
       returnType: suffix,
       parameters,
     }
@@ -4867,7 +4938,7 @@ While
 
 Yield
   "yield" NonIdContinue ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, type: "Yield" }
 
 ## JSX
 
@@ -7581,7 +7652,7 @@ Init
           const {signature, block} = f
           const isConstructor = signature.name       === "constructor"
           const isVoid        = isVoidType(signature.returnType?.t)
-          const isSet         = signature.modifier   === "set"
+          const isSet         = signature.modifier?.set
 
           if (!isConstructor && !isSet && !isVoid) {
             insertReturn(block)
@@ -7792,11 +7863,11 @@ Init
     // Given a MethodDefinition, convert into a FunctionExpression
     module.convertMethodToFunction = function(method) {
       const {signature, block} = method
-      let opening = signature.children[0] // MethodModifier
+      let opening = signature.modifier // MethodModifier
       if (opening) {
-        if (opening[0].type === 'GetOrSet') {
+        if (opening.get || opening.set) {
           throw new Error('cannot convert get/set method to function')
-        } else if (opening[0][0]?.type === 'Async') {
+        } else if (opening.async) {
           // put function after async
           opening = [opening[0][0], " function ", ...opening.slice(1)]
         } else {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1614,7 +1614,7 @@ ThinArrowFunction
       async = "async "
     }
 
-    let generator = ""
+    let generator
     if (hasYield(block)) {
       generator = "*"
     }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -362,9 +362,8 @@ YieldTail
 ArrowFunction
   ThinArrowFunction
   ( Async _ )?:async Parameters:parameters ReturnTypeSuffix?:suffix FatArrow FatArrowBody:expOrBlock ->
-    if (!async) async = []
-    if (hasAwait(expOrBlock) && !async.length) {
-      async.push("async ")
+    if (hasAwait(expOrBlock) && !async) {
+      async = "async "
     }
 
     return {
@@ -628,7 +627,7 @@ FieldDefinition
     switch (exp.type) {
       // TODO: => functions
       case "FunctionExpression":
-        const fnTokenIndex = exp.children.findIndex(c => c.token === "function")
+        const fnTokenIndex = exp.children.findIndex(c => c?.token === "function")
         // copy
         const children = exp.children.slice()
         // replace "function" token with id
@@ -1591,9 +1590,8 @@ AmpersandUnaryPrefix
 
 ThinArrowFunction
   ( Async _ )?:async Parameters:parameters ReturnTypeSuffix?:suffix _* Arrow:arrow BracedOrEmptyBlock:block ->
-    if (!async) async = []
-    if (hasAwait(block) && !async.length) {
-      async.push("async ")
+    if (hasAwait(block) && !async) {
+      async = "async "
     }
 
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -363,7 +363,7 @@ ArrowFunction
   ThinArrowFunction
   ( Async _ )?:async Parameters:parameters ReturnTypeSuffix?:suffix FatArrow FatArrowBody:expOrBlock ->
     if (!async) async = []
-    if (hasAwait(expOrBlock)) {
+    if (hasAwait(expOrBlock) && !async.length) {
       async.push("async ")
     }
 
@@ -1592,7 +1592,7 @@ AmpersandUnaryPrefix
 ThinArrowFunction
   ( Async _ )?:async Parameters:parameters ReturnTypeSuffix?:suffix _* Arrow:arrow BracedOrEmptyBlock:block ->
     if (!async) async = []
-    if (hasAwait(block)) {
+    if (hasAwait(block) && !async.length) {
       async.push("async ")
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2389,8 +2389,6 @@ MethodDefinition
   MethodSignature:signature !PropertyAccess BracedOrEmptyBlock:block ->
     let children = $0
 
-    debugger
-
     if (hasAwait(block)) {
       children = children.slice()
       // get or set

--- a/test/class.civet
+++ b/test/class.civet
@@ -797,3 +797,18 @@ describe "class", ->
       abstract /* c6 */ readonly /* c7 */ num = 10
     } // c8
   """
+
+  describe "implicit async", ->
+    testCase """
+      implicit async
+      ---
+      class A
+        f()
+          await 3
+      ---
+      class A {
+        async f() {
+          return await 3
+        }
+      }
+    """

--- a/test/class.civet
+++ b/test/class.civet
@@ -812,3 +812,75 @@ describe "class", ->
         }
       }
     """
+
+    testCase """
+      does not double insert implicit async
+      ---
+      class A
+        async f()
+          await 3
+      ---
+      class A {
+        async f() {
+          return await 3
+        }
+      }
+    """
+
+  describe "implicit generator", ->
+    testCase """
+      implicit generator
+      ---
+      class A
+        f()
+          yield 3
+      ---
+      class A {
+        *f() {
+          return yield 3
+        }
+      }
+    """
+
+    testCase """
+      does not double insert implicit generator
+      ---
+      class A
+        *f()
+          yield 3
+      ---
+      class A {
+        *f() {
+          return yield 3
+        }
+      }
+    """
+
+  describe "implicit async generator", ->
+    testCase """
+      implicit async generator
+      ---
+      class A
+        f()
+          yield await 3
+      ---
+      class A {
+        async *f() {
+          return yield await 3
+        }
+      }
+    """
+
+    testCase """
+      does not double insert implicit async generator
+      ---
+      class A
+        async *f()
+          yield await 3
+      ---
+      class A {
+        async *f() {
+          return yield await 3
+        }
+      }
+    """

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -15,3 +15,33 @@ describe "coffeeClasses", ->
       }
     }
   """
+
+  testCase """
+    implicit async
+    ---
+    "civet coffeeClasses"
+    class Foo
+      bar: ->
+        await x
+    ---
+    class Foo {
+      async bar() {
+        return await x
+      }
+    }
+  """
+
+  testCase """
+    implicit generator
+    ---
+    "civet coffeeClasses"
+    class Foo
+      bar: ->
+        yield x
+    ---
+    class Foo {
+      *bar() {
+        return yield x
+      }
+    }
+  """

--- a/test/function.civet
+++ b/test/function.civet
@@ -144,6 +144,28 @@ describe "function", ->
     """
 
     testCase """
+      implicit generator
+      ---
+      ->
+        yield 5
+      ---
+      (function*() {
+        return yield 5
+      })
+    """
+
+    testCase """
+      explicit generator doesn't get double added
+      ---
+      function*
+        yield 5
+      ---
+      (function*() {
+        return yield 5
+      })
+    """
+
+    testCase """
       thick arrow
       ---
       f := =>

--- a/test/function.civet
+++ b/test/function.civet
@@ -133,6 +133,17 @@ describe "function", ->
     """
 
     testCase """
+      explicit async doesn't get double added
+      ---
+      async ->
+        await 5
+      ---
+      (async function() {
+        return await 5
+      })
+    """
+
+    testCase """
       thick arrow
       ---
       f := =>

--- a/test/function.civet
+++ b/test/function.civet
@@ -95,6 +95,62 @@ describe "function", ->
     async function defaultLoad () {}
   """
 
+  describe "implicit async", ->
+    testCase """
+      basic
+      ---
+      function f
+        await 5
+      ---
+      async function f() {
+        return await 5
+      }
+    """
+
+    testCase """
+      nested function boundary
+      ---
+      function f
+        function g
+          await 5
+      ---
+      function f() {
+        return async function g() {
+          return await 5
+        }
+      }
+    """
+
+    testCase """
+      arrow
+      ---
+      f := ->
+        await 5
+      ---
+      async function f () {
+        return await 5
+      }
+    """
+
+    testCase """
+      thick arrow
+      ---
+      f := =>
+        await 5
+      ---
+      const f = async () => {
+        return await 5
+      }
+    """
+
+    testCase """
+      inline thick arrow
+      ---
+      f := => await 5
+      ---
+      const f = async () => await 5
+    """
+
   describe "argumentless without parens", ->
     testCase """
       inline

--- a/test/infra/esm.civet
+++ b/test/infra/esm.civet
@@ -12,9 +12,9 @@ describe "esm", ->
     resolve("somefile.civet", {}, next)
     resolve("somefile.js", {}, next)
 
-  it "should load", async ->
+  it "should load", ->
     // This sets up a hacky loader next vaguely like the one in node's esm loading
-    next := async (url: string, context: unknown) ->
+    next := (url: string, context: unknown) ->
       // This simulates Node.js loading the modified source returned from the previous context
       defaultLoad := async ->
         return {

--- a/test/infra/import.civet
+++ b/test/infra/import.civet
@@ -14,7 +14,7 @@ describe "build importable", ->
     Civet := require "../.."
     assert Civet.compile
 
-  it.skip "dynamic ESM file", async ->
+  it.skip "dynamic ESM file", ->
     @timeout 10000
     // TODO: Why does this take 3s?
     Civet := await import "../../dist/main.mjs"

--- a/test/object.civet
+++ b/test/object.civet
@@ -374,6 +374,21 @@ describe "object", ->
   """
 
   testCase """
+    implicit generator method definition
+    ---
+    x = {
+      x()
+        yield 5
+    }
+    ---
+    x = {
+      *x() {
+        return yield 5
+      }
+    }
+  """
+
+  testCase """
     async generator method definition
     ---
     x = {

--- a/test/object.civet
+++ b/test/object.civet
@@ -344,6 +344,21 @@ describe "object", ->
   """
 
   testCase """
+    implicit async method definition
+    ---
+    x = {
+      x()
+        await 5
+    }
+    ---
+    x = {
+      async x() {
+        return await 5
+      }
+    }
+  """
+
+  testCase """
     generator method definition
     ---
     x = {


### PR DESCRIPTION
- Implicit async for functions, arrow functions, and methods.
- Implicit generator for functions, thin arrows, and methods.

Fixes #427