### PR TITLE
Added private this shorthand. Fixes #633

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -1173,6 +1173,20 @@ bound := object@method
 bound := @@method
 </Playground>
 
+### Private Fields
+
+[Private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
+do not need an explicit `this.` or `@` prefix.
+
+<Playground>
+class Counter
+  #count = 0
+  increment(): void
+    #count++
+  add(other: Counter): void
+    #count += other.#count if #count in other
+</Playground>
+
 ### Static Fields
 
 <Playground>
@@ -1369,7 +1383,7 @@ block comment
 ### `#` Comments
 
 If you do not need
-[private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields),
+[private class fields](#private-fields),
 you can enable `#` one-line comments (as in many other languages)
 via a `"civet"` directive at the beginning of your file:
 
@@ -1600,7 +1614,7 @@ no
 
 ### CoffeeScript Comments
 
-If you don't need [private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields),
+If you don't need [private class fields](#private-fields),
 you can enable `#` for single-line comments:
 
 <Playground>

--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -1185,6 +1185,7 @@ class Counter
     #count++
   add(other: Counter): void
     #count += other.#count if #count in other
+  set(#count)
 </Playground>
 
 ### Static Fields

--- a/source/lib.js
+++ b/source/lib.js
@@ -1821,11 +1821,11 @@ function needsRef(expression, base = "ref") {
   return makeRef(base)
 }
 
-function makeRef(base = "ref") {
+function makeRef(base = "ref", id = base) {
   return {
     type: "Ref",
-    base: base,
-    id: base,
+    base,
+    id,
   }
 }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1198,7 +1198,7 @@ NWBindingIdentifier
 
 AtIdentifierRef
   ReservedWord:r ->
-    return makeRef(`_${r}`)
+    return makeRef(`_${r}`, r)
   IdentifierName:id ->
     return makeRef(id.name)
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -789,9 +789,22 @@ ThisLiteral
   This
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
-  AtThis:at $( "#"? IdentifierName ):id ->
+  AtThis:at $( Hash? IdentifierName ):id ->
     return [at, ".", id]
   AtThis
+  PrivateThis
+
+# Adds a #id -> this.#id shorthand as a "PrivateThis" literal in most cases
+# with the exception of keeping `#a in b` as is for branded in checks.
+# https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in#using_the_in_operator_to_implement_branded_checks
+# This is slightly different from how https://262.ecma-international.org/#sec-relational-operators handles relational operators
+# grammatically but should be equivalent in practice
+PrivateThis
+  PrivateIdentifier:id &( _+ ( ( Not __ In ) / In ) ) ->
+    return id
+
+  PrivateIdentifier:id ->
+    return [ "this.", id ]
 
 # NOTE: Added '@' as a 'this' shorthand from CoffeeScript
 AtThis
@@ -2617,7 +2630,7 @@ ClassElementName
   PrivateIdentifier
 
 PrivateIdentifier
-  $("#" IdentifierName) ->
+  $(Hash IdentifierName) ->
     return {
       type: "Identifier",
       name: $0,
@@ -4841,6 +4854,10 @@ Function
 GetOrSet
   ( "get" / "set" ) NonIdContinue ->
     return { $loc, token: $1, type: 'GetOrSet' }
+
+Hash
+  "#" ->
+    return { $loc, token: $1 }
 
 If
   # NOTE: Pull a single space into the 'if ' token so if it is replaced

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1183,6 +1183,14 @@ NWBindingIdentifier
       children: [ref],
       ref,
     }
+  # Likewise for private identifiers
+  Hash AtIdentifierRef:ref ->
+    ref = { ...ref, id: `#${ref.id}` }
+    return {
+      type: "AtBinding",
+      children: [ref],
+      ref,
+    }
   Identifier:id
   # NOTE: Support for return := 1 and let return: number
   ReturnValue ->
@@ -1190,11 +1198,7 @@ NWBindingIdentifier
 
 AtIdentifierRef
   ReservedWord:r ->
-    return {
-      type: "Ref",
-      base: `_${r}`,
-      id: r,
-    }
+    return makeRef(`_${r}`)
   IdentifierName:id ->
     return makeRef(id.name)
 

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -187,6 +187,22 @@ describe "binary operations", ->
   """
 
   testCase """
+    branded in
+    ---
+    #a in b
+    ---
+    #a in b
+  """
+
+  testCase """
+    branded not in
+    ---
+    #a not in b
+    ---
+    !(#a in b)
+  """
+
+  testCase """
     is in operator
     ---
     a is in b

--- a/test/class.civet
+++ b/test/class.civet
@@ -58,14 +58,23 @@ describe "class", ->
     ---
     class X
       #count = 0
+      @(#count)
       increment(): void
         #count++
+      add(other: Counter): void
+        #count += other.#count if #count in other
+      set(#count)
     ---
     class X {
       #count = 0
+      constructor(count){this.#count = count;}
       increment(): void {
         this.#count++
       }
+      add(other: Counter): void {
+        if (#count in other) { this.#count += other.#count }
+      }
+      set(count1){this.#count = count1;}
     }
   """
 

--- a/test/class.civet
+++ b/test/class.civet
@@ -54,6 +54,22 @@ describe "class", ->
   """
 
   testCase """
+    private field this shorthand
+    ---
+    class X
+      #count = 0
+      increment(): void
+        #count++
+    ---
+    class X {
+      #count = 0
+      increment(): void {
+        this.#count++
+      }
+    }
+  """
+
+  testCase """
     function field
     ---
     class X
@@ -265,14 +281,14 @@ describe "class", ->
     ---
     export class CustomError extends Error {
       constructor(message: string) {
-        super(message) 
+        super(message)
         this.name = "CustomError"
       }
     }
     ---
     export class CustomError extends Error {
       constructor(message: string) {
-        super(message) 
+        super(message)
         this.name = "CustomError"
       }
     }

--- a/test/function.civet
+++ b/test/function.civet
@@ -309,6 +309,14 @@ describe "function", ->
     """
 
     testCase """
+      keyword @ params
+      ---
+      (@var) ->
+      ---
+      (function(_var) {this.var = _var;})
+    """
+
+    testCase """
       local reference
       ---
       (@a, @b) ->


### PR DESCRIPTION
Added shorthand for `#a` -> `this.#a` except in the case of branded `in` check.

Could use docs.