### PR TITLE
Possessive object access

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -166,13 +166,22 @@ To specify a blank body, use `;` or `{}`.
 
 :::
 
-### Property Access Shorthand
+### Property Access
+
+Many more values can appear after a `.` to access an object property:
 
 <Playground>
 json.'long property'
 json.`${movie} name`
 matrix.0.0
 array.-1
+</Playground>
+
+You can also write property access as an English possessive:
+
+<Playground>
+mario's brother's name
+json's "long property"'s `${movie} name`
 </Playground>
 
 ## Arrays

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -168,7 +168,7 @@ To specify a blank body, use `;` or `{}`.
 
 ### Property Access
 
-Many more values can appear after a `.` to access an object property:
+Many more literals can appear after a `.` to access an object property:
 
 <Playground>
 json.'long property'
@@ -181,6 +181,7 @@ You can also write property access as an English possessive:
 
 <Playground>
 mario's brother's name
+mario?'s name
 json's "long property"'s `${movie} name`
 </Playground>
 

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -177,7 +177,8 @@ matrix.0.0
 array.-1
 </Playground>
 
-You can also write property access as an English possessive:
+You can also write property access as an English possessive
+(inspired by [_hyperscript](https://hyperscript.org/expressions/possessive/)):
 
 <Playground>
 mario's brother's name

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -925,6 +925,8 @@ MemberBracketContent
 
   # NOTE: Added shorthand x."string" -> x["string"]
   Dot:dot ( TemplateLiteral / StringLiteral ):str ->
+    // Possessive dots are arrays where the first item is the dot
+    if (Array.isArray(dot)) dot = dot[0]
     return {
       type: "Index",
       children: [
@@ -936,6 +938,8 @@ MemberBracketContent
 
   # NOTE: Added shorthand x.3 -> x[3]
   Dot:dot IntegerLiteral:num ->
+    // Possessive dots are arrays where the first item is the dot
+    if (Array.isArray(dot)) dot = dot[0]
     return {
       type: "Index",
       children: [
@@ -4849,6 +4853,12 @@ Do
 Dot
   "." ->
     return { $loc, token: $1 }
+  # English possessive
+  /['’]s/ _:ws ->
+    return [
+      { $loc, token: "." },
+      insertTrimmingSpace(ws, ""),
+    ]
 
 DotDot
   ".." !"." ->

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "property access", ->
   testCase """
@@ -289,4 +289,57 @@ describe "property access", ->
       f @@x
       ---
       f(this.x.bind(this))
+    """
+
+  describe "possessive form", ->
+    testCase """
+      's
+      ---
+      mario's brother's name
+      ---
+      mario.brother.name
+    """
+
+    testCase """
+      ’s
+      ---
+      mario’s brother’s name
+      ---
+      mario.brother.name
+    """
+
+    testCase """
+      lhs
+      ---
+      mario’s name = 'mario'
+      ---
+      mario.name = 'mario'
+    """
+
+    testCase """
+      comments
+      ---
+      mario's /*real*/ name
+      ---
+      mario./*real*/ name
+    """
+
+    testCase """
+      quotes and numbers
+      ---
+      json's "long property"'s `${movie} name`'s -1's 0
+      ---
+      json["long property"][`${movie} name`].at(-1)[0]
+    """
+
+    throws """
+      needs space
+      ---
+      mario'sname
+    """
+
+    throws """
+      invalid start to template string
+      ---
+      mario's s'
     """

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -325,6 +325,14 @@ describe "property access", ->
     """
 
     testCase """
+      optional
+      ---
+      mario?'s name
+      ---
+      mario?.name
+    """
+
+    testCase """
       quotes and numbers
       ---
       json's "long property"'s `${movie} name`'s -1's 0


### PR DESCRIPTION
Inspired by [this tweet](https://twitter.com/judofyr/status/1685580152565055488), [this follow-up thread](https://twitter.com/nicuveo/status/1685745407421284352), and [_hyperscript](https://hyperscript.org/expressions/possessive/), via Discord: `'s` followed by whitespace simulates `.`.

```js
mario's brother's name
↓↓↓
mario.brother.name
```

In Unicode, `’s` works too.

I think there are contexts (such as the example above) where this improves readability of code, so seems like a generally good thing. Of course, this might deserve some discussion about whether this feature is a good idea.

The one thing this breaks is template strings starting with `foo's `. Previously, `foo's s'` compiled to ``foo`s s` ``. My sense is that this is not a big deal though; single-quoted template strings (which can't have any interpolation) seems like a bit of a niche feature already (though natural and inherited from CoffeeScript), and starting one with `s` and a space feels especially unusual.

I experimented with adding Japanese possessive form, as in `marioのbrotherのname` (mentioned in the [the follow-up thread](https://twitter.com/nicuveo/status/1685745407421284352)) which would be kind of cool, but it's also kind of breaking: currently `marioのbrotherのname` parses as a single identifier, and I imagine it does in most programming languages, so perhaps Japanese authors use this when naming their variables.  (I kind of want to now...)  We could support a spaced form such as `mario の brother の name`, though that could also be considered an implicit function call to `の`, and I don't think it is very grammatical in Japanese (normally there are no spaces around `の`). So in the end I decided not to pursue this.