### PR TITLE
For loop optimizations and generalizations

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -816,6 +816,12 @@ promise :=
     await fetch url
 </Playground>
 
+### Postfix Loop
+
+<Playground>
+console.log item for item of array
+</Playground>
+
 ### Infinite Loop
 
 <Playground>
@@ -823,6 +829,18 @@ i .= 0
 loop
   i++
   break if i > 5
+</Playground>
+
+### Range Loop
+
+<Playground>
+for i of [0...array.length]
+  array[i] = array[i].toString()
+</Playground>
+
+<Playground>
+for [1..5]
+  attempt()
 </Playground>
 
 ### Until Loop

--- a/source/lib.js
+++ b/source/lib.js
@@ -269,7 +269,7 @@ function forRange(open, forDeclaration, range, stepExp, close) {
   }
 
   let varAssign = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
-  if (forDeclaration.declare) { // var/let/const declaration of variable
+  if (forDeclaration?.declare) { // var/let/const declaration of variable
     if (forDeclaration.declare.token === "let") {
       const varName = forDeclaration.children.splice(1)  // strip let
       varAssign = [...insertTrimmingSpace(varName, ""), " = "]
@@ -280,7 +280,7 @@ function forRange(open, forDeclaration, range, stepExp, close) {
         ["", forDeclaration, " = ", counterRef, ";\n"]
       ]
     }
-  } else { // Coffee-style for loop
+  } else if (forDeclaration) { // Coffee-style for loop
     varAssign = varLetAssign = [forDeclaration, " = "]
     blockPrefix = [
       ["", {
@@ -294,7 +294,7 @@ function forRange(open, forDeclaration, range, stepExp, close) {
   const declaration = {
     type: "Declaration",
     children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec],
-    names: forDeclaration.names,
+    names: forDeclaration?.names,
   }
 
   const counterPart = inclusive

--- a/source/lib.js
+++ b/source/lib.js
@@ -215,11 +215,22 @@ function forRange(open, forDeclaration, range, stepExp, close) {
 
   const startRefDec = (startRef !== start) ? [startRef, " = ", start, ", "] : []
   const endRefDec = (endRef !== end) ? [endRef, " = ", end, ", "] : []
-  const ascDec = stepRef
-  ? stepRef !== stepExp
-    ? [", step = ", stepExp]
-    : []
-  : [", asc = ", startRef, " <= ", endRef]
+
+  let ascDec, ascRef
+  if (stepRef) {
+    if (stepRef !== stepExp) {
+      ascDec = [", ", stepRef, " = ", stepExp]
+    } else {
+      ascDec = []
+    }
+  } else {
+    ascRef = {
+      type: "Ref",
+      base: "asc",
+      id: "asc",
+    }
+    ascDec = [", ", ascRef, " = ", startRef, " <= ", endRef]
+  }
 
   let varAssign = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
   if (forDeclaration.declare) { // var/let/const declaration of variable
@@ -228,7 +239,7 @@ function forRange(open, forDeclaration, range, stepExp, close) {
       varAssign = [...insertTrimmingSpace(varName, ""), " = "]
       varLet = [",", ...varName, " = ", counterRef]
     } else { // const or var: put inside loop
-      // TODO: missing indentatino
+      // TODO: missing indentation
       blockPrefix = [
         ["", forDeclaration, " = ", counterRef, ";\n"]
       ]
@@ -256,11 +267,11 @@ function forRange(open, forDeclaration, range, stepExp, close) {
 
   const condition = stepRef
     ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"]
-    : ["asc ? ", ...counterPart]
+    : [ascRef, " ? ", ...counterPart]
 
   const increment = stepRef
   ? [...varAssign, counterRef, " += ", stepRef]
-  : [...varAssign, "asc ? ++", counterRef, " : --", counterRef]
+  : [...varAssign, ascRef, " ? ++", counterRef, " : --", counterRef]
 
   return {
     declaration,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3090,9 +3090,20 @@ WhileClause
 # NOTE: Merged into single rule
 ForStatement
   ForClause:clause Block:block ->
-    // TODO: remove mutation
     if (clause.blockPrefix) {
-      block.expressions.splice(0, 0, ...clause.blockPrefix)
+      const expressions = [...clause.blockPrefix, ...block.expressions]
+      block = {
+        ...block,
+        expressions,
+        children: block.children === block.expressions ? expressions :
+          block.children.map((c) => c === block.expressions ? expressions : c),
+      }
+      // Add braces if block lacked them
+      if (block.bare) {
+        // Now copied, so mutation is OK
+        block.children = [" {\n", ...block.children, "\n}"]
+        block.bare = false
+      }
     }
     return {
       ...clause,
@@ -6661,6 +6672,7 @@ Init
           varAssign = [...module.insertTrimmingSpace(varName, ""), " = "]
           varLet = [",", ...varName, " = ", counterRef]
         } else { // const or var: put inside loop
+          // TODO: missing indentatino
           blockPrefix = [
             ["", forDeclaration, " = ", counterRef, ";\n"]
           ]

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3282,6 +3282,7 @@ CoffeeForStatementParameters
       children: [$1, open, declaration, $5, kind, " ", exp, close],
       blockPrefix,
     }
+  ForRangeParameters
 
 CoffeeForIndex
   _?:ws1 Comma _?:ws2 BindingIdentifier:id ->
@@ -3340,6 +3341,14 @@ ForStatementParameters
       declaration: declaration,
       children: $0,
     }
+  ForRangeParameters
+
+ForRangeParameters
+  # NOTE: CoffeeScript-style `for [start..end] by step` without declaration
+  ( Await __ )? OpenParen:open OpenBracket RangeExpression:exp CloseBracket ( __ By ExpressionWithIndentedApplicationForbidden )?:step CloseParen:close ->
+    return forRange(open, null, exp, step, close)
+  ( Await __ )? InsertOpenParen:open OpenBracket RangeExpression:exp CloseBracket ( __ By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
+    return forRange(open, null, exp, step, close)
 
 # NOTE: Consolidated declarations
 ForInOfDeclaration

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3137,7 +3137,7 @@ WhenCondition
 
 CoffeeForStatementParameters
   # NOTE: Coffee for loops can't have parens
-  ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExpressionWithIndentedApplicationForbidden:exp ( __ By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
+  ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExpressionWithIndentedApplicationForbidden:exp ( _? By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
     let blockPrefix = []
     const indent = module.currentIndent.token + "  "
     exp = module.insertTrimmingSpace(exp, "")
@@ -3190,87 +3190,8 @@ CoffeeForStatementParameters
         case "Identifier":
           expRef = exp
           break
-        case "RangeExpression": {
-          const {start, end, inclusive} = exp
-
-          let stepExp = step?.[2]
-          let stepRef
-          if (stepExp) {
-            stepExp = module.insertTrimmingSpace(stepExp, "")
-            if (stepExp.type === "Literal") {
-              stepRef = stepExp
-            } else {
-              stepRef = {
-                type: "Ref",
-                base: "step",
-                id: "step",
-              }
-            }
-          }
-
-          let startRef, endRef
-          if (start.type === "Literal") {
-            startRef = start
-          } else if (start.type === "Identifier") {
-            startRef = start
-          } else {
-            startRef = {
-              type: "Ref",
-              base: "ref",
-              id: "ref",
-            }
-          }
-
-          if (end.type === "Literal") {
-            endRef = end
-          } else if (end.type === "Identifier") {
-            endRef = end
-          } else {
-            endRef = {
-              type: "Ref",
-              base: "ref",
-              id: "ref",
-            }
-          }
-
-          const startRefDec = (startRef !== start) ? [startRef, " = ", start, ", "] : []
-          const endRefDec = (endRef !== end) ? [endRef, " = ", end, ", "] : []
-          const varRef = declaration
-          const ascDec = stepRef
-          ? stepRef !== stepExp
-            ? [", step = ", stepExp]
-            : []
-          : [", asc = ", startRef, " <= ", endRef]
-          declaration = {
-            type: "Declaration",
-            children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", varRef, " = ", startRef, ...ascDec],
-            names: varRef.names,
-          }
-
-          blockPrefix./**/push(["", {
-            type: "AssignmentExpression",
-            children: [], // Empty assignment to trigger auto-var
-            names: varRef.names,
-          }])
-
-          const counterPart = inclusive
-            ? [counterRef, " <= ", endRef, " : ", counterRef, " >= ", endRef]
-            : [counterRef, " < " , endRef, " : ", counterRef, " > " , endRef]
-
-          const condition = stepRef
-            ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"]
-            : ["asc ? ", ...counterPart]
-
-          const increment = stepRef
-          ? [varRef, " = ", counterRef, " += ", stepRef]
-          : [varRef, " = asc ? ++", counterRef, " : --", counterRef]
-
-          return {
-            declaration,
-            children: [$1, open, declaration, "; ", ...condition, "; ", ...increment, close],
-            blockPrefix,
-          }
-        }
+        case "RangeExpression":
+          return module.forRange(open, declaration, exp, step?.[2], close)
         default:
           expRef = {
             type: "Ref",
@@ -3383,13 +3304,23 @@ ForStatementParameters
   # https://262.ecma-international.org/#prod-ForInOfStatement
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
-  ( Await __ )? OpenParen __    ForInOfDeclaration:declaration __ ( In / Of ) ExpressionWithIndentedApplicationForbidden __ CloseParen ->
+  ( Await __ )? OpenParen:open __    ForInOfDeclaration:declaration __ ( In / Of ):op ExpressionWithIndentedApplicationForbidden:exp ( __ By ExpressionWithIndentedApplicationForbidden )?:step __ CloseParen:close ->
+    if (exp.type === "RangeExpression" && op.token === "of") {
+      return module.forRange(open, declaration, exp, step, close)
+    } else if (step) {
+      throw new Error("for..of/in cannot use 'by' except with range literals")
+    }
     return {
       declaration,
       children: $0,
     }
   # NOTE: Added optional parens
-  ( Await __ )? InsertOpenParen ForInOfDeclaration:declaration __ ( In / Of ) ExpressionWithIndentedApplicationForbidden InsertCloseParen ->
+  ( Await __ )? InsertOpenParen:open ForInOfDeclaration:declaration __ ( In / Of ):op ExpressionWithIndentedApplicationForbidden:exp ( __ By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
+    if (exp.type === "RangeExpression" && op.token === "of") {
+      return module.forRange(open, declaration, exp, step, close)
+    } else if (step) {
+      throw new Error("for..of/in cannot use 'by' except with range literals")
+    }
     return {
       declaration: declaration,
       children: $0,
@@ -3401,6 +3332,7 @@ ForInOfDeclaration
     return {
       type: "ForDeclaration",
       children: $0,
+      declare: $1,
       names: binding.names,
     }
   ForDeclaration
@@ -3408,10 +3340,11 @@ ForInOfDeclaration
 
 # https://262.ecma-international.org/#prod-ForDeclaration
 ForDeclaration
-  LetOrConst:c NonIdContinue ForBinding:binding ->
+  LetOrConst:c ForBinding:binding ->
     return {
       type: "ForDeclaration",
       children: [c, binding],
+      declare: c,
       names: binding.names,
     }
   # NOTE: Added default implicit const to for bindings
@@ -3421,6 +3354,7 @@ ForDeclaration
     return {
       type: "ForDeclaration",
       children: [c, binding],
+      declare: c,
       names: binding.names,
     }
 
@@ -6560,6 +6494,7 @@ Init
       }
       return node
     }
+
     module.processUnaryExpression = (pre, exp, post) => {
       // Handle "?" postfix
       if (post?.token === "?") {
@@ -6661,6 +6596,109 @@ Init
         return parseInt(raw, 10)
       }
       throw new Error("Unrecognized literal " + JSON.stringify(literal))
+    }
+
+    module.forRange = function(open, forDeclaration, range, stepExp, close) {
+      const {start, end, inclusive} = range
+
+      const counterRef = {
+        type: "Ref",
+        base: "i",
+        id: "i",
+      }
+
+      let stepRef
+      if (stepExp) {
+        stepExp = module.insertTrimmingSpace(stepExp, "")
+        if (stepExp.type === "Literal") {
+          stepRef = stepExp
+        } else {
+          stepRef = {
+            type: "Ref",
+            base: "step",
+            id: "step",
+          }
+        }
+      }
+
+      let startRef, endRef
+      if (start.type === "Literal") {
+        startRef = start
+      } else if (start.type === "Identifier") {
+        startRef = start
+      } else {
+        startRef = {
+          type: "Ref",
+          base: "ref",
+          id: "ref",
+        }
+      }
+
+      if (end.type === "Literal") {
+        endRef = end
+      } else if (end.type === "Identifier") {
+        endRef = end
+      } else {
+        endRef = {
+          type: "Ref",
+          base: "ref",
+          id: "ref",
+        }
+      }
+
+      const startRefDec = (startRef !== start) ? [startRef, " = ", start, ", "] : []
+      const endRefDec = (endRef !== end) ? [endRef, " = ", end, ", "] : []
+      const ascDec = stepRef
+      ? stepRef !== stepExp
+        ? [", step = ", stepExp]
+        : []
+      : [", asc = ", startRef, " <= ", endRef]
+
+      let varAssign = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
+      if (forDeclaration.declare) { // var/let/const declaration of variable
+        if (forDeclaration.declare.token === "let") {
+          const varName = forDeclaration.children.splice(1)  // strip let
+          varAssign = [...module.insertTrimmingSpace(varName, ""), " = "]
+          varLet = [",", ...varName, " = ", counterRef]
+        } else { // const or var: put inside loop
+          blockPrefix = [
+            ["", forDeclaration, " = ", counterRef, ";\n"]
+          ]
+        }
+      } else { // Coffee-style for loop
+        varAssign = varLetAssign = [forDeclaration, " = "]
+        blockPrefix = [
+          ["", {
+            type: "AssignmentExpression",
+            children: [], // Empty assignment to trigger auto-var
+            names: forDeclaration.names,
+          }]
+        ]
+      }
+
+      const declaration = {
+        type: "Declaration",
+        children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec],
+        names: forDeclaration.names,
+      }
+
+      const counterPart = inclusive
+        ? [counterRef, " <= ", endRef, " : ", counterRef, " >= ", endRef]
+        : [counterRef, " < " , endRef, " : ", counterRef, " > " , endRef]
+
+      const condition = stepRef
+        ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"]
+        : ["asc ? ", ...counterPart]
+
+      const increment = stepRef
+      ? [...varAssign, counterRef, " += ", stepRef]
+      : [...varAssign, "asc ? ++", counterRef, " : --", counterRef]
+
+      return {
+        declaration,
+        children: [open, declaration, "; ", ...condition, "; ", ...increment, close],
+        blockPrefix,
+      }
     }
 
     module.expressionizeIfClause = function(clause, b, e) {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8,12 +8,15 @@
 const {
   clone,
   deepCopy,
+  forRange,
   gatherNodes,
   gatherRecursive,
   gatherRecursiveAll,
   gatherRecursiveWithinFunction,
+  getTrimmingSpace,
   hasAwait,
   hasYield,
+  insertTrimmingSpace,
   isFunction,
   removeParentPointers,
 } = require("./lib.js")
@@ -128,7 +131,7 @@ ImplicitArguments
         module.isEmptyBareBlock(args[0].block)) {
       return $skip
     }
-    return [ta?.[0], open, module.insertTrimmingSpace(ws, ""), args, close]
+    return [ta?.[0], open, insertTrimmingSpace(ws, ""), args, close]
 
 ExplicitArguments
   TypeArguments? OpenParen ArgumentList? ( __ Comma )? __ CloseParen
@@ -177,7 +180,7 @@ ArgumentList
   ArgumentPart ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+
   # NOTE: Added nested arguments on separate new lines
   NestedImplicitObjectLiteral ->
-    return module.insertTrimmingSpace($1, '')
+    return insertTrimmingSpace($1, '')
   NestedArgumentList
   # NOTE: Eliminated left recursion
   _? ArgumentPart ( CommaDelimiter _? ArgumentPart )* ->
@@ -188,7 +191,7 @@ NonPipelineArgumentList
   NonPipelineArgumentPart ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+
   # NOTE: Added nested arguments on separate new lines
   NestedImplicitObjectLiteral ->
-    return module.insertTrimmingSpace($1, '')
+    return insertTrimmingSpace($1, '')
   NestedArgumentList
   # NOTE: Eliminated left recursion
   _? NonPipelineArgumentPart ( CommaDelimiter _? NonPipelineArgumentPart )* ->
@@ -261,7 +264,7 @@ UnaryExpression
   # NOTE: This is a little hacky to match CoffeeScript's behavior
   # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
   CoffeeDoEnabled Do __:ws ( ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / ArrowFunction / ExtendedExpression ):exp ->
-    ws = module.insertTrimmingSpace(ws, "")
+    ws = insertTrimmingSpace(ws, "")
     return ["(", ...ws, exp, ")()"]
 
 UnaryPostfix
@@ -973,7 +976,7 @@ NonEmptyParameters
         const spliceRef = module.getRef("splice")
 
         blockPrefix = {
-          children: ["[", module.insertTrimmingSpace(after, ""), "] = ", spliceRef, ".call(", restIdentifier, ", -", after.length.toString(), ")"],
+          children: ["[", insertTrimmingSpace(after, ""), "] = ", spliceRef, ".call(", restIdentifier, ", -", after.length.toString(), ")"],
           names: after.flatMap(p => p.names)
         }
       }
@@ -1539,7 +1542,7 @@ OperatorDeclaration
   # `operator {x, y} := ...` declaration while blessing
   Operator:op _:w LexicalDeclaration:decl ->
     decl.names.forEach((name) => module.operators.add(name))
-    return [module.insertTrimmingSpace(w, ""), decl]
+    return [insertTrimmingSpace(w, ""), decl]
   # `operator id(a, b) {...}` defines a function
   OperatorSignature:signature BracedBlock:block ->
     module.operators.add(signature.id.name)
@@ -1564,7 +1567,7 @@ OperatorSignature
     if (!func) {
       func = { $loc: op.$loc, token: "function" }
     } else {
-      func = [ module.insertTrimmingSpace(func[0], ""), func[1] ]
+      func = [ insertTrimmingSpace(func[0], ""), func[1] ]
     }
     return {
       type: "FunctionSignature",
@@ -3051,7 +3054,7 @@ DoWhileStatement
 
 DoStatement
   Do NoPostfixBracedBlock:block ->
-    block = module.insertTrimmingSpace(block, "")
+    block = insertTrimmingSpace(block, "")
     return {
       type: "DoStatement",
       children: [block],
@@ -3135,7 +3138,7 @@ ForStatementControl
           [indent, {
             type: "IfStatement",
             then: block,
-            children: ["if (!(", module.insertTrimmingSpace($3, ""), ")) ", block],
+            children: ["if (!(", insertTrimmingSpace($3, ""), ")) ", block],
           }]
         ],
       }
@@ -3151,8 +3154,8 @@ CoffeeForStatementParameters
   ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExpressionWithIndentedApplicationForbidden:exp ( _? By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
     let blockPrefix = []
     const indent = module.currentIndent.token + "  "
-    exp = module.insertTrimmingSpace(exp, "")
-    declaration = module.insertTrimmingSpace(declaration, "")
+    exp = insertTrimmingSpace(exp, "")
+    declaration = insertTrimmingSpace(declaration, "")
 
     if (kind.token === "from") {
       if (step) {
@@ -3202,7 +3205,7 @@ CoffeeForStatementParameters
           expRef = exp
           break
         case "RangeExpression":
-          return module.forRange(open, declaration, exp, step?.[2], close)
+          return forRange(open, declaration, exp, step?.[2], close)
         default:
           expRef = {
             type: "Ref",
@@ -3217,14 +3220,14 @@ CoffeeForStatementParameters
         assignmentNames = [...varRef.names]
 
       if (index) {
-        index = module.insertTrimmingSpace(index, "")
+        index = insertTrimmingSpace(index, "")
         indexAssignment = [index, "="]
         assignmentNames./**/push(...index.names)
       }
 
       const expRefDec = (expRef !== exp)
         // Trim a single leading space if present
-        ? [expRef, " = ", module.insertTrimmingSpace(exp, ""), ", "]
+        ? [expRef, " = ", insertTrimmingSpace(exp, ""), ", "]
         : []
 
       blockPrefix./**/push([indent, {
@@ -3243,7 +3246,7 @@ CoffeeForStatementParameters
 
       if (step) {
         let [stepWs, , stepExp] = step
-        stepWs = module.insertTrimmingSpace(stepWs, "")
+        stepWs = insertTrimmingSpace(stepWs, "")
         if (stepExp.type === "Literal") {
           increment = [" +=", ...stepWs, stepExp]
           // Negative step loops are reversed
@@ -3281,7 +3284,7 @@ CoffeeForStatementParameters
 
 CoffeeForIndex
   _?:ws1 Comma _?:ws2 BindingIdentifier:id ->
-    ws2 = module.insertTrimmingSpace(ws1, "")
+    ws2 = insertTrimmingSpace(ws1, "")
 
     return {
       ...id,
@@ -3317,7 +3320,7 @@ ForStatementParameters
   # NOTE: Consolidated optional 'await'
   ( Await __ )? OpenParen:open __    ForInOfDeclaration:declaration __ ( In / Of ):op ExpressionWithIndentedApplicationForbidden:exp ( __ By ExpressionWithIndentedApplicationForbidden )?:step __ CloseParen:close ->
     if (exp.type === "RangeExpression" && op.token === "of") {
-      return module.forRange(open, declaration, exp, step, close)
+      return forRange(open, declaration, exp, step, close)
     } else if (step) {
       throw new Error("for..of/in cannot use 'by' except with range literals")
     }
@@ -3328,7 +3331,7 @@ ForStatementParameters
   # NOTE: Added optional parens
   ( Await __ )? InsertOpenParen:open ForInOfDeclaration:declaration __ ( In / Of ):op ExpressionWithIndentedApplicationForbidden:exp ( __ By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
     if (exp.type === "RangeExpression" && op.token === "of") {
-      return module.forRange(open, declaration, exp, step, close)
+      return forRange(open, declaration, exp, step, close)
     } else if (step) {
       throw new Error("for..of/in cannot use 'by' except with range literals")
     }
@@ -3498,9 +3501,9 @@ CaseExpressionList
     if (!first) return $skip
     // Convert comma separated expression list to `case <exp>:`
     const result = rest.map(([ws, _comma, exp, col]) => {
-      exp = module.insertTrimmingSpace(exp, "")
+      exp = insertTrimmingSpace(exp, "")
 
-      if (ws.length) return [module.insertTrimmingSpace("case ", ws), exp, col]
+      if (ws.length) return [insertTrimmingSpace("case ", ws), exp, col]
       return ["case ", exp, col]
     })
     result./**/unshift(first)
@@ -3584,7 +3587,7 @@ Condition
   InsertOpenParen:open ExpressionWithIndentedApplicationForbidden:expression InsertCloseParen:close ->
     // Don't double wrap parethesized expressions
     if (expression.type === "ParenthesizedExpression") return expression
-    expression = module.insertTrimmingSpace(expression, "")
+    expression = insertTrimmingSpace(expression, "")
     return {
       type: "ParenthesizedExpression",
       children: [open, expression, close],
@@ -3850,7 +3853,7 @@ TypeAndImportSpecifier
     return {
       ...spec,
       children: [
-        ws, module.insertTrimmingSpace(spec[0], ""),
+        ws, insertTrimmingSpace(spec[0], ""),
         spec.children.slice(1),
       ],
     }
@@ -4486,7 +4489,7 @@ NonNewlineWhitespace
 # Whitespace / comments with a single leading space trimmed off if possible
 Trimmed_
   _*:ws ->
-    return module.insertTrimmingSpace(ws, "")
+    return insertTrimmingSpace(ws, "")
 
 # Optional whitespace including newlines and comments
 __
@@ -5152,7 +5155,7 @@ JSXAttribute
           if (part.name.type === 'ComputedPropertyName') {
             rest.push(part)
           } else {
-            parts.push([part.name, '={', module.insertTrimmingSpace(part.value, ''), '}'])
+            parts.push([part.name, '={', insertTrimmingSpace(part.value, ''), '}'])
           }
           break
         case 'SpreadProperty':
@@ -6457,8 +6460,8 @@ Init
               throw new Error("Glob pattern must have call or member expression value")
             }
             let value = part.value ?? part.name
-            const wValue = module.getTrimmingSpace(part.value)
-            value = prefix.concat(module.insertTrimmingSpace(value, ""))
+            const wValue = getTrimmingSpace(part.value)
+            value = prefix.concat(insertTrimmingSpace(value, ""))
             if (wValue) value.unshift(wValue)
             if (part.type === "SpreadProperty") {
               parts.push({
@@ -6607,110 +6610,6 @@ Init
         return parseInt(raw, 10)
       }
       throw new Error("Unrecognized literal " + JSON.stringify(literal))
-    }
-
-    module.forRange = function(open, forDeclaration, range, stepExp, close) {
-      const {start, end, inclusive} = range
-
-      const counterRef = {
-        type: "Ref",
-        base: "i",
-        id: "i",
-      }
-
-      let stepRef
-      if (stepExp) {
-        stepExp = module.insertTrimmingSpace(stepExp, "")
-        if (stepExp.type === "Literal") {
-          stepRef = stepExp
-        } else {
-          stepRef = {
-            type: "Ref",
-            base: "step",
-            id: "step",
-          }
-        }
-      }
-
-      let startRef, endRef
-      if (start.type === "Literal") {
-        startRef = start
-      } else if (start.type === "Identifier") {
-        startRef = start
-      } else {
-        startRef = {
-          type: "Ref",
-          base: "ref",
-          id: "ref",
-        }
-      }
-
-      if (end.type === "Literal") {
-        endRef = end
-      } else if (end.type === "Identifier") {
-        endRef = end
-      } else {
-        endRef = {
-          type: "Ref",
-          base: "ref",
-          id: "ref",
-        }
-      }
-
-      const startRefDec = (startRef !== start) ? [startRef, " = ", start, ", "] : []
-      const endRefDec = (endRef !== end) ? [endRef, " = ", end, ", "] : []
-      const ascDec = stepRef
-      ? stepRef !== stepExp
-        ? [", step = ", stepExp]
-        : []
-      : [", asc = ", startRef, " <= ", endRef]
-
-      let varAssign = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
-      if (forDeclaration.declare) { // var/let/const declaration of variable
-        if (forDeclaration.declare.token === "let") {
-          const varName = forDeclaration.children.splice(1)  // strip let
-          varAssign = [...module.insertTrimmingSpace(varName, ""), " = "]
-          varLet = [",", ...varName, " = ", counterRef]
-        } else { // const or var: put inside loop
-          // TODO: missing indentatino
-          blockPrefix = [
-            ["", forDeclaration, " = ", counterRef, ";\n"]
-          ]
-        }
-      } else { // Coffee-style for loop
-        varAssign = varLetAssign = [forDeclaration, " = "]
-        blockPrefix = [
-          ["", {
-            type: "AssignmentExpression",
-            children: [], // Empty assignment to trigger auto-var
-            names: forDeclaration.names,
-          }]
-        ]
-      }
-
-      const declaration = {
-        type: "Declaration",
-        children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec],
-        names: forDeclaration.names,
-      }
-
-      const counterPart = inclusive
-        ? [counterRef, " <= ", endRef, " : ", counterRef, " >= ", endRef]
-        : [counterRef, " < " , endRef, " : ", counterRef, " > " , endRef]
-
-      const condition = stepRef
-        ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"]
-        : ["asc ? ", ...counterPart]
-
-      const increment = stepRef
-      ? [...varAssign, counterRef, " += ", stepRef]
-      : [...varAssign, "asc ? ++", counterRef, " : --", counterRef]
-
-      return {
-        declaration,
-        children: [open, declaration, "; ", ...condition, "; ", ...increment, close],
-        blockPrefix,
-      }
     }
 
     module.expressionizeIfClause = function(clause, b, e) {
@@ -7117,17 +7016,17 @@ Init
 
           let children
           if (op.call) {
-            wsOp = module.insertTrimmingSpace(wsOp, "")
+            wsOp = insertTrimmingSpace(wsOp, "")
 
             if (op.reversed) {
-              wsB = module.insertTrimmingSpace(wsB, "")
+              wsB = insertTrimmingSpace(wsB, "")
               children = [wsOp, op.call, "(", wsB, b, ", ", a, ")", op.suffix]
             } else {
               children = [wsOp, op.call, "(", a, ",", wsB, b, ")", op.suffix]
             }
           } else if (op.method) {
-            wsOp = module.insertTrimmingSpace(wsOp, "")
-            wsB = module.insertTrimmingSpace(wsB, "")
+            wsOp = insertTrimmingSpace(wsOp, "")
+            wsB = insertTrimmingSpace(wsB, "")
             if (op.reversed) {
               children = [wsB, b, wsOp, ".", op.method, "(", a, ")"]
             } else {
@@ -7276,37 +7175,6 @@ Init
       return target
     }
 
-    // Trims the first single space from the spacing array or node's children if present
-    // maintains $loc for source maps
-    module.insertTrimmingSpace = function(target, c) {
-      if (!target) return target
-
-      if (Array.isArray(target)) return target.map((e, i) => {
-        if (i === 0) return module.insertTrimmingSpace(e, c)
-        return e
-      })
-      if (target.children) return Object.assign({}, target, {
-        children: target.children.map((e, i) => {
-          if (i === 0) return module.insertTrimmingSpace(e, c)
-          return e
-        })
-      })
-
-      if (target.token) return Object.assign({}, target, {
-        token: target.token.replace(/^ ?/, c)
-      })
-
-      return target
-    }
-
-    // Returns leading space as a string, or undefined if none
-    module.getTrimmingSpace = function(target) {
-      if (!target) return
-      if (Array.isArray(target)) return module.getTrimmingSpace(target[0])
-      if (target.children) return module.getTrimmingSpace(target.children[0])
-      if (target.token) return target.token.match(/^ ?/)[0]
-    }
-
     // Split out leading newlines from the first indented line
     const initialSpacingRe = /^(?:\r?\n|\n)*((?:\r?\n|\n)\s+)/
 
@@ -7426,7 +7294,7 @@ Init
 
           blockPrefix = {
             type: "PostRestBindingElements",
-            children: ["[", module.insertTrimmingSpace(after, ""), "] = ", spliceRef, ".call(", restIdentifier, ", -", after.length.toString(), ")"],
+            children: ["[", insertTrimmingSpace(after, ""), "] = ", spliceRef, ".call(", restIdentifier, ", -", after.length.toString(), ")"],
             names: after.flatMap(p => p.names),
           }
         }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -18,6 +18,7 @@ const {
   hasYield,
   insertTrimmingSpace,
   isFunction,
+  literalValue,
   removeParentPointers,
 } = require("./lib.js")
 ```
@@ -1943,8 +1944,8 @@ RangeExpression
     range.token = ","
 
     if (s.type === "Literal" && e.type === "Literal") {
-      const start = module.literalValue(s)
-      const end = module.literalValue(e)
+      const start = literalValue(s)
+      const end = literalValue(e)
 
       if (typeof start !== typeof end) {
         throw new Error("Range start and end must be of the same type")
@@ -6574,42 +6575,6 @@ Init
             id: base,
           }
       }
-    }
-
-    // Convert (non-Template) Literal to actual JavaScript value
-    module.literalValue = function(literal) {
-      let {raw} = literal
-      switch (raw) {
-        case "null": return null
-        case "true": return true
-        case "false": return false
-      }
-      if (
-        (raw.startsWith('"') && raw.endsWith('"')) ||
-        (raw.startsWith("'") && raw.endsWith("'"))
-      ) {
-        return raw.slice(1, -1)
-      }
-      const numeric = literal.children.find(
-        (child) => child.type === "NumericLiteral"
-      )
-      if (numeric) {
-        raw = raw.replace(/_/g, "")
-        const {token} = numeric
-        if (token.endsWith("n")) {
-          return BigInt(raw.slice(0, -1))
-        } else if (token.match(/[\.eE]/)) {
-          return parseFloat(raw)
-        } else if (token.startsWith("0")) {
-          switch (token.charAt(1).toLowerCase()) {
-            case "x": return parseInt(raw.replace(/0[xX]/, ""), 16)
-            case "b": return parseInt(raw.replace(/0[bB]/, ""), 2)
-            case "o": return parseInt(raw.replace(/0[oO]/, ""), 8)
-          }
-        }
-        return parseInt(raw, 10)
-      }
-      throw new Error("Unrecognized literal " + JSON.stringify(literal))
     }
 
     module.expressionizeIfClause = function(clause, b, e) {

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -64,7 +64,33 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a
-    for (let i = a = 1, asc = 1 <= 10; asc ? i <= 10 : i >= 10; a = asc ? ++i : --i) {
+    for (let i = a = 1; i <= 10; a = ++i) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for in range fixed reverse
+    ---
+    "civet coffee-compat"
+    for a in [10..1]
+      console.log a
+    ---
+    var a
+    for (let i = a = 10; i >= 1; a = --i) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for in range fixed exclusive
+    ---
+    "civet coffee-compat"
+    for a in [0...10]
+      console.log a
+    ---
+    var a
+    for (let i = a = 0; i < 10; a = ++i) {
       console.log(a)
     }
   """
@@ -77,7 +103,7 @@ describe "coffeeForLoops", ->
       c()
     ---
     var i
-    for (let i1 = i = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; i = asc ? ++i1 : --i1) {
+    for (let i1 = i = 1; i1 <= 10; i = ++i1) {
       c()
     }
   """

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -122,6 +122,21 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for in range with ref start, end already in scope
+    ---
+    "civet coffee-compat"
+    start = end = asc = null
+    for a in [x()...y()]
+      console.log a
+    ---
+    var start, end, asc, a
+    start = end = asc = null
+    for (let start1 = x(), end1 = y(), i = a = start1, asc1 = start1 <= end1; asc1 ? i < end1 : i > end1; a = asc1 ? ++i : --i) {
+      console.log(a)
+    }
+  """
+
+  testCase """
     for in in variable range with literal step
     ---
     "civet coffee-compat"
@@ -156,6 +171,21 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let start = x(), end = y(), i = a = start, step = z(); step !== 0 && (step > 0 ? i < end : i > end); a = i += step) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for in range with ref start, end, step already in scope
+    ---
+    "civet coffee-compat"
+    start = end = step = null
+    for a in [x()...y()] by z()
+      console.log a
+    ---
+    var start, end, step, a
+    start = end = step = null
+    for (let start1 = x(), end1 = y(), i = a = start1, step1 = z(); step1 !== 0 && (step1 > 0 ? i < end1 : i > end1); a = i += step1) {
       console.log(a)
     }
   """

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -109,6 +109,19 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for in range with ref start, end
+    ---
+    "civet coffee-compat"
+    for a in [x()...y()]
+      console.log a
+    ---
+    var a
+    for (let start = x(), end = y(), i = a = start, asc = start <= end; asc ? i < end : i > end; a = asc ? ++i : --i) {
+      console.log(a)
+    }
+  """
+
+  testCase """
     for in in variable range with literal step
     ---
     "civet coffee-compat"
@@ -129,7 +142,20 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a
-    for (let i = a = x, step = z; step !== 0 && (step > 0 ? i < y : i > y); a = i += step) {
+    for (let i = a = x; z !== 0 && (z > 0 ? i < y : i > y); a = i += z) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for in range with ref start, end, step
+    ---
+    "civet coffee-compat"
+    for a in [x()...y()] by z()
+      console.log a
+    ---
+    var a
+    for (let start = x(), end = y(), i = a = start, step = z(); step !== 0 && (step > 0 ? i < end : i > end); a = i += step) {
       console.log(a)
     }
   """

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -16,6 +16,19 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for in then
+    ---
+    "civet coffee-compat"
+    for a in b then a.i
+    ---
+    var a
+    for (let i = 0, len = b.length; i < len; i++) {
+      a = b[i]
+     a.i
+    }
+  """
+
+  testCase """
     for in with object literal
     ---
     "civet coffee-compat"

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -109,6 +109,18 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    range without declaration
+    ---
+    "civet coffee-compat"
+    for [1..10]
+      console.log("hello")
+    ---
+    for (let i = 1; i <= 10; ++i) {
+      console.log("hello")
+    }
+  """
+
+  testCase """
     for in range variable end
     ---
     "civet coffee-compat"

--- a/test/for.civet
+++ b/test/for.civet
@@ -96,7 +96,7 @@ describe "for", ->
     ---
     for (i of [1..10]) console.log(i)
     ---
-    for (let i1 = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; asc ? ++i1 : --i1) {
+    for (let i1 = 1; i1 <= 10; ++i1) {
     const i = i1;
      console.log(i)
     }
@@ -108,7 +108,7 @@ describe "for", ->
     for i of [1..10]
       console.log(i)
     ---
-    for (let i1 = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; asc ? ++i1 : --i1) {
+    for (let i1 = 1; i1 <= 10; ++i1) {
     const i = i1;
       console.log(i)
     }
@@ -120,7 +120,7 @@ describe "for", ->
     for var i of [1..10]
       console.log(i)
     ---
-    for (let i1 = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; asc ? ++i1 : --i1) {
+    for (let i1 = 1; i1 <= 10; ++i1) {
     var i = i1;
       console.log(i)
     }
@@ -132,7 +132,7 @@ describe "for", ->
     for let i of [1..10]
       console.log(i)
     ---
-    for (let i1 = 1, i = i1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; i = asc ? ++i1 : --i1) {
+    for (let i1 = 1, i = i1; i1 <= 10; i = ++i1) {
       console.log(i)
     }
   """

--- a/test/for.civet
+++ b/test/for.civet
@@ -137,6 +137,17 @@ describe "for", ->
     }
   """
 
+  testCase """
+    range without declaration
+    ---
+    for [1..10]
+      console.log("hello")
+    ---
+    for (let i = 1; i <= 10; ++i) {
+      console.log("hello")
+    }
+  """
+
   describe "", ->
     testCase """
       binding lefthandside

--- a/test/for.civet
+++ b/test/for.civet
@@ -91,6 +91,49 @@ describe "for", ->
     for (var i in x) console.log(i)
   """
 
+  testCase """
+    of range one-line
+    ---
+    for (i of [1..10]) console.log(i)
+    ---
+    for (let i1 = 1; i1 <= 10; i1++) console.log(i)
+  """
+
+  testCase """
+    const of range
+    ---
+    for i of [1..10]
+      console.log(i)
+    ---
+    for (let i1 = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; asc ? ++i1 : --i1) {
+    const i = i1;
+      console.log(i)
+    }
+  """
+
+  testCase """
+    var of range
+    ---
+    for var i of [1..10]
+      console.log(i)
+    ---
+    for (let i1 = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; asc ? ++i1 : --i1) {
+    var i = i1;
+      console.log(i)
+    }
+  """
+
+  testCase """
+    let of range
+    ---
+    for let i of [1..10]
+      console.log(i)
+    ---
+    for (let i1 = 1, i = i1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; i = asc ? ++i1 : --i1) {
+      console.log(i)
+    }
+  """
+
   describe "", ->
     testCase """
       binding lefthandside

--- a/test/for.civet
+++ b/test/for.civet
@@ -92,11 +92,14 @@ describe "for", ->
   """
 
   testCase """
-    of range one-line
+    const of range one-line
     ---
     for (i of [1..10]) console.log(i)
     ---
-    for (let i1 = 1; i1 <= 10; i1++) console.log(i)
+    for (let i1 = 1, asc = 1 <= 10; asc ? i1 <= 10 : i1 >= 10; asc ? ++i1 : --i1) {
+    const i = i1;
+     console.log(i)
+    }
   """
 
   testCase """


### PR DESCRIPTION
Fixes #412 and fixes #440

* Factor out RangeLiteral loop generation code into `lib.js` (new `forRange` helper)
* Cleanup ref handling with new `needsRef` and `maybeRef` helpers
* Fix missing use of ref for `asc` and `step` (previously would shadow/use the wrong variables)
* Fix `blockPrefix` mechanism with bare block (#440)
* Optimize `for x of [a..b]` in the same way that we did for CoffeeScript `for x in [a..b]` (#412)
* Support `for [a..b]` (a CoffeeScript feature) both inside and outside `coffee-compat` mode (#412)
