### PR TITLE
Small whitespace fix for trailing splat

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5814,7 +5814,9 @@ TypeElement
   # NOTE: Allow for postfix splat like CoffeeScript
   Type:type ( _? DotDotDot )?:dots ->
     if (!dots) return type
-    return [ dots, type ]
+    const ws = getTrimmingSpace(type)
+    if (!ws) return [ dots[1], dots[0], type ]
+    return [ ws, dots[1], dots[0], insertTrimmingSpace(type, '') ]
 
 NestedTypeList
   PushIndent NestedType*:types PopIndent ->

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -316,5 +316,5 @@ describe "[TS] type declaration", ->
     ---
     type Test = [string, string[]...] | [string, Array<string> ...]
     ---
-    type Test = [string,... string[]] | [string, ... Array<string>]
+    type Test = [string, ...string[]] | [string, ... Array<string>]
   """


### PR DESCRIPTION
This is probably the least important thing I could do, but it was bugging me slightly, so...
Maybe it's a model for other whitespace tweaks.