### PR TITLE
Fix tuple-matching behavior

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6084,7 +6084,7 @@ TypeElement
   # NOTE: Match named form first, to avoid matching `foo: bar,` as Type
   # and then DotDotDot from next entry.
   __:ws ( DotDotDot __ )?:dots1 IdentifierName:name ( _? DotDotDot )?:dots2 (__ (QuestionMark _?)? Colon __):colon Type:type ->
-    const dots = dots1 || (dots2 && [dots2[1], dots2[0]] /* space at end */)
+    let dots = dots1 || (dots2 && [dots2[1], dots2[0]] /* space at end */)
     if (dots1 && dots2) {
       dots = [dots, {
         type: "Error",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6043,10 +6043,10 @@ TypeIndexedAccess
   OpenBracket Type? __ CloseBracket
 
 TypePrimary
+  _? TypeTuple
   InterfaceBlock
   _? FunctionType
   _? InlineInterfaceLiteral
-  _? TypeTuple
   _? ImportType
   _? TypeLiteral:t ->
     return {
@@ -6081,15 +6081,24 @@ TypeList
 
 TypeElement
   # NOTE: Allow for postfix splat like CoffeeScript
-  __:ws IdentifierName:name _?:space DotDotDot:dots (__ (QuestionMark _?)? Colon __):colon Type:type ->
-    return [ ws, dots, space, name, colon, type ]
-  Type:type _?:space DotDotDot:dots ->
+  # NOTE: Match named form first, to avoid matching `foo: bar,` as Type
+  # and then DotDotDot from next entry.
+  __:ws ( DotDotDot __ )?:dots1 IdentifierName:name ( _? DotDotDot )?:dots2 (__ (QuestionMark _?)? Colon __):colon Type:type ->
+    const dots = dots1 || (dots2 && [dots2[1], dots2[0]] /* space at end */)
+    if (dots1 && dots2) {
+      dots = [dots, {
+        type: "Error",
+        message: "... both before and after identifier",
+      }]
+    }
+    return [ ws, dots, name, colon, type ]
+  __ DotDotDot __ Type:type
+  Type:type ( _? DotDotDot )?:spaceDots ->
+    if (!spaceDots) return type
+    const [ space, dots ] = spaceDots
     const ws = getTrimmingSpace(type)
     if (!ws) return [ dots, space, type ]
     return [ ws, dots, space, insertTrimmingSpace(type, '') ]
-  # Main form, allowing name. Must come after postfix splat forms,
-  # so that postfix splat gets consumed if present.
-  ( __ DotDotDot )? ( __ IdentifierName __ (QuestionMark _?)? Colon __ )? Type
 
 NestedTypeList
   PushIndent NestedType*:types PopIndent ->

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -372,6 +372,14 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    named splat
+    ---
+    type Test = [x: number, ...rest: string[]]
+    ---
+    type Test = [x: number, ...rest: string[]]
+  """
+
+  testCase """
     named splats
     ---
     type Test = [...nums: number[], strings...: string[]]


### PR DESCRIPTION
Fix #534 again

This was tricky to debug. The trouble is that `foo: bar,` is a valid type (equivalent to `{foo: bar,}`, as in CoffeeScript), which meant that `Type DotDotDot` was matching `foo: bar, ...` where the `...` is from the next tuple entry!  To avoid this, this PR checks for all possible named tuple entries first, and only upon failure checks for `Type DotDotDot?`.

I also moved `TypeTuple` up in the `TypePrimary` list, as it should fail early via the initial OpenBracket. Just a hunch that this is more efficient.