### PR TITLE
`not` support outside coffeeCompat mode

### DIFF
--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -161,7 +161,7 @@ Civet provides a compatibility prologue directive that aims to be 97+% compatibl
 | coffeeForLoops      | for in, of, from loops behave like they do in CoffeeScript |
 | coffeeInterpolation | `"a string with #{myVar}"` |
 | coffeeIsnt          | `isnt` → `!==` |
-| coffeeNot           | `not` → `!`    |
+| coffeeNot           | `not` → `!`, disabling Civet extensions like `is not` |
 | coffeeOf            | `a of b` → `a in b`, `a not of b` → `!(a in b)`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
 | coffeePrototype     | enables `x::` -> `x.prototype` and `x::y` -> `x.prototype.y` shorthand.
 

--- a/source/lib.js
+++ b/source/lib.js
@@ -1412,6 +1412,10 @@ function makeLeftHandSideExpression(expression) {
     case "CallExpression":
     case "MemberExpression":
     case "ParenthesizedExpression":
+    case "DebuggerExpression": // wrapIIFE
+    case "SwitchExpression": // wrapIIFE
+    case "ThrowExpression": // wrapIIFE
+    case "TryExpression": // wrapIIFE
       return expression
     default:
       return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -183,8 +183,12 @@ ForbiddenImplicitCalls
   # Don't treat @@decorator @@decorator class ... as implicit calls
   ClassImplicitCallForbidden ( Class / AtAt )
   Identifier "=" Whitespace
-  Identifier !"(" ->
-    if (module.operators.has($1.name)) return $1
+  # NOTE: Custom operators created via `operator`
+  Identifier:id !"(" ->
+    if (module.operators.has(id.name)) return $0
+    return $skip
+  Not _? Identifier:id ->
+    if (module.operators.has(id.name)) return $0
     return $skip
 
 ArgumentsWithTrailingMemberExpressions
@@ -2607,7 +2611,7 @@ BinaryOp
       call: id,
       special: true,
     }
-  "not" NonIdContinue __ Identifier:id ->
+  Not __ Identifier:id ->
     if (!module.operators.has(id.name)) return $skip
     return {
       call: id,
@@ -2695,7 +2699,7 @@ BinaryOpSymbol
       relational: true,
       special: true, // for typeof shorthand
     }
-  "not" NonIdContinue __ "instanceof" NonIdContinue ->
+  Not __ "instanceof" NonIdContinue ->
     return {
       $loc,
       token: "instanceof",
@@ -2703,21 +2707,21 @@ BinaryOpSymbol
       special: true,
       negated: true,
     }
-  ( !CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ) / ( CoffeeOfEnabled "not" NonIdContinue __ "of" NonIdContinue ) ->
+  ( !CoffeeOfEnabled Not __ In ) / ( CoffeeOfEnabled Not __ "of" NonIdContinue ) ->
     return {
       $loc,
       token: "in",
       special: true,
       negated: true,
     }
-  "is" NonIdContinue __ "in" NonIdContinue ->
+  Is __ In ->
     return {
       method: "includes",
       relational: true,
       reversed: true,
       special: true,
     }
-  CoffeeOfEnabled "in" NonIdContinue ->
+  CoffeeOfEnabled In ->
     return {
       call: [module.getRef("indexOf"), ".call"],
       relational: true,
@@ -2725,7 +2729,7 @@ BinaryOpSymbol
       suffix: " >= 0",
       special: true,
     }
-  "is" NonIdContinue __ "not" NonIdContinue __ "in" NonIdContinue ->
+  Is __ Not __ In ->
     return {
       method: "includes",
       relational: true,
@@ -2733,7 +2737,7 @@ BinaryOpSymbol
       special: true,
       negated: true,
     }
-  CoffeeOfEnabled "not" NonIdContinue __ "in" NonIdContinue ->
+  CoffeeOfEnabled Not __ In ->
     return {
       call: [module.getRef("indexOf"), ".call"],
       relational: true,
@@ -2742,7 +2746,7 @@ BinaryOpSymbol
       special: true,
     }
   # NOTE: "is not" must come after "is not in"
-  !CoffeeNotEnabled "is" NonIdContinue __ "not" NonIdContinue ->
+  !CoffeeNotEnabled Is __ Not ->
     if (module.config.objectIs) {
       return {
         call: module.getRef("is"),
@@ -2754,7 +2758,7 @@ BinaryOpSymbol
     }
     return "!=="
   # NOTE: "is" must come after "is not" and "is in"
-  "is" NonIdContinue ->
+  Is ->
     if (module.config.objectIs) {
       return {
         call: module.getRef("is"),
@@ -2764,8 +2768,8 @@ BinaryOpSymbol
       }
     }
     return "==="
-  "in" NonIdContinue ->
-    return $1
+  In ->
+    return "in"
   "&"
   "^"
   "|"
@@ -2782,7 +2786,7 @@ UnaryOp
     return { $loc, token: $0 }
   AwaitOp
   ( Delete / Void / Typeof ) !":" _?
-  Not # only when CoffeeNotEnabled (see definition of `Not`)
+  Not " "? _? -> [$1, $3]
 
 # https://github.com/tc39/proposal-await.ops
 AwaitOp
@@ -4742,6 +4746,14 @@ Const
   "const" NonIdContinue ->
     return { $loc, token: $1 }
 
+In
+  "in" NonIdContinue ->
+    return { $loc, token: $1 }
+
+Is
+  "is" NonIdContinue ->
+    return { $loc, token: $1 }
+
 LetOrConstOrVar
   LetOrConst
   Var
@@ -4756,8 +4768,7 @@ New
     return { $loc, token: $1 }
 
 Not
-  # Not keyword only active in compat mode
-  CoffeeNotEnabled "not" NonIdContinue " "? !( _? ":" ) ->
+  "not" NonIdContinue !( _? ":" ) ->
     return { $loc, token: "!" }
 
 Of

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4757,7 +4757,7 @@ New
 
 Not
   # Not keyword only active in compat mode
-  CoffeeNotEnabled "not" NonIdContinue " "? ->
+  CoffeeNotEnabled "not" NonIdContinue " "? !( _? ":" ) ->
     return { $loc, token: "!" }
 
 Of

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -516,8 +516,10 @@ describe "assignment", ->
       min=y
     """
 
-    throws """
-      not form doesn't work
+    testCase """
+      not form isn't an assignment
       ---
       x not min= y
+      ---
+      x(!min)= y
     """

--- a/test/object.civet
+++ b/test/object.civet
@@ -561,6 +561,15 @@ describe "object", ->
       ({${line}: 1})
     ```
 
+    testCase ```
+      coffee compat braceless inline object with ${line} as key
+      ---
+      "civet coffeeCompat"
+      ${line}: 1
+      ---
+      ({${line}: 1})
+    ```
+
   testCase """
     braceless inline object in function call
     ---

--- a/test/unary-expression.civet
+++ b/test/unary-expression.civet
@@ -25,10 +25,26 @@ describe "unary expression", ->
     typeof x
   """
 
-  testCase.skip """
+  testCase """
     not
     ---
     not a
     ---
     !a
+  """
+
+  testCase """
+    not with extra space
+    ---
+    not  a
+    ---
+    ! a
+  """
+
+  testCase """
+    not without space
+    ---
+    not(a)
+    ---
+    !(a)
   """


### PR DESCRIPTION
* Add support for `not x` → `!x` in all cases, not just coffeeCompat
  * Note that `not` was already a keyword; it just didn't do anything by itself, only in `is not`, etc.
* Fix `not: 1` (using `not` as an object property, which was previously broken in coffeeCompat mode)
* Fix `not  x` (previously didn't support more than one space)
* Keep support for `not op` except in coffeeCompat mode
* Some code cleanup

Spun off from #548 as suggested in https://github.com/DanielXMoore/Civet/pull/548#issuecomment-1601149303