### PR TITLE
Fix inner assignments mixed with operator assignments

### DIFF
--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -483,6 +483,14 @@ describe "assignment", ->
       ++x, x++
     """
 
+    testCase """
+      complex example
+      ---
+      (counts[match[1]] ??= 0) max= parseInt match[2], 10
+      ---
+      (counts[match[1]] ??= 0), counts[match[1]] = max(counts[match[1]], parseInt(match[2], 10))
+    """
+
   describe "function assignment operator", ->
     testCase """
       space on both sides

--- a/test/label.civet
+++ b/test/label.civet
@@ -44,7 +44,7 @@ describe "labels", ->
     ---
     "$": a = 1
     ---
-    ({"$":a = 1})
+    ({"$": a = 1})
   """
 
   testCase """
@@ -52,7 +52,7 @@ describe "labels", ->
     ---
     {$: a = 1}
     ---
-    ({$:a = 1})
+    ({$: a = 1})
   """
 
   testCase """


### PR DESCRIPTION
Example (from [this code](https://github.com/edemaine/beancount/blob/1c632c654427ad2eebf7a54968e269bdb414cf68/index.civet#L57), also posted on Discord):

```coffee
(counts[match[1]] ??= 0) max= parseInt match[2], 10
```

Before this PR:

```js
(counts[match[1]] ??= 0), counts[match[1]] = max((counts[match[1]] ??= 0), parseInt(match[2], 10))
```

Note the double occurrence of `counts[match[1]] ??= 0`.

After this PR:

```js
(counts[match[1]] ??= 0), counts[match[1]] = max(counts[match[1]], parseInt(match[2], 10))
```

This mainly involved swapping the order of "pull out inner assignments" (which now goes first) and "handle identifier= assignment" (which now goes second). But this required rewriting some code that previously overwrote `children` from scratch, but now has to handle the case that there were some additional assignments at the front or back of `children` (via appropriate `splice`).

I also ran into a subtle bug in pipes, specifically `x |>= y |> z` where the `|>=` set `children` one way and then `|>` reset it so that `children` no longer had `lhs` in it.  I'm not sure why the test passed before, but the `if (i === 0)` at least seems necessary with the new code that processes the assignment further.