### PR TITLE
Fix export functions getting implicit empty blocks

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4132,15 +4132,15 @@ ImportedBinding
 # https://262.ecma-international.org/#prod-ExportDeclaration
 ExportDeclaration
   # NOTE: Using ExtendedExportDeclaration to allow If/Switch expressions
-  Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / ExtendedExpression ) ->
-    return { type: "ExportDeclaration", children: $0 }
+  Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / ExtendedExpression ):declaration ->
+    return { type: "ExportDeclaration", declaration, children: $0 }
   Export __ ExportFromClause __ FromClause ->
     return { type: "ExportDeclaration", ts: $3.ts, children: $0 }
   # NOTE: Declaration and VariableStatement should come before NamedExports
   # so that NamedExports doesn't grab function, async, type, var, etc.
   # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
-  Decorators? Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):decl ->
-    return { type: "ExportDeclaration", ts: decl.ts, children: $0 }
+  Decorators? Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
+    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
 
 # CoffeeScript style `export x = 3` -> `export var x = 3`
 ExportVarDec

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -267,6 +267,16 @@ describe "[TS] function", ->
   """
 
   testCase """
+    export overload has no implicit body
+    ---
+    export function noop(a: number, b: number): void
+    export function noop(a: string, b: string): void
+    ---
+    export function noop(a: number, b: number): void
+    export function noop(a: string, b: string): void
+  """
+
+  testCase """
     overloads
     ---
     function add(a: number, b: number): number


### PR DESCRIPTION
Fixes #591 introduced by #542: exported functions should never get an implicit empty block.

Also refactored some ancestor finding code. (At some point I used the refactored code for this purpose, but then realized I didn't really need to recurse, only check parent. Still, should be useful for more hoisting later.)