### PR TITLE
Pattern matching gather duplicate bindings

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -10,16 +10,21 @@
  * Adjust the alias of a binding property, adding an alias if one doesn't exist or
  * replacing an existing alias. This mutates the property in place.
  */
-function aliasBindingProperty(p, ref) {
+function aliasBinding(p, ref) {
   if (p.type === "Identifier") {
+    // Array element binding
     // TODO: This ignores `name` and `names` properties of Identifier and
     // hackily converts it to a container for a Ref.
     p.children[0] = ref
+  } else if (p.type === "BindingRestElement") {
+    aliasBinding(p.binding, ref)
   } else if (p.value?.type === "Identifier") {
+    // aliased property binding
     p.value = ref
     // TODO: nasty
     p.children[5] = ref
   } else {
+    // non-aliased property binding
     p.value = ref
     p.children.push(": ", ref)
   }
@@ -760,7 +765,7 @@ function processUnaryExpression(pre, exp, post) {
 }
 
 module.exports = {
-  aliasBindingProperty,
+  aliasBinding,
   blockWithPrefix,
   clone,
   convertMethodToFunction,

--- a/source/lib.js
+++ b/source/lib.js
@@ -7,6 +7,25 @@
  */
 
 /**
+ * Adjust the alias of a binding property, adding an alias if one doesn't exist or
+ * replacing an existing alias. This mutates the property in place.
+ */
+function aliasBindingProperty(p, ref) {
+  if (p.type === "Identifier") {
+    // TODO: This ignores `name` and `names` properties of Identifier and
+    // hackily converts it to a container for a Ref.
+    p.children[0] = ref
+  } else if (p.value?.type === "Identifier") {
+    p.value = ref
+    // TODO: nasty
+    p.children[5] = ref
+  } else {
+    p.value = ref
+    p.children.push(": ", ref)
+  }
+}
+
+/**
  * Duplicate a block and attach statements prefixing the block.
  * Adds braces if the block is bare.
  *
@@ -741,6 +760,7 @@ function processUnaryExpression(pre, exp, post) {
 }
 
 module.exports = {
+  aliasBindingProperty,
   blockWithPrefix,
   clone,
   convertMethodToFunction,

--- a/source/lib.js
+++ b/source/lib.js
@@ -20,9 +20,7 @@ function aliasBinding(p, ref) {
     aliasBinding(p.binding, ref)
   } else if (p.value?.type === "Identifier") {
     // aliased property binding
-    p.value = ref
-    // TODO: nasty
-    p.children[5] = ref
+    aliasBinding(p.value, ref)
   } else {
     // non-aliased property binding
     p.value = ref

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6,7 +6,7 @@
 
 ```
 const {
-  aliasBindingProperty,
+  aliasBinding,
   blockWithPrefix,
   clone,
   convertMethodToFunction,
@@ -1339,14 +1339,21 @@ BindingElement
 BindingRestElement
   _?:ws DotDotDot:dots ( BindingIdentifier / BindingPattern / EmptyBindingPattern ):binding ->
     return {
-      ...binding,
-      children: [...(ws || []), dots, ...binding.children],
+      type: "BindingRestElement",
+      children: [...(ws || []), dots, binding],
+      binding,
+      name: binding.name,
+      names: binding.names,
       rest: true,
     }
+
   _?:ws ( BindingIdentifier / BindingPattern ):binding DotDotDot:dots ->
     return {
-      ...binding,
-      children: [...(ws || []), dots, ...binding.children],
+      type: "BindingRestElement",
+      children: [...(ws || []), dots, binding],
+      binding,
+      name: binding.name,
+      names: binding.names,
       rest: true,
     }
 
@@ -7209,8 +7216,8 @@ Init
         restIndex = -1,
         restCount = 0
 
-      elements.forEach(({rest}, i) => {
-        if (rest) {
+      elements.forEach(({type}, i) => {
+        if (type === "BindingRestElement") {
           if (restIndex < 0) restIndex = i
           restCount++
         }
@@ -7231,7 +7238,7 @@ Init
         if (rest.ref) {
           restIdentifier = rest.ref
         } else {
-          restIdentifier = rest.names[0]
+          restIdentifier = rest.binding
           names./**/push(...rest.names)
         }
 
@@ -7818,7 +7825,12 @@ Init
     }
 
     function elideMatchersFromArrayBindings(elements) {
-      return elements.map(({ children: [ws, e, sep] }) => {
+      return elements.map((el) => {
+        // TODO: this isn't unified with the element [ws, e, sep] tuple yet
+        if (el.type === "BindingRestElement") {
+          return ["", el, undefined]
+        }
+        const { children: [ws, e, sep] } = el
         switch (e.type) {
           case "Literal":
           case "RegularExpressionLiteral":
@@ -7908,6 +7920,8 @@ Init
             const [,e] = element
             if (e.type === "Identifier") {
               props.push(e)
+            } else if (e.type === "BindingRestElement") {
+              props.push(e)
             }
           }
         })
@@ -7943,7 +7957,7 @@ Init
               base: `_${key}`,
               id: key,
             }
-            aliasBindingProperty(p, ref)
+            aliasBinding(p, ref)
           });
           // Don't push declarations for reserved words
           return
@@ -7959,7 +7973,11 @@ Init
             id: key,
           }
 
-          aliasBindingProperty(p, ref)
+          aliasBinding(p, ref)
+
+          if (p.type === "BindingRestElement") {
+            return ["...", ref]
+          }
 
           return ref
         })

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6,6 +6,7 @@
 
 ```
 const {
+  aliasBindingProperty,
   blockWithPrefix,
   clone,
   convertMethodToFunction,
@@ -7867,8 +7868,15 @@ Init
 
     function nonMatcherBindings(pattern) {
       switch (pattern.type) {
-        case "ArrayBindingPattern":
-          return ["[", elideMatchersFromArrayBindings(pattern.elements), "]"]
+        case "ArrayBindingPattern": {
+          const elements = elideMatchersFromArrayBindings(pattern.elements)
+          const children = ["[", elements, "]"]
+          return {
+            ...pattern,
+            children,
+            elements,
+          }
+        }
         case "PostRestBindingElements": {
           const els = elideMatchersFromArrayBindings(pattern.children[1])
 
@@ -7891,6 +7899,20 @@ Init
 
     function aggregateDuplicateBindings(bindings) {
       const props = gatherRecursiveAll(bindings, n => n.type === "BindingProperty")
+      const arrayBindings = gatherRecursiveAll(bindings, n => n.type === "ArrayBindingPattern")
+
+      arrayBindings.forEach((a) => {
+        const { elements } = a
+        elements.forEach((element) => {
+          if (Array.isArray(element)) {
+            const [,e] = element
+            if (e.type === "Identifier") {
+              props.push(e)
+            }
+          }
+        })
+      })
+
       const declarations = []
 
       const propsGroupedByName = new Map
@@ -7898,7 +7920,8 @@ Init
       for(const p of props) {
         const { name, value } = p
 
-        const key = value?.name || name.name
+        // This is to handle aliased props, non-aliased props, and binding identifiers in arrays
+        const key = value?.name || name.name || name
         if (propsGroupedByName.has(key)) {
           propsGroupedByName.get(key).push(p)
         } else {
@@ -7920,7 +7943,7 @@ Init
               base: `_${key}`,
               id: key,
             }
-            p.children.push(": ", ref)
+            aliasBindingProperty(p, ref)
           });
           // Don't push declarations for reserved words
           return
@@ -7936,7 +7959,7 @@ Init
             id: key,
           }
 
-          p.children.push(": ", ref)
+          aliasBindingProperty(p, ref)
 
           return ref
         })

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1017,13 +1017,8 @@ NonEmptyParameters
   TypeParameters?:tp OpenParen:open ThisType?:tt ParameterElement*:pes FunctionRestParameter?:rest ParameterElement*:after ( __ CloseParen ):close ->
     const names = pes.flatMap(p => p.names)
     if (rest) {
-      let restIdentifier
-      if (rest.binding.ref) {
-        restIdentifier = rest.binding.ref
-      } else {
-        names.push(...rest.names)
-        restIdentifier = rest.names[0]
-      }
+      const restIdentifier = rest.binding.ref || rest.binding
+      names.push(...rest.names || [])
 
       let blockPrefix
       if (after.length) {
@@ -1064,7 +1059,7 @@ FunctionRestParameter
       type: "FunctionRestParameter",
       children: $0,
       names: id.names,
-      binding: id,
+      binding: id.binding,
     }
 
 # NOTE: Similar to BindingElement but appears in formal parameters list
@@ -7234,13 +7229,8 @@ Init
         const rest = elements[restIndex]
         const after = elements.slice(restIndex + 1)
 
-        let restIdentifier
-        if (rest.ref) {
-          restIdentifier = rest.ref
-        } else {
-          restIdentifier = rest.binding
-          names./**/push(...rest.names)
-        }
+        const restIdentifier = rest.binding.ref || rest.binding
+        names./**/push(...rest.names || [])
 
         if (after.length) {
           blockPrefix = {
@@ -7935,7 +7925,7 @@ Init
         const { name, value } = p
 
         // This is to handle aliased props, non-aliased props, and binding identifiers in arrays
-        const key = value?.name || name.name || name
+        const key = value?.name || name?.name || name
         if (propsGroupedByName.has(key)) {
           propsGroupedByName.get(key).push(p)
         } else {

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -898,7 +898,7 @@ describe "switch", ->
           y}
     """
 
-    testCase.only """
+    testCase """
       multi array duplicate bindings with bound rest
       ---
       switch x

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -819,7 +819,7 @@ describe "switch", ->
           x}
     """
 
-    testCase  """
+    testCase """
       duplicate aliases
       ---
       switch x
@@ -895,5 +895,18 @@ describe "switch", ->
       if(Array.isArray(x) && x.length === 2 && Array.isArray(x[0]) && x[0].length === 2 && Array.isArray(x[1]) && x[1].length === 2) {
           const [[y1, y2], [y3, y4]] = x;
           const y = [y1, y2, y3, y4];
+          y}
+    """
+
+    testCase.only """
+      multi array duplicate bindings with bound rest
+      ---
+      switch x
+        [[y, y], ...y, [y, y]]
+          y
+      ---
+      if(Array.isArray(x) && x.length >= 2 && Array.isArray(x[0]) && x[0].length === 2 && Array.isArray(x[x.length - 1]) && x[x.length - 1].length === 2) {
+          const [[y1, y2], ...y3] = x, [[y4, y5]] = y3.splice(-1);
+          const y = [y1, y2, ...y3, y4, y5];
           y}
     """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -819,6 +819,19 @@ describe "switch", ->
           x}
     """
 
+    testCase  """
+      duplicate aliases
+      ---
+      switch x
+        {a: y, b: y}
+          y
+      ---
+      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x) {
+          const {a: y1, b: y2} = x;
+          const y = [y1, y2];
+          y}
+    """
+
     testCase """
       duplicate bindings with rest
       ---
@@ -872,7 +885,7 @@ describe "switch", ->
           x}
     """
 
-    testCase.skip """
+    testCase """
       multi array duplicate bindings
       ---
       switch x


### PR DESCRIPTION
This fixes duplicate binding merging for ArrayBindingPatterns and adds support for merging with BindingRestElement as well.