### PR TITLE
Fix empty objects in if statements

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1636,9 +1636,11 @@ ImplicitNestedBlock
 
 # NOTE: This is the body of if/else/for/case etc.
 Block
-  ExplicitBlock
   # NOTE: Added indentation based implied braces
   ImplicitNestedBlock
+  # NOTE: Explicit block after implicit block so that a properly indented `{}`
+  # gets treated like an object literal, not an empty block.
+  ExplicitBlock
 
   ThenClause
   # NOTE: !EOS prevents capturing a following unindented Statement

--- a/test/function.civet
+++ b/test/function.civet
@@ -1185,6 +1185,20 @@ describe "function", ->
     """
 
     testCase """
+      if with empty object literal
+      ---
+      (x) ->
+        if x
+          {}
+      ---
+      (function(x) {
+        if (x) {
+          return ({})
+        };return
+      })
+    """
+
+    testCase """
       nested if else
       ---
       (x) ->

--- a/test/if.civet
+++ b/test/if.civet
@@ -78,6 +78,30 @@ describe "if", ->
     if (x) y; else z
   """
 
+  // TODO: fix missing }s
+  testCase.skip """
+    if inline, empty blocks
+    ---
+    if (x) {} else {}
+    ---
+    if (x) {} else {}
+  """
+
+  // TODO: fix missing }s
+  testCase.skip """
+    if with empty blocks on separate lines
+    ---
+    if (x)
+    {}
+    else
+    {}
+    ---
+    if (x)
+    {}
+    else
+    {}
+  """
+
   testCase """
     if then
     ---
@@ -534,6 +558,28 @@ describe "if", ->
       x = (a unless y)
       ---
       x = ((!(y))?a:void 0)
+    """
+
+    testCase """
+      empty object in then, implicit parens
+      ---
+      x = if y
+        {}
+      ---
+      x = (y)?(
+        {}
+      ):void 0
+    """
+
+    testCase """
+      empty object in then, explicit parens
+      ---
+      x = if (y)
+        {}
+      ---
+      x = (y)?(
+        {}
+      ):void 0
     """
 
   // TODO Eventually


### PR DESCRIPTION
Fix #559 as discussed in https://github.com/DanielXMoore/Civet/issues/559#issuecomment-1624411555

`{}` will be treated as an empty block if it starts on the same line as the `if`, and if it's on an unindented line.  But if it's on an indented line, it will be treated like an object literal.

I feel like this is sufficiently JS compatible, because the difference between doing nothing and creating an empty object literal (and similarly for doing something vs. creating an object literal with that something) only matters when interacting with implicit returns or `if` expressions, which are already differences from JS anyway.

I also ran into a weird bug with `if (x) {} else {}`, but that's for another issue/PR.