### PR TITLE
Fix implicit calls with bind and decorators

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -180,9 +180,8 @@ ForbiddenImplicitCalls
   /(as|of|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
   # NOTE: Don't allow non-heregex regexes that begin with a space as first argument without parens
   "/ "
-  # Don't treat @@decorator class ... as an implicit call
-  ClassImplicitCallForbidden Class
-  AtAt # experimentalDecorators
+  # Don't treat @@decorator @@decorator class ... as implicit calls
+  ClassImplicitCallForbidden ( Class / AtAt )
   Identifier "=" Whitespace
   Identifier !"(" ->
     if (module.operators.has($1.name)) return $1
@@ -3659,19 +3658,19 @@ ExpressionWithIndentedApplicationForbidden
 
 ForbidClassImplicitCall
   "" ->
-    module.forbidIndentedApplication.push(true)
+    module.forbidClassImplicitCall.push(true)
 
 AllowClassImplicitCall
   "" ->
-    module.forbidIndentedApplication.push(false)
+    module.forbidClassImplicitCall.push(false)
 
 RestoreClassImplicitCall
   "" ->
-    module.forbidIndentedApplication.pop()
+    module.forbidClassImplicitCall.pop()
 
 ClassImplicitCallForbidden
   "" ->
-    if (module.classImplicitCallForbidden) return $skip
+    if (!module.classImplicitCallForbidden) return $skip
     return
 
 ForbidIndentedApplication

--- a/test/class.civet
+++ b/test/class.civet
@@ -767,6 +767,17 @@ describe "class", ->
       }
     """
 
+    testCase """
+      multiple decorator call expressions
+      ---
+      @@entity.name "dog" @@entity.age 3
+      class Dog
+      ---
+      @entity.name("dog") @entity.age(3)
+      class Dog {
+      }
+    """
+
   testCase """
     constructor params
     ---

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -282,3 +282,11 @@ describe "property access", ->
       ---
       this.x.bind(this)
     """
+
+    testCase """
+      call @@
+      ---
+      f @@x
+      ---
+      f(this.x.bind(this))
+    """


### PR DESCRIPTION
Fixing #539 turned out to be easier than expected because we already had a flag. The code was buggy though. 😅 

Fixes #539, and fixes `ClassImplicitCall` rules which used the wrong flag and were backwards. Whoops!