### PR TITLE
Fix a typo when loading `civetPlugin`

### DIFF
--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -146,7 +146,7 @@ import civetPlugin from '@danielx/civet/esbuild-plugin'
 esbuild.build({
   // ...
   plugins: [
-    civetPlugin
+    civetPlugin()
   ]
 }).catch(() => process.exit(1))
 ```


### PR DESCRIPTION
It [looks like](https://github.com/DanielXMoore/Civet/blob/b57e75e6c6dbd8acbbf542c7e67cc017958fbecd/lsp/build/build.civet#L19) `civetPlugin` is a function. I changed the documentation accordingly. 

ciao!