### PR TITLE
for own..in

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -987,6 +987,14 @@ for key, value in object
   console.log `${key} maps to ${value}`
 </Playground>
 
+If your object might have a prototype with enumerable properties,
+you can skip them with `own`:
+
+<Playground>
+for own key in object
+  console.log key
+</Playground>
+
 ### Loop Expressions
 
 If needed, loops automatically assemble an Array of the last value

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -67,7 +67,8 @@ Civet.
   - NOTE: CoffeeScript `not` precedence is dubious. `not a < b` should be equivalent to `!(a < b)` but it is in fact `!a < b`
 - `do` keyword (replaced with JS `do...while` blocks and new `do` blocks; replace with `((x) -> ...)(x)` syntax or use `"civet coffeeCompat"`, or `"civet coffeeDo"`)
 - `for from` (use JS `for of`, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
-- `for own of` (use JS `for in` and check manually, switch to `Map#keys/values/entries`, or use `Object.create(null)`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
+- `for in` (use `for each of`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
+- `for own of` (use `for own in`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for ... when <condition>` (use `continue if exp` inside loop, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `a ? b` (use `a ?? b`, though it doesn't check for undeclared variables; `"civet coffeeCompat"`, or `"civet coffeeBinaryExistential"` enables `a ? b` at the cost of losing JS ternary operator)
 - `a of b` (use `a in b` as in JS, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3454,7 +3454,7 @@ CoffeeForIndex
 
 CoffeeForDeclaration
   # NOTE: Coffee doesn't allow expression bindings like `for a.x in b`
-  ( __ "own" NonIdContinue )?:own ForBinding:binding ->
+  ( __ Own )?:own ForBinding:binding ->
     return {
       type: "AssignmentExpression",
       own: Boolean(own),
@@ -3479,11 +3479,11 @@ ForStatementParameters
   # https://262.ecma-international.org/#prod-ForInOfStatement
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
-  ( Await __ )? ( Each __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
-    return processForInOf($0)
+  ( Await __ )? ( (Each / Own) __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
+    return processForInOf($0, module.getRef)
   # NOTE: Added optional parens
-  ( Await __ )? ( Each __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
-    return processForInOf($0)
+  ( Await __ )? ( (Each / Own) __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
+    return processForInOf($0, module.getRef)
   ForRangeParameters
 
 ForRangeParameters
@@ -4934,6 +4934,10 @@ OpenParen
 
 Operator
   "operator" NonIdContinue ->
+    return { $loc, token: $1 }
+
+Own
+  "own" NonIdContinue ->
     return { $loc, token: $1 }
 
 Public

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3350,7 +3350,7 @@ CoffeeForStatementParameters
       if (declaration.own) {
         const hasPropRef = module.getRef("hasProp")
 
-        blockPrefix./**/push(["", "if (!", hasPropRef, ".call(", exp, ", ", declaration, ")) continue", ";"])
+        blockPrefix./**/push(["", "if (!", hasPropRef, "(", exp, ", ", declaration, ")) continue", ";"])
       }
 
       // index is actually value in Coffee "for of", y = z[x]
@@ -6504,10 +6504,10 @@ Reset
       hasProp(hasPropRef) {
         const typeSuffix = {
           ts: true,
-          children: [": <T>(this: T, prop: keyof T) => boolean"]
+          children: [": <T>(object: T, prop: keyof T) => boolean"]
         }
         // [indent, statement]
-        module.prelude.push(["", [preludeVar, hasPropRef, typeSuffix, " = {}.hasOwnProperty", asAny, ";\n"]])
+        module.prelude.push(["", [preludeVar, hasPropRef, typeSuffix, " = {}.constructor.hasOwn", asAny, ";\n"]])
       },
       is(isRef) {
         // Thanks to @thetarnav for help with this TypeScript magic.

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -416,9 +416,9 @@ describe "coffeeForLoops", ->
     for own a of b
       console.log a
     ---
-    var a;var hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
+    var a;var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
     for (a in b) {
-      if (!hasProp.call(b, a)) continue;
+      if (!hasProp(b, a)) continue;
       console.log(a)
     }
   """
@@ -429,9 +429,9 @@ describe "coffeeForLoops", ->
     "civet coffee-compat"
     log(a) for own a of b when a != "y"
     ---
-    var a;var hasProp: <T>(this: T, prop: keyof T) => boolean = {}.hasOwnProperty as any;
+    var a;var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
     for (a in b) {
-    if (!hasProp.call(b, a)) continue;if (!(a !== "y")) continue;log(a)
+    if (!hasProp(b, a)) continue;if (!(a !== "y")) continue;log(a)
     }
   """
 

--- a/test/for.civet
+++ b/test/for.civet
@@ -304,62 +304,132 @@ describe "for", ->
     }
   """
 
-  testCase """
-    each..of
-    ---
-    for each item of array
-      console.log item
-    ---
-    for (let i = 0, len = array.length; i < len; i++) {
-      const item = array[i];
-      console.log(item)
-    }
-  """
+  describe "each..of", ->
+    testCase """
+      each..of
+      ---
+      for each item of array
+        console.log item
+      ---
+      for (let i = 0, len = array.length; i < len; i++) {
+        const item = array[i];
+        console.log(item)
+      }
+    """
 
-  throws """
-    foreach doesn't work
-    ---
-    foreach item of getArray()
-      console.log item
-  """
+    throws """
+      foreach doesn't work
+      ---
+      foreach item of getArray()
+        console.log item
+    """
 
-  testCase """
-    each..of with complex expression
-    ---
-    for each item of getArray()
-      console.log item
-    ---
-    for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {
-      const item = ref[i];
-      console.log(item)
-    }
-  """
+    testCase """
+      each..of with complex expression
+      ---
+      for each item of getArray()
+        console.log item
+      ---
+      for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {
+        const item = ref[i];
+        console.log(item)
+      }
+    """
 
-  testCase """
-    each..of with two implicit declarations
-    ---
-    for each item, index of getArray()
-      console.log item
-    ---
-    for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {
-      const index = i;
-      const item = ref[i];
-      console.log(item)
-    }
-  """
+    testCase """
+      each..of with two implicit declarations
+      ---
+      for each item, index of getArray()
+        console.log item
+      ---
+      for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {
+        const index = i;
+        const item = ref[i];
+        console.log(item)
+      }
+    """
 
-  testCase """
-    each..of with two explicit declarations
-    ---
-    for each var item, let index of array
-      console.log item
-    ---
-    for (let i = 0, len = array.length; i < len; i++) {
-      let index = i;
-      var item = array[i];
-      console.log(item)
-    }
-  """
+    testCase """
+      each..of with two explicit declarations
+      ---
+      for each var item, let index of array
+        console.log item
+      ---
+      for (let i = 0, len = array.length; i < len; i++) {
+        let index = i;
+        var item = array[i];
+        console.log(item)
+      }
+    """
+
+  describe "own..in", ->
+    testCase """
+      own..in
+      ---
+      for own key in object
+        console.log key
+      ---
+      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      for (const key in object) {
+        if (!hasProp(object, key)) continue;
+        console.log(key)
+      }
+    """
+
+    testCase """
+      own..in with complex expression
+      ---
+      for own key in getObject()
+        console.log key
+      ---
+      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      let ref;for (const key in ref = getObject()) {
+        if (!hasProp(ref, key)) continue;
+        console.log(key)
+      }
+    """
+
+    testCase """
+      own..in with two implicit declarations
+      ---
+      for own key, value in object
+        console.log key, value
+      ---
+      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      for (const key in object) {
+        if (!hasProp(object, key)) continue;
+        const value = object[key];
+        console.log(key, value)
+      }
+    """
+
+    testCase """
+      own..in with two implicit declarations and complex expression
+      ---
+      for own key, value in getObject()
+        console.log key, value
+      ---
+      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      let ref;for (const key in ref = getObject()) {
+        if (!hasProp(ref, key)) continue;
+        const value = ref[key];
+        console.log(key, value)
+      }
+    """
+
+    testCase """
+      own..in with two explicit declarations
+      ---
+      for own var key, let value in object
+        console.log key, value
+      ---
+      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      for (var key in object) {
+        if (!hasProp(object, key)) continue;
+        let value = object[key];
+        console.log(key, value)
+      }
+    """
 
   testCase """
     postfix


### PR DESCRIPTION
Yet another feature from CoffeeScript for loops:

```js
for own key in object
↓↓↓
for (key in object) {
  if (!Object.hasOwn(object, key)) continue;
```

I also switched from `Object.prototype.hasOwnProperty` to `Object.hasProp` (still without using `Object` as an explicit name),
 as recommended in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn

Also fixed up types some around this code (but there are still errors).