### PR TITLE
Allow trailing CallExpression after ExpressionizedStatement

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -1439,6 +1439,7 @@ function makeLeftHandSideExpression(expression) {
     case "AmpersandRef":
     case "Identifier":
     case "Literal":
+    case "IterationExpression": // already a CallExpression
     case "CallExpression":
     case "MemberExpression":
     case "ParenthesizedExpression":

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -115,15 +115,28 @@ NonPipelineExtendedExpression
 NonAssignmentExtendedExpression
   # Check for nested expressionized statements first
   NestedNonAssignmentExtendedExpression
-  __ ExpressionizedStatement ->
+  __ ExpressionizedStatementWithTrailingCallExpressions ->
+    if ($2.length) {
+      return [...$1, ...$2]
+    }
     return {...$2,
       children: [...$1, ...$2.children]
     }
 
 NestedNonAssignmentExtendedExpression
-  &EOS PushIndent ( Nested ExpressionizedStatement )?:expression PopIndent ->
+  &EOS PushIndent ( Nested ExpressionizedStatementWithTrailingCallExpressions )?:expression PopIndent ->
     if (expression) return expression
     return $skip
+
+ExpressionizedStatementWithTrailingCallExpressions
+  ExpressionizedStatement AllowedTrailingCallExpressions? ->
+    if (!$2) return $1
+    // Some expressionized statements, such as `if`s,
+    // need to be wrapped in parens
+    return [
+      makeLeftHandSideExpression($1),
+      $2,
+    ]
 
 ExpressionizedStatement
   DebuggerExpression
@@ -207,6 +220,14 @@ TrailingMemberExpressions
 AllowedTrailingMemberExpressions
   TrailingMemberPropertyAllowed TrailingMemberExpressions -> $2
   MemberExpressionRest*
+
+TrailingCallExpressions
+  # NOTE: Assert "." to not match "?" or "!" or string literal
+  # as a call expression on the following line
+  ( ( Samedent / IndentedFurther ) &( "?"? "." ![0-9] ) CallExpressionRest+ )+
+
+AllowedTrailingCallExpressions
+  TrailingMemberPropertyAllowed TrailingCallExpressions -> $2
 
 CommaDelimiter
   ( Samedent / IndentedFurther )? _* Comma
@@ -293,7 +314,7 @@ SingleLineBinaryOpRHS
 RHS
   ParenthesizedAssignment
   UnaryExpression
-  ExpressionizedStatement
+  ExpressionizedStatementWithTrailingCallExpressions
 
 ParenthesizedAssignment
   InsertOpenParen ActualAssignment InsertCloseParen

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -124,9 +124,10 @@ NonAssignmentExtendedExpression
     }
 
 NestedNonAssignmentExtendedExpression
-  &EOS PushIndent ( Nested ExpressionizedStatementWithTrailingCallExpressions )?:expression PopIndent ->
-    if (expression) return expression
-    return $skip
+  &EOS PushIndent ( Nested ExpressionizedStatementWithTrailingCallExpressions )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+    if (!expression) return $skip
+    if (!trailing) return expression
+    return [ expression, trailing ]
 
 ExpressionizedStatementWithTrailingCallExpressions
   ExpressionizedStatement AllowedTrailingCallExpressions? ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -127,17 +127,23 @@ NestedNonAssignmentExtendedExpression
   &EOS PushIndent ( Nested ExpressionizedStatementWithTrailingCallExpressions )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
     if (!expression) return $skip
     if (!trailing) return expression
-    return [ expression, trailing ]
+    return {
+      type: "CallExpression",
+      children: [ expression, ...trailing.flat() ]
+    }
 
 ExpressionizedStatementWithTrailingCallExpressions
   ExpressionizedStatement AllowedTrailingCallExpressions? ->
     if (!$2) return $1
     // Some expressionized statements, such as `if`s,
     // need to be wrapped in parens
-    return [
-      makeLeftHandSideExpression($1),
-      $2,
-    ]
+    return {
+      type: "CallExpression",
+      children: [
+        makeLeftHandSideExpression($1),
+        $2,
+      ],
+    }
 
 ExpressionizedStatement
   DebuggerExpression

--- a/test/for.civet
+++ b/test/for.civet
@@ -348,3 +348,20 @@ describe "for", ->
         .sort()
         .reverse()
     """
+
+    testCase """
+      trailing method calls after dedent
+      ---
+      sorted :=
+        for item of list
+          item.toString()
+      .sort()
+      .reverse()
+      ---
+      const sorted =
+        (()=>{const results=[];for (const item of list) {
+          results.push(item.toString())
+        }; return results})()
+      .sort()
+      .reverse()
+    """

--- a/test/for.civet
+++ b/test/for.civet
@@ -331,3 +331,20 @@ describe "for", ->
         results.push(await x)
       }; return results})()
     """
+
+    testCase """
+      trailing method calls
+      ---
+      sorted :=
+        for item of list
+          item.toString()
+        .sort()
+        .reverse()
+      ---
+      const sorted =
+        (()=>{const results=[];for (const item of list) {
+          results.push(item.toString())
+        }; return results})()
+        .sort()
+        .reverse()
+    """

--- a/test/if.civet
+++ b/test/if.civet
@@ -604,6 +604,24 @@ describe "if", ->
       ):void 0
     """
 
+    testCase """
+      trailing method call
+      ---
+      greeting =
+        if x
+          y
+        else
+          z
+        .say 'hello'
+      ---
+      greeting =
+        ((x)?
+          y
+        :
+          z)
+        .say('hello')
+    """
+
   describe "return if expression", ->
     testCase """
       return if expression

--- a/test/if.civet
+++ b/test/if.civet
@@ -604,14 +604,13 @@ describe "if", ->
       ):void 0
     """
 
-  // TODO Eventually
-  describe.skip "return if expression", ->
+  describe "return if expression", ->
     testCase """
       return if expression
       ---
       return if y then 1 else 0
       ---
-      return (y)? 1:  0
+      return (y)? 1 : 0
     """
 
     testCase """
@@ -621,8 +620,8 @@ describe "if", ->
       then 1
       else 0
       ---
-      return (y)? 1:
-       0
+      return (y)? 1
+      : 0
     """
 
     testCase """
@@ -633,12 +632,10 @@ describe "if", ->
       else
         0
       ---
-      return (y)?(
+      return (y)?
         1
-      ):
-      (
+      :
         0
-      )
     """
 
   describe "DeclarationCondition", ->


### PR DESCRIPTION
Fixes #582 by allowing on-their-own-line not-dedented `CallExpressionRest` after all `ExpressionizedStatement`, if `TrailingMemberPropertyAllowed` is true.

We had a facility for `TrailingMemberExpressions` but not for `TraillingCallExpressions`.  This sufficed in the past because the trailing member was previously used in a `CallExpression` context, so the call part got captured there.  Here we haven't started a `CallExpression` so I had to build some more rules.

This PR allows for this form from https://github.com/DanielXMoore/Civet/issues/582#issuecomment-1636989322:

```coffee
sorted :=
  for item of list
    item.toString()
  .sort()
```

In the third commit, I also modified the indentation rules in `NestedNonAssignmentExtendedExpression` to allow the originally requested indentation of #582:

```coffee
sorted :=
  for item of list
    item.toString()
.sort()
```

I hope I got these situations correct. It's possible that I'm allowing `CallExpressionRest` where it shouldn't be.

We may want to allow `TrailingCallExpressions` in more contexts too. For example, `for` loops can only get them in expression contexts, such as right-hand sides of assignments, but we might also want them in statement contexts like so:

```coffee
for item of list
  item.toString()
.outputToFile 'foo'
```

This would probably be most useful in combination with implicit returns from functions. The tricky part is that this forces them to transform from `IterationStatement` to `IterationExpression`, which I'm not quite sure how to do. I tried adding `!TrailingCallExpressions` to the end of certain `Statement` rules to force parsing as `ExpressionStatement` but haven't gotten it working yet.

In the first commit, I also enabled some "return-if" tests that were already essentially working.