### PR TITLE
Add missing parentheses to glob assignments with refs

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -548,7 +548,7 @@ function processCallMemberExpression(node) {
     if (glob?.type === "PropertyGlob") {
       let prefix = children.slice(0, i)
       const parts = []
-      let hoistDec, refAssignment = []
+      let hoistDec, refAssignment
       // add ref to ensure object base evaluated only once
       if (prefix.length > 1) {
         const ref = {
@@ -607,16 +607,22 @@ function processCallMemberExpression(node) {
           })
         }
       }
-      const object = {
+      let object = {
         type: "ObjectExpression",
         children: [
-          ...refAssignment,
           glob.object.children[0], // {
           ...parts,
           glob.object.children.at(-1), // whitespace and }
         ],
         properties: parts,
         hoistDec,
+      }
+      if (refAssignment) {
+        object = {
+          type: "ParenthesizedExpression",
+          children: ["(", ...refAssignment, object, ")"],
+          expression: object,
+        }
       }
       if (i === children.length - 1) return object
       return processCallMemberExpression({  // in case there are more

--- a/test/object.civet
+++ b/test/object.civet
@@ -900,6 +900,22 @@ describe "object", ->
       ({a:obj.a, b:obj.b, ...obj.rest} = x)
     """
 
+    testCase """
+      ref in function call
+      ---
+      f a.b.{x,y}
+      ---
+      let ref;f((ref = a.b,{x:ref.x,y:ref.y}))
+    """
+
+    testCase """
+      ref in multi-argument function call
+      ---
+      f first, a.b.{x,y}, last
+      ---
+      let ref;f(first, (ref = a.b,{x:ref.x,y:ref.y}), last)
+    """
+
     throws """
       no initializer
       ---


### PR DESCRIPTION
Fixes #566

I wonder if we can craft a helper function, as parenthesization for refs is done in a couple places (e.g. `processPatternMatching`, which currently seems to add parens even if there are no refs — not sure whether that can be improved).