### PR TITLE
Existence operator chaining and cleanup

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -351,6 +351,13 @@ obj?[key]
 fun?(arg)
 </Playground>
 
+## Existence Checking
+
+<Playground>
+x?
+x.y[z]?
+</Playground>
+
 ### Chained Comparisons
 
 <Playground>
@@ -359,6 +366,7 @@ a ≤ b ≤ c  // Unicode
 a ≡ b ≣ c ≠ d ≢ e
 a is b is not c
 a instanceof b not instanceof c
+x? instanceof Function
 </Playground>
 
 ### `instanceof` shorthand

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -535,10 +535,20 @@ ParenthesizedExpression
   OpenParen:open AllowAll ( PostfixedExpression __ CloseParen )? RestoreAll ->
     if (!$3) return $skip
     const [exp, ws, close] = $3
-    // Avoid extra parenthetical wrapping in `(for x in y ...)`
     switch (exp.type) {
       case "IterationExpression":
+        // Avoid extra parenthetical wrapping in `(for x in y ...)`
+        // TODO: losing comments in `ws`
         return exp
+      case "ParenthesizedExpression":
+        if (exp.implicit) {
+          return {
+            ...exp,
+            children: [open, exp.expression, ws, close],
+            implicit: false,
+          }
+        }
+        break
     }
     return {
       type: "ParenthesizedExpression",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1464,18 +1464,32 @@ AmpersandFunctionExpression
 
     // Only unary ops
     if (!rhs) {
-      ref = {
+      body = ref = {
         type: "Ref",
         base: "$",
         id: "$"
       }
-      body = [ prefix, ref ]
     } else {
-      ({ ref } = rhs)
-      body = [ prefix, rhs ]
+      // &? gets wrapped in UnaryExpression and ParenthesizedExpression;
+      // descend into `expression` property until `ref` is defined
+      let exp = rhs
+      while (!exp.ref && exp.expression) {
+        exp = exp.expression
+      }
+      ({ref} = exp)
+      if (!ref) {
+        throw new Error("Could not find ref in ampersand shorthand block")
+      }
+      body = rhs
+    }
+    if (prefix) {
+      body = {
+        type: "UnaryExpression",
+        children: [ prefix, body, undefined ]
+      }
     }
 
-    const children = [ ref, " => ", ...body ]
+    const children = [ ref, " => ", body ]
     if (hasAwait(body)) {
       children.unshift("async ")
     }
@@ -1537,7 +1551,7 @@ AmpersandBlockRHS
 
 AmpersandBlockRHSBody
   (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( ![&] BinaryOpRHS+ )?:binopRHS ->
-    if (!callExpRest && !binopRHS) return $skip
+    if (!callExpRest && !binopRHS && !unaryPostfix) return $skip
     const ref = {
       type: "Ref",
       base: "$",
@@ -2810,7 +2824,7 @@ Xnor
 UnaryOp
   # Lookahead to prevent unary operators from overriding update operators
   # ++/-- or block unary operator shorthand
-  /(?!\+\+|--)[!~+-](?!\s|[!~+-]*&)/ ->
+  /(?!\+\+|--)[!~+-](?!\s|[!~+-]*[&.])/ ->
     return { $loc, token: $0 }
   AwaitOp
   ( Delete / Void / Typeof ) !":" _?
@@ -2951,6 +2965,10 @@ UnlessClause
   Unless:kind Condition:condition ->
     // Rewrite unless to if
     kind = { ...kind, token: "if" }
+
+    // Move leading space to after if
+    kind.token += getTrimmingSpace(condition)
+    condition = insertTrimmingSpace(condition, '')
 
     return {
       type: "IfStatement",

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -45,7 +45,7 @@ describe "example code", ->
     ---
     var tag;var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
     tag =
-      (colon || prev != null &&
+      (colon || (prev != null) &&
          (indexOf.call(['.', '?.', '::', '?::'], prev[0]) >= 0 ||
          !prev.spaced && prev[0] === '@'))?
         'PROPERTY'
@@ -209,7 +209,7 @@ describe "example code", ->
     else
       @returnKeyword
     ---
-    if ((this.expression) != null) {
+    if (this.expression != null) {
       ({locationData: mergeLocationData(this.returnKeyword.locationData, this.expression.locationData)})
     }
     else {

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -77,7 +77,7 @@ describe "examples (from real life)", ->
     const createCompilerHost = function(options, moduleSearchLocations) {
       var fileExists, readFile, getSourceFile, resolveModuleNames;
       fileExists = function(fileName) {
-        return ((fileCache[fileName]) != null)
+        return (fileCache[fileName] != null)
       }
 
       readFile = function(fileName) {

--- a/test/existential.civet
+++ b/test/existential.civet
@@ -41,3 +41,11 @@ describe "existential", ->
     ---
     x != null && 0 < x && x < 1
   """
+
+  testCase """
+    don't chain when parenthesized
+    ---
+    (x?) < 1
+    ---
+    (x != null) < 1
+  """

--- a/test/existential.civet
+++ b/test/existential.civet
@@ -1,19 +1,27 @@
 {testCase} from ./helper.civet
 
 describe "existential", ->
+  // TODO: only add parens when necessary given context
   testCase """
     default
     ---
     a?
     ---
-    a != null
+    (a != null)
   """
 
-  // TODO: remove excess parens
   testCase """
     after access
     ---
     a.b?
     ---
-    ((a.b) != null)
+    (a.b != null)
+  """
+
+  testCase """
+    with binary operator
+    ---
+    count + item?
+    ---
+    count + (item != null)
   """

--- a/test/existential.civet
+++ b/test/existential.civet
@@ -25,3 +25,19 @@ describe "existential", ->
     ---
     count + (item != null)
   """
+
+  testCase """
+    chain with instanceof
+    ---
+    x? instanceof Function
+    ---
+    x != null && x instanceof Function
+  """
+
+  testCase """
+    chain with comparisons
+    ---
+    0 < x? < 1
+    ---
+    x != null && 0 < x && x < 1
+  """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -276,7 +276,31 @@ describe "&. function block shorthand", ->
   testCase """
     non-null
     ---
+    arr.filter &?
+    ---
+    arr.filter($ => ($ != null))
+  """
+
+  testCase """
+    null
+    ---
+    arr.filter !&?
+    ---
+    arr.filter($ => !($ != null))
+  """
+
+  testCase """
+    property non-null
+    ---
     hasNull := arr.every .x?
     ---
-    const hasNull = arr.every($ => $.x != null)
+    const hasNull = arr.every($ => ($.x != null))
+  """
+
+  testCase """
+    property null
+    ---
+    hasNull := arr.every !.x?
+    ---
+    const hasNull = arr.every($ => !($.x != null))
   """

--- a/test/if.civet
+++ b/test/if.civet
@@ -299,7 +299,7 @@ describe "if", ->
     return "" unless h?
     let x = 2
     ---
-    if(!(h != null)) { return "" }
+    if (!(h != null)) { return "" }
     let x = 2
   """
 


### PR DESCRIPTION
* Chaining logical operators with existence operator `x?` (but without `null` being chained)
  * As discussed in Discord
  * Matches CoffeeScript
* Support `&?`
* Fix `!.x?`
* Fewer parentheses given unary context
* New `Existence` AST node
* `UnaryExpression` AST nodes more consistently
* `ParenthesizedExpression` has `implicit` property if auto-generated
* Documentation