### PR TITLE
Fix implicit return with switch+then

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1796,7 +1796,7 @@ NoPostfixBracedBlock
   NonSingleBracedBlock
   # Nonempty one liner
   InsertOpenBrace:o !EOS SingleLineStatements:s InsertSpace:ws InsertCloseBrace:c ->
-    if (!s.children.length) return $skip
+    if (!s.expressions.length) return $skip
     return {
       type: "BlockStatement",
       expressions: s.expressions,
@@ -1833,13 +1833,13 @@ SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
   ForbidNewlineBinaryOp ( ( _? !EOS ) Statement SemicolonDelimiter )*:stmts ( ( _? !EOS ) Statement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ->
-    const children = [...stmts]
-    if (last) children.push(last)
+    const expressions = [...stmts]
+    if (last) expressions.push(last)
 
     return {
       type: "BlockStatement",
-      expressions: children,
-      children,
+      expressions,
+      children: [expressions], // avoid aliasing
       bare: true,
     }
 

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -919,6 +919,22 @@ describe "switch", ->
     """
 
     testCase """
+      implicit return with then
+      ---
+      ->
+        switch x
+          1 then 2
+          2 then 3
+          else 4
+      ---
+      (function() {
+        if(x === 1) { return 2}
+      else if(x === 2) { return 3}
+      else  { return 4 }
+      })
+    """
+
+    testCase """
       iteration result
       ---
       y := for x in [1, 2, 3]


### PR DESCRIPTION
Remove aliasing between `expressions` and `children`

Fix #615