### PR TITLE
autoVar/autoLet should treat `=>` and methods same as functions

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -2669,7 +2669,7 @@ function createVarDecs(statements, scopes, pushVar) {
     if (!hasDec(x)) return a.indexOf(x) === i
   }).forEach(pushVar)
 
-  const fnNodes = gatherNodes(statements, (s) => s.type === "FunctionExpression")
+  const fnNodes = gatherNodes(statements, isFunction)
   const forNodes = gatherNodes(statements, (s) => s.type === "ForStatement")
 
   const blockNodes = new Set(gatherNodes(statements, (s) => s.type === "BlockStatement"))

--- a/source/lib.js
+++ b/source/lib.js
@@ -2747,7 +2747,7 @@ function createLetDecs(statements, scopes) {
   let currentScope = new Set()
   scopes.push(currentScope)
 
-  const fnNodes = gatherNodes(statements, (s) => s.type === "FunctionExpression")
+  const fnNodes = gatherNodes(statements, isFunction)
   const forNodes = gatherNodes(statements, (s) => s.type === "ForStatement")
 
   let targetStatements = []

--- a/test/auto-let.civet
+++ b/test/auto-let.civet
@@ -324,6 +324,63 @@ describe "auto-let", ->
   """
 
   testCase """
+    nested arrow function
+    ---
+    "civet auto-let"
+    x = 1
+    a = =>
+      x = 2
+      y = 1
+      b = =>
+        x = 3
+        y = 2
+        z = 1
+    ---
+    let x = 1
+    let a = () => {
+      x = 2
+      let y = 1
+      let b
+      return b = () => {
+        x = 3
+        y = 2
+        let z
+        return z = 1
+      }
+    }
+  """
+
+  testCase """
+    nested methods
+    ---
+    "civet auto-let"
+    x = 1
+    {a()
+      x = 2
+      y = 1
+      {b()
+        x = 3
+        y = 2
+        z = 1
+      }
+    }
+    ---
+    let x = 1;
+    ({a() {
+      x = 2
+      let y = 1;
+      return ({b() {
+        x = 3
+        y = 2
+        let z
+        return z = 1
+      }
+      })
+    }
+    })
+  """
+
+  testCase """
     function with parameters
     ---
     "civet auto-let"

--- a/test/compat/auto-var.civet
+++ b/test/compat/auto-var.civet
@@ -322,6 +322,66 @@ describe "auto-var", ->
   """
 
   testCase """
+    nested arrow function
+    ---
+    "civet auto-var"
+    x = 1
+    a = =>
+      x = 2
+      y = 1
+      b = =>
+        x = 3
+        y = 2
+        z = 1
+    ---
+    var x, a;
+    x = 1
+    a = () => {
+      var y, b;
+      x = 2
+      y = 1
+      return b = () => {
+        var z;
+        x = 3
+        y = 2
+        return z = 1
+      }
+    }
+  """
+
+  testCase """
+    nested methods
+    ---
+    "civet auto-var"
+    x = 1
+    {a()
+      x = 2
+      y = 1
+      {b()
+        x = 3
+        y = 2
+        z = 1
+      }
+    }
+    ---
+    var x;
+    x = 1;
+    ({a() {
+      var y;
+      x = 2
+      y = 1;
+      return ({b() {
+        var z;
+        x = 3
+        y = 2
+        return z = 1
+      }
+      })
+    }
+    })
+  """
+
+  testCase """
     sibling function declaration with nested block in first function
     ---
     "civet auto-var"


### PR DESCRIPTION
Fixes #588