### PR TITLE
Updated the Bun-related how-to

### DIFF
--- a/source/bun-civet.coffee
+++ b/source/bun-civet.coffee
@@ -1,9 +1,12 @@
 ###
-Bun plugin for Civet files.  Import this plugin from a .js or .ts file,
-and afterward you'll be able to import .civet files.  For example:
+Bun plugin for Civet files. Simply follow the steps below:
 
-import "@danielx/civet/bun-civet"
-import "./foo.civet"
+1. Create bunconfig.civet if it doesn't exist
+2. Add the following line:
+preload = ["@danielx/civet/bun-civet"]
+
+After that, you can use .civet files with the Bun cli, like:
+$ bun file.civet
 ###
 
 import { plugin } from 'bun'

--- a/source/bun-civet.coffee
+++ b/source/bun-civet.coffee
@@ -1,7 +1,7 @@
 ###
 Bun plugin for Civet files. Simply follow the steps below:
 
-1. Create bunconfig.civet if it doesn't exist
+1. Create bunconfig.toml if it doesn't exist
 2. Add the following line:
 preload = ["@danielx/civet/bun-civet"]
 


### PR DESCRIPTION
The Bun-related instructions are outdated since [Bun 0.5.8](https://bun.sh/blog/bun-v0.5.8).

Couple things:
1. With the "new" loader support .civet files can now be loaded "organically" (`bun file.civet`), there's no need to have a `ts` file where you include your first .civet file that includes the rest 🥰
2. Apart from the steps I included at the top of the file, there's also a way to skip `bunfig` and just pass a `preload` param to the `bun cli` (described in the blog post), but I couldn't make that work. So I only included instructions for the `bunfig` option.
3. We could mention the Bun compatibility and the instructions in the README. I would do it, but I wasn't sure you wanted to, so it's not part of this PR