### PR TITLE
Inline implicit object literals can't end with comma

### DIFF
--- a/source/main.coffee
+++ b/source/main.coffee
@@ -38,6 +38,7 @@ uncacheable = new Set [
   "ConditionalExpression"
   "Declaration"
   "Debugger"
+  "Dedented"
   "ElementListWithIndentedApplicationForbidden"
   "ElseClause"
   "Expression"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2240,24 +2240,20 @@ NestedPropertyDefinition
     }))
 
 InlineObjectLiteral
-  InsertInlineOpenBrace:open SnugNamedProperty ImplicitInlineObjectPropertyDelimiter ( ( Samedent / _* ) ImplicitNamedProperty ImplicitInlineObjectPropertyDelimiter )* InsertCloseBrace:close ->
+  InsertInlineOpenBrace:open SnugNamedProperty:first ( ImplicitInlineObjectPropertyDelimiter ImplicitNamedProperty )*:rest InsertCloseBrace:close ->
     return {
       type: "ObjectExpression",
-      children: [open, $2, $3, ...$4, close],
+      children: [open, first, ...rest, close],
     }
 
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
 # Instead we see if the next line matches a NamedProperty and if so we insert a comma
 ImplicitInlineObjectPropertyDelimiter
-  _? Comma
-  &( ( Samedent / _* ) NamedProperty ) InsertComma -> $2
-  # NOTE: This is hacky but used when an inline object is inside a ternary conditional
-  # Also if inline object is in an argument list or subexpression
-  &( __  ( ":" / ")" / "]" / "}" / ReservedWord ) ) -> ""
-  &EOS -> ""
+  _? Comma __
+  &( Samedent ImplicitNamedProperty ) InsertComma ( Samedent / _? ) -> [$2, $3]
 
 ObjectPropertyDelimiter
-  _* Comma
+  _? Comma
   # Object closing delimits the property
   &( __ "}" )
   &EOS InsertComma -> $2
@@ -4073,8 +4069,8 @@ TypeAndNamedExports
 NamedExports
   OpenBrace ExportSpecifier* (__ Comma )? __ CloseBrace
   # Unbraced version: export x, y
-  InsertInlineOpenBrace:open ImplicitExportSpecifier ( _ ImplicitExportSpecifier )* InsertCloseBrace:close ->
-    return [open, $2, ...$3, close]
+  InsertInlineOpenBrace:open ImplicitExportSpecifier:first ( ImplicitInlineObjectPropertyDelimiter ImplicitExportSpecifier )*:rest InsertCloseBrace:close &( StatementDelimiter / ( __ From )) ->
+    return [open, first, ...rest, close]
 
 # https://262.ecma-international.org/#prod-ExportSpecifier
 ExportSpecifier
@@ -4083,7 +4079,7 @@ ExportSpecifier
     return { ts: true, children: $0 }
 
 ImplicitExportSpecifier
-  !Default ModuleExportName ( __ As __ ModuleExportName )? ( &( __ From ) / ImplicitInlineObjectPropertyDelimiter )
+  !Default ModuleExportName ( __ As __ ModuleExportName )?
 
 # https://262.ecma-international.org/#prod-Declaration
 Declaration

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2240,16 +2240,16 @@ NestedPropertyDefinition
     }))
 
 InlineObjectLiteral
-  InsertInlineOpenBrace:open SnugNamedProperty:first ( ImplicitInlineObjectPropertyDelimiter ImplicitNamedProperty )*:rest InsertCloseBrace:close ->
+  InsertInlineOpenBrace:open SnugNamedProperty:first ( ImplicitInlineObjectPropertyDelimiter ImplicitNamedProperty )*:rest ( _? Comma &Dedented )?:trailing InsertCloseBrace:close ->
     return {
       type: "ObjectExpression",
-      children: [open, first, ...rest, close],
+      children: [open, first, ...rest, trailing, close],
     }
 
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
 # Instead we see if the next line matches a NamedProperty and if so we insert a comma
 ImplicitInlineObjectPropertyDelimiter
-  _? Comma __
+  _? Comma ( NotDedented / _? )
   &( Samedent ImplicitNamedProperty ) InsertComma ( Samedent / _? ) -> [$2, $3]
 
 ObjectPropertyDelimiter
@@ -8717,6 +8717,9 @@ NotDedented
     if ($1) ws.push(...$1)
     if ($2) ws.push(...$2)
     return ws.flat(Infinity).filter(Boolean)
+
+Dedented
+  !( Samedent / IndentedFurther ) EOS -> $2
 
 # Indents one level deeper
 # Must be matched with PopIndent

--- a/test/export.civet
+++ b/test/export.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "export", ->
   testCase """
@@ -44,11 +44,21 @@ describe "export", ->
     ---
     export a
     export a,
+      b,
+      c
     export a, b, c
     ---
     export {a}
-    export {a,}
+    export {a,
+      b,
+      c}
     export {a, b, c}
+  """
+
+  throws """
+    unbraced named with trailing comma
+    ---
+    export a,
   """
 
   testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -459,7 +459,6 @@ describe "object", ->
     ({tokens: this.tokens, index: i})
   """
 
-  // TODO: Should this be wrapped in parens?
   testCase """
     braceless inline object
     ---
@@ -484,6 +483,53 @@ describe "object", ->
     ---
     ({a: 1, b: 2,
     c: 3, d: 4})
+  """
+
+  throws """
+    braceless inline object with trailing comma
+    ---
+    a: 1,
+  """
+
+  throws """
+    2-element braceless inline object with trailing comma
+    ---
+    a: 1,
+    b: 2,
+  """
+
+  testCase """
+    braceless inline object in function call
+    ---
+    f a: 1, b: 2, c, d
+    ---
+    f({a: 1, b: 2}, c, d)
+  """
+
+  testCase """
+    braceless object in function call with commas
+    ---
+    f
+      a: 1,
+      b: 2,
+    ---
+    f({
+      a: 1,
+      b: 2,
+    })
+  """
+
+  testCase """
+    braceless object in function call without commas
+    ---
+    f
+      a: 1
+      b: 2
+    ---
+    f({
+      a: 1,
+      b: 2,
+    })
   """
 
   testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -499,6 +499,19 @@ describe "object", ->
   """
 
   testCase """
+    indented 2-element braceless inline object with trailing comma
+    ---
+    if x
+      a: 1,
+      b: 2,
+    ---
+    if (x) {
+      ({a: 1,
+      b: 2,})
+    }
+  """
+
+  testCase """
     braceless inline object in function call
     ---
     f a: 1, b: 2, c, d
@@ -530,6 +543,19 @@ describe "object", ->
       a: 1,
       b: 2,
     })
+  """
+
+  testCase """
+    dedented braceless object literals
+    ---
+    if x
+      a: 1,
+    b: 2
+    ---
+    if (x) {
+      ({a: 1,})
+    }
+    ({b: 2})
   """
 
   testCase """


### PR DESCRIPTION
Fixes #478 by forbidding commas at the end of an inline object literals or implicit `export` list.
The intuition is that commas indicate a continuation onto the next line in these cases, so we can't have arbitrary content on the next line, only more items.

These are now forbidden:

```coffee
a: 1,
b: 2,
```

```coffee
a: 1, b: 2,
```

This matches CoffeeScript behavior, which [forbids](https://coffeescript.org/#try:a%3A%201%2C) [both](https://coffeescript.org/#try:a%3A%201%2C%0Ab%3A%202%2C).

**Open question:** I'm not sure that the above really need to be forbidden, when at the top level like this.  Mainly I want to forbid the second one in an inline context like function arguments.

Non-inline object literal with extra commas are still allowed, [as in CoffeeScript](https://coffeescript.org/#try:f%0A%20%20a%3A%201%2C%0A%20%20b%3A%202%2C):

```coffee
f
  a: 1,
  b: 2,
```

---

**Open question:** Currently, the comma lets you break indentation: the following parses to a single object literal.

```coffee
if condition
  x: 1,
y: 2
```

This is [different from CoffeeScript](https://coffeescript.org/#try:if%20condition%0A%20%20x%3A%201%2C%0Ay%3A%202%0A). Should I replace `__` with `Samedent / _?`?