### PR TITLE
Unicode operators ≤≥≠≢≡≣⩶⩵«»⋙‖⁇∈∉∋∌▷‥…≔→⇒

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -332,6 +332,7 @@ a?
 item is in array
 item is not in array
 substring is in string
+item1 ∈ container ∌ item2  // Unicode
 </Playground>
 
 ### Assignment Operators
@@ -354,6 +355,7 @@ fun?(arg)
 
 <Playground>
 a < b <= c
+a ≤ b ≤ c ≠ d  // Unicode
 a is b is not c
 a instanceof b not instanceof c
 </Playground>

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -609,6 +609,12 @@ circle := (degrees: number): {x: number, y: number} =>
   y: Math.sin radians
 </Playground>
 
+You can also use Unicode arrows:
+
+<Playground>
+curryAdd := (a: number) → (b: number) ⇒ a + b
+</Playground>
+
 ### `return.value`
 
 Instead of specifying a function's return value when it returns,

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -479,6 +479,12 @@ url |> fetch |> await
 |> callback
 </Playground>
 
+Unicode forms:
+
+<Playground>
+data ▷= func1 |▷ func2 ▷ func3
+</Playground>
+
 ### Await Operators
 
 [TC39 proposal: `await` operations](https://github.com/tc39/proposal-await.ops)

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -355,7 +355,8 @@ fun?(arg)
 
 <Playground>
 a < b <= c
-a ≤ b ≤ c ≠ d  // Unicode
+a ≤ b ≤ c  // Unicode
+a ≡ b ≣ c ≠ d ≢ e
 a is b is not c
 a instanceof b not instanceof c
 </Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2634,7 +2634,9 @@ BinaryOpSymbol
   "+"
   "-"
   "<="
+  "≤" -> "<="
   ">="
+  "≥" -> ">="
   # NOTE: added <? instanceof shorthand
   "<?" ->
     return {
@@ -2652,33 +2654,39 @@ BinaryOpSymbol
       negated: true,
     }
   "<<"
+  "«" -> "<<"
   # NOTE: Avoid matching JSX opening tag by requiring non-identifier character
   # (e.g. whitespace) after "<".  This does forbid 1<2 or x<y.
   /<(?!\p{ID_Start}|[_$])/ ->
     return "<"
   ">>>"
+  "⋙" -> ">>>"
   ">>"
+  "»" -> ">>"
   ">"
   "!=="
+  "≢" -> "!=="
   # NOTE: CoffeeScript converts "!=" -> "!=="
   # Convert if CoffeeScript compat flag is set
-  "!=" ->
+  "!=" / "≠" ->
     if(module.config.coffeeEq) return "!=="
-    return $1
+    return "!="
   "isnt" NonIdContinue ->
     if(module.config.coffeeIsnt) return "!=="
     return $skip
   "==="
+  "≡" / "⩶" -> "==="
   # NOTE: CoffeeScript converts "==" -> "==="
   # Convert if CoffeeScript compat flag is set
-  "==" ->
+  "==" / "⩵" ->
     if(module.config.coffeeEq) return "==="
-    return $1
+    return "=="
   "and" NonIdContinue -> "&&"
   "&&"
   CoffeeOfEnabled "of" NonIdContinue -> "in"
   "or" NonIdContinue -> "||"
   "||"
+  "‖" -> "||"
   # NOTE: ^^ must be above ^
   "^^" / ( "xor" NonIdContinue ) ->
     return {
@@ -2691,6 +2699,7 @@ BinaryOpSymbol
       special: true,
     }
   "??"
+  "⁇" -> "??"
   CoffeeBinaryExistentialEnabled "?" -> "??"
   "instanceof" NonIdContinue ->
     return {
@@ -2714,7 +2723,7 @@ BinaryOpSymbol
       special: true,
       negated: true,
     }
-  Is __ In ->
+  ( Is __ In ) / "∈" ->
     return {
       method: "includes",
       relational: true,
@@ -2729,7 +2738,7 @@ BinaryOpSymbol
       suffix: " >= 0",
       special: true,
     }
-  Is __ Not __ In ->
+  ( Is __ Not __ In ) / "∉" ->
     return {
       method: "includes",
       relational: true,
@@ -4103,7 +4112,7 @@ LexicalDeclaration
     return processLetAssignmentDeclaration(...$0)
 
 ConstAssignment
-  ":=" ->
+  ":=" / "≔" ->
     return { $loc, token: "=" }
 
 LetAssignment
@@ -4673,10 +4682,14 @@ Dot
 DotDot
   ".." !"." ->
     return { $loc, token: $1 }
+  "‥" ->
+    return { $loc, token: ".." }
 
 DotDotDot
   "..." ->
     return { $loc, token: $1 }
+  "…" ->
+    return { $loc, token: "..." }
 
 DoubleColon
   "::" ->
@@ -4808,14 +4821,14 @@ Protected
     return { $loc, token: $1 }
 
 Pipe
-  "||>" ->
-    return { $loc, token: $1 }
+  "||>" / "|▷" ->
+    return { $loc, token: "||>" }
 
-  "|>=" ->
-    return { $loc, token: $1 }
+  "|>=" / "▷=" ->
+    return { $loc, token: "|>=" }
 
-  "|>" ->
-    return { $loc, token: $1 }
+  "|>" / "▷" ->
+    return { $loc, token: "|>" }
 
 QuestionMark
   "?" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -433,10 +433,10 @@ ArrowFunction
 
 FatArrow
   # Ensures at least one space before arrow
-  _?:ws "=>" ->
+  _?:ws ( "=>" / "⇒" ) ->
     if (!ws)
       return " =>"
-    return $0
+    return [ $1, "=>" ]
 
 # NOTE Different from
 # https://262.ecma-international.org/#prod-ConciseBody
@@ -1603,8 +1603,8 @@ ThinArrowFunction
     }
 
 Arrow
-  "->" ->
-    return { $loc, token: $1}
+  "->" / "→" ->
+    return { $loc, token: "->" }
 
 ExplicitBlock
   __ OpenBrace __ CloseBrace ->
@@ -5994,9 +5994,7 @@ FunctionType
     return [...$0, "void"]
 
 TypeArrowFunction
-  "=>" ->
-    return { $loc, token: "=>" }
-  "->" ->
+  "=>" / "⇒" / "->" / "→" ->
     return { $loc, token: "=>" }
 
 TypeArguments

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2730,6 +2730,19 @@ BinaryOpSymbol
       reversed: true,
       special: true,
     }
+  "∋" ->
+    return {
+      method: "includes",
+      relational: true,
+      special: true,
+    }
+  "∌" ->
+    return {
+      method: "includes",
+      relational: true,
+      special: true,
+      negated: true,
+    }
   CoffeeOfEnabled In ->
     return {
       call: [module.getRef("indexOf"), ".call"],

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2675,10 +2675,10 @@ BinaryOpSymbol
     if(module.config.coffeeIsnt) return "!=="
     return $skip
   "==="
-  "≡" / "⩶" -> "==="
+  "≣" / "⩶" -> "==="
   # NOTE: CoffeeScript converts "==" -> "==="
   # Convert if CoffeeScript compat flag is set
-  "==" / "⩵" ->
+  "==" / "≡" / "⩵" ->
     if(module.config.coffeeEq) return "==="
     return "=="
   "and" NonIdContinue -> "&&"

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -205,9 +205,9 @@ describe "binary operations", ->
   testCase """
     Unicode is in operator
     ---
-    a ∈ b ∉ c
+    a ∈ b ∉ c ∋ d ∌ e
     ---
-    b.includes(a) && !c.includes(a)
+    b.includes(a) && !c.includes(b) && c.includes(d) && !d.includes(e)
   """
 
   testCase """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -383,9 +383,9 @@ describe "binary operations", ->
   testCase """
     Unicode relations
     ---
-    a ≤ b ≥ c ≠ d ≡ e
+    a ≤ b ≥ c ≠ d ≢ e ≡ f ≣ g
     ---
-    a <= b && b >= c && c != d && d === e
+    a <= b && b >= c && c != d && d !== e && e == f && f === g
   """
 
 describe "custom identifier infix operators", ->

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -203,6 +203,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    Unicode is in operator
+    ---
+    a ∈ b ∉ c
+    ---
+    b.includes(a) && !c.includes(a)
+  """
+
+  testCase """
     bitwise
     ---
     a | b
@@ -362,6 +370,22 @@ describe "binary operations", ->
     a not instanceof b
     ---
     !(a instanceof b)
+  """
+
+  testCase """
+    Unicode computation
+    ---
+    a « b » c ⋙ d ‖ e ⁇ f
+    ---
+    a << b >> c >>> d || e ?? f
+  """
+
+  testCase """
+    Unicode relations
+    ---
+    a ≤ b ≥ c ≠ d ≡ e
+    ---
+    a <= b && b >= c && c != d && d === e
   """
 
 describe "custom identifier infix operators", ->

--- a/test/function.civet
+++ b/test/function.civet
@@ -95,6 +95,22 @@ describe "function", ->
     async function defaultLoad () {}
   """
 
+  testCase """
+    Unicode ->
+    ---
+    (x) → x
+    ---
+    (function(x) { return x })
+  """
+
+  testCase """
+    Unicode =>
+    ---
+    (x) ⇒ x
+    ---
+    (x) => x
+  """
+
   describe "implicit async", ->
     testCase """
       basic


### PR DESCRIPTION
For fun, here are some simpler and less controversial Unicode operators from #555.

The only one I'm less sure about is `≡` mapping to `===`. But given that `≠` makes `!=` and `≢` makes `!==`, this feels natural. And anyway it's good to encourage `===` over `==`. Alternatively, we could use `≣` for `===` and `≡` for `==`...

Incidentally, TIL there are symbols for double and triple equals: `⩵` and `⩶`.

Going forward:
* I'm less sure about the symbols with equals and such because they look like comparisons to me, but Civet uses them as assignments.
* I think the power operators, specifically `²`, would be handy, but that's a little more complicated, so left for the future.
* If there are other Unicode operators you think I should add now, let me know!