### PR TITLE
Fix sourcemap support from CLI

### DIFF
--- a/register.js
+++ b/register.js
@@ -22,4 +22,13 @@ if (require.extensions) {
     module._compile(js, filename);
     return;
   };
+
+  try {
+    require('@cspotcode/source-map-support').install({
+      environment: 'node',
+      hookRequire: true  // support inline source maps
+    })
+  } catch (e) {
+    // ignore missing dependency
+  }
 }

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -198,7 +198,6 @@ cli = ->
   if options.run
     options.js = true
     options.inlineMap = true
-    require '../register.js'
 
   return repl options if options.repl
 
@@ -280,6 +279,7 @@ cli = ->
           await fs.unlink filename
         process.exit child.status
       else
+        require '../register.js'
         try
           module.filename = await fs.realpath filename
         catch

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -44,7 +44,7 @@ ensureRegister := ->
       let path = pathOrUrl
       // If it's a file URL, convert to local path
       // I could not find a way to handle non-URLs except to swallow an error
-      if path.startsWith('file://')
+      if path.startsWith('file:')
         try
           path = fileURLToPath(path)
       path = normalizeSlashes(path)
@@ -92,9 +92,9 @@ export async function load(url: string, context: any, next: any)
 
     // parse source map from downstream (ts-node) result
     // compose with civet source map
-    result.source = SourceMap.remap(result.source, sourceMap, url, "")
+    result.source = SourceMap.remap(result.source, sourceMap, url, result.responseURL ?? transpiledPath)
     // NOTE: This path needs to match what ts-node uses so we can override the source map
-    outputCache.set(normalizeSlashes(path), result.source)
+    outputCache.set(normalizeSlashes(path) + ".tsx", result.source)
 
     return result
 

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -4,7 +4,7 @@ import parser from "./parser.hera"
 { parse } = parser
 import generate, { prune } from "./generate.coffee"
 import * as util from "./util.coffee"
-{ SourceMap, base64Encode } = util
+{ SourceMap } = util
 export { parse, generate, util }
 
 # Rules that are not cacheable
@@ -165,9 +165,7 @@ export compile = (src, options) ->
     code = generate ast, options
 
     if options.inlineMap
-      srcMapJSON = sm.json(filename, "")
-      # NOTE: separate comment to prevent this string getting picked up as actual sourceMappingURL in tools
-      return "#{code}\n#{"//#"} sourceMappingURL=data:application/json;base64,#{base64Encode JSON.stringify(srcMapJSON)}\n"
+      return SourceMap.remap code, sm, filename, filename + '.tsx'
     else
       return {
         code,

--- a/source/util.coffee
+++ b/source/util.coffee
@@ -129,13 +129,13 @@ to use a new source map referencing upstream source files.
 SourceMap.remap = (codeWithSourceMap, upstreamMap, sourcePath, targetPath) ->
   # Extract downstream source map, if any
   sourceMapText = null
-  codeWithoutSourceMap = codeWithSourceMap.replace(smRegexp, (match) =>
-    sourceMapText = match
+  codeWithoutSourceMap = codeWithSourceMap.replace(smRegexp, (match, sm) =>
+    sourceMapText = sm
     ""
   )
 
   if sourceMapText
-    parsed = SourceMap.parseWithLines sourceMapText[1]
+    parsed = SourceMap.parseWithLines sourceMapText
     composedLines = SourceMap.composeLines upstreamMap.data.lines, parsed.lines
     upstreamMap.data.lines = composedLines
 


### PR DESCRIPTION
* Install `@cspotcode/source-map-support` in CJS mode via `register.js`, including `hookRequire: true` flag needed for CJS mode
* Fix `esm` loader to use correct cache filename and thereby enable `@cspotcode/source-map-support` to find source maps
* Modify `SourceMap.remap` to just use our sourcemap when downstream code has no sourcemap (e.g. no further loaders). Avoids "No source map found in code" error.
* Refactor code to only encode SourceMap in one place (using new `SourceMap.remap`)