### PR TITLE
Implicit returns of (last) declaration

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -1699,7 +1699,7 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
   splices = splices.map(s => [", ", s])
   thisAssignments = thisAssignments.map(a => ["", a, ";"])
 
-  const initializer = [assign, e]
+  const initializer = [ws, assign, e]
   const binding = {
     type: "Binding",
     pattern: id,
@@ -1707,7 +1707,7 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
     splices,
     suffix,
     thisAssignments,
-    children: [id, suffix, ...ws, initializer]
+    children: [id, suffix, initializer]
   }
 
   const children = [decl, binding]

--- a/source/lib.js
+++ b/source/lib.js
@@ -1115,7 +1115,12 @@ function insertReturn(node) {
     case "EmptyStatement":
     case "ReturnStatement":
     case "ThrowStatement":
+      return
     case "Declaration":
+      exp.children.push(["", {
+        type: "ReturnStatement",
+        children: [";return ", exp.names.at(-1)],
+      }])
       return
     case "ForStatement":
     case "IterationStatement":

--- a/source/lib.js
+++ b/source/lib.js
@@ -722,7 +722,9 @@ function insertPush(node, ref) {
     case "EmptyStatement":
     case "ReturnStatement":
     case "ThrowStatement":
+      return
     case "Declaration":
+      exp.children.push(["", [";", ref, ".push(", exp.names.at(-1), ")"]])
       return
     case "ForStatement":
     case "IterationStatement":

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1304,17 +1304,17 @@ BindingProperty
   # NOTE: Must be checked first to pick up trailing "..." form
   BindingRestProperty
 
-  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value Initializer?:init ->
+  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value Initializer?:initializer ->
     return {
       type: "BindingProperty",
       children: $0,
       name,
       value,
-      init,
+      initializer,
       names: value.names,
     }
 
-  _?:ws "^"?:pin BindingIdentifier:binding Initializer?:init ->
+  _?:ws "^"?:pin BindingIdentifier:binding Initializer?:initializer ->
     // TODO make this work with pin
     if (binding.type === "AtBinding") {
       return {
@@ -1322,7 +1322,7 @@ BindingProperty
         children: $0,
         binding,
         ref: binding.ref,
-        init,
+        initializer,
         names: [],
       }
     }
@@ -1344,7 +1344,7 @@ BindingProperty
       children: $0,
       name: binding,
       value: undefined,
-      init,
+      initializer,
       names: binding.names,
       identifier: binding,
     }
@@ -5912,11 +5912,11 @@ EnumDeclaration
           ["let ", id, " = {};\n"],
           ...block.properties.map((property, i) => {
             let init, isString
-            if (property.init) {
+            if (property.initializer) {
               // Replace references to other enum members.
               // TS further restricts this to past enum members,
               // but we don't need to enforce that here.
-              init = replaceNodes(deepCopy(property.init),
+              init = replaceNodes(deepCopy(property.initializer),
                 n => n.type === "Identifier" && names.has(n.name),
                 n => [id, '["', n.name, '"]'])
               const value = init[init.length - 1]
@@ -5979,11 +5979,11 @@ NestedEnumProperty
     }
 
 EnumProperty
-  Identifier:name ( __ Equals ExtendedExpression )?:init ObjectPropertyDelimiter ->
+  Identifier:name ( __ Equals ExtendedExpression )?:initializer ObjectPropertyDelimiter ->
     return {
       type: "EnumProperty",
       name,
-      init,
+      initializer,
       children: $0,
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1212,7 +1212,7 @@ ObjectBindingPattern
   _? OpenBrace ObjectBindingPatternContent:c __ CloseBrace ->
     return {
       type: "ObjectBindingPattern",
-      children: $0,
+      children: [$1, $2, c.children, $4, $5],
       names: c.names,
       properties: c.children,
     }
@@ -1230,6 +1230,7 @@ BindingPropertyList
     return props.map(([prop, delim]) => {
       return {
         ...prop,
+        delim,
         children: [...prop.children, delim],
       }
     })
@@ -1239,11 +1240,10 @@ BindingPropertyList
 ArrayBindingPattern
   _? OpenBracket ArrayBindingPatternContent:c __ CloseBracket ->
     return {
+      ...c, // names, blockPrefix, length
       type: "ArrayBindingPattern",
-      children: $0,
-      names: c.names,
       elements: c.children,
-      length: c.length,
+      children: [$1, $2, c.children, $4, $5],
     }
 
 ArrayBindingPatternContent
@@ -1254,23 +1254,25 @@ ArrayBindingPatternContent
 
     return adjustBindingElements(elements)
 
+# children is an array of tuples of the form [ws, element, delim]
 BindingElementList
   ( BindingElement ArrayElementDelimiter )+:elements ->
     return elements.map(([element, delim]) => {
       return {
         ...element,
+        // BindingElement.children is a tuple of the form [ws, element]
         children: [...element.children, delim],
       }
     })
 
 NestedBindingElementList
-  Nested:ws BindingElementList:elements ->
+  Nested:indent BindingElementList:elements ->
     // Attach whitespace to first element
     return elements.map( (element, i) => {
       if (i > 0) return element
       return {
         ...element,
-        children: [ws, ...element.children],
+        children: [indent, ...element.children.slice(1)], // replace ws wth indent
       }
     })
 
@@ -1368,16 +1370,12 @@ NestedBindingElements
   PushIndent NestedBindingElementList*:elements PopIndent ->
     if (!elements.length) return $skip
 
+    // Each item of elements is a list of BindingElements;
+    // combine into one big array
     return adjustBindingElements(elements.flat())
 
-NestedBindingElement
-  Nested:indent BindingElement:element ->
-    return {
-      ...element,
-      children: [indent, ...element.children],
-    }
-
 # https://262.ecma-international.org/#prod-BindingElement
+# children is an array of tuples of the form [ws, element]
 BindingElement
   BindingRestElement
 
@@ -1388,6 +1386,7 @@ BindingElement
     if (binding.children) {
       binding = {
         ...binding,
+        initializer,
         children: [...binding.children, initializer],
       }
     }
@@ -1412,7 +1411,7 @@ BindingRestElement
   _?:ws DotDotDot:dots ( BindingIdentifier / BindingPattern / EmptyBindingPattern ):binding ->
     return {
       type: "BindingRestElement",
-      children: [...(ws || []), dots, binding],
+      children: [ws, [dots, binding]],
       binding,
       name: binding.name,
       names: binding.names,
@@ -4295,7 +4294,6 @@ HoistableDeclaration
 LexicalDeclaration
   # NOTE: Eliminated left recursion
   LetOrConst:decl LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
-    const { splices, thisAssignments } = binding
     const bindings = [binding].concat(tail.map(([,,,b]) => b))
 
     return {
@@ -4304,8 +4302,8 @@ LexicalDeclaration
       names: bindings.flatMap(b => b.names),
       bindings,
       decl,
-      splices,
-      thisAssignments,
+      splices: bindings.flatMap(b => b.splices),
+      thisAssignments: bindings.flatMap(b => b.thisAssignments),
     }
   # NOTE: Added const shorthand
   # NOTE: Using ExtendedExpression to allow for If/SwitchExpressions
@@ -4328,7 +4326,7 @@ LetAssignment
 # merged with https://262.ecma-international.org/#prod-VariableDeclaration
 LexicalBinding
   BindingPattern:pattern TypeSuffix?:suffix Initializer:initializer ->
-    const [splices, thisAssignments] = gatherBindingCode(pattern.children)
+    const [splices, thisAssignments] = gatherBindingCode(pattern)
 
     return {
       type: "Binding",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -32,8 +32,7 @@ const {
   processBinaryOpExpression,
   processCallMemberExpression,
   processCoffeeInterpolation,
-  processConstAssignmentDeclaration,
-  processLetAssignmentDeclaration,
+  processAssignmentDeclaration,
   processProgram,
   processUnaryExpression,
   quoteString,
@@ -3824,18 +3823,21 @@ DeclarationCondition
       base: "ref",
     }
 
-    const { binding, initializer, splices, thisAssignments } = dec
+    const { decl, bindings, suffix } = dec
+    // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
+    const binding = bindings[0]
+    const { pattern, initializer, splices, thisAssignments } = binding
 
     const initCondition = {
       type: "AssignmentExpression",
-      children: [ref, " ", initializer],
+      children: [ref, (getTrimmingSpace(initializer) ? "" : " "), initializer],
       hoistDec: {
         type: "Declaration",
         children: ["let ", ref],
         names: [],
       },
       blockPrefix: [
-        ["", [ binding, "= ", ref, ...splices ], ";"],
+        ["", [ decl, pattern, " = ", ref, ...splices ], ";"],
         ...thisAssignments
       ],
     }
@@ -4292,30 +4294,27 @@ HoistableDeclaration
 # https://262.ecma-international.org/#prod-LexicalDeclaration
 LexicalDeclaration
   # NOTE: Eliminated left recursion
-  # TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
-  LetOrConst:d LexicalBinding:binding ( __ Comma LexicalBinding )*:tail ->
+  LetOrConst:decl LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
     const { splices, thisAssignments } = binding
+    const bindings = [binding].concat(tail.map(([,,,b]) => b))
 
     return {
       type: "Declaration",
       children: $0,
-      names: [...binding.names].concat(tail.flatMap(([,,b]) => b.names)),
-      binding: {
-        ...binding.binding,
-        children: [d, ...binding.binding.children],
-      },
-      initializer: binding.initializer,
+      names: bindings.flatMap(b => b.names),
+      bindings,
+      decl,
       splices,
       thisAssignments,
     }
   # NOTE: Added const shorthand
   # NOTE: Using ExtendedExpression to allow for If/SwitchExpressions
   InsertConst ( BindingPattern / BindingIdentifier ) TypeSuffix? __ ConstAssignment ExtendedExpression ->
-    return processConstAssignmentDeclaration(...$0)
+    return processAssignmentDeclaration(...$0)
 
   # Note added let shorthand
   InsertLet:l ( BindingPattern / BindingIdentifier ):id TypeSuffix?:suffix __:ws LetAssignment:la ExtendedExpression:e ->
-    return processLetAssignmentDeclaration(...$0)
+    return processAssignmentDeclaration(...$0)
 
 ConstAssignment
   ":=" / "≔" ->
@@ -4326,40 +4325,29 @@ LetAssignment
     return { $loc, token: "=" }
 
 # https://262.ecma-international.org/#prod-LexicalBinding
+# merged with https://262.ecma-international.org/#prod-VariableDeclaration
 LexicalBinding
-  BindingPattern:binding TypeSuffix?:suffix _?:ws Initializer:initializer ->
-    const bindingChildren = [...binding.children]
-    if (suffix) bindingChildren.push(suffix)
-    if (ws) bindingChildren.push(...ws)
-    binding = {
-      ...binding,
-      children: bindingChildren,
-    }
-
-    const [splices, thisAssignments] = gatherBindingCode(binding.children)
+  BindingPattern:pattern TypeSuffix?:suffix Initializer:initializer ->
+    const [splices, thisAssignments] = gatherBindingCode(pattern.children)
 
     return {
-      children: [binding, initializer],
-      names: binding.names,
-      binding,
+      type: "Binding",
+      children: $0,
+      names: pattern.names,
+      pattern,
+      suffix,
       initializer,
       splices: splices.map(s => [",", s]),
       thisAssignments: thisAssignments.map(s => ["", s, ";"]),
     }
 
-  BindingIdentifier:binding TypeSuffix?:suffix _?:ws Initializer?:initializer ->
-    const bindingChildren = [...binding.children]
-    if (suffix) bindingChildren.push(suffix)
-    if (ws) bindingChildren.push(...ws)
-    binding = {
-      ...binding,
-      children: bindingChildren,
-    }
-
+  BindingIdentifier:pattern TypeSuffix?:suffix Initializer?:initializer ->
     return {
-      children: [binding, initializer],
-      names: binding.names,
-      binding,
+      type: "Binding",
+      children: $0,
+      names: pattern.names,
+      pattern,
+      suffix,
       initializer,
       splices: [],
       thisAssignments: [],
@@ -4380,40 +4368,14 @@ VariableStatement
 
 # https://262.ecma-international.org/#prod-VariableDeclarationList
 VariableDeclarationList
-  VariableDeclaration ( __ Comma __ VariableDeclaration )* ->
-    let children
-    let names = $1.names
-    if ($2.length) {
-      children = [$1, ...$2]
-      names = names.concat($2.flatMap(([, , , d]) => d.names))
-    }else {
-      children = [$1]
-    }
+  LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
+    const bindings = [binding].concat(tail.map(([,,,b]) => b))
 
     return {
       type: "Declaration",
-      children,
-      names,
-    }
-
-# https://262.ecma-international.org/#prod-VariableDeclaration
-VariableDeclaration
-  BindingPattern TypeSuffix? Initializer ->
-    const children = [...$1.children]
-    if ($2) children./**/push($2)
-    children./**/push($3)
-    return {
-      children,
-      names: $1.names,
-    }
-
-  BindingIdentifier TypeSuffix? Initializer? ->
-    const children = [...$1.children]
-    if ($2) children./**/push($2)
-    if ($3) children./**/push($3)
-    return {
-      children,
-      names: $1.names,
+      children: [binding, ...tail],
+      bindings,
+      names: bindings.flatMap(b => b.names),
     }
 
 # https://262.ecma-international.org/#prod-NumericLiteral

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4373,21 +4373,22 @@ Initializer
 # https://262.ecma-international.org/#prod-VariableStatement
 VariableStatement
   Var __ VariableDeclarationList ->
-    return Object.assign({}, $3, {
+    return {
+      ...$3,
       children: [$1, ...$2, ...$3.children],
-    })
+    }
 
 # https://262.ecma-international.org/#prod-VariableDeclarationList
 VariableDeclarationList
   VariableDeclaration ( __ Comma __ VariableDeclaration )* ->
     let children
+    let names = $1.names
     if ($2.length) {
       children = [$1, ...$2]
+      names = names.concat($2.flatMap(([, , , d]) => d.names))
     }else {
       children = [$1]
     }
-
-    const names = children.flatMap((c) => c.names || [])
 
     return {
       type: "Declaration",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3823,21 +3823,21 @@ DeclarationCondition
       base: "ref",
     }
 
-    const { decl, bindings, suffix } = dec
+    const { decl, bindings } = dec
     // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
     const binding = bindings[0]
-    const { pattern, initializer, splices, thisAssignments } = binding
+    const { pattern, suffix, initializer, splices, thisAssignments } = binding
 
     const initCondition = {
       type: "AssignmentExpression",
-      children: [ref, (getTrimmingSpace(initializer) ? "" : " "), initializer],
+      children: [ref, initializer],
       hoistDec: {
         type: "Declaration",
-        children: ["let ", ref],
+        children: ["let ", ref, suffix],
         names: [],
       },
       blockPrefix: [
-        ["", [ decl, pattern, " = ", ref, ...splices ], ";"],
+        ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
         ...thisAssignments
       ],
     }

--- a/test/auto-let.civet
+++ b/test/auto-let.civet
@@ -501,7 +501,7 @@ describe "complicated auto-let", ->
         let b = 1
         function b(a) {
             a = 1
-            var b = 2
+            var b = 2;return b
         }
         let a = 2
         let c = (b) => {

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -279,7 +279,7 @@ describe "examples (from real life)", ->
 
     changeNumbers := ->
       inner := 1
-      outer := 10
+      outer := 10;
 
     inner = "1"
     ---
@@ -287,7 +287,7 @@ describe "examples (from real life)", ->
 
     function changeNumbers () {
       const inner = 1
-      const outer = 10
+      const outer = 10;
     }
 
     inner = "1"
@@ -324,7 +324,7 @@ describe "examples (from real life)", ->
     }
 
     function resolveModuleNames (moduleNames: string[], containingFile: string) {
-      const resolvedModules = []
+      const resolvedModules = [];return resolvedModules
     }
   """
 
@@ -373,7 +373,7 @@ describe "examples (from real life)", ->
       const reDefs: string[] = []
       /** heyy
       */
-      const x = 3
+      const x = 3;return x
     })
   """
 

--- a/test/function.civet
+++ b/test/function.civet
@@ -966,6 +966,20 @@ describe "function", ->
     """
 
     testCase """
+      loop with assignment
+      ---
+      (x) ->
+        loop
+          y := x
+      ---
+      (function(x) {
+        const results=[];while(true) {
+          const y = x;results.push(y)
+        };return results;
+      })
+    """
+
+    testCase """
       while
       ---
       (x) ->

--- a/test/function.civet
+++ b/test/function.civet
@@ -504,7 +504,7 @@ describe "function", ->
     }
     ---
     function f() {
-      var x = 3
+      var x = 3;return x
     }
   """
 
@@ -759,7 +759,7 @@ describe "function", ->
       { parentURL = baseURL } := context
     ---
     export function resolve(specifier: string, context: any, next: any) {
-      const { parentURL = baseURL } = context
+      const { parentURL = baseURL } = context;return parentURL
     }
   """
 
@@ -817,6 +817,17 @@ describe "function", ->
       ---
       (function(x) {
         x;
+      })
+    """
+
+    testCase """
+      declaration with semicolon
+      ---
+      (x) ->
+        var x = 5;
+      ---
+      (function(x) {
+        var x = 5;
       })
     """
 
@@ -1101,7 +1112,7 @@ describe "function", ->
         a := x
       ---
       (function(x) {
-        const a = x
+        const a = x;return a
       })
     """
 
@@ -1109,10 +1120,10 @@ describe "function", ->
       const declaration
       ---
       (x) ->
-        const a = 3
+        const a = 3, b = 4
       ---
       (function(x) {
-        const a = 3
+        const a = 3, b = 4;return b
       })
     """
 
@@ -1120,10 +1131,10 @@ describe "function", ->
       var declaration
       ---
       (x) ->
-        var a = 3
+        var a = 3, b = 4
       ---
       (function(x) {
-        var a = 3
+        var a = 3, b = 4;return b
       })
     """
 
@@ -1131,10 +1142,10 @@ describe "function", ->
       let declaration
       ---
       (x) ->
-        let a = 3
+        let a = 3, b = 4
       ---
       (function(x) {
-        let a = 3
+        let a = 3, b = 4;return b
       })
     """
 

--- a/test/function.civet
+++ b/test/function.civet
@@ -759,7 +759,7 @@ describe "function", ->
       { parentURL = baseURL } := context
     ---
     export function resolve(specifier: string, context: any, next: any) {
-      const { parentURL = baseURL } = context;return parentURL
+      const { parentURL = baseURL } = context;return { parentURL }
     }
   """
 
@@ -877,6 +877,17 @@ describe "function", ->
       -> $2.implicit = $1.generated; $2;
       ---
       (function() { $2.implicit = $1.generated; $2; })
+    """
+
+    testCase """
+      complex declaration
+      ---
+      ->
+        [ { x: other, y = init, ...r, }, z = 0, ...rest ] := list
+      ---
+      (function() {
+        const [ { x: other, y = init, ...r, }, z = 0, ...rest ] = list;return [ { x, y, ...r, }, z, ...rest ]
+      })
     """
 
     describe.skip "TODO", ->

--- a/test/if.civet
+++ b/test/if.civet
@@ -670,6 +670,30 @@ describe "if", ->
     """
 
     testCase """
+      if declaration with type
+      ---
+      if m: Match := s.match(re)
+        s
+      ---
+      let ref: Match;if (ref = s.match(re)) {
+        const m: Match = ref;
+        s
+      }
+    """
+
+    testCase """
+      if declaration with comments
+      ---
+      if [_, s]/*left*/:=/*right*/s.match(re)
+        s
+      ---
+      let ref;if (ref/*left*/=/*right*/s.match(re)) {
+        const [_, s] = ref;
+        s
+      }
+    """
+
+    testCase """
       if declaration with @ rest
       ---
       if [_, ...@s] := s.match(re)

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -433,6 +433,24 @@ describe "switch", ->
     """
 
     testCase """
+      indented array pattern
+      ---
+      switch x
+        [
+          a
+          b
+          4
+        ]
+          console.log a, b
+      ---
+      if(Array.isArray(x) && x.length === 3 && x[2] === 4) {
+          const [
+          a,
+          b,] = x;
+          console.log(a, b)}
+    """
+
+    testCase """
       empty array
       ---
       switch x


### PR DESCRIPTION
In the spirit of "everything is an expression", and e.g. `if x := 5`

BREAKING CHANGE: `x := 5` now implicitly returns `x`

More complex example:

```js
->
  let x = 5, y = x
↓↓↓
function() {
  let x = 5, y = x;return y
}
```

Oren motivates it as giving a name to the return value, which helps define a semantic meaning.  It can't really have much other purpose.

I'm pretty sure I remember @STRd6 saying he preferred this behavior. Could be worth a minor version bump though given that it would break some code that uses declarations to prevent return (but this seems like bad practice).

Also fix a bug in `names` computation for `var` declarations. If we don't merge this PR, we should at least fix that.