### PR TITLE
Semicolon-separated statements in blocks

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1842,7 +1842,6 @@ NestedBlockStatements
     }
 
 NestedBlockStatement
-  # NOTE: _? allows for leading inline comments
   Nested:nested BlockStatementPart+:statements ->
     return [
       [nested, ...statements[0]],
@@ -1850,6 +1849,7 @@ NestedBlockStatement
     ]
 
 BlockStatementPart
+  # NOTE: _? allows for leading inline comments
   !EOS _?:ws StatementListItem:statement StatementDelimiter:delimiter ->
     if (ws) {
       statement = {...statement, children: [ ws, ...statement.children ]}

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -53,11 +53,11 @@ NestedTopLevelStatements
 
 # Multiple top-level statements on the same line
 TopLevelSingleLineStatements
-  ( !EOS TopLevelStatement )+:statements ->
-    return statements.map(([, statement]) => statement)
+  TopLevelStatement+
 
 TopLevelStatement
-  _?:ws ModuleItem:statement StatementDelimiter:delimiter ->
+  # NOTE: _? allows for leading inline comments
+  !EOS _?:ws ModuleItem:statement StatementDelimiter:delimiter ->
     if (ws) {
       statement = {
         ...statement,
@@ -1839,6 +1839,7 @@ NestedBlockStatements
     }
 
 NestedBlockStatement
+  # NOTE: _? allows for leading inline comments
   Nested:nested _?:ws StatementListItem:statement StatementDelimiter:delimiter ->
     if (ws) {
       statement = {...statement, children: [ ws, ...statement.children ]}

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -51,11 +51,12 @@ NestedTopLevelStatements
       ...statements.slice(1).map(s => ["", ...s]),
     ]
 
-# Multiple top-level statements on the same line
+# Multiple top-level semicolon-separated statements
 TopLevelSingleLineStatements
   TopLevelStatement+
 
 TopLevelStatement
+  # NOTE: !EOS forces semicolon after all but last statement, forbids leading __
   # NOTE: _? allows for leading inline comments
   !EOS _?:ws ModuleItem:statement StatementDelimiter:delimiter ->
     if (ws) {
@@ -1849,6 +1850,7 @@ NestedBlockStatement
     ]
 
 BlockStatementPart
+  # NOTE: !EOS forces semicolon after all but last statement, forbids leading __
   # NOTE: _? allows for leading inline comments
   !EOS _?:ws StatementListItem:statement StatementDelimiter:delimiter ->
     if (ws) {
@@ -3027,6 +3029,8 @@ NestedBlockExpression
     ]
 
 BlockExpressionPart
+  # NOTE: !EOS forces semicolon after all but last statement, forbids leading __
+  # NOTE: _? allows for leading inline comments
   !EOS _?:ws PostfixedExpression:exp ExpressionDelimiter:delimiter ->
     if (ws) {
       exp = {...exp, children: [ ws, ...exp.children ]}

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2956,6 +2956,9 @@ ElseExpressionClause
 # Block of expressions that can't include pure statements
 ExpressionBlock
   InsertOpenParen NestedBlockExpressions:exps InsertNewline InsertIndent InsertCloseParen ->
+    // Each element of exps is a list of same-line expressions. Flatten.
+    exps = exps.flat()
+
     // If there is only one expression and it doesn't require parens, then return it as is, preserving whitespace
     if (exps.length === 1) {
       let [ws, exp] = exps[0]
@@ -2983,6 +2986,9 @@ ExpressionBlock
 
 ElseExpressionBlock
   InsertOpenParen NestedBlockExpressions:exps InsertNewline InsertIndent InsertCloseParen ->
+    // Each element of exps is a list of same-line expressions. Flatten.
+    exps = exps.flat()
+
     // If there is only one expression and it doesn't require parens, then return it as is, preserving whitespace
     if (exps.length === 1) {
       let [ws, exp] = exps[0]
@@ -3014,7 +3020,18 @@ NestedBlockExpressions
     return exps
 
 NestedBlockExpression
-  Nested:ws PostfixedExpression:exp ExpressionDelimiter:d
+  Nested:nested BlockExpressionPart+:expressions ->
+    return [
+      [nested, ...expressions[0]],
+      ...expressions.slice(1).map(s => ["", ...s]),
+    ]
+
+BlockExpressionPart
+  !EOS _?:ws PostfixedExpression:exp ExpressionDelimiter:delimiter ->
+    if (ws) {
+      exp = {...exp, children: [ ws, ...exp.children ]}
+    }
+    return [exp, delimiter]
 
 # https://262.ecma-international.org/#prod-IterationStatement
 IterationStatement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1822,6 +1822,9 @@ NestedBlockStatements
   PushIndent NestedBlockStatement*:statements PopIndent ->
     if (!statements.length) return $skip
 
+    // Each element of statements is a list of same-line statements. Flatten.
+    statements = statements.flat()
+
     // separate first EOS from indent for easier insertion to top of block
     const first = statements[0]
     const ws = first[0]
@@ -1840,11 +1843,18 @@ NestedBlockStatements
 
 NestedBlockStatement
   # NOTE: _? allows for leading inline comments
-  Nested:nested _?:ws StatementListItem:statement StatementDelimiter:delimiter ->
+  Nested:nested BlockStatementPart+:statements ->
+    return [
+      [nested, ...statements[0]],
+      ...statements.slice(1).map(s => ["", ...s]),
+    ]
+
+BlockStatementPart
+  !EOS _?:ws StatementListItem:statement StatementDelimiter:delimiter ->
     if (ws) {
       statement = {...statement, children: [ ws, ...statement.children ]}
     }
-    return [nested, statement, delimiter]
+    return [statement, delimiter]
 
 # https://262.ecma-international.org/#prod-Literal
 Literal

--- a/test/if.civet
+++ b/test/if.civet
@@ -102,14 +102,29 @@ describe "if", ->
     }
   """
 
+  testCase """
+    if with multiple semicolon-separated commented statements
+    ---
+    if x
+      /*a*/ a; /*b*/ b
+    else
+      /*c*/ c; /*d*/ d
+    ---
+    if (x) {
+      /*a*/ a; /*b*/ b
+    }
+    else {
+      /*c*/ c; /*d*/ d
+    }
+  """
+
   // TODO
   testCase.skip """
     if then nothing
     ---
     if x then
     ---
-    if (x) {
-    }
+    if (x);
   """
 
   testCase """
@@ -419,6 +434,38 @@ describe "if", ->
       )
       :
         "c"
+    """
+
+    testCase """
+      if expression with multiple semicolon-separated statements
+      ---
+      x = if y
+        a; b
+      else
+        c; d
+      ---
+      x = (y)?(
+        a, b
+      )
+      :(
+        c, d
+      )
+    """
+
+    testCase """
+      if expression with multiple semicolon-separated commented statements
+      ---
+      x = if y
+        /*a*/ a; /*b*/ b
+      else
+        /*c*/ c; /*d*/ d
+      ---
+      x = (y)?(
+        /*a*/ a, /*b*/ b
+      )
+      :(
+        /*c*/ c, /*d*/ d
+      )
     """
 
     testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -86,6 +86,22 @@ describe "if", ->
     if (x) y
   """
 
+  testCase """
+    if with multiple semicolon-separated statements
+    ---
+    if x
+      a; b
+    else
+      c; d
+    ---
+    if (x) {
+      a; b
+    }
+    else {
+      c; d
+    }
+  """
+
   // TODO
   testCase.skip """
     if then nothing


### PR DESCRIPTION
`a; b` was supported at the top level but not in deeper blocks, e.g., within an `if`!

This adds support to both regular blocks and if/else expressions.  It also refactors the top-level support to be cleaner, before I copied it two more times.