### PR TITLE
CLI can run ESM scripts via import

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ civet
 civet -c
 # Compile Civet source file to TypeScript
 civet < source.civet > output.ts
-# Execute a simple .civet script (no imports)
+# Execute a .civet script
 civet source.civet ...args...
 # Execute a .civet source file in node using ts-node
 node --loader ts-node/esm --loader @danielx/civet/esm source.civet

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -66,19 +66,26 @@ To use TypeScript for type checking, create a `tsconfig.json` file. For example:
 
 ## Executing code
 
-Simple execution of .civet source file without `import`s:
+Simple execution of a .civet source file (CommonJS or ESM):
 
 ```sh
 civet source.civet ...args...
 ```
 
-Directly execute a .civet source file without `import`s in Node:
+Directly execute a .civet CommonJS source file in Node:
 
 ```sh
 node -r @danielx/civet/register source.civet ...args...
 ```
 
-Execute an ESM .civet source file with `import`s in Node using ts-node:
+Directly execute a .civet ESM source file in Node:
+
+```sh
+node --loader @danielx/civet/esm source.civet ...args...
+```
+
+Directly execute a .civet or .ts source file that mixes .civet and .ts code,
+using [ts-node](https://typestrong.org/ts-node/):
 
 ```sh
 node --loader ts-node/esm --loader @danielx/civet/esm source.civet ...args...

--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -26,3 +26,4 @@ title: Integrations
 ## Testing
 
 - [c8 + Mocha](https://github.com/DanielXMoore/Civet#c8--mocha)
+- [Civet CLI](https://civet.dev/getting-started#executing-code)

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -20,6 +20,7 @@ if process.argv.includes "--help"
         civet                                        # REPL for executing code
         civet -c                                     # REPL for transpiling code
         civet --ast                                  # REPL for parsing code
+        civet [options] input.civet                  # run input.civet
         civet [options] -c input.civet               # -> input.civet.tsx
         civet [options] -c input.civet -o .ts        # -> input.ts
         civet [options] -c input.civet -o dir        # -> dir/input.civet.tsx
@@ -48,7 +49,7 @@ encoding = "utf8"
 fs = require "fs/promises"
 path = require "path"
 
-parseArgs = (args = process.argv[2..]) ->
+parseArgs = (args) ->
   options = {}
   Object.defineProperty options, 'run',
     get: -> not (@ast or @compile)
@@ -183,7 +184,8 @@ repl = (options) ->
         callback new nodeRepl.Recoverable "Enter a blank line to execute code."
 
 cli = ->
-  {filenames, scriptArgs, options} = parseArgs()
+  argv = process.argv  # process.argv gets overridden when running scripts
+  {filenames, scriptArgs, options} = parseArgs argv[2..]
   unless filenames.length
     if process.stdin.isTTY
       options.repl = true
@@ -254,14 +256,28 @@ cli = ->
           console.error "#{outputFilename} failed to write:"
           console.error error
     else # run
-      module.filename = await fs.realpath filename
-      process.argv = ["civet", module.filename, ...scriptArgs]
-      module.paths =
-        require('module')._nodeModulePaths path.dirname module.filename
-      try
-        module._compile output, module.filename
-      catch error
-        console.error "#{filename} crashed while running:"
-        console.error error
+      esm = /^\s*(import|export)\b/m.test output
+      if esm
+        if stdin
+          console.error "Cannot use ESM import/export when reading Civet code from stdin"
+          process.exit 1
+        child = require('child_process').spawnSync argv[0], [
+          '--loader'
+          '@danielx/civet/esm'
+          filename
+          ...scriptArgs
+        ], stdio: 'inherit'
+        process.exit child.status
+      else
+        module.filename = await fs.realpath filename
+        process.argv = ["civet", module.filename, ...scriptArgs]
+        module.paths =
+          require('module')._nodeModulePaths path.dirname module.filename
+        try
+          module._compile output, module.filename
+        catch error
+          console.error "#{filename} crashed while running in CJS mode:"
+          console.error error
+          process.exit 1
 
 cli() if require.main == module

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -75,6 +75,7 @@ export async function load(url: string, context: any, next: any)
     {code: tsSource, sourceMap} := compile source,
       filename: path
       sourceMap: true
+      js: true
 
     transpiledPath := url + ".tsx"
 


### PR DESCRIPTION
* `civet filename.civet` now works with code that `import`s `.civet` or `.js` files (in new ESM mode)
* `@danielx/civet/esm` now transpiles with `js: true` so we don't *always* need ts-node