### PR TITLE
x@y and @@x bind shorthand, plus JSX fixes

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -991,6 +991,14 @@ id := @id
 obj := { @id }
 </Playground>
 
+### Bind
+
+<Playground>
+bound := object@.method
+bound := object@method
+bound := @@method
+</Playground>
+
 ### Static Fields
 
 <Playground>
@@ -1245,6 +1253,7 @@ Implicit elements must start with `id` or `class` shorthand (`#` or `.`).
 <div {foo}>Civet
 <div {props.name}>Civet
 <div {data()}>Civet
+<div {@@onClick}>Civet
 <div ...foo>Civet
 <div [expr]={value}>Civet
 </Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5292,7 +5292,7 @@ JSXAttribute
     return [ " ", id, "={", value, "}" ]
 
 JSXAttributeSpace
-  /[\s>]/
+  /[\s>]|\/>/
 
 JSXShorthandString
   /(?:[\w\-:]+|\([^()]*\)|\[[^\[\]]*\])+/ ->
@@ -5322,7 +5322,7 @@ JSXAttributeValue
   OpenBrace PostfixedExpression Whitespace? CloseBrace
   JSXElement
   JSXFragment
-  InsertInlineOpenBrace InlineJSXAttributeValue:value InsertCloseBrace ->
+  InsertInlineOpenBrace:open InlineJSXAttributeValue:value InsertCloseBrace:close &JSXAttributeSpace ->
     // Check for string literal resulting from CoffeeScript interpolated
     // double-quoted string that didn't end up actually interpolating.
     if (value.type === "StringLiteral") {
@@ -5330,7 +5330,7 @@ JSXAttributeValue
       // which avoids e.g. converting newlines into \n.
       return $skip
     }
-    return $0
+    return [open, value, close]  // omit &JSXAttributeSpace
   # NOTE: InlineJSXAttributeValue which contains TemplateLiteral must be before
   # StringLiteral, so that CoffeeScript interpolated strings get checked first.
   # NOTE: JSX strings allow newlines, and they get passed through as-is.
@@ -5375,25 +5375,56 @@ InlineJSXUpdateExpression
 # This also acts as a replacement for LeftHandSideExpression
 # (we don't allow New because that has whitespace).
 InlineJSXCallExpression
-  "super" ExplicitArguments
-  "import" OpenParen PostfixedExpression __ CloseParen
-  InlineJSXMemberExpression InlineJSXCallExpressionRest* ->
-    if ($2.length) return $0
-    return $1
+  "super" ExplicitArguments:args InlineJSXCallExpressionRest*:rest ->
+    return module.processCallMemberExpression({
+      type: "CallExpression",
+      children: [
+        $1,
+        { type: "Call", children: [args] },
+        ...rest.flat()
+      ],
+    })
+  "import" ExplicitArguments:args InlineJSXCallExpressionRest*:rest ->
+    return module.processCallMemberExpression({
+      type: "CallExpression",
+      children: [
+        $1,
+        { type: "Call", children: [args] },
+        ...rest.flat()
+      ],
+    })
+  InlineJSXMemberExpression:member InlineJSXCallExpressionRest*:rest ->
+    if (rest.length) {
+      rest = rest.flat()
+      return module.processCallMemberExpression({
+        type: "CallExpression",
+        children: [member, ...rest]
+      })
+    }
+    return member
 
 # CallExpressionRest, with only explicit function calls.
 InlineJSXCallExpressionRest
-  MemberExpressionRest
-  TemplateLiteral
-  ( OptionalShorthand / NonNullAssertion )? ExplicitArguments
+  InlineJSXMemberExpressionRest
+  TemplateLiteral / StringLiteral ->
+    if ($1.type === "StringLiteral") {
+      return "`" + $1.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
+    }
+    return $1
+  ( OptionalShorthand / NonNullAssertion )? ExplicitArguments ->
+    if (!$1) return $2
+    return [ $1, ...$2 ]
 
 # MemberExpression, with PrimaryExpression -> InlineJSXPrimaryExpression
 InlineJSXMemberExpression
-  InlineJSXPrimaryExpression InlineJSXMemberExpressionRest* ->
-    if ($2.length) return $0
+  ( InlineJSXPrimaryExpression / SuperProperty / MetaProperty ) InlineJSXMemberExpressionRest*:rest ->
+    if (rest.length || Array.isArray($1)) {
+      return module.processCallMemberExpression({
+        type: "MemberExpression",
+        children: [$1, ...rest].flat(),
+      })
+    }
     return $1
-  SuperProperty
-  MetaProperty
 
 # MemberExpressionRest without optional IndentFurther before PropertyAccess
 InlineJSXMemberExpressionRest
@@ -5408,6 +5439,8 @@ InlineJSXMemberExpressionRest
     }
     return $2
   PropertyAccess
+  PropertyGlob
+  PropertyBind
   NonNullAssertion
 
 # Subset of PrimaryExpression; omissions documented below.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -730,7 +730,7 @@ LeftHandSideExpression
 CallExpression
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
   "super" ArgumentsWithTrailingMemberExpressions CallExpressionRest*:rest ->
-    return module.processGlob({
+    return module.processCallMemberExpression({
       type: "CallExpression",
       children: [$1, ...$2, ...rest.flat()],
     })
@@ -738,7 +738,7 @@ CallExpression
   # (At top level, ImportDeclaration will match first.)
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
   "import" ArgumentsWithTrailingMemberExpressions CallExpressionRest*:rest ->
-    return module.processGlob({
+    return module.processCallMemberExpression({
       type: "CallExpression",
       children: [$1, ...$2, ...rest.flat()],
     })
@@ -746,7 +746,7 @@ CallExpression
   MemberExpression:member AllowedTrailingMemberExpressions:trailing CallExpressionRest*:rest ->
     if (rest.length || trailing.length) {
       rest = rest.flat()
-      return module.processGlob({
+      return module.processCallMemberExpression({
         type: "CallExpression",
         children: [member, ...trailing, ...rest]
       })
@@ -787,7 +787,7 @@ MemberExpression
   # NOTE: Eliminated left recursion
   ( PrimaryExpression / SuperProperty / MetaProperty ) MemberExpressionRest*:rest ->
     if (rest.length || Array.isArray($1)) {
-      return module.processGlob({
+      return module.processCallMemberExpression({
         type: "MemberExpression",
         children: [$1, ...rest].flat(),
       })
@@ -809,6 +809,7 @@ MemberExpressionRest
   # NOTE: Combined Optional and Property access
   PropertyAccess
   PropertyGlob
+  PropertyBind
   # NOTE: Added TypeScript '!' non-null assertion
   NonNullAssertion
 
@@ -946,11 +947,21 @@ PropertyAccess
 
 PropertyGlob
   # NOTE: Added shorthand obj.{a,b:c} -> {a: obj.a, c: obj.b}
-  OptionalDot BracedObjectLiteral:object ->
+  OptionalDot:dot BracedObjectLiteral:object ->
     return {
       type: "PropertyGlob",
+      dot,
       object,
-      children: $0
+      children: $0,
+    }
+
+PropertyBind
+  # NOTE: foo@.bar and foo@bar shorthand for foo.bar.bind(foo)
+  ( QuestionMark / NonNullAssertion )?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id ->
+    return {
+      type: "PropertyBind",
+      name: id.name,
+      children: [modifier, dot, id],  // omit `@` from children
     }
 
 SuperProperty
@@ -6502,14 +6513,15 @@ Init
       }
     })
 
-    module.processGlob = (node) => {
+    // Process globs and bind shorthand in Call/MemberExpression
+    module.processCallMemberExpression = (node) => {
       const {children} = node
       for (let i = 0; i < children.length; i++) {
         const glob = children[i]
         if (glob?.type === "PropertyGlob") {
           // TODO: add ref to ensure object base evaluated only once
           const prefix = children.slice(0, i)
-          .concat(glob.children[0]) // dot
+          .concat(glob.dot)
           const parts = []
           for (const part of glob.object.content) {
             if (part.type === "MethodDefinition") {
@@ -6559,9 +6571,24 @@ Init
             ],
           }
           if (i === children.length-1) return object
-          return module.processGlob({  // in case there are more globs
+          return module.processCallMemberExpression({  // in case there are more
             ...node,
             children: [ object, ...children.slice(i+1) ]
+          })
+        } else if (glob?.type === "PropertyBind") {
+          // TODO: add ref to ensure object base evaluated only once
+          const prefix = children.slice(0, i)
+          return module.processCallMemberExpression({  // in case there are more
+            ...node,
+            children: [
+              prefix,
+              {
+                ...glob,
+                type: "PropertyAccess",
+                children: [ ...glob.children, ".bind(", prefix, ")" ]
+              },
+              ...children.slice(i+1)
+            ]
           })
         }
       }

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -90,6 +90,30 @@ describe "braced JSX attributes", ->
   """
 
   testCase """
+    dynamic import attribute access
+    ---
+    <Component x=import('x').y />
+    ---
+    <Component x={import('x').y} />
+  """
+
+  testCase """
+    glob
+    ---
+    <Component x=a{b, c} />
+    ---
+    <Component x={{b:a.b, c:a.c}} />
+  """
+
+  testCase """
+    bind shorthand
+    ---
+    <Component x=a@b />
+    ---
+    <Component x={a.b.bind(a)} />
+  """
+
+  testCase """
     ++ and --
     ---
     <Component post=foo++ pre=++foo />

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -108,6 +108,14 @@ describe "JSX", ->
   """
 
   testCase """
+    boolean attribute
+    ---
+    <input checked/>
+    ---
+    <input checked/>
+  """
+
+  testCase """
     elements as attributes
     ---
     <Component sub=<div>Hello</div> self-close=<div/> frag=<>...</>/>

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -208,3 +208,77 @@ describe "property access", ->
       ---
       x.at(-1)
     """
+
+  describe "bind shorthand", ->
+    testCase """
+      @.
+      ---
+      x@.y
+      ---
+      x.y.bind(x)
+    """
+
+    testCase """
+      @
+      ---
+      x@y
+      ---
+      x.y.bind(x)
+    """
+
+    testCase """
+      optional
+      ---
+      x?@y
+      ---
+      x?.y.bind(x)
+    """
+
+    testCase """
+      non-null
+      ---
+      x!@y
+      ---
+      x!.y.bind(x)
+    """
+
+    testCase """
+      longer prefix
+      ---
+      x.y@z
+      ---
+      x.y.z.bind(x.y)
+    """
+
+    testCase """
+      longer suffix
+      ---
+      x@y.z
+      ---
+      x.y.bind(x).z
+    """
+
+    // TODO: needs ref
+    testCase """
+      multiple bind
+      ---
+      x@y@z
+      ---
+      x.y.bind(x).z.bind(x.y.bind(x))
+    """
+
+    testCase """
+      @@.
+      ---
+      @@.x
+      ---
+      this.x.bind(this)
+    """
+
+    testCase """
+      @@
+      ---
+      @@x
+      ---
+      this.x.bind(this)
+    """


### PR DESCRIPTION
As discussed in Discord:
* `x@y` and `x@.y` → `x.y.bind(x)`
* `@@x` and `@@.x` → `this.x.bind(x)`
* Longer chains, optional property access, and non-null assertions also work
* No shadowing of `@@` decorators (this came for free, I guess because they are checked first)
* (No refs yet)

I also noticed that a bunch of updates to how properties work hadn't made it to the JSX fork. So I also fixed unbraced attribute values with:
* Additional access or calls for `super` properties and dynamic `import`
* Object globs
* New bind shorthand
* Bug fix: `<input checked/>` didn't work because of our "assert there's a following space" (to avoid invalid class name shorthand) didn't allow for `/>`