### PR TITLE
Fix weird custom operator behavior

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -279,7 +279,9 @@ BinaryOpRHS
   # Does not match
   # a
   # +b
-  NewlineBinaryOpAllowed ( NotDedented BinaryOp ( _ / ( EOS __ ) ) RHS ):rhs -> rhs
+  NewlineBinaryOpAllowed ( NotDedentedBinaryOp ( _ / ( EOS __ ) ) RHS ):rhs ->
+    // NOTE: Flatten NotDedentedBinaryOp into whitespace and operator
+    return [...rhs[0], ...rhs.slice(1)]
   !NewlineBinaryOpAllowed SingleLineBinaryOpRHS -> $2
 
 SingleLineBinaryOpRHS
@@ -2630,6 +2632,19 @@ AssignmentOpSymbol
 CoffeeWordAssignmentOp
   "and=" -> "&&="
   "or=" -> "||="
+
+# NOTE: Similar to `NotDedented BinaryOp`,
+# but forbid Samedent with custom infix operators
+NotDedentedBinaryOp
+  IndentedFurther? _? BinaryOp ->
+    const ws = []
+    if ($1) ws.push(...$1)
+    if ($2) ws.push(...$2)
+    return [ ws, $3 ]
+  Samedent _? !Identifier BinaryOp ->
+    const ws = [...$1]
+    if ($2) ws.push(...$2)
+    return [ ws, $4 ]
 
 BinaryOp
   BinaryOpSymbol ->

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -416,9 +416,11 @@ describe "custom identifier infix operators", ->
     ---
     operator foo
     foo a, b
+    foo c, d
     ---
 
     foo(a, b)
+    foo(c, d)
   """
 
   testCase """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -412,6 +412,20 @@ describe "custom identifier infix operators", ->
   """
 
   testCase """
+    chain over multiple lines
+    ---
+    operator foo
+    a
+      foo b
+      foo c
+    ---
+
+
+      foo(
+      foo(a, b), c)
+  """
+
+  testCase """
     use operator as leading function
     ---
     operator foo


### PR DESCRIPTION
Fixes #511 by forbidding custom infix operators to start at beginning of lines; must be strictly indented. 

By contrast, regular operators like `+` can appear at the start of lines.  I also allowed `not op` at the beginning of a line for a custom infix operator `op`, as that seems more intentional (but not totally sure about this).