### PR TITLE
Indentation after await operator

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -94,6 +94,7 @@ uncacheable = new Set [
   "NestedJSXChildExpression"
   "NestedModuleItem"
   "NestedModuleItems"
+  "NestedNonAssignmentExtendedExpression"
   "NestedObject"
   "NestedPropertyDefinitions"
   "NonSingleBracedBlock"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -113,13 +113,16 @@ NonPipelineExtendedExpression
 
 NonAssignmentExtendedExpression
   # Check for nested expressionized statements first
-  &EOS PushIndent ( Nested ExpressionizedStatement )?:expression PopIndent ->
-    if (expression) return expression
-    return $skip
+  NestedNonAssignmentExtendedExpression
   __ ExpressionizedStatement ->
     return {...$2,
       children: [...$1, ...$2.children]
     }
+
+NestedNonAssignmentExtendedExpression
+  &EOS PushIndent ( Nested ExpressionizedStatement )?:expression PopIndent ->
+    if (expression) return expression
+    return $skip
 
 ExpressionizedStatement
   DebuggerExpression
@@ -287,7 +290,7 @@ UnaryExpression
   # NOTE: Merged AwaitExpression with UnaryOp
   # https://262.ecma-international.org/#prod-AwaitExpression
   # NOTE: Eliminated left recursion
-  UnaryOp*:pre UpdateExpression:exp UnaryPostfix?:post ->
+  UnaryOp*:pre ( UpdateExpression / NestedNonAssignmentExtendedExpression ):exp UnaryPostfix?:post ->
     return processUnaryExpression(pre, exp, post)
 
   # NOTE: This is a little hacky to match CoffeeScript's behavior
@@ -2850,7 +2853,7 @@ UnaryOp
 
 # https://github.com/tc39/proposal-await.ops
 AwaitOp
-  Await:a ( Dot IdentifierName )?:op ( _ / &OpenParen ):ws ->
+  Await:a ( Dot IdentifierName )?:op ( &OpenParen / _ / &EOS ):ws ->
     if (op) {
       return {
         ...a,

--- a/test/await.civet
+++ b/test/await.civet
@@ -32,3 +32,19 @@ describe "await expression", ->
     ---
     await Promise.race(doIt())
   """
+
+  testCase """
+    await with indentation and expressionized statement
+    ---
+    await.all
+      for item of array
+        async do
+          await item.process()
+    ---
+    await Promise.all(
+      (()=>{const results=[];for (const item of array) {
+        results.push((async ()=>{{
+          return await item.process()
+        }})())
+      }; return results})())
+  """


### PR DESCRIPTION
Fixes #473

I tried just adding support directly to `AwaitOp`:

```diff
diff --git a/source/parser.hera b/source/parser.hera
index 77ab5ec..ae55026 100644
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2850,7 +2850,7 @@ UnaryOp

 # https://github.com/tc39/proposal-await.ops
 AwaitOp
-  Await:a ( Dot IdentifierName )?:op ( _ / &OpenParen ):ws ->
+  Await:a ( Dot IdentifierName )?:op ( &OpenParen / _ / IndentedFurther ):ws ->
     if (op) {
       return {
         ...a,
```

But `UnaryExpression` only allows `UpdateExpression` children, but we need `ExpressionizedStatement`.  So I've added part of `NonAssignmentExtendedExpression` (which already had nice `Nested` logic) as a possible child for `UnaryExpression`.