### PR TITLE
`switch` fixes

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2443,11 +2443,15 @@ ComputedPropertyName
       type: "ComputedPropertyName",
       children: $0,
       expression,
+      implicit: true,
     }
   InsertOpenBracket "-" NumericLiteral InsertCloseBracket ->
+    const expression = [ $2, $3 ]
     return {
       type: "ComputedPropertyName",
-      children: $0,
+      expression,
+      children: [ $1, expression, $4 ],
+      implicit: true,
     }
 
 Decorator
@@ -3669,6 +3673,7 @@ CaseExpression
   # an object literal, but treat `case [foo]:` like an array literal
   PropertyName:value &( _? Colon ) ->
     if (value.type === "ComputedPropertyName") {
+      if (value.implicit) return value.expression
       return {...value, type: "ArrayExpression"}
     }
     return value

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1687,7 +1687,7 @@ ImplicitNestedBlock
       bare: false,
     }
 
-# NOTE: This is the body of if/else/for/case etc.
+# NOTE: This is the body of if/else/for/when etc.
 Block
   # NOTE: Added indentation based implied braces
   ImplicitNestedBlock
@@ -1705,6 +1705,33 @@ Block
       children: [expressions],
       bare: true,
     }
+
+BareNestedBlock
+  # NOTE: Check &EOS needed by eventual PushIndent to skip work if not needed
+  &EOS AllowAll NestedBlockStatements? RestoreAll ->
+    if (!$3) return $skip
+    return $3
+
+# NOTE: This is the body of a case, where no braces are necessary.
+# Essentially `Block` but with ImplicitNestedBlock replaced by BareNestedBlock,
+# and allowing EmptyBareBlock.
+BareBlock
+  BareNestedBlock
+  # NOTE: Explicit block after implicit block so that a properly indented `{}`
+  # gets treated like an object literal, not an empty block.
+  ExplicitBlock
+
+  ThenClause
+  # NOTE: !EOS prevents capturing a following unindented Statement
+  _?:ws !EOS Statement:s ->
+    const expressions = [[ws, s]]
+    return {
+      type: "BlockStatement",
+      expressions,
+      children: [expressions],
+      bare: true,
+    }
+  EmptyBareBlock
 
 ThenClause
   Then SingleLineStatements -> $2
@@ -3575,19 +3602,19 @@ NestedCaseClause
 
 # https://262.ecma-international.org/#prod-CaseClause
 CaseClause
-  PatternExpressionList:patterns ( ThenClause / NestedBlockStatements / EmptyBareBlock ):block ->
+  PatternExpressionList:patterns ( ThenClause / BareBlock ):block ->
     return {
       type: "PatternClause",
       children: $0,
       block,
       patterns,
     }
-  Case CaseExpressionList ( NestedBlockStatements / EmptyBareBlock ) -> {
+  Case CaseExpressionList IgnoreColon ( ThenClause / BareBlock ) -> {
     type: "CaseClause",
     children: $0
   }
   # NOTE: Added "when" from CoffeeScript. `when` always inserts `break;`.
-  When CaseExpressionList:cases InsertOpenBrace ( ThenClause / NestedBlockStatements / EmptyBareBlock ):block InsertBreak:b InsertNewline InsertIndent InsertCloseBrace ->
+  When CaseExpressionList:cases IgnoreColon InsertOpenBrace ( ThenClause / BareBlock ):block InsertBreak:b InsertNewline InsertIndent InsertCloseBrace ->
     return {
       type: "WhenClause",
       cases,
@@ -3596,8 +3623,7 @@ CaseClause
       children: $0,
     }
   # NOTE: Merged in default clause
-  # NOTE: Matching NestedBlockStatements before Block to avoid braces
-  Default ImpliedColon ( NestedBlockStatements / Block ):block ->
+  Default ImpliedColon ( ThenClause / BareBlock):block ->
     return {
       type: "DefaultClause",
       block,
@@ -3625,7 +3651,7 @@ ConditionFragment
     }
 
 CaseExpressionList
-  ForbidMultiLineImplicitObjectLiteral ( _* ExpressionWithObjectApplicationForbidden ImpliedColon )?:first ( __ Comma ExpressionWithObjectApplicationForbidden ImpliedColon )*:rest RestoreMultiLineImplicitObjectLiteral ->
+  ForbidMultiLineImplicitObjectLiteral ( _? ExpressionWithObjectApplicationForbidden InsertColon )?:first ( __ Comma ExpressionWithObjectApplicationForbidden InsertColon )*:rest RestoreMultiLineImplicitObjectLiteral ->
     if (!first) return $skip
     // Convert comma separated expression list to `case <exp>:`
     const result = rest.map(([ws, _comma, exp, col]) => {
@@ -3640,8 +3666,12 @@ CaseExpressionList
 
 ImpliedColon
   _? Colon
-  "" ->
-    return { $loc, token: ":" }
+  InsertColon
+
+# Optionally match Colon and throw it away
+IgnoreColon
+  ( _? Colon )? ->
+    if ($1) return $1[0]
 
 # https://262.ecma-international.org/#prod-TryStatement
 TryStatement
@@ -6207,6 +6237,10 @@ DebugHere
     debugger
 
 # Insertions
+
+InsertColon
+  "" ->
+    return { $loc, token: ":" }
 
 InsertSemicolon
   "" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3666,8 +3666,12 @@ CaseExpressionList
 
 CaseExpression
   # NOTE: Explicitly matching `case foo:` to prevent this from looking like
-  # an object literal
-  PropertyName &( _? Colon ) -> $1
+  # an object literal, but treat `case [foo]:` like an array literal
+  PropertyName:value &( _? Colon ) ->
+    if (value.type === "ComputedPropertyName") {
+      return {...value, type: "ArrayExpression"}
+    }
+    return value
   ExpressionWithObjectApplicationForbidden
 
 ImpliedColon

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3651,7 +3651,7 @@ ConditionFragment
     }
 
 CaseExpressionList
-  ForbidMultiLineImplicitObjectLiteral ( _? ExpressionWithObjectApplicationForbidden InsertColon )?:first ( __ Comma ExpressionWithObjectApplicationForbidden InsertColon )*:rest RestoreMultiLineImplicitObjectLiteral ->
+  ForbidMultiLineImplicitObjectLiteral ( _? CaseExpression InsertColon )?:first ( __ Comma CaseExpression InsertColon )*:rest RestoreMultiLineImplicitObjectLiteral ->
     if (!first) return $skip
     // Convert comma separated expression list to `case <exp>:`
     const result = rest.map(([ws, _comma, exp, col]) => {
@@ -3663,6 +3663,12 @@ CaseExpressionList
     result./**/unshift(first)
 
     return result
+
+CaseExpression
+  # NOTE: Explicitly matching `case foo:` to prevent this from looking like
+  # an object literal
+  PropertyName &( _? Colon ) -> $1
+  ExpressionWithObjectApplicationForbidden
 
 ImpliedColon
   _? Colon

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3596,7 +3596,8 @@ CaseClause
       children: $0,
     }
   # NOTE: Merged in default clause
-  Default ImpliedColon ( NestedBlockStatements / EmptyBareBlock ):block ->
+  # NOTE: Matching NestedBlockStatements before Block to avoid braces
+  Default ImpliedColon ( NestedBlockStatements / Block ):block ->
     return {
       type: "DefaultClause",
       block,

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -16,6 +16,18 @@ describe "switch", ->
   """
 
   testCase """
+    same line
+    ---
+    switch (x) {
+      case 1: break
+    }
+    ---
+    switch (x) {
+      case 1: break
+    }
+  """
+
+  testCase """
     optional parens
     ---
     switch x {
@@ -72,11 +84,27 @@ describe "switch", ->
   """
 
   testCase """
-    multiple cases
+    multiple cases with colon
     ---
     switch (x) {
       case 1:
       case 2:
+        break
+    }
+    ---
+    switch (x) {
+      case 1:
+      case 2:
+        break
+    }
+  """
+
+  testCase """
+    multiple cases without colon
+    ---
+    switch (x) {
+      case 1
+      case 2
         break
     }
     ---

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -102,6 +102,18 @@ describe "switch", ->
   """
 
   testCase """
+    default one-liner
+    ---
+    switch (x) {
+      default break
+    }
+    ---
+    switch (x) {
+      default: break
+    }
+  """
+
+  testCase """
     else
     ---
     switch (x) {
@@ -113,6 +125,18 @@ describe "switch", ->
       default: {
         break
       }
+    }
+  """
+
+  testCase """
+    else one-liner
+    ---
+    switch (x) {
+      else break
+    }
+    ---
+    switch (x) {
+      default: { break }
     }
   """
 

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -84,6 +84,33 @@ describe "switch", ->
   """
 
   testCase """
+    case doesn't allow object literal, same line
+    ---
+    switch x
+      case 1: 2
+    ---
+    switch(x) {
+      case 1: 2
+    }
+  """
+
+  // #593
+  testCase """
+    case doesn't allow object literal with object literal
+    ---
+    switch x
+      case 1: {
+        console.log('hello')
+      }
+    ---
+    switch(x) {
+      case 1: {
+        console.log('hello')
+      }
+    }
+  """
+
+  testCase """
     multiple cases with colon
     ---
     switch (x) {

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -122,6 +122,19 @@ describe "switch", ->
   """
 
   testCase """
+    implicit computed property isn't a computed property
+    ---
+    switch x
+      case `hi ${y}`: y
+      case -5: 5
+    ---
+    switch(x) {
+      case `hi ${y}`: y
+      case -5: 5
+    }
+  """
+
+  testCase """
     multiple cases with colon
     ---
     switch (x) {

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -111,6 +111,17 @@ describe "switch", ->
   """
 
   testCase """
+    case matching array isn't a computed property
+    ---
+    switch x
+      case [1]: 2
+    ---
+    switch(x) {
+      case [1]: 2
+    }
+  """
+
+  testCase """
     multiple cases with colon
     ---
     switch (x) {


### PR DESCRIPTION
* Allow same-line bodies after `case ...:` and `default` (`else` already worked)
* No longer allow `case 1:, 2:` (which seems pretty weird)
* Fix #593 by forbidding same-line object literals too
* New `InsertColon`, `IgnoreColon`, and `BareBlock` rules

Thanks to the `CaseExpression → PropertyName &Colon` rule for #593, all tests now pass if we remove `ForbidMultiLineImplicitObjectLiteral`/`RestoreMultiLineImplicitObjectLiteral` from the `CaseExpressionList` rule. This is the only place this rule is used. Can you think of another context where it would be useful, or should I remove the entire `ForbidMultiLineImplicitObjectLiteral` mechanism?