### PR TITLE
Postfix expressions inside indented implicit object literals

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2414,7 +2414,7 @@ PropertyDefinition
 NamedProperty
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser
   # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
-  PropertyName:name _? Colon ExtendedExpression:exp ->
+  PropertyName:name _? Colon PostfixedExpression:exp ->
     return {
       type: "Property",
       children: $0,
@@ -2425,6 +2425,8 @@ NamedProperty
 
 # Named property but doesn't allow any space between name and colon
 # used to distinguish between braceless inline objects and ternary expression conditions
+# Also does not support postfixed expressions (unlike NamedProperty),
+# as these are ambiguous for inline objects
 SnugNamedProperty
   PropertyName Colon ExtendedExpression:exp ->
     return {

--- a/test/object.civet
+++ b/test/object.civet
@@ -549,6 +549,31 @@ describe "object", ->
       ({a: 1,
       b: 2,})
     }
+  """
+
+  // NOTE: This deviates from CoffeeScript
+  testCase """
+    postfix within inline braceless object, 1 prop
+    ---
+    f
+      a: 1 if hasA
+    ---
+    f({
+      a:(hasA)? 1:void 0,
+    })
+  """
+
+  testCase """
+    postfix within inline braceless object, 2 props
+    ---
+    f
+      a: 1 if hasA
+      b: 2 if hasB
+    ---
+    f({
+      a:(hasA)? 1:void 0,
+      b:(hasB)? 2:void 0,
+    })
   """; // TODO: thinks next triple quote is a call expression
 
   """


### PR DESCRIPTION
Fix #628 using the "right" interpretation for both 1 and 2-property indented implicit object literals.  This turned out to be a one-line change. But it differs from CoffeeScript's interpretation for 1 property.

I didn't make the change for "inline" object literals (which uses `SnugNamedProperty`) because it would change the interpretation of this test from CS's `lexer.coffee`:

```coffee
addTokenData token, initialChunk: yes if i is 0
```

and generally seems dangerous.  Unfortunately, this means that the following doesn't do what you'd expect:

```coffee
function f()
  a: 1 if hasA
  b: 2 if hasB
```

(This is treated as two top-level statements, the second of which gets implicitly returned.)