### PR TITLE
Implement config file

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,10 +11,10 @@ chmod +x "$BIN"
 rm dist/cli.js
 
 # esbuild-plugin
-./dist/civet --js -c source/esbuild-plugin.civet -o dist/esbuild-plugin.js
+./dist/civet --no-config --js -c source/esbuild-plugin.civet -o dist/esbuild-plugin.js
 
 # esm loader
-./dist/civet --js -c source/esm.civet -o dist/esm.mjs
+./dist/civet --no-config --js -c source/esm.civet -o dist/esm.mjs
 
 # types
 cp types/types.d.ts dist/types.d.ts

--- a/build/esbuild.coffee
+++ b/build/esbuild.coffee
@@ -50,6 +50,24 @@ esbuild.build({
   ]
 }).catch -> process.exit 1
 
+esbuild.build({
+  entryPoints: ['source/config.coffee']
+  bundle: false
+  sourcemap
+  minify
+  watch
+  platform: 'node'
+  format: 'cjs'
+  outfile: 'dist/config.js'
+  plugins: [
+    resolveExtensions
+    coffeeScriptPlugin
+      bare: true
+      inlineMap: sourcemap
+    heraPlugin
+  ]
+}).catch -> process.exit 1
+
 for esm in [false, true]
   esbuild.build({
     entryPoints: ['source/main.coffee']

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -92,7 +92,7 @@
     "watch": "node build.mjs --watch"
   },
   "devDependencies": {
-    "@danielx/civet": "^0.5.3",
+    "@danielx/civet": "link:..",
     "@danielx/hera": "^0.7.12",
     "@types/coffeescript": "^2.5.2",
     "@types/mocha": "^9",

--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -435,10 +435,7 @@ function TSService(projectURL = "./") {
   CivetConfig.findConfig(projectPath).then(async configPath => {
     if (configPath) {
       console.info("Loading Civet config @", configPath)
-      const envLsp = process.env.CIVET_LSP
-      process.env.CIVET_LSP = "true"
       const config = await CivetConfig.loadConfig(configPath)
-      process.env.CIVET_LSP = envLsp
       console.info("Found civet config!")
       civetConfig = config
     } else console.info("No Civet config found")

--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -6,6 +6,7 @@ import type {
 	CompileOptions,
 } from "@danielx/civet"
 import BundledCivetModule from "@danielx/civet"
+import BundledCivetConfigModule from "@danielx/civet/config"
 
 import ts, {
   CompilerHost,
@@ -431,10 +432,13 @@ function TSService(projectURL = "./") {
   }
 
   let civetConfig: CompileOptions = {}
-  CivetConfig.findConfig(projectPath).then(async (configPath: string) => {
+  CivetConfig.findConfig(projectPath).then(async configPath => {
     if (configPath) {
       console.info("Loading Civet config @", configPath)
+      const envLsp = process.env.CIVET_LSP
+      process.env.CIVET_LSP = "true"
       const config = await CivetConfig.loadConfig(configPath)
+      process.env.CIVET_LSP = envLsp
       console.info("Found civet config!")
       civetConfig = config
     } else console.info("No Civet config found")
@@ -479,10 +483,10 @@ function TSService(projectURL = "./") {
 
   function transpileCivet(path: string, source: string) {
     return Civet.compile(source, {
-			...civetConfig,
-			filename: path,
-			sourceMap: true,
-		})
+      ...civetConfig,
+      filename: path,
+      sourceMap: true,
+    })
   }
 }
 

--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -1,8 +1,11 @@
 import assert from "assert"
 import path from "path"
 
+import type {
+	SourceMap as CivetSourceMap,
+	CompileOptions,
+} from "@danielx/civet"
 import BundledCivetModule from "@danielx/civet"
-import type { SourceMap as CivetSourceMap } from "@danielx/civet"
 
 import ts, {
   CompilerHost,
@@ -20,9 +23,9 @@ const {
   sys,
 } = ts
 
-import { TextDocument } from "vscode-languageserver-textdocument"
-import { fileURLToPath, pathToFileURL } from "url"
 import { createRequire } from "module"
+import { fileURLToPath, pathToFileURL } from "url"
+import { TextDocument } from "vscode-languageserver-textdocument"
 // TODO: project Coffee version?
 import { compile as coffeeCompile } from "coffeescript"
 import { convertCoffeeScriptSourceMap } from "./util.mjs"
@@ -416,16 +419,28 @@ function TSService(projectURL = "./") {
   const projectRequire = createRequire(projectURL)
 
   // Use Civet from the project if present
-  let Civet: typeof BundledCivetModule
+  let Civet = BundledCivetModule
+  let CivetConfig = BundledCivetConfigModule
   try {
     const civetPath = "@danielx/civet"
     Civet = projectRequire(civetPath)
-
+    CivetConfig = projectRequire(`${civetPath}/config`)
     console.info(`LOADED PROJECT CIVET: ${path.join(projectURL, civetPath)} \n\n`)
   } catch (e) {
     console.info("USING BUNDLED CIVET")
-    Civet = BundledCivetModule
   }
+
+  let civetConfig: CompileOptions = {}
+  CivetConfig.findConfig(projectPath).then(async (configPath: string) => {
+    if (configPath) {
+      console.info("Loading Civet config @", configPath)
+      const config = await CivetConfig.loadConfig(configPath)
+      console.info("Found civet config!")
+      civetConfig = config
+    } else console.info("No Civet config found")
+  }).catch((e: unknown) => {
+    console.error("Error loading Civet config", e)
+  })
 
   return Object.assign({}, service, {
     host,
@@ -464,9 +479,10 @@ function TSService(projectURL = "./") {
 
   function transpileCivet(path: string, source: string) {
     return Civet.compile(source, {
-      filename: path,
-      sourceMap: true
-    })
+			...civetConfig,
+			filename: path,
+			sourceMap: true,
+		})
   }
 }
 

--- a/lsp/yarn.lock
+++ b/lsp/yarn.lock
@@ -302,12 +302,9 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@^0.5.3":
-  version "0.5.94"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.5.94.tgz#2699454d451f954259f7a0f72620caefdbf73e22"
-  integrity sha512-imdBhH5u3fE4jW4lX1VG+rhmSei+XHtzJoaw5oeoy6c6bjzzem+BSRcnwn74oMXLSMCqiAq3O4frJFVoYdwibg==
-  dependencies:
-    "@cspotcode/source-map-support" "^0.8.1"
+"@danielx/civet@link:..":
+  version "0.0.0"
+  uid ""
 
 "@danielx/hera@^0.7.12":
   version "0.7.12"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./esbuild-plugin": "./dist/esbuild-plugin.js",
     "./bun-civet": "./dist/bun-civet.mjs",
     "./register": "./register.js",
+    "./config": "./dist/config.js",
     "./*": "./*",
     "./dist/*": "./dist/*"
   },

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -192,7 +192,7 @@ cli = ->
   {filenames, scriptArgs, options} = parseArgs argv[2..]
 
   if not options.config
-    options.config = await findConfig()
+    options.config = await findConfig(process.cwd())
   
   if options.config
     options = {

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -34,7 +34,7 @@ if process.argv.includes "--help"
       --version        Show the version number
       -o / --output XX Specify output directory and/or extension, or filename
       -c / --compile   Compile input files to TypeScript (or JavaScript)
-      --config XX      Specify a config file (default finds the nearest config.civet, .civetconfig or civet.json file)
+      --config XX      Specify a config file (default scans for a config.civet, civet.json, civetconfig.civet or civetconfig.json file, optionally in a .config directory, or starting with a .)
       --js             Strip out all type annotations; default to .jsx extension
       --ast            Print the AST instead of the compiled code
       --inline-map     Generate a sourcemap

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -35,6 +35,7 @@ if process.argv.includes "--help"
       -o / --output XX Specify output directory and/or extension, or filename
       -c / --compile   Compile input files to TypeScript (or JavaScript)
       --config XX      Specify a config file (default scans for a config.civet, civet.json, civetconfig.civet or civetconfig.json file, optionally in a .config directory, or starting with a .)
+      --no-config      Don't scan for a config file
       --js             Strip out all type annotations; default to .jsx extension
       --ast            Print the AST instead of the compiled code
       --inline-map     Generate a sourcemap
@@ -82,6 +83,8 @@ parseArgs = (args) ->
         options.output = args[++i]
       when '--config'
         options.config = args[++i]
+      when '--no-config'
+        options.config = false
       when '--ast'
         options.ast = true
       when '--no-cache'
@@ -191,8 +194,8 @@ cli = ->
   argv = process.argv  # process.argv gets overridden when running scripts
   {filenames, scriptArgs, options} = parseArgs argv[2..]
 
-  if not options.config
-    options.config = await findConfig(process.cwd())
+  if options.config isnt false # --no-config
+    options.config ?= await findConfig(process.cwd())
   
   if options.config
     options = {

--- a/source/cli.coffee
+++ b/source/cli.coffee
@@ -41,6 +41,8 @@ if process.argv.includes "--help"
       --no-cache       Disable compiler caching (slow, for debugging)
 
     You can use - to read from stdin or (prefixed by -o) write to stdout.
+
+
   """
   process.exit(0)
 

--- a/source/config.coffee
+++ b/source/config.coffee
@@ -1,0 +1,34 @@
+import path from "path"
+import fs from "fs/promises"
+import { compile } from "./main"
+import { pathToFileURL } from "url"
+
+export findConfig = ->
+    curr = process.cwd()
+    parent = path.dirname curr
+    while curr isnt parent # root directory (/, C:, etc.)
+        dir = await fs.opendir curr
+        for await entry from dir
+            if entry.name in ['config.civet', '.civetconfig', 'civet.json'] 
+                return path.join curr, entry.name
+        curr = parent
+        parent = path.dirname curr
+    null
+
+export loadConfig = (path) ->
+    config = await fs.readFile path, 'utf8'
+    if path.endsWith '.json'
+        JSON.parse config
+    else
+        js = compile config, js: true
+        
+        tmpPath = path + ".civet-tmp-#{Date.now()}.mjs"
+        await fs.writeFile tmpPath, js
+        try
+            exports = await import(pathToFileURL(tmpPath))
+        finally
+            await fs.unlink tmpPath
+        if typeof exports.default isnt 'object'
+            throw new Error "config.civet must export an object"
+        exports.default
+    

--- a/source/config.coffee
+++ b/source/config.coffee
@@ -28,7 +28,7 @@ export loadConfig = (path) ->
             exports = await import(pathToFileURL(tmpPath))
         finally
             await fs.unlink tmpPath
-        if typeof exports.default isnt 'object'
-            throw new Error "config.civet must export an object"
+        if typeof exports.default isnt 'object' or exports.default is null
+            throw new Error "civet config file must export an object"
         exports.default
     

--- a/source/config.coffee
+++ b/source/config.coffee
@@ -11,11 +11,11 @@ findInDir = (dirPath) ->
         if entry.isFile() 
             name = entry.name.replace(/^\./, '') # allow both .civetconfig.civet and civetconfig.civet   
             if name in ['config.civet', 'civet.json', 'civetconfig.civet', 'civetconfig.json']
-                return path.join curr, entry.name 
+                return path.join dirPath, entry.name 
     null
 
-export findConfig = ->
-    curr = process.cwd()
+export findConfig = (startDir) ->
+    curr = startDir
     parent = path.dirname curr
     while curr isnt parent # root directory (/, C:, etc.)
         if configPath = await findInDir curr

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -148,12 +148,13 @@ export compile = (src, options) ->
   else
     options = {...options}
 
+  options.parseOptions ?= {}
+
   filename = options.filename or "unknown"
 
-  # TODO: This makes source maps slightly off in the first line.
   if filename.endsWith('.coffee') and not
      /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
-    src = "\"civet coffeeCompat\"; #{src}"
+    options.parseOptions.coffeeCompat = true
 
   if !options.noCache
     events = makeCache()

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -158,6 +158,7 @@ export compile = (src, options) ->
   if !options.noCache
     events = makeCache()
 
+  parse.config = options.parseOptions
   ast = prune parse(src, {
     filename
     events

--- a/source/main.coffee
+++ b/source/main.coffee
@@ -158,7 +158,7 @@ export compile = (src, options) ->
   if !options.noCache
     events = makeCache()
 
-  parse.config = options.parseOptions
+  parse.config = options.parseOptions or {}
   ast = prune parse(src, {
     filename
     events

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6271,7 +6271,7 @@ Reset
       })
     }
 
-    const DEFAULT = {
+    module.config = {
       autoVar: false,
       autoLet: false,
       coffeeBinaryExistential: false,
@@ -6299,8 +6299,6 @@ Reset
       tab: undefined, // default behavior = same as space
       verbose: false,
     }
-
-    module.config = parse.config = Object.assign({}, DEFAULT, parse.config)
 
     const asAny = {
       ts: true,
@@ -6446,6 +6444,9 @@ Reset
         }
       }
     })
+    
+    Object.assign(module.config, parse.config)
+    parse.config = module.config
 
 Init
   Shebang? DirectivePrologue*:directives "" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6271,7 +6271,7 @@ Reset
       })
     }
 
-    module.config = parse.config = {
+    const DEFAULT = {
       autoVar: false,
       autoLet: false,
       coffeeBinaryExistential: false,
@@ -6299,6 +6299,8 @@ Reset
       tab: undefined, // default behavior = same as space
       verbose: false,
     }
+
+    module.config = parse.config = Object.assign({}, DEFAULT, parse.config)
 
     const asAny = {
       ts: true,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -94,10 +94,10 @@ declare module "@danielx/civet/esbuild-plugin" {
 
 declare module "@danielx/civet/config" {
   const Config: {
-		findConfig: (path: string) => Promise<string | null>
-		loadConfig: (
-			path: string
-		) => Promise<import("@danielx/civet").CompileOptions>
-	}
+    findConfig: (path: string) => Promise<string | null>
+    loadConfig: (
+      path: string
+    ) => Promise<import("@danielx/civet").CompileOptions>
+  }
   export default Config
 }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -93,9 +93,11 @@ declare module "@danielx/civet/esbuild-plugin" {
 }
 
 declare module "@danielx/civet/config" {
-  type Config = {
-    findConfig: (path: string) => Promise<string | null>,
-    loadConfig: (path: string) => Promise<import("@danielx/civet").CompileOptions>,
-  }
+  const Config: {
+		findConfig: (path: string) => Promise<string | null>
+		loadConfig: (
+			path: string
+		) => Promise<import("@danielx/civet").CompileOptions>
+	}
   export default Config
 }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -91,3 +91,11 @@ declare module "@danielx/civet/esbuild-plugin" {
   const plugin: ((options: Options) => Plugin) & Plugin
   export default plugin
 }
+
+declare module "@danielx/civet/config" {
+  type Config = {
+    findConfig: (path: string) => Promise<string | null>,
+    loadConfig: (path: string) => Promise<import("@danielx/civet").CompileOptions>,
+  }
+  export default Config
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,9 +1,38 @@
 declare module "@danielx/civet" {
   export type CivetAST = unknown
+  export type ParseOptions = Partial<{
+    autoVar: boolean
+    autoLet: boolean
+    coffeeBinaryExistential: boolean
+    coffeeBooleans: boolean
+    coffeeClasses: boolean
+    coffeeComment: boolean
+    coffeeDo: boolean
+    coffeeEq: boolean
+    coffeeForLoops: boolean
+    coffeeInterpolation: boolean
+    coffeeIsnt: boolean
+    coffeeJSX: boolean
+    coffeeLineContinuation: boolean
+    coffeeNot: boolean
+    coffeeOf: boolean
+    coffeePrototype: boolean
+    defaultElement: string
+    implicitReturns: boolean
+    objectIs: boolean
+    react: boolean
+    solid: boolean
+    client: boolean
+    rewriteTsImports: boolean
+    server: boolean
+    tab: number
+    verbose: boolean
+  }>
   export type CompileOptions = {
     filename?: string
     js?: boolean
     sourceMap?: boolean
+    parseOptions?: ParseOptions
   }
 
   export type SourceMapping = [number] | [number, number, number, number]


### PR DESCRIPTION
Add `--config` option to specify a config file,
otherwise looks for a `config.civet`, `.civetconfig`, or `civet.json` file in the current directory and all parent directories. If found, it is loaded and used to override the default options.

config.civet and .civetconfig get compiled & run, but can't import other civet files.
 - `export default`s the config object

civet.json is just parsed as json