### PR TITLE
Function implicit bodies

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1405,9 +1405,11 @@ FunctionSignature
     if (!async) async = []
     if (!generator) generator = []
 
+    const id = wid?.[1]
     return {
       type: "FunctionSignature",
-      id: wid?.[1],
+      id,
+      name: id?.name,
       parameters,
       returnType: suffix,
       ts: false,
@@ -1426,8 +1428,11 @@ FunctionExpression
   FunctionSignature:signature BracedBlock?:block ->
     // TS Function overloads
     if (!block) {
-      signature.ts = true
-      return signature
+      return {
+        ...signature,
+        type: "FunctionExpression",
+        ts: true,
+      }
     }
 
     if (hasAwait(block) && !signature.async.length) {

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -65,6 +65,54 @@ describe "[TS] class", ->
   """
 
   testCase """
+    method with implicit body
+    ---
+    class UserAccount
+      register()
+    ---
+    class UserAccount {
+      register(){}
+    }
+  """
+
+  testCase """
+    override method with implicit body
+    ---
+    class UserAccount
+      register(): void
+      register(@id: number): void
+    ---
+    class UserAccount {
+      register(): void
+      register(id: number): void{this.id = id;}
+    }
+  """
+
+  testCase """
+    constructor with implicit body
+    ---
+    class UserAccount
+      @(@id: number)
+    ---
+    class UserAccount {
+      constructor(id: number){this.id = id;}
+    }
+  """
+
+  testCase """
+    override constructor with implicit body
+    ---
+    class UserAccount
+      @()
+      @(@id: number)
+    ---
+    class UserAccount {
+      constructor()
+      constructor(id: number){this.id = id;}
+    }
+  """
+
+  testCase """
     nested
     ---
     class UserAccount

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -182,6 +182,34 @@ describe "[TS] function", ->
   """
 
   testCase """
+    implicit body
+    ---
+    function noop()
+    ---
+    function noop(){}
+  """
+
+  testCase """
+    overload with implicit body
+    ---
+    function noop(a: number, b: number): void
+    function noop(a: string, b: string): void
+    ---
+    function noop(a: number, b: number): void
+    function noop(a: string, b: string): void{}
+  """
+
+  testCase.js """
+    overload with implicit body, JavaScript output
+    ---
+    function noop(a: number, b: number): void
+    function noop(a: string, b: string): void
+    ---
+
+    function noop(a, b){}
+  """
+
+  testCase """
     overloads
     ---
     function add(a: number, b: number): number
@@ -192,6 +220,21 @@ describe "[TS] function", ->
     function add(a: number, b: number): number
     function add(a: string, b: string): string
     function add(a: number | string, b: number | string): number | string {
+      return a + b
+    }
+  """
+
+  testCase.js """
+    overloads, JavaScript output
+    ---
+    function add(a: number, b: number): number
+    function add(a: string, b: string): string
+    function add(a: number | string, b: number | string): number | string
+      return a + b
+    ---
+
+
+    function add(a, b) {
       return a + b
     }
   """


### PR DESCRIPTION
Following up on #540 discussion, this PR makes `function`s also have an implicit empty block when they're used in an expression context (e.g. not a `declare` block, and not a braced object literal), similar to methods behavior added in #540. Also added tests for both.