### PR TITLE
Forbid binary op after newline within SingleLineStatements (e.g. `then`)

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1832,7 +1832,7 @@ NonSingleBracedBlock
 SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
-  ( ( _? !EOS ) Statement SemicolonDelimiter )*:stmts ( ( _? !EOS ) Statement SemicolonDelimiter? )?:last ->
+  ForbidNewlineBinaryOp ( ( _? !EOS ) Statement SemicolonDelimiter )*:stmts ( ( _? !EOS ) Statement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ->
     const children = [...stmts]
     if (last) children.push(last)
 

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -819,6 +819,21 @@ describe "switch", ->
     """
 
     testCase """
+      binary op rhs patterns with then
+      ---
+      switch x
+        < 0 then console.log "it's negative"
+        > 0 then console.log "it's positive"
+        is 0 then console.log "it's zero"
+        else console.log "it's something else"
+      ---
+      if(x < 0) { console.log("it's negative")}
+      else if(x > 0) { console.log("it's positive")}
+      else if(x === 0) { console.log("it's zero")}
+      else  { console.log("it's something else") }
+    """
+
+    testCase """
       advanced binary operators rhs pattern
       ---
       switch x


### PR DESCRIPTION
Fix #607

I forgot we had this flag. 😅 Made this really easy to fix!