### PR TITLE
Added optional prefixed union syntax for TypeScript. Fixes #544

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5816,9 +5816,11 @@ Type
   TypeConditional
 
 TypeBinary
-  TypeUnary ( __ TypeBinaryOp __ TypeUnary )* ->
-    if ($2.length) return $0
-    return $1
+  ( __ TypeBinaryOp __ )?:optionalPrefix TypeUnary:t ( __ TypeBinaryOp __ TypeUnary )*:ops ->
+    if (!ops.length && !optionalPrefix) return t
+    if (!ops.length) return [optionalPrefix, t]
+    if (!optionalPrefix) return [t, ...ops]
+    return [optionalPrefix, t, ops]
 
 TypeUnary
   ( __ TypeUnaryOp NonIdContinue )* TypePrimary TypeUnarySuffix* ->
@@ -6444,7 +6446,7 @@ Reset
         }
       }
     })
-    
+
     Object.assign(module.config, parse.config)
     parse.config = module.config
 

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -114,6 +114,18 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    prefix |
+    ---
+    type X =
+      | number
+      | string
+    ---
+    type X =
+      | number
+      | string
+  """
+
+  testCase """
     typeof
     ---
     const data = [1, 2, 3]


### PR DESCRIPTION
I'm pretty sure this is the correct place in the grammar because of this example: https://www.typescriptlang.org/play?experimentalDecorators=true#code/C4TwDgpgBAKlC8UCuA7A1ig9gdxQKFEigFUEoBnYAJwEsUBzPAY0xUqgA8AuKAMligAfEmQBEITKKA