### PR TITLE
for key, value in object

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -908,8 +908,17 @@ switch x
 
 ## Loops
 
-All JavaScript loops are available, with optional parentheses around the clause
-and iteration variables defaulting to `const`.
+All JavaScript loops are available,
+with optional parentheses around the clause.
+
+<Playground>
+for let i = 0; i < 100; i++
+  console.log i
+</Playground>
+
+### for..of
+
+Looping over an iterator via `for..of` defaults to `const`:
 
 <Playground>
 for item of list
@@ -922,24 +931,35 @@ for let item of list
   console.log item
 </Playground>
 
+You can also keep track of the current index of the iteration
+by specifying a comma and a second variable (also defaulting to `const`):
+
+<Playground>
+for item, index of list
+  console.log `${index}th item is ${item}`
+</Playground>
+
+### for..in
+
+Looping over properties of an object via `for..in` defaults to `const`:
+
 <Playground>
 for key in object
   console.log key
 </Playground>
 
 <Playground>
-for let i = 0; i < 100; i++
-  console.log i
+for var key in object
+  console.log key
+console.log `Last key is ${key}`
 </Playground>
 
-### Iterator Count
-
-When looping over an iterator via `for..of`, you can get the current index
+You can also retrieve the corresponding value
 by specifying a comma and a second variable (also defaulting to `const`):
 
 <Playground>
-for item, index of list
-  console.log `${index}th item is ${item}`
+for key, value in object
+  console.log `${key} maps to ${value}`
 </Playground>
 
 ### Loop Expressions

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3518,6 +3518,7 @@ ForInOfDeclaration
       type: "ForDeclaration",
       children: $0,
       declare: $1,
+      binding,
       names: binding.names,
     }
   ForDeclaration
@@ -3530,6 +3531,7 @@ ForDeclaration
       type: "ForDeclaration",
       children: [c, binding],
       declare: c,
+      binding,
       names: binding.names,
     }
   # NOTE: Added default implicit const to for bindings
@@ -3540,6 +3542,7 @@ ForDeclaration
       type: "ForDeclaration",
       children: [c, binding],
       declare: c,
+      binding,
       names: binding.names,
     }
 

--- a/test/for.civet
+++ b/test/for.civet
@@ -256,6 +256,55 @@ describe "for", ->
   """
 
   testCase """
+    in with two implicit declarations
+    ---
+    for key, value in array
+      console.log `${key}: ${value}`
+    ---
+    for (const key in array) {
+      const value = array[key];
+      console.log(`${key}: ${value}`)
+    }
+  """
+
+  testCase """
+    in with two explicit declarations
+    ---
+    for var key, let value in object
+      console.log `${key}: ${value}`
+    ---
+    for (var key in object) {
+      let value = object[key];
+      console.log(`${key}: ${value}`)
+    }
+  """
+
+  testCase """
+    in with pattern matching key and value
+    ---
+    for var [a, b], let [x, y] in object
+      console.log `${a}, ${b}: ${x}, ${y}`
+    ---
+    for (const key in object) {
+      var [a, b] = key;
+      let [x, y] = object[key];
+      console.log(`${a}, ${b}: ${x}, ${y}`)
+    }
+  """
+
+  testCase """
+    in with two explicit declarations and complex object
+    ---
+    for var key, let value in getObject()
+      console.log `${key}: ${value}`
+    ---
+    let ref;for (var key in ref = getObject()) {
+      let value = ref[key];
+      console.log(`${key}: ${value}`)
+    }
+  """
+
+  testCase """
     postfix
     ---
     console.log(i) for let i = 0; i < 10; i++


### PR DESCRIPTION
This is the equivalent of CoffeeScript's `for key, value of object`.

It should properly use refs, and supports when `key` is actually a pattern (see tests).