### PR TITLE
implicit JSX element

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5019,7 +5019,7 @@ JSXElement
 
 # https://facebook.github.io/jsx/#prod-JSXSelfClosingElement
 JSXSelfClosingElement
-  "<" $JSXElementName TypeArguments? JSXAttributes? Whitespace? "/>" ->
+  "<" JSXElementName TypeArguments? JSXAttributes? Whitespace? "/>" ->
     return { type: "JSXElement", children: $0, tag: $2 }
 
 PushJSXOpeningElement
@@ -5033,7 +5033,7 @@ PopJSXStack
 
 # https://facebook.github.io/jsx/#prod-JSXOpeningElement
 JSXOpeningElement
-  "<" $JSXElementName TypeArguments? JSXAttributes? Whitespace? ">"
+  "<" JSXElementName TypeArguments? JSXAttributes? Whitespace? ">"
 
 JSXOptionalClosingElement
   Whitespace? JSXClosingElement:close ->
@@ -5043,7 +5043,7 @@ JSXOptionalClosingElement
 
 # https://facebook.github.io/jsx/#prod-JSXClosingElement
 JSXClosingElement
-  "</" Whitespace? $JSXElementName Whitespace? ">"
+  "</" Whitespace? JSXElementName Whitespace? ">"
 
 # https://facebook.github.io/jsx/#prod-JSXFragment
 JSXFragment
@@ -5086,9 +5086,12 @@ JSXClosingFragment
 
 # https://facebook.github.io/jsx/#prod-JSXElementName
 JSXElementName
+  # Implicit element name
+  &( ( "#" / Dot ) JSXShorthandString ) ->
+    return module.config.defaultElement
   # Merged in https://facebook.github.io/jsx/#prod-JSXNamespacedName
   # Merged in https://facebook.github.io/jsx/#prod-JSXMemberExpression
-  JSXIdentifierName ( (Colon JSXIdentifierName) / ( Dot JSXIdentifierName )* )
+  $( JSXIdentifierName ( (Colon JSXIdentifierName) / ( Dot JSXIdentifierName )* ) )
 
 # NOTE: Like IdentifierName but includes hyphens after start
 # NOTE: Combined from recursive https://facebook.github.io/jsx/#prod-JSXIdentifier definition
@@ -6249,6 +6252,7 @@ Reset
       coffeeNot: false,
       coffeeOf: false,
       coffeePrototype: false,
+      defaultElement: "div",
       implicitReturns: true,
       objectIs: false,
       react: false,

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -227,3 +227,20 @@ describe "JSX XML comments", ->
       }}
     </For>
   """
+
+  testCase """
+    implicit div
+    ---
+    <.app>
+    ---
+    <div class="app" />
+  """
+
+  testCase """
+    config implicit default element
+    ---
+    "civet defaultElement=span"
+    <.app>
+    ---
+    <span class="app" />
+  """


### PR DESCRIPTION
Implicit JSX elements.

Defaults to `div` but can be set with `"civet defaultElement=span"` etc.

```
<.main>
```

```
<div class="main" />
```

```
"civet defaultElement=span"
<.app>
```

```typescript
<span class="app" />
```

Currently limited to requiring `.class` or `#id` because it could be ambiguous with some JSX attributes.