### PR TITLE
Fix missing closing braces

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1612,7 +1612,7 @@ ExplicitBlock
     return {
       type: "BlockStatement",
       expressions,
-      children: [$1, expressions, $2],
+      children: [$1, $2, expressions, $3, $4],
       bare: false,
       empty: true,
     }

--- a/test/if.civet
+++ b/test/if.civet
@@ -78,8 +78,7 @@ describe "if", ->
     if (x) y; else z
   """
 
-  // TODO: fix missing }s
-  testCase.skip """
+  testCase """
     if inline, empty blocks
     ---
     if (x) {} else {}
@@ -87,8 +86,7 @@ describe "if", ->
     if (x) {} else {}
   """
 
-  // TODO: fix missing }s
-  testCase.skip """
+  testCase """
     if with empty blocks on separate lines
     ---
     if (x)


### PR DESCRIPTION
Fixes #572

This makes me wonder the following: is it safe to modify `$0` in place?  In this case it isn't pretty (`$0.splice(2, 0, expressions)`) but often we want to just replace a specific item in `$0` with a wrapped version.