### PR TITLE
Refactor block indentation

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -170,12 +170,21 @@ function gatherRecursiveAll(node, predicate) {
 }
 
 /**
- * Gets the indentation node from a statement.
+ * Gets the indentation node from a statement. Includes newline,
+ * excludes comments, strips location info.
  */
 function getIndent(statement) {
+  debugger
   let indent = statement?.[0]
-  // Hacky way to get the indent out of [EOS, indent] pair
-  if (Array.isArray(indent)) indent = indent[indent.length - 1]
+  if (Array.isArray(indent)) {
+    indent = indent.flat(Infinity)
+
+    return indent.filter((n) => n && !(n.type === "Comment")).map((n) => {
+      if (typeof n === "string") return n
+      if (n.token != null) return n.token
+      return ""
+    })
+  }
   return indent
 }
 

--- a/source/lib.js
+++ b/source/lib.js
@@ -174,7 +174,6 @@ function gatherRecursiveAll(node, predicate) {
  * excludes comments, strips location info.
  */
 function getIndent(statement) {
-  debugger
   let indent = statement?.[0]
   if (Array.isArray(indent)) {
     indent = indent.flat(Infinity)

--- a/source/lib.js
+++ b/source/lib.js
@@ -376,7 +376,7 @@ function forRange(open, forDeclaration, range, stepExp, close) {
     } else { // const or var: put inside loop
       // TODO: missing indentation
       blockPrefix = [
-        ["", forDeclaration, " = ", counterRef, ";\n"]
+        ["", forDeclaration, " = ", counterRef, ";"]
       ]
     }
   } else if (forDeclaration) { // Coffee-style for loop

--- a/source/lib.js
+++ b/source/lib.js
@@ -14,7 +14,7 @@
  */
 function blockWithPrefix(prefixStatements, block) {
   if (prefixStatements && prefixStatements.length) {
-    const indent = getIndent(block.expressions[0])
+    const indent = block.expressions[0][0]
     // Match prefix statements to block indent level
     if (indent) {
       prefixStatements = prefixStatements.map((statement) => [indent, ...statement.slice(1)])
@@ -31,7 +31,7 @@ function blockWithPrefix(prefixStatements, block) {
     // Add braces if block lacked them
     if (block.bare) {
       // Now copied, so mutation is OK
-      block.children = [[" {\n", indent], ...block.children, "}"]
+      block.children = [[" {"], ...block.children, "}"]
       block.bare = false
     }
   }

--- a/source/lib.js
+++ b/source/lib.js
@@ -14,7 +14,7 @@
  */
 function blockWithPrefix(prefixStatements, block) {
   if (prefixStatements && prefixStatements.length) {
-    const indent = block.expressions[0][0]
+    const indent = getIndent(block.expressions[0])
     // Match prefix statements to block indent level
     if (indent) {
       prefixStatements = prefixStatements.map((statement) => [indent, ...statement.slice(1)])

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -43,6 +43,7 @@ Program
       expressions: statements,
       children: [statements],
       bare: true,
+      root: true,
     })
     return $0
 
@@ -3169,12 +3170,12 @@ ForStatementControl
   !CoffeeForLoopsEnabled ForStatementParameters -> $2
   CoffeeForLoopsEnabled CoffeeForStatementParameters WhenCondition? ->
     if ($3) {
-      const indent = module.currentIndent.token + "  "
-      const block = "continue\n"
+      // TODO: actual block and continue ast nodes
+      const block = "continue;"
       $2 = {
         ...$2,
         blockPrefix: [...$2.blockPrefix,
-          [indent, {
+          ["", {
             type: "IfStatement",
             then: block,
             children: ["if (!(", insertTrimmingSpace($3, ""), ")) ", block],
@@ -3192,7 +3193,6 @@ CoffeeForStatementParameters
   # NOTE: Coffee for loops can't have parens
   ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExpressionWithIndentedApplicationForbidden:exp ( _? By ExpressionWithIndentedApplicationForbidden )?:step InsertCloseParen:close ->
     let blockPrefix = []
-    const indent = module.currentIndent.token + "  "
     exp = insertTrimmingSpace(exp, "")
     declaration = insertTrimmingSpace(declaration, "")
 
@@ -3211,12 +3211,12 @@ CoffeeForStatementParameters
       if (declaration.own) {
         const hasPropRef = module.getRef("hasProp")
 
-        blockPrefix./**/push([indent, "if (!", hasPropRef, ".call(", exp, ", ", declaration, ")) continue\n"])
+        blockPrefix./**/push(["", "if (!", hasPropRef, ".call(", exp, ", ", declaration, ")) continue", ";"])
       }
 
       // index is actually value in Coffee "for of", y = z[x]
       if (index) {
-        blockPrefix./**/push([indent, {
+        blockPrefix./**/push(["", {
           type: "AssignmentExpression",
           children: [index, " = ", exp, "[", declaration, "]"],
           names: index.names,
@@ -3269,11 +3269,11 @@ CoffeeForStatementParameters
         ? [expRef, " = ", insertTrimmingSpace(exp, ""), ", "]
         : []
 
-      blockPrefix./**/push([indent, {
+      blockPrefix./**/push(["", {
         type: "AssignmentExpression",
         children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
         names: assignmentNames,
-      }])
+      }, ";"])
 
       declaration = {
         type: "Declaration",
@@ -6863,11 +6863,11 @@ Init
           // else block
           if (exp.else) insertReturn(exp.else[2])
           // Add explicit return after if block if no else block
-          else {
-            debugger
-            // TODO: this is the indent of the space befor the `if` in an `else if` when it should be the same indent as the first if in the whole series.
-            exp.children.push([indent, wrapWithReturn()])
-          }
+          else exp.children.push([{
+            type: "ReturnStatement",
+            // NOTE: add a prefixed semi-colon because the if block may not be braced
+            children: [";return"],
+          }])
           return
         case "PatternMatchingStatement":
           insertReturn(exp.children[0][0])
@@ -8432,7 +8432,12 @@ Init
       if (varIds.length) {
         // get indent from first statement
         const indent = getIndent(statements[0])
-        statements.unshift([indent, "var ", varIds.join(", "), "\n"])
+        let delimiter = ";"
+        if (statements[0][1]?.parent?.root) {
+          delimiter = "\n"
+        }
+        // TODO: Declaration ast node
+        statements.unshift([indent, "var ", varIds.join(", "), delimiter])
       }
 
       scopes.pop()

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1846,19 +1846,10 @@ NestedBlockStatements
     // Each element of statements is a list of same-line statements. Flatten.
     statements = statements.flat()
 
-    // separate first EOS from indent for easier insertion to top of block
-    const first = statements[0]
-    const ws = first[0]
-    const indent = ws.at(-1)
-    statements = [
-      [indent, ...first.slice(1)],
-      ...statements.slice(1),
-    ]
-
     return {
       type: "BlockStatement",
       expressions: statements,
-      children: [ws.slice(0, -1), statements],
+      children: [statements],
       bare: true,
     }
 
@@ -3679,7 +3670,7 @@ DeclarationCondition
       type: "AssignmentExpression",
       children: [ref, " ", initializer],
       hoistDec: [["", ["let ", ref], ";"]],
-      blockPrefix: [["", [ binding, "= ", ref ], ";\n"]],
+      blockPrefix: [["", [ binding, "= ", ref ], ";"]],
     }
 
     return initCondition

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6863,7 +6863,7 @@ Init
           // else block
           if (exp.else) insertReturn(exp.else[2])
           // Add explicit return after if block if no else block
-          else exp.children.push([{
+          else exp.children.push(["", {
             type: "ReturnStatement",
             // NOTE: add a prefixed semi-colon because the if block may not be braced
             children: [";return"],
@@ -7388,15 +7388,20 @@ Init
         injectParamProps: f.name === 'constructor'
       })
 
+      const delimiter = {
+        type: "SemicolonDelimiter",
+        children: [";"],
+      }
+
       const prefix = splices
         .map(s => ["let ", s])
         .concat(thisAssignments)
         .map((s) => s.type
           ? {
             ...s,
-            children: [indent, ...s.children, ";"]
+            children: [indent, ...s.children, delimiter]
           }
-          : [indent, s, ";"]
+          : [indent, s, delimiter]
         )
 
       expressions.unshift(...prefix)
@@ -8434,7 +8439,7 @@ Init
         const indent = getIndent(statements[0])
         let delimiter = ";"
         if (statements[0][1]?.parent?.root) {
-          delimiter = "\n"
+          delimiter = ";\n"
         }
         // TODO: Declaration ast node
         statements.unshift([indent, "var ", varIds.join(", "), delimiter])

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3220,7 +3220,7 @@ CoffeeForStatementParameters
           type: "AssignmentExpression",
           children: [index, " = ", exp, "[", declaration, "]"],
           names: index.names,
-        }, ";\n"])
+        }, ";"])
       }
 
       kind.token = "in"
@@ -3271,7 +3271,7 @@ CoffeeForStatementParameters
 
       blockPrefix./**/push([indent, {
         type: "AssignmentExpression",
-        children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]\n"],
+        children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
         names: assignmentNames,
       }])
 
@@ -4429,7 +4429,7 @@ SingleLineComment
 JSSingleLineComment
   # JS Comments are two slashes not followed by a third (because that is a heregex)
   /\/\/(?!\/)[^\r\n]*/ ->
-    return { $loc, token: $0 }
+    return { type: "Comment", $loc, token: $0 }
 
 # https://262.ecma-international.org/#prod-MultiLineComment
 MultiLineComment
@@ -4439,17 +4439,17 @@ MultiLineComment
 
 JSMultiLineComment
   $( "/*" (!"*/" . )* "*/" ) ->
-    return { $loc, token: $1 }
+    return { type: "Comment", $loc, token: $1 }
 
 CoffeeSingleLineComment
   # NOTE: CoffeeScript style single line comments
   /#(?!##(?!#))([^\r\n]*)/ ->
-    return { $loc, token: `//${$1}` }
+    return { type: "Comment", $loc, token: `//${$1}` }
 
 CoffeeMultiLineComment
   CoffeeHereCommentStart $/[^]*?###/ ->
     $2 = $2.slice(0, $2.length-3).replace(/\*\//g, "* /")
-    return { $loc, token: `/*${$2}*/` }
+    return { type: "Comment", $loc, token: `/*${$2}*/` }
 
 CoffeeHereCommentStart
   /###(?!#)/
@@ -6863,7 +6863,11 @@ Init
           // else block
           if (exp.else) insertReturn(exp.else[2])
           // Add explicit return after if block if no else block
-          else exp.children.push(["\n", indent, wrapWithReturn()])
+          else {
+            debugger
+            // TODO: this is the indent of the space befor the `if` in an `else if` when it should be the same indent as the first if in the whole series.
+            exp.children.push([indent, wrapWithReturn()])
+          }
           return
         case "PatternMatchingStatement":
           insertReturn(exp.children[0][0])
@@ -7390,9 +7394,9 @@ Init
         .map((s) => s.type
           ? {
             ...s,
-            children: [indent, ...s.children, ";\n"]
+            children: [indent, ...s.children, ";"]
           }
-          : [indent, s, ";\n"]
+          : [indent, s, ";"]
         )
 
       expressions.unshift(...prefix)
@@ -7464,9 +7468,10 @@ Init
           getIndent(block.expressions[0]),
           {
             type: "Declaration",
-            children: ["let ", ref, returnType, ";\n"],
+            children: ["let ", ref, returnType],
             names: [],
-          }
+          },
+          ";"
         ])
       }
 
@@ -7481,7 +7486,7 @@ Init
       // Implicit return before }
       if (block.children.at(-2)?.type !== "ReturnStatement") {
         block.expressions.push([
-          [ "\n", getIndent(block.expressions.at(-1)) ],
+          [ getIndent(block.expressions.at(-1)) ],
           {
             type: "ReturnStatement",
             expression: ref,
@@ -8078,13 +8083,13 @@ Init
               const patternBindings = nonMatcherBindings(pattern)
 
               splices = splices.map(s => [", ", nonMatcherBindings(s)])
-              thisAssignments = thisAssignments.map(a => [indent, a, ";\n"])
+              thisAssignments = thisAssignments.map(a => [indent, a, ";"])
 
               const duplicateDeclarations = aggregateDuplicateBindings([patternBindings, splices])
 
-              prefix.push([indent, "const ", patternBindings, " = ", ref, splices, ";\n"])
+              prefix.push([indent, "const ", patternBindings, " = ", ref, splices, ";"])
               prefix.push(...thisAssignments)
-              prefix.push(...duplicateDeclarations.map(d => [indent, d, ";\n"]))
+              prefix.push(...duplicateDeclarations.map(d => [indent, d, ";"]))
 
               break
             }

--- a/test/class.civet
+++ b/test/class.civet
@@ -581,8 +581,7 @@ describe "class", ->
         @(@a=5)
       ---
       class {
-        constructor(a=5) {this.a = a;
-      }
+        constructor(a=5) {this.a = a;}
       }
     """
 

--- a/test/compat/auto-var.civet
+++ b/test/compat/auto-var.civet
@@ -8,7 +8,7 @@ describe "auto-var", ->
     a = b = c = d
     a = 2
     ---
-    var a, b, c
+    var a, b, c;
     a = b = c = d
     a = 2
   """
@@ -30,7 +30,7 @@ describe "auto-var", ->
     a = 1
     b = a
     ---
-    var a
+    var a;
     let b = 2
     a = 1
     b = a
@@ -44,7 +44,7 @@ describe "auto-var", ->
     a = 1
     b = a
     ---
-    var a
+    var a;
     var b = 2
     a = 1
     b = a
@@ -102,7 +102,7 @@ describe "auto-var", ->
     "civet auto-var"
     [a, b] = [1, 2]
     ---
-    var a, b
+    var a, b;
     [a, b] = [1, 2]
   """
 
@@ -115,7 +115,7 @@ describe "auto-var", ->
       b
     ] = [1, 2]
     ---
-    var a, b
+    var a, b;
     [
       a,
       b
@@ -128,7 +128,7 @@ describe "auto-var", ->
     "civet auto-var"
     {a, b} = {a: 1, b: 2}
     ---
-    var a, b
+    var a, b;
     ({a, b} = {a: 1, b: 2})
   """
 
@@ -141,7 +141,7 @@ describe "auto-var", ->
       b
     } = {a: 1, b: 2}
     ---
-    var a, b
+    var a, b;
     ({
       a,
       b
@@ -154,7 +154,7 @@ describe "auto-var", ->
     "civet auto-var"
     {a: b, c: d} = {a: 1, c: 2}
     ---
-    var b, d
+    var b, d;
     ({a: b, c: d} = {a: 1, c: 2})
   """
 
@@ -167,7 +167,7 @@ describe "auto-var", ->
       d: e
     } = {a: 1, c: 2}
     ---
-    var c, e
+    var c, e;
     ({
       a: {b: c},
       d: e
@@ -183,7 +183,7 @@ describe "auto-var", ->
       d: e
     } = {a: 1, c: 2}
     ---
-    var b, c, e
+    var b, c, e;
     ({
       a: [b, {c}],
       d: e
@@ -197,7 +197,7 @@ describe "auto-var", ->
     for i = 0; i < 10; i++
       a = i
     ---
-    var i, a
+    var i, a;
     for (i = 0; i < 10; i++) {
       a = i
     }
@@ -210,7 +210,7 @@ describe "auto-var", ->
     for let a in b
       a = c = 1
     ---
-    var c
+    var c;
     for (let a in b) {
       a = c = 1
     }
@@ -223,7 +223,7 @@ describe "auto-var", ->
     for a in b
       a = c = 1
     ---
-    var c
+    var c;
     for (const a in b) {
       a = c = 1
     }
@@ -235,7 +235,7 @@ describe "auto-var", ->
     "civet auto-var"
     a = b = c = 1
     ---
-    var a, b, c
+    var a, b, c;
     a = b = c = 1
   """
 
@@ -246,7 +246,7 @@ describe "auto-var", ->
     let a = 1
     a = b = c = 1
     ---
-    var b, c
+    var b, c;
     let a = 1
     a = b = c = 1
   """
@@ -257,7 +257,7 @@ describe "auto-var", ->
     "civet auto-var"
     {a, b} = c = d
     ---
-    var a, b, c
+    var a, b, c;
     ({a, b} = c = d)
   """
 
@@ -267,7 +267,7 @@ describe "auto-var", ->
     "civet auto-var"
     a = {b, c} = d
     ---
-    var a, b, c
+    var a, b, c;
     a = ({b, c} = d)
   """
 
@@ -278,7 +278,7 @@ describe "auto-var", ->
     let a = 1
     {a, b} = c = d
     ---
-    var b, c
+    var b, c;
     let a = 1;
     ({a, b} = c = d)
   """
@@ -289,7 +289,7 @@ describe "auto-var", ->
     "civet auto-var"
     {a, b} = {c, d} = x
     ---
-    var a, b, c, d
+    var a, b, c, d;
     ({a, b} = {c, d} = x)
   """
 
@@ -306,7 +306,7 @@ describe "auto-var", ->
         y = 2
         z = 1
     ---
-    var x, a
+    var x, a;
     x = 1
     a = function() {
       var y, b;
@@ -351,7 +351,7 @@ describe "auto-var", ->
       x = 1
       c = 2
     ---
-    var a
+    var a;
     a = function(b, c) {
       var x;
       x = 1
@@ -377,7 +377,7 @@ describe "auto-var", ->
       }
     }
     ---
-    var x, y, z
+    var x, y, z;
     x = 1
     {
       x = 2
@@ -413,7 +413,7 @@ describe "auto-var", ->
       var a = 2
     }
     ---
-    var a
+    var a;
     a = 1
     {
       var a = 2

--- a/test/compat/auto-var.civet
+++ b/test/compat/auto-var.civet
@@ -309,11 +309,11 @@ describe "auto-var", ->
     var x, a
     x = 1
     a = function() {
-      var y, b
+      var y, b;
       x = 2
       y = 1
       return b = function() {
-        var z
+        var z;
         x = 3
         y = 2
         return z = 1
@@ -332,14 +332,13 @@ describe "auto-var", ->
       i = 10
     ---
     function f() {
-      var i
+      var i;
       if (true) {
         return i = 5
-      }
-      return
+      };return
     }
     function g() {
-      var i
+      var i;
       return i = 10
     }
   """
@@ -354,7 +353,7 @@ describe "auto-var", ->
     ---
     var a
     a = function(b, c) {
-      var x
+      var x;
       x = 1
       return c = 2
     }

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -10,7 +10,7 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
+      a = b[i];
       a.i
     }
   """
@@ -22,9 +22,7 @@ describe "coffeeForLoops", ->
     for a in b then a.i
     ---
     var a
-    for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
-     a.i}
+    for (let i = 0, len = b.length; i < len; i++) { a = b[i]; a.i}
   """
 
   testCase """
@@ -36,7 +34,7 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
+      a = b[i];
       ({x: a})
     }
   """
@@ -50,7 +48,7 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let i1 = 0, len = b.length; i1 < len; i1++) {
-      a = b[i1]
+      a = b[i1];
       a[i]++
     }
   """
@@ -236,7 +234,7 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let ref = b.x, i = 0, len = ref.length; i < len; i++) {
-      a = ref[i]
+      a = ref[i];
       a.x
     }
   """
@@ -247,12 +245,9 @@ describe "coffeeForLoops", ->
     "civet coffeeCompat"
     coffees = (s for s in scripts when s.type in coffeetypes)
     ---
-    var coffees, s
-    var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
+    var coffees, s;var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     coffees = (()=>{const results=[];for (let i = 0, len = scripts.length; i < len; i++) {
-      s = scripts[i]
-      if (!(indexOf.call(coffeetypes, s.type) >= 0)) continue
-      results.push(s)
+    s = scripts[i];if (!(indexOf.call(coffeetypes, s.type) >= 0)) continue;results.push(s)
     }; return results})()
   """
 
@@ -265,7 +260,7 @@ describe "coffeeForLoops", ->
     ---
     var a, i
     for (let i1 = 0, len = b.length; i1 < len; i1++) {
-      a = b[i=i1]
+      a = b[i=i1];
       a.x
     }
   """
@@ -279,7 +274,7 @@ describe "coffeeForLoops", ->
     ---
     var x
     for (let ref = [...a], i = 0, len = ref.length; i < len; i++) {
-      x = ref[i]
+      x = ref[i];
       x
     }
   """
@@ -293,8 +288,8 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
-      if (!(a > 0)) continue
+      a = b[i];
+      if (!(a > 0)) continue;
       a.x
     }
   """
@@ -308,8 +303,8 @@ describe "coffeeForLoops", ->
     ---
     var a
     for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
-      if (!(a > 0)) continue
+      a = b[i];
+      if (!(a > 0)) continue;
       ({x: a})
     }
   """
@@ -327,12 +322,12 @@ describe "coffeeForLoops", ->
     ---
     var a, c
     for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
+      a = b[i];
       a.x
     }
 
     for (let i1 = 0, len1 = d.length; i1 < len1; i1++) {
-      c = d[i1]
+      c = d[i1];
       c.x
     }
   """
@@ -352,17 +347,17 @@ describe "coffeeForLoops", ->
       return
     ---
     function f() {
-      var i
+      var i;
       for (let i1 = 0, len = x.length; i1 < len; i1++) {
-        i = x[i1]
+        i = x[i1];
         i
       }
       return
     }
     function g() {
-      var i
+      var i;
       for (let i2 = 0, len1 = x.length; i2 < len1; i2++) {
-        i = x[i2]
+        i = x[i2];
         i
       }
       return
@@ -379,9 +374,9 @@ describe "coffeeForLoops", ->
     ---
     var a, c
     for (let i = 0, len = b.length; i < len; i++) {
-      a = b[i]
+      a = b[i];
       for (let i1 = 0, len1 = d.length; i1 < len1; i1++) {
-        c = d[i1]
+        c = d[i1];
         a.x
       }
     }
@@ -421,10 +416,9 @@ describe "coffeeForLoops", ->
     for own a of b
       console.log a
     ---
-    var a
-    var hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
+    var a;var hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
     for (a in b) {
-      if (!hasProp.call(b, a)) continue
+      if (!hasProp.call(b, a)) continue;
       console.log(a)
     }
   """
@@ -435,12 +429,9 @@ describe "coffeeForLoops", ->
     "civet coffee-compat"
     log(a) for own a of b when a != "y"
     ---
-    var a
-    var hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
+    var a;var hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
     for (a in b) {
-      if (!hasProp.call(b, a)) continue
-      if (!(a !== "y")) continue
-      log(a)
+    if (!hasProp.call(b, a)) continue;if (!(a !== "y")) continue;log(a)
     }
   """
 

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -8,7 +8,7 @@ describe "coffeeForLoops", ->
     for a in b
       a.i
     ---
-    var a
+    var a;
     for (let i = 0, len = b.length; i < len; i++) {
       a = b[i];
       a.i
@@ -21,7 +21,7 @@ describe "coffeeForLoops", ->
     "civet coffee-compat"
     for a in b then a.i
     ---
-    var a
+    var a;
     for (let i = 0, len = b.length; i < len; i++) { a = b[i]; a.i}
   """
 
@@ -32,7 +32,7 @@ describe "coffeeForLoops", ->
     for a in b
       x: a
     ---
-    var a
+    var a;
     for (let i = 0, len = b.length; i < len; i++) {
       a = b[i];
       ({x: a})
@@ -46,7 +46,7 @@ describe "coffeeForLoops", ->
     for a in b
       a[i]++
     ---
-    var a
+    var a;
     for (let i1 = 0, len = b.length; i1 < len; i1++) {
       a = b[i1];
       a[i]++
@@ -60,7 +60,7 @@ describe "coffeeForLoops", ->
     for a in [1..10]
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = 1; i <= 10; a = ++i) {
       console.log(a)
     }
@@ -73,7 +73,7 @@ describe "coffeeForLoops", ->
     for a in [10..1]
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = 10; i >= 1; a = --i) {
       console.log(a)
     }
@@ -86,7 +86,7 @@ describe "coffeeForLoops", ->
     for a in [0...10]
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = 0; i < 10; a = ++i) {
       console.log(a)
     }
@@ -99,7 +99,7 @@ describe "coffeeForLoops", ->
     for i in [1..10]
       c()
     ---
-    var i
+    var i;
     for (let i1 = i = 1; i1 <= 10; i = ++i1) {
       c()
     }
@@ -124,7 +124,7 @@ describe "coffeeForLoops", ->
     for a in [1..b]
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = 1, asc = 1 <= b; asc ? i <= b : i >= b; a = asc ? ++i : --i) {
       console.log(a)
     }
@@ -137,7 +137,7 @@ describe "coffeeForLoops", ->
     for a in [x...y]
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = x, asc = x <= y; asc ? i < y : i > y; a = asc ? ++i : --i) {
       console.log(a)
     }
@@ -150,7 +150,7 @@ describe "coffeeForLoops", ->
     for a in [x()...y()]
       console.log a
     ---
-    var a
+    var a;
     for (let start = x(), end = y(), i = a = start, asc = start <= end; asc ? i < end : i > end; a = asc ? ++i : --i) {
       console.log(a)
     }
@@ -164,7 +164,7 @@ describe "coffeeForLoops", ->
     for a in [x()...y()]
       console.log a
     ---
-    var start, end, asc, a
+    var start, end, asc, a;
     start = end = asc = null
     for (let start1 = x(), end1 = y(), i = a = start1, asc1 = start1 <= end1; asc1 ? i < end1 : i > end1; a = asc1 ? ++i : --i) {
       console.log(a)
@@ -178,7 +178,7 @@ describe "coffeeForLoops", ->
     for a in [x..y] by 2
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = x; 2 !== 0 && (2 > 0 ? i <= y : i >= y); a = i += 2) {
       console.log(a)
     }
@@ -191,7 +191,7 @@ describe "coffeeForLoops", ->
     for a in [x...y] by z
       console.log a
     ---
-    var a
+    var a;
     for (let i = a = x; z !== 0 && (z > 0 ? i < y : i > y); a = i += z) {
       console.log(a)
     }
@@ -204,7 +204,7 @@ describe "coffeeForLoops", ->
     for a in [x()...y()] by z()
       console.log a
     ---
-    var a
+    var a;
     for (let start = x(), end = y(), i = a = start, step = z(); step !== 0 && (step > 0 ? i < end : i > end); a = i += step) {
       console.log(a)
     }
@@ -218,7 +218,7 @@ describe "coffeeForLoops", ->
     for a in [x()...y()] by z()
       console.log a
     ---
-    var start, end, step, a
+    var start, end, step, a;
     start = end = step = null
     for (let start1 = x(), end1 = y(), i = a = start1, step1 = z(); step1 !== 0 && (step1 > 0 ? i < end1 : i > end1); a = i += step1) {
       console.log(a)
@@ -232,7 +232,7 @@ describe "coffeeForLoops", ->
     for a in b.x
       a.x
     ---
-    var a
+    var a;
     for (let ref = b.x, i = 0, len = ref.length; i < len; i++) {
       a = ref[i];
       a.x
@@ -258,7 +258,7 @@ describe "coffeeForLoops", ->
     for a, i in b
       a.x
     ---
-    var a, i
+    var a, i;
     for (let i1 = 0, len = b.length; i1 < len; i1++) {
       a = b[i=i1];
       a.x
@@ -272,7 +272,7 @@ describe "coffeeForLoops", ->
     for x in [a...]
       x
     ---
-    var x
+    var x;
     for (let ref = [...a], i = 0, len = ref.length; i < len; i++) {
       x = ref[i];
       x
@@ -286,7 +286,7 @@ describe "coffeeForLoops", ->
     for a in b when a > 0
       a.x
     ---
-    var a
+    var a;
     for (let i = 0, len = b.length; i < len; i++) {
       a = b[i];
       if (!(a > 0)) continue;
@@ -301,7 +301,7 @@ describe "coffeeForLoops", ->
     for a in b when a > 0
       x: a
     ---
-    var a
+    var a;
     for (let i = 0, len = b.length; i < len; i++) {
       a = b[i];
       if (!(a > 0)) continue;
@@ -320,7 +320,7 @@ describe "coffeeForLoops", ->
     for c in d
       c.x
     ---
-    var a, c
+    var a, c;
     for (let i = 0, len = b.length; i < len; i++) {
       a = b[i];
       a.x
@@ -372,7 +372,7 @@ describe "coffeeForLoops", ->
       for c in d
         a.x
     ---
-    var a, c
+    var a, c;
     for (let i = 0, len = b.length; i < len; i++) {
       a = b[i];
       for (let i1 = 0, len1 = d.length; i1 < len1; i1++) {
@@ -389,7 +389,7 @@ describe "coffeeForLoops", ->
     for a of b
       console.log a
     ---
-    var a
+    var a;
     for (a in b) {
       console.log(a)
     }
@@ -402,7 +402,7 @@ describe "coffeeForLoops", ->
     for x, y of z
       y
     ---
-    var x, y
+    var x, y;
     for (x in z) {
       y = z[x];
       y
@@ -442,7 +442,7 @@ describe "coffeeForLoops", ->
     for a from b
       console.log a
     ---
-    var a
+    var a;
     for (a of b) {
       console.log(a)
     }
@@ -455,7 +455,7 @@ describe "coffeeForLoops", ->
     for {a, b} from c
       console.log a
     ---
-    var a, b
+    var a, b;
     for ({a, b} of c) {
       console.log(a)
     }

--- a/test/compat/coffee-of.civet
+++ b/test/compat/coffee-of.civet
@@ -70,8 +70,7 @@ describe "coffeeOf", ->
     a = 3
     a in b
     ---
-    var a
-    var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
+    var a;var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     a = 3
     indexOf.call(b, a) >= 0
   """

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -8,7 +8,7 @@ describe "example code", ->
     if id is 'do' and regExSuper = /^(\\s*super)(?!\\(\\))/.exec @chunk[3...]
       @token 'SUPER', 'super'
     ---
-    var regExSuper
+    var regExSuper;
     if (id === 'do' && (regExSuper = /^(\\s*super)(?!\\(\\))/.exec(this.chunk.slice(3)))) {
       this.token('SUPER', 'super')
     }
@@ -109,7 +109,7 @@ describe "example code", ->
           else
             ' '
     ---
-    var val, indentRegex
+    var val, indentRegex;
     val =
       (!(this.fromSourceString))?
         val
@@ -177,7 +177,7 @@ describe "example code", ->
     for fragment, i in fragments by -1 when fragment.fragments
       fragments[i..i] = @expand fragment.fragments
     ---
-    var fragment, i
+    var fragment, i;
     for (let i1 = fragments.length - 1; i1 >= 0; i1 += -1) {
       fragment = fragments[i=i1];
       if (!(fragment.fragments)) continue;
@@ -192,7 +192,7 @@ describe "example code", ->
     for fragment, i in fragments by 1 when fragment.fragments
       fragments[i..i] = @expand fragment.fragments
     ---
-    var fragment, i
+    var fragment, i;
     for (let i1 = 0, len = fragments.length; i1 < len; i1 += 1) {
       fragment = fragments[i=i1];
       if (!(fragment.fragments)) continue;
@@ -293,7 +293,7 @@ describe "example code", ->
       code = value.compileToFragments o
       return if o.level >= LEVEL_OP then @wrapInParentheses code else code
     ---
-    var code
+    var code;
     if (olen === 0) {
       code = value.compileToFragments(o)
       return (o.level >= LEVEL_OP)? this.wrapInParentheses(code) : code
@@ -353,7 +353,7 @@ describe "example code", ->
 
     module.exports = MEANING_OF_LIFE
     ---
-    var MEANING_OF_LIFE
+    var MEANING_OF_LIFE;
     MEANING_OF_LIFE = 42
 
     module.exports = MEANING_OF_LIFE

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -43,8 +43,7 @@ describe "example code", ->
       else
         'IDENTIFIER'
     ---
-    var tag
-    var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
+    var tag;var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     tag =
       (colon || prev != null &&
          (indexOf.call(['.', '?.', '::', '?::'], prev[0]) >= 0 ||
@@ -180,8 +179,8 @@ describe "example code", ->
     ---
     var fragment, i
     for (let i1 = fragments.length - 1; i1 >= 0; i1 += -1) {
-      fragment = fragments[i=i1]
-      if (!(fragment.fragments)) continue
+      fragment = fragments[i=i1];
+      if (!(fragment.fragments)) continue;
       fragments.splice(i, 1 + i - i, ...this.expand(fragment.fragments))
     }
   """
@@ -195,8 +194,8 @@ describe "example code", ->
     ---
     var fragment, i
     for (let i1 = 0, len = fragments.length; i1 < len; i1 += 1) {
-      fragment = fragments[i=i1]
-      if (!(fragment.fragments)) continue
+      fragment = fragments[i=i1];
+      if (!(fragment.fragments)) continue;
       fragments.splice(i, 1 + i - i, ...this.expand(fragment.fragments))
     }
   """
@@ -236,9 +235,8 @@ describe "example code", ->
       varPart += ", #{@toC}" if @toC isnt @toVar
     ---
     (function(o) {
-      var varPart
-      if (this.toC !== this.toVar) { return varPart += `, ${this.toC}` }
-      return
+      var varPart;
+      if (this.toC !== this.toVar) { return varPart += `, ${this.toC}` };return
     })
   '''
 

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -75,7 +75,7 @@ describe "examples (from real life)", ->
     const fileCache = {}
 
     const createCompilerHost = function(options, moduleSearchLocations) {
-      var fileExists, readFile, getSourceFile, resolveModuleNames
+      var fileExists, readFile, getSourceFile, resolveModuleNames;
       fileExists = function(fileName) {
         return ((fileCache[fileName]) != null)
       }
@@ -85,17 +85,16 @@ describe "examples (from real life)", ->
       }
 
       getSourceFile = function(fileName, languageVersion, onError) {
-        var sourceText
+        var sourceText;
         sourceText = ts.sys.readFile(fileName)
 
         if (sourceText != null) {
           return ts.createSourceFile(fileName, sourceText, languageVersion)
-        }
-        return
+        };return
       }
 
       resolveModuleNames = function(moduleNames, containingFile) {
-        var resolvedModules, moduleName, result, location, modulePath
+        var resolvedModules, moduleName, result, location, modulePath;
         resolvedModules = []
 
         for (moduleName of moduleNames) {

--- a/test/for.civet
+++ b/test/for.civet
@@ -96,9 +96,7 @@ describe "for", ->
     ---
     for (i of [1..10]) console.log(i)
     ---
-    for (let i1 = 1; i1 <= 10; ++i1) {
-      const i = i1;
-     console.log(i)}
+    for (let i1 = 1; i1 <= 10; ++i1) { const i = i1; console.log(i)}
   """
 
   testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -270,7 +270,7 @@ describe "function", ->
       ---
       (@a, @b) ->
       ---
-      (function(a, b) {this.a = a;return this.b = b;})
+      (function(a, b) {this.a = a;this.b = b;})
     """
 
     testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -270,9 +270,7 @@ describe "function", ->
       ---
       (@a, @b) ->
       ---
-      (function(a, b) {this.a = a;
-      return this.b = b;
-      })
+      (function(a, b) {this.a = a;return this.b = b;})
     """
 
     testCase """
@@ -1108,8 +1106,7 @@ describe "function", ->
       ---
       (x) -> a if x
       ---
-      (function(x) { if (x) { return a }
-      return })
+      (function(x) { if (x) { return a };return })
     """
 
     testCase """
@@ -1165,8 +1162,7 @@ describe "function", ->
       (function(x) {
         if (x) {
           return a
-        }
-        return
+        };return
       })
     """
 
@@ -1191,8 +1187,7 @@ describe "function", ->
           else {
             if (z) {
               return b
-            }
-            return
+            };return
           }
         }
         else {
@@ -1201,8 +1196,7 @@ describe "function", ->
       })
     """
 
-    // TODO: last return spacing is dubious
-    testCase.only """
+    testCase """
       if else if
       ---
       (x) ->
@@ -1222,8 +1216,7 @@ describe "function", ->
         }
         else if (z) {
           return c
-        }
-       return
+        };return
       })
     """
 
@@ -1237,8 +1230,7 @@ describe "function", ->
       (function(x) {
         if(!(x)) {
           return a
-        }
-        return
+        };return
       })
     """
 

--- a/test/function.civet
+++ b/test/function.civet
@@ -1202,7 +1202,7 @@ describe "function", ->
     """
 
     // TODO: last return spacing is dubious
-    testCase """
+    testCase.only """
       if else if
       ---
       (x) ->

--- a/test/top-level.civet
+++ b/test/top-level.civet
@@ -18,7 +18,7 @@ describe "top-level", ->
       x = 5
       return
     ---
-      var x
+      var x;
       x = 5
       return
   """

--- a/test/while.civet
+++ b/test/while.civet
@@ -134,7 +134,8 @@ describe "while", ->
         ;
       ---
       f = function() {
-        let ref;  while (ref = next()) {
+        let ref;
+        while (ref = next()) {
           const {x, y} = ref;
           x++
         }


### PR DESCRIPTION
- [x] Don't split EOS from indent in first block statement
- [x] Make block prefix statements consistent
- [x] Map indent into each prefix statement
- [x] Update getIndent to get all non-comment ws tokens

A lot of the block additions are more consistent now and mostly improved. One liners remain one liners (so we have to insert more semi-colons). Indentation is mapped from a statement in the block into the statements in `blockPrefix`.