### PR TITLE
source/lib.js -> source/lib.ts

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -42,7 +42,7 @@ const {
   replaceNodes,
   typeOfJSX,
   wrapIIFE,
-} = require("./lib.js")
+} = require("./lib.ts")
 ```
 
 Program


### PR DESCRIPTION
This is the very beginning of switching `lib.js` -> `lib.ts`

I probably won't have the fortitude to finish it all in one go but it works as is and we can continue to improve it bit by bit.

We're no worse off than without the typechecking even if it is so noisy as to not be useful yet.

If we merge this then we can keep adding types and eventually it will be good.