### PR TITLE
`type` declaration without `=`

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -1180,8 +1180,13 @@ type ID = number | string
 type Point = x: number, y: number
 </Playground>
 
+The `=` is optional if the content is indented:
+
 <Playground>
-type Point =
+type ID
+  | number
+  | string
+type Point
   x: number
   y: number
 </Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5745,10 +5745,14 @@ TypeDeclaration
 # NOTE: These are declarations even without a `declare` prefix
 TypeDeclarationRest
   # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
-  TypeKeyword _? IdentifierName TypeParameters? __ Equals ( ( _? Type ) / ( __ Type ) )
+  TypeKeyword _? IdentifierName TypeParameters? OptionalEquals ( ( _? Type ) / ( __ Type ) )
   Interface   _? IdentifierName TypeParameters? InterfaceExtendsClause? InterfaceBlock
   Namespace   _? IdentifierName ModuleBlock
   FunctionSignature
+
+OptionalEquals
+  __ Equals
+  &IndentedFurther InsertSpaceEquals -> $2
 
 # NOTE: These are all guaranteed to be preceded by a `declare` keyword
 TypeLexicalDeclaration
@@ -6314,6 +6318,10 @@ InsertCloseBracket
 InsertComma
   "" ->
     return { $loc, token: "," }
+
+InsertSpaceEquals
+  "" ->
+    return { $loc, token: " =" }
 
 InsertConst
   # NOTE: Includes a trailing space

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -23,6 +23,19 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    nested braceless type, no equals
+    ---
+    type Point
+      x: number
+      y: number
+    ---
+    type Point = {
+      x: number
+      y: number
+    }
+  """
+
+  testCase """
     inline braceless type
     ---
     type Point = x: number, y: number
@@ -96,6 +109,20 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    nested or after newline, no equals
+    ---
+    type A
+      B |
+      C |
+      D
+    ---
+    type A =
+      B |
+      C |
+      D
+  """
+
+  testCase """
     binary ops
     ---
     type A = B | C
@@ -117,6 +144,18 @@ describe "[TS] type declaration", ->
     prefix |
     ---
     type X =
+      | number
+      | string
+    ---
+    type X =
+      | number
+      | string
+  """
+
+  testCase """
+    prefix |, no equals
+    ---
+    type X
       | number
       | string
     ---


### PR DESCRIPTION
@orenelbaum requested this on Discord:
```js
type Point
  x: number
  y: number
↓↓↓
type Point = {
  x: number,
  y: number
}
```

This makes the symmetry between `type` and `interface` even more profound (just replace the one word), but sticks to the particular form used by the programmer because this can have implications (`interface`s can be extended, etc.).

The rule I went with was: if there's indented content for the `type`, then `=` is optional at the end of a line. This lets you do other cool things like this:

```js
type ID
  | number
  | string
↓↓↓
type ID =
  | number
  | string
```