### PR TITLE
Fix hoisting around IIFE

### DIFF
--- a/source/lib.js
+++ b/source/lib.js
@@ -33,7 +33,7 @@ function addParentPointers(node, parent) {
 /**
  * Just update parent pointers for the children of a node,
  * recursing into arrays but not objects.  More efficient version of
- * `addParentPointers` which just injecting one new node.
+ * `addParentPointers` when just injecting one new node.
  */
 function updateParentPointers(node, parent, depth = 1) {
   if (node == null) return
@@ -50,7 +50,7 @@ function updateParentPointers(node, parent, depth = 1) {
   if (parent != null) node.parent = parent
   if (depth && node.children) {
     for (const child of node.children) {
-      addParentPointers(child, node, depth-1)
+      updateParentPointers(child, node, depth-1)
     }
   }
 }
@@ -2739,6 +2739,9 @@ function processProgram(root, config, m, ReservedWord) {
   gatherRecursiveAll(statements, n => n.type === "IterationExpression")
     .forEach((e) => expressionizeIteration(e))
 
+  // Hoist hoistDec attributes to actual declarations.
+  // NOTE: This should come after iteration expressions get processed
+  // into IIFEs.
   hoistRefDecs(statements)
 
   // Insert prelude

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3190,6 +3190,7 @@ IterationExpression
       subtype: statement.type,
       children: [statement],
       block: statement.block,
+      statement,
       async,
     }
 

--- a/test/do.civet
+++ b/test/do.civet
@@ -89,7 +89,7 @@ describe "do", ->
       y * y
     ---
     const x = 1
-    const z = (()=>{ {
+    const z = (()=>{{
       const y = x * x
       return y * y
     }})()
@@ -106,7 +106,7 @@ describe "do", ->
     ---
     function f(x) {
       x = x * x
-      return (()=>{ {
+      return (()=>{{
         const y = x * x
         return y * y
       }})()
@@ -158,7 +158,7 @@ describe "do", ->
         y * y
     ---
     async function f(x) {
-      return (await (async ()=>{ {
+      return (await (async ()=>{{
         const y = await x
         return y * y
       }})())

--- a/test/for.civet
+++ b/test/for.civet
@@ -503,9 +503,25 @@ describe "for", ->
         for item, index of array
           `${index}. ${item}`
       ---
-      let i = 0;const strings =
-        (()=>{const results=[];for (const item of array) {
+      const strings =
+        (()=>{const results=[];let i = 0;for (const item of array) {
           const index = i++;
           results.push(`${index}. ${item}`)
         }; return results})()
+    """
+
+    testCase """
+      of with two implicit declarations inside function with parens
+      ---
+      function f
+        (for item, index of array
+          `${index}. ${item}`
+        )
+      ---
+      function f() {
+        return (()=>{const results=[];let i = 0;for (const item of array) {
+          const index = i++;
+          results.push(`${index}. ${item}`)
+        }; return results})()
+      }
     """


### PR DESCRIPTION
Fixes #624

* `hoistRefDecs` needed to happen after expressionizing
* Parent pointers needed updating after `wrapIIFE` so that new wrapping block gets discovered.
* In these situations, `hoistDec` needs to work with raw expressions that lack `[ws, exp, delim]` format.
* Remove some extra array wrapping
