### PR TITLE
Postfix expressions inside inline object literals

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2425,14 +2425,17 @@ NamedProperty
 
 # Named property but doesn't allow any space between name and colon
 # used to distinguish between braceless inline objects and ternary expression conditions
-# Also does not support postfixed expressions (unlike NamedProperty),
-# as these are ambiguous for inline objects
+# Allow postfixed expression only if this first property isn't the last
 SnugNamedProperty
-  PropertyName Colon ExtendedExpression:exp ->
+  PropertyName:name Colon:colon ExtendedExpression:expression ( ( _? PostfixStatement ) &( Nested NamedProperty ) )?:post ->
+    if (post) {
+      // post[0] drops the lookahead assertion
+      expression = attachPostfixStatementAsExpression(expression, post[0])
+    }
     return {
       type: "Property",
-      children: $0,
-      names: exp.names || [],
+      children: [name, colon, expression],
+      names: expression.names || [],
     }
 
 PropertyName

--- a/test/object.civet
+++ b/test/object.civet
@@ -553,7 +553,7 @@ describe "object", ->
 
   // NOTE: This deviates from CoffeeScript
   testCase """
-    postfix within inline braceless object, 1 prop
+    postfix within indented braceless object, 1 prop
     ---
     f
       a: 1 if hasA
@@ -564,7 +564,7 @@ describe "object", ->
   """
 
   testCase """
-    postfix within inline braceless object, 2 props
+    postfix within indented braceless object, 2 props
     ---
     f
       a: 1 if hasA
@@ -574,6 +574,27 @@ describe "object", ->
       a:(hasA)? 1:void 0,
       b:(hasB)? 2:void 0,
     })
+  """
+
+  testCase """
+    postfix within inline braceless object, 1 prop
+    ---
+    f a: 1 if call
+    ---
+    if (call) { f({a: 1}) }
+  """
+
+  testCase """
+    postfix within inline braceless object, 2 props
+    ---
+    function f()
+      a: 1 if hasA
+      b: 2 if hasB
+    ---
+    function f() {
+      return ({a:(hasA)? 1:void 0,
+      b:(hasB)? 2:void 0})
+    }
   """; // TODO: thinks next triple quote is a call expression
 
   """


### PR DESCRIPTION
Followup to #630 based on the discussion there. I found a way to handle postfix expressions in inline object literals, as long as the prop isn't the only prop. I also required a newline (`Nested`) after the postfix; commas seem like they could be ambiguous.