### PR TITLE
Remove tsx after ESM transpilation

### DIFF
--- a/source/esm.civet
+++ b/source/esm.civet
@@ -77,10 +77,11 @@ export async function load(url: string, context: any, next: any)
       sourceMap: true
       js: true
 
-    transpiledPath := url + ".tsx"
+    // NOTE: Append .tsx to URL so ts-node treats as TypeScript
+    transpiledUrl := url + ".tsx"
 
     // NOTE: Assuming ts-node hook follows load hook
-    result := await next transpiledPath,
+    result := await next transpiledUrl,
       // ts-node won't transpile unless this is module
       // can't use commonjs since we don't rewrite imports
       format: "module"
@@ -90,11 +91,15 @@ export async function load(url: string, context: any, next: any)
     // NOTE: we must install our source map support after ts-node does to take priority
     ensureRegister()
 
+    // Remove .tsx extension for final URL
+    result.responseURL = (result.responseURL ?? transpiledUrl)
+    .replace /.tsx$/, ''
+
     // parse source map from downstream (ts-node) result
     // compose with civet source map
-    result.source = SourceMap.remap(result.source, sourceMap, url, result.responseURL ?? transpiledPath)
+    result.source = SourceMap.remap(result.source, sourceMap, url, result.responseURL)
     // NOTE: This path needs to match what ts-node uses so we can override the source map
-    outputCache.set(normalizeSlashes(path) + ".tsx", result.source)
+    outputCache.set(normalizeSlashes(path), result.source)
 
     return result
 


### PR DESCRIPTION
Fixes #490

Good point in https://github.com/DanielXMoore/Civet/issues/490#issuecomment-1493166386 that we can remove `.tsx` after finishing the transpilation chain.

`process.argv[1]` now gets set to a valid file, so `process.argv[1] === url.fileURLToPath import.meta.url` works!