### PR TITLE
Fix #599

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -475,11 +475,14 @@ FatArrow
       return " =>"
     return [ $1, "=>" ]
 
+TrailingDeclaration
+  ( _* ( ConstAssignment / LetAssignment ))
+
 # NOTE Different from
 # https://262.ecma-international.org/#prod-ConciseBody
 FatArrowBody
   # If same-line single expression, avoid wrapping in braces
-  !EOS NonPipelinePostfixedExpression:exp !SemicolonDelimiter -> exp
+  !EOS NonPipelinePostfixedExpression:exp !TrailingDeclaration !SemicolonDelimiter -> exp
   # Otherwise, wrap block body in braces and insert returns
   BracedOrEmptyBlock
 
@@ -1828,11 +1831,15 @@ NonSingleBracedBlock
       children: [$1, s, $3],
     }
 
+DeclarationOrStatement
+  Declaration
+  Statement
+
 # NOTE: SingleLineStatements includes the empty case
 SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
-  ForbidNewlineBinaryOp ( ( _? !EOS ) Statement SemicolonDelimiter )*:stmts ( ( _? !EOS ) Statement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ->
+  ForbidNewlineBinaryOp ( ( _? !EOS ) DeclarationOrStatement SemicolonDelimiter )*:stmts ( ( _? !EOS ) DeclarationOrStatement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ->
     const expressions = [...stmts]
     if (last) expressions.push(last)
 
@@ -1844,7 +1851,7 @@ SingleLineStatements
     }
 
 PostfixedSingleLineStatements
-  ( ( _? !EOS ) PostfixedStatement SemicolonDelimiter )*:stmts ( ( _? !EOS ) PostfixedStatement SemicolonDelimiter? )?:last ->
+  ( ( _? !EOS ) StatementListItem SemicolonDelimiter )*:stmts ( ( _? !EOS ) StatementListItem SemicolonDelimiter? )?:last ->
     const children = [...stmts]
     if (last) children.push(last)
 
@@ -1857,13 +1864,7 @@ PostfixedSingleLineStatements
 
 BracedContent
   NestedBlockStatements
-  _? Statement ->
-    const expressions = [["", $2]]
-    return {
-      type: "BlockStatement",
-      expressions,
-      children: [$1, expressions],
-    }
+  SingleLineStatements
   # Empty content
   &( __ "}" ) ->
     const expressions = []
@@ -4678,6 +4679,8 @@ StatementDelimiter
   # before value, or parens not actually added around ObjectLiteral).
   &( Nested ( "(" / "[" / "`" / "+" / "-" / "*" / "/" / ObjectLiteral / Arrow / FatArrow / ( Function ( _? Star )? _? "(" ) ) ) InsertSemicolon
   &EOS
+  # Allow for closing a block within the same line as a nested statement
+  &( _* "}" )
 
 SemicolonDelimiter
   _? Semicolon TrailingComment ->

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -592,3 +592,68 @@ describe "examples (from real life)", ->
       .map($ => $.split('\t'))
       .filter($1 => $1.some((v) => v))
   """
+
+  describe "#599", ->
+    testCase """
+      function with inline declaration
+      ---
+      function f() { const x = 1 }
+      ---
+      function f() { const x = 1;return  x }
+    """
+
+    testCase """
+      function with irregular block
+      ---
+      function f() {
+        const x = 1 }
+      ---
+      function f() {
+        const x = 1;return  x }
+    """
+
+    testCase """
+      function with multiple inline statements
+      ---
+      function f() { a; b }
+      function f() { ;b }
+      ---
+      function f() { a; return b }
+      function f() { ;return b }
+    """
+
+    testCase """
+      function with braced single expression
+      ---
+      function f() { a }
+      function f() { a
+      }
+      function f() {
+        a }
+      ---
+      function f() { return a }
+      function f() { return a
+      }
+      function f() {
+        return a }
+    """
+
+    testCase """
+      declaration in inline thin arrow function
+      ---
+      -> x := 5
+      -> x := 5; x
+      ---
+      (function() { const x = 5;return x });
+      (function() { const x = 5; return x })
+    """
+
+    testCase """
+      declaration in inline thick arrow function
+      ---
+      => x := 5
+      => x := 5; x
+      ---
+      () => { const x = 5;return x };
+      () => { const x = 5; return x }
+    """


### PR DESCRIPTION
- Added assertion for upcoming closing brace to end statements.
- Made `BracedContent` into `SingleLineStatements`.
- Allowed for Declarations in `SingleLineStatements`
- Allowed for Declarations in `PostfixedSingleLineStatements`

Things to look into in the future:

- Declarations in `then` will need to check if they should add braces.
- `BracedContent` may actually need to be something closer to `( SingleLineStatements EOS )+`