### PR TITLE
Arrow function types fixes: `abstract new` and `asserts`/predicates

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5885,18 +5885,23 @@ TypeSuffix
   }
 
 ReturnTypeSuffix
-  _? Colon ( __ "asserts" NonIdContinue )?:asserts TypePredicate:t ->
+  _? Colon ReturnType:t ->
+    return { ...t, children: [ $1, $2, ...t.children ] }
+
+ReturnType
+  ( __ "asserts" NonIdContinue )?:asserts TypePredicate:t ->
     if (asserts) {
       t = {
         type: "AssertsType",
         t,
         children: [asserts[0], asserts[1], t],
+        ts: true,
       }
     }
 
     return {
       type: "ReturnTypeAnnotation",
-      children: [$1, $2, t],
+      children: [t],
       t,
       ts: true,
     }
@@ -6048,7 +6053,7 @@ TypeBinaryOp
     return { $loc, token: "&" }
 
 FunctionType
-  ( ( Abstract _? )? New _? )? Parameters __ TypeArrowFunction Type?:type ->
+  ( ( Abstract _? )? New _? )? Parameters __ TypeArrowFunction ReturnType?:type ->
     if (type) {
       return $0
     }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6048,7 +6048,7 @@ TypeBinaryOp
     return { $loc, token: "&" }
 
 FunctionType
-  ( New _? )? Parameters __ TypeArrowFunction Type?:type ->
+  ( ( Abstract _? )? New _? )? Parameters __ TypeArrowFunction Type?:type ->
     if (type) {
       return $0
     }

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -124,6 +124,30 @@ describe "[TS] function", ->
   """
 
   testCase """
+    arrow type asserts
+    ---
+    let type: (x: unknown) => asserts x
+    ---
+    let type: (x: unknown) => asserts x
+  """
+
+  testCase """
+    arrow type asserts predicate
+    ---
+    let type: (x: unknown) => asserts x is T
+    ---
+    let type: (x: unknown) => asserts x is T
+  """
+
+  testCase """
+    arrow type predicate
+    ---
+    let type: (x: unknown) => x is T
+    ---
+    let type: (x: unknown) => x is T
+  """
+
+  testCase """
     optional parameter
     ---
     const x = (a: number, b?: number) : number ->
@@ -138,10 +162,21 @@ describe "[TS] function", ->
     asserts
     ---
     assert = (value: unknown): asserts value ->
-      return !!value
+      throw new Error "falsey" unless value
     ---
     assert = function(value: unknown): asserts value {
-      return !!value
+      if(!(value)) { throw new Error("falsey") };return
+    }
+  """
+
+  testCase """
+    asserts predicate
+    ---
+    assertString = (value: unknown): asserts value is string ->
+      throw new Error "not string" unless value <? "string"
+    ---
+    assertString = function(value: unknown): asserts value is string {
+      if(!(typeof value === "string")) { throw new Error("not string") };return
     }
   """
 

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -1,4 +1,4 @@
-{testCase} from ../helper.civet
+{testCase, throws} from ../helper.civet
 
 describe "[TS] function", ->
   testCase """
@@ -107,6 +107,20 @@ describe "[TS] function", ->
     let type: new () => T
     ---
     let type: new () => T
+  """
+
+  testCase """
+    abstract new arrow function type
+    ---
+    let type: abstract new () => T
+    ---
+    let type: abstract new () => T
+  """
+
+  throws """
+    abstract requires new
+    ---
+    let type: abstract () => T
   """
 
   testCase """


### PR DESCRIPTION
1. Fix #562 (again) by supporting `abstract new`. See https://www.typescriptlang.org/docs/handbook/2/classes.html#abstract-classes-and-members
2. Fix #579 by supporting `asserts` and `is` predicates in arrow types (previously was supported only in `function` colon annotations).