### PR TITLE
for each..of

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -939,6 +939,28 @@ for item, index of list
   console.log `${index}th item is ${item}`
 </Playground>
 
+### for each..of
+
+For Arrays and other objects implementing `.length` and `[i]` indexing,
+you can use `for each..of` as an optimized form of `for..of`
+(without building an iterator):
+
+<Playground>
+for each item of list
+  console.log item
+</Playground>
+
+<Playground>
+for each let item of list
+  item *= item
+  console.log item
+</Playground>
+
+<Playground>
+for each item, index of list
+  console.log `${index}th item is ${item}`
+</Playground>
+
 ### for..in
 
 Looping over properties of an object via `for..in` defaults to `const`:

--- a/source/lib.js
+++ b/source/lib.js
@@ -444,11 +444,7 @@ function expressionizeIteration(exp) {
     return
   }
 
-  const resultsRef = {
-    type: "Ref",
-    base: "results",
-    id: "results",
-  }
+  const resultsRef = makeRef("results")
 
   // insert `results.push` to gather results array
   insertPush(exp.block, resultsRef)
@@ -543,10 +539,7 @@ function processCallMemberExpression(node) {
       let hoistDec, refAssignment
       // add ref to ensure object base evaluated only once
       if (prefix.length > 1) {
-        const ref = {
-          type: "Ref",
-          base: "ref",
-        }
+        const ref = makeRef()
         hoistDec = {
           type: "Declaration",
           children: ["let ", ref],
@@ -651,11 +644,7 @@ function wrapIterationReturningResults(statement, outerRef) {
     return
   }
 
-  const resultsRef = {
-    type: "Ref",
-    base: "results",
-    id: "results",
-  }
+  const resultsRef = makeRef("results")
 
   const declaration = {
     type: "Declaration",
@@ -1310,11 +1299,7 @@ function processForInOf($0) {
 
   switch (inOf.token) {
     case "of": { // for item, index of iter
-      const counterRef = {
-        type: "Ref",
-        base: "i",
-        id: "i",
-      }
+      const counterRef = makeRef("i")
       hoistDec = {
         type: "Declaration",
         children: ["let ", counterRef, " = 0"],
@@ -1346,11 +1331,7 @@ function processForInOf($0) {
       // so that we can use it to dereference value.
       let { binding } = declaration
       if (binding?.type !== "Identifier") {
-        const keyRef = {
-          type: "Ref",
-          base: "key",
-          id: "key",
-        }
+        const keyRef = makeRef("key")
         blockPrefix.push(["", [
           declaration, " = ", keyRef
         ], ";"])
@@ -1385,11 +1366,7 @@ function processForInOf($0) {
 function forRange(open, forDeclaration, range, stepExp, close) {
   const { start, end, inclusive } = range
 
-  const counterRef = {
-    type: "Ref",
-    base: "i",
-    id: "i",
-  }
+  const counterRef = makeRef("i")
 
   let stepRef
   if (stepExp) {
@@ -1411,11 +1388,7 @@ function forRange(open, forDeclaration, range, stepExp, close) {
   } else if (start.type === "Literal" && end.type === "Literal") {
     asc = literalValue(start) <= literalValue(end)
   } else {
-    ascRef = {
-      type: "Ref",
-      base: "asc",
-      id: "asc",
-    }
+    ascRef = makeRef("asc")
     ascDec = [", ", ascRef, " = ", startRef, " <= ", endRef]
   }
 
@@ -1595,16 +1568,6 @@ function makeLeftHandSideExpression(expression) {
   }
 }
 
-// Transform into a ref if needed
-function maybeRef(exp, base = "ref") {
-  if (!needsRef(exp)) return exp
-  return {
-    type: "Ref",
-    base: base,
-    id: base,
-  }
-}
-
 // Adjust a parsed string by escaping newlines
 function modifyString(str) {
   // Replace non-escaped newlines with escaped newlines
@@ -1727,13 +1690,22 @@ function needsRef(expression, base = "ref") {
     case "Identifier":
     case "Literal":
       return
-    default:
-      return {
-        type: "Ref",
-        base,
-        id: base,
-      }
   }
+  return makeRef(base)
+}
+
+function makeRef(base = "ref") {
+  return {
+    type: "Ref",
+    base: base,
+    id: base,
+  }
+}
+
+// Transform into a ref if needed
+function maybeRef(exp, base = "ref") {
+  if (!needsRef(exp)) return exp
+  return makeRef(base)
 }
 
 // Return an array of Rule names that correspond to the current call stack
@@ -2339,11 +2311,7 @@ function aggregateDuplicateBindings(bindings, ReservedWord) {
 
     // Create a ref alias for each duplicate binding
     const refs = shared.map((p) => {
-      const ref = {
-        type: "Ref",
-        base: key,
-        id: key,
-      }
+      const ref = makeRef(key)
 
       aliasBinding(p, ref)
 
@@ -2551,7 +2519,7 @@ function processPipelineExpressions(statements) {
                     break outer
                 }
 
-                usingRef = needsRef({}) // hacky: using this like a "createRef"
+                usingRef = makeRef()
                 initRef = {
                   type: "AssignmentExpression",
                   children: [usingRef, " = ", arg, ","],
@@ -2931,11 +2899,7 @@ function processReturnValue(func) {
     ({ type }) => type === "ReturnValue")
   if (!values.length) return false
 
-  const ref = {
-    type: "Ref",
-    base: "ret",
-    id: "ret",
-  }
+  const ref = makeRef("ret")
 
   let declared
   values.forEach(value => {
@@ -3320,6 +3284,7 @@ module.exports = {
   makeAsConst,
   makeEmptyBlock,
   makeLeftHandSideExpression,
+  makeRef,
   maybeRef,
   modifyString,
   needsRef,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3441,7 +3441,7 @@ CoffeeForDeclaration
 
 ForStatementParameters
   # https://262.ecma-international.org/#prod-ForStatement
-  OpenParen __       ( LexicalDeclaration / VariableStatement / Expression? ):declaration __ Semicolon Expression? Semicolon Expression? __ CloseParen ->
+  OpenParen __ ( LexicalDeclaration / VariableStatement / Expression? ):declaration __ Semicolon Expression? Semicolon Expression? __ CloseParen ->
     return {
       declaration,
       children: $0,
@@ -3456,10 +3456,10 @@ ForStatementParameters
   # https://262.ecma-international.org/#prod-ForInOfStatement
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
-  ( Await __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
+  ( Await __ )? ( Each __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
     return processForInOf($0)
   # NOTE: Added optional parens
-  ( Await __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
+  ( Await __ )? ( Each __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
     return processForInOf($0)
   ForRangeParameters
 
@@ -4794,6 +4794,10 @@ DoubleColon
 
 DoubleQuote
   "\"" ->
+    return { $loc, token: $1 }
+
+Each
+  "each" NonIdContinue ->
     return { $loc, token: $1 }
 
 Else

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -27,6 +27,7 @@ const {
   literalValue,
   makeEmptyBlock,
   makeLeftHandSideExpression,
+  makeRef,
   maybeRef,
   modifyString,
   processAssignmentDeclaration,
@@ -510,10 +511,7 @@ ShortCircuitExpression
 PipelineExpression
   _?:ws PipelineHeadItem:head ( NotDedented Pipe __ PipelineTailItem )+:body ->
     if (head.token === "&") {
-      const ref = {
-        type: "Ref",
-        base: "$",
-      }
+      const ref = makeRef("$")
 
       const arrowBody = {
         type: "PipelineExpression",
@@ -1185,11 +1183,7 @@ AtIdentifierRef
       id: r,
     }
   IdentifierName:id ->
-    return {
-      type: "Ref",
-      base: id.name,
-      id: id.name,
-    }
+    return makeRef(id.name)
 
 PinPattern
   "^" Identifier:identifier ->
@@ -1432,11 +1426,7 @@ BindingRestElement
 # NOTE: Allows for empty binding rest pattern like in CoffeeScript
 EmptyBindingPattern
   "" ->
-    const ref = {
-      type: "Ref",
-      base: "ref",
-      id: "ref"
-    }
+    const ref = makeRef()
     return {
       type: "EmptyBinding",
       children: [ref],
@@ -1514,11 +1504,7 @@ AmpersandFunctionExpression
 
     // Only unary ops
     if (!rhs) {
-      body = ref = {
-        type: "Ref",
-        base: "$",
-        id: "$"
-      }
+      body = ref = makeRef("$")
     } else {
       // &? gets wrapped in UnaryExpression and ParenthesizedExpression;
       // descend into `expression` property until `ref` is defined
@@ -1602,11 +1588,7 @@ AmpersandBlockRHS
 AmpersandBlockRHSBody
   (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( ![&] BinaryOpRHS+ )?:binopRHS ->
     if (!callExpRest && !binopRHS && !unaryPostfix) return $skip
-    const ref = {
-      type: "Ref",
-      base: "$",
-      id: "$"
-    }
+    const ref = makeRef("$")
 
     let exp = {
       type: "AmpersandRef",
@@ -2155,12 +2137,7 @@ ArrayElementExpression
   # NOTE: Allow empty exp spread for destructuring
   ExtendedExpression?:exp __:ws DotDotDot:dots &ArrayElementDelimiter ->
     if (!exp) {
-      exp = {
-        type: "Ref",
-        base: "ref",
-        id: "ref",
-        names: [],
-      }
+      exp = { ...makeRef(), names: [] }
     }
 
     return {
@@ -3364,33 +3341,15 @@ CoffeeForStatementParameters
 
       kind.token = "in"
     } else if (kind.token === "in") { // CoffeeScript loop comprehensions
-      const counterRef = {
-        type: "Ref",
-        base: "i",
-        id: "i",
-      }
+      const counterRef = makeRef("i")
+      const lenRef = makeRef("len")
 
-      const lenRef = {
-        type: "Ref",
-        base: "len",
-        id: "len",
+      if (exp.type === "RangeExpression") {
+        return forRange(open, declaration, exp, step?.[2], close)
       }
 
       // If exp isn't a simple identifier use a ref
-      let expRef
-      switch(exp.type) {
-        case "Identifier":
-          expRef = exp
-          break
-        case "RangeExpression":
-          return forRange(open, declaration, exp, step?.[2], close)
-        default:
-          expRef = {
-            type: "Ref",
-            base: "ref",
-            id: "ref",
-          }
-      }
+      const expRef = maybeRef(exp)
 
       const varRef = declaration
       let increment = "++",
@@ -3804,10 +3763,7 @@ Condition
 
 DeclarationCondition
   LexicalDeclaration:dec ->
-    const ref = {
-      type: "Ref",
-      base: "ref",
-    }
+    const ref = makeRef()
 
     const { decl, bindings } = dec
     // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
@@ -6594,11 +6550,7 @@ Reset
 
     module.getRef = function (base) {
       if (refs.hasOwnProperty(base)) return refs[base]
-      const ref = {
-        type: "Ref",
-        base,
-        id: base,
-      }
+      const ref = makeRef(base)
       if (declareRef.hasOwnProperty(base)) declareRef[base](ref)
       return refs[base] = ref
     }

--- a/test/for.civet
+++ b/test/for.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "for", ->
   testCase """
@@ -301,6 +301,63 @@ describe "for", ->
     let ref;for (var key in ref = getObject()) {
       let value = ref[key];
       console.log(`${key}: ${value}`)
+    }
+  """
+
+  testCase """
+    each..of
+    ---
+    for each item of array
+      console.log item
+    ---
+    for (let i = 0, len = array.length; i < len; i++) {
+      const item = array[i];
+      console.log(item)
+    }
+  """
+
+  throws """
+    foreach doesn't work
+    ---
+    foreach item of getArray()
+      console.log item
+  """
+
+  testCase """
+    each..of with complex expression
+    ---
+    for each item of getArray()
+      console.log item
+    ---
+    for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {
+      const item = ref[i];
+      console.log(item)
+    }
+  """
+
+  testCase """
+    each..of with two implicit declarations
+    ---
+    for each item, index of getArray()
+      console.log item
+    ---
+    for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {
+      const index = i;
+      const item = ref[i];
+      console.log(item)
+    }
+  """
+
+  testCase """
+    each..of with two explicit declarations
+    ---
+    for each var item, let index of array
+      console.log item
+    ---
+    for (let i = 0, len = array.length; i < len; i++) {
+      let index = i;
+      var item = array[i];
+      console.log(item)
     }
   """
 


### PR DESCRIPTION
Sequel to #621: more efficient array-specific loops, as in CoffeeScript's `for..in`.

Also some code cleanup via new `makeRef` helper function.