### PR TITLE
Initial auto-const

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6461,6 +6461,7 @@ Reset
     }
 
     module.config = {
+      autoConst: false,
       autoVar: false,
       autoLet: false,
       coffeeBinaryExistential: false,

--- a/test/auto-const.civet
+++ b/test/auto-const.civet
@@ -1,0 +1,593 @@
+{testCase} from ./helper.civet
+
+describe "auto-const", ->
+  testCase """
+    multiple assignment
+    ---
+    "civet auto-const"
+    a = b = c = d
+    a = 2
+    ---
+    let a, b, c
+    a = b = c = d
+    a = 2
+  """
+
+  testCase """
+    assignment to variable indexed array
+    ---
+    "civet auto-const"
+    a[x] = 1
+    ---
+    a[x] = 1
+  """
+
+  testCase """
+    with a declaration
+    ---
+    "civet auto-const"
+    let b = 2
+    a = 1
+    b = a
+    ---
+    let b = 2
+    const a = 1
+    b = a
+  """
+
+  testCase """
+    with a var declaration
+    ---
+    "civet auto-const"
+    var b = 2
+    a = 1
+    b = a
+    ---
+    var b = 2
+    const a = 1
+    b = a
+  """
+
+  testCase """
+    with a binding pattern
+    ---
+    "civet auto-const"
+    let [a, b] = [1, 2]
+    a = 3
+    ---
+    let [a, b] = [1, 2]
+    a = 3
+  """
+
+  testCase """
+    with import named binding
+    ---
+    "civet auto-const"
+    import {a, b} from 'c'
+    a = 1
+    ---
+    import {a, b} from 'c'
+    a = 1
+  """
+
+  testCase """
+    with default import
+    ---
+    "civet auto-const"
+    import a from 'b'
+    a = 1
+    ---
+    import a from 'b'
+    a = 1
+  """
+
+  testCase """
+    with default and named import
+    ---
+    "civet auto-const"
+    import a, {b, c} from 'd'
+    a = 1
+    b = 2
+    ---
+    import a, {b, c} from 'd'
+    a = 1
+    b = 2
+  """
+
+  testCase """
+    with an array destructuring assignment
+    ---
+    "civet auto-const"
+    [a, b] = [1, 2]
+    [c] = [3]
+    ---
+    let a, b
+    [a, b] = [1, 2];
+    const [c] = [3]
+  """
+
+  testCase """
+    with nested array destructuring assignment
+    ---
+    "civet auto-const"
+    [
+      a
+      b
+    ] = [1, 2]
+    ---
+    let a, b
+    [
+      a,
+      b
+    ] = [1, 2]
+  """
+
+  testCase """
+    with an object destructuring assignment
+    ---
+    "civet auto-const"
+    {a, b} = {a: 1, b: 2}
+    {c} = {c: 3}
+    ---
+    let a, b
+    ({a, b} = {a: 1, b: 2});
+    let c
+    ({c} = {c: 3})
+  """
+
+  testCase """
+    with nested object destructuring assignment
+    ---
+    "civet auto-const"
+    {
+      a
+      b
+    } = {a: 1, b: 2}
+    ---
+    let a, b
+    ({
+      a,
+      b
+    } = {a: 1, b: 2})
+  """
+
+  testCase """
+    with destructuring assignment renaming
+    ---
+    "civet auto-const"
+    {a: b, c: d} = {a: 1, c: 2}
+    ---
+    let b, d
+    ({a: b, c: d} = {a: 1, c: 2})
+  """
+
+  testCase """
+    with destructuring assignment nested renaming
+    ---
+    "civet auto-const"
+    {
+      a: {b: c}
+      d: e
+    } = {a: 1, c: 2}
+    ---
+    let c, e
+    ({
+      a: {b: c},
+      d: e
+    } = {a: 1, c: 2})
+  """
+
+  testCase """
+    with destructuring assignment object in array in object
+    ---
+    "civet auto-const"
+    {
+      a: [b, {c}]
+      d: e
+    } = {a: 1, c: 2}
+    ---
+    let b, c, e
+    ({
+      a: [b, {c}],
+      d: e
+    } = {a: 1, c: 2})
+  """
+
+  testCase """
+    for i loop
+    ---
+    "civet auto-const"
+    for i = 0; i < 10; i++
+      a = i
+    ---
+    let i
+    for (i = 0; i < 10; i++) {
+      const a = i
+    }
+  """
+
+  testCase """
+    for in loop with let dec
+    ---
+    "civet auto-const"
+    for let a in b
+      a = c = 1
+    ---
+    for (let a in b) {
+      let c
+      a = c = 1
+    }
+  """
+
+  testCase """
+    for loop implied const
+    ---
+    "civet auto-const"
+    for a in b
+      a = c = 1
+    ---
+    for (const a in b) {
+      let c
+      a = c = 1
+    }
+  """
+
+  testCase """
+    chained assignment
+    ---
+    "civet auto-const"
+    a = b = c = 1
+    ---
+    let a, b, c
+    a = b = c = 1
+  """
+
+  testCase """
+    chained assignment with a declaration
+    ---
+    "civet auto-const"
+    let a = 1
+    a = b = c = 1
+    ---
+    let a = 1
+    let b, c
+    a = b = c = 1
+  """
+
+  testCase """
+    chained assignment with destructuring
+    ---
+    "civet auto-const"
+    {a, b} = c = d
+    ---
+    let a, b, c
+    ({a, b} = c = d)
+  """
+
+  testCase """
+    chained assignment with destructuring in other order
+    ---
+    "civet auto-const"
+    a = {b, c} = d
+    ---
+    let a, b, c
+    a = ({b, c} = d)
+  """
+
+  testCase """
+    chained assignment with destructuring and a declaration
+    ---
+    "civet auto-const"
+    let a = 1
+    {a, b} = c = d
+    ---
+    let a = 1;
+    let b, c
+    ({a, b} = c = d)
+  """
+
+  testCase """
+    multiple chained destructuring assignments
+    ---
+    "civet auto-const"
+    {a, b} = {c, d} = x
+    ---
+    let a, b, c, d
+    ({a, b} = {c, d} = x)
+  """
+
+  testCase """
+    nested function
+    ---
+    "civet auto-const"
+    x = 1
+    a = ->
+      x = 2
+      y = 1
+      b = ->
+        x = 3
+        y = 2
+        z = 1
+    ---
+    const x = 1
+    const a = function() {
+      x = 2
+      const y = 1
+      let b
+      return b = function() {
+        x = 3
+        y = 2
+        let z
+        return z = 1
+      }
+    }
+  """
+
+  testCase """
+    nested arrow function
+    ---
+    "civet auto-const"
+    x = 1
+    a = =>
+      x = 2
+      y = 1
+      b = =>
+        x = 3
+        y = 2
+        z = 1
+    ---
+    const x = 1
+    const a = () => {
+      x = 2
+      const y = 1
+      let b
+      return b = () => {
+        x = 3
+        y = 2
+        let z
+        return z = 1
+      }
+    }
+  """
+
+  testCase """
+    nested methods
+    ---
+    "civet auto-const"
+    x = 1
+    {a()
+      x = 2
+      y = 1
+      {b()
+        x = 3
+        y = 2
+        z = 1
+      }
+    }
+    ---
+    const x = 1;
+    ({a() {
+      x = 2
+      const y = 1;
+      return ({b() {
+        x = 3
+        y = 2
+        let z
+        return z = 1
+      }
+      })
+    }
+    })
+  """
+
+  testCase """
+    function with parameters
+    ---
+    "civet auto-const"
+    a = (b, c) ->
+      x = 1
+      c = 2
+    ---
+    const a = function(b, c) {
+      const x = 1
+      return c = 2
+    }
+  """
+
+  testCase """
+    nested blocks
+    ---
+    "civet auto-const"
+    x = 1
+    {
+      x = 2
+      y = 1
+      {
+        x = 3
+        y = 2
+        z = 1
+      }
+      {
+        z = 2
+      }
+    }
+    ---
+    const x = 1
+    {
+      x = 2
+      const y = 1
+      {
+        x = 3
+        y = 2
+        const z = 1
+      }
+      {
+        const z = 2
+      }
+    }
+  """
+
+
+  // This case is disabled because the 'export var' cannot be detected due to the var token is not in declaration.
+  testCase """
+    export implicit const dec
+    ---
+    "civet auto-const"
+    a = 1
+    export a = 2
+    ---
+    a = 1
+    export var a = 2
+  """
+
+  testCase """
+    const dec inside block
+    ---
+    "civet auto-const"
+    a = 1
+    {
+      let a = 2
+    }
+    ---
+    const a = 1
+    {
+      let a = 2
+    }
+  """
+
+  describe "complicated auto-const", ->
+    testCase """
+        auto const nest
+        ---
+        "civet auto-const"
+        let v1 = 0
+        v2 = 0
+        for i of [1]
+            v1 = 1
+            var v2 = 1
+            v3 = 1
+            for j of [1]
+                v1 = 2
+            v2 = 2
+        v3 = 2
+        ---
+        let v1 = 0
+        v2 = 0
+        for (const i of [1]) {
+            v1 = 1
+            var v2 = 1
+            const v3 = 1
+            for (const j of [1]) {
+                v1 = 2
+            }
+            v2 = 2
+        }
+        const v3 = 2
+    """
+    testCase """
+        auto const with function
+        ---
+        "civet auto-const"
+        b = 1
+        function b(a) {
+            a = 1
+            var b = 2
+        }
+        a = 2
+        let c = (b) => {
+            c = 1
+        }
+        ---
+        const b = 1
+        function b(a) {
+            a = 1
+            var b = 2;return b
+        }
+        const a = 2
+        let c = (b) => {
+            let c
+            return c = 1
+        }
+    """
+    testCase """
+        auto const with multiple declaration
+        ---
+        "civet auto-const"
+        c = "str"
+        [a, b] = [1, 2]
+        [c, d] = [3, 4]
+        ---
+        const c = "str";
+        let a, b
+        [a, b] = [1, 2];
+        let d
+        [c, d] = [3, 4]
+    """
+    testCase """
+    auto const inner assignment expression
+    ---
+    "civet auto-const"
+    [a, b] = function(a) {
+        a = 2
+        b = 2
+        return [a, b]
+    }(a)
+    ---
+    let a, b
+    [a, b] = function(a) {
+        a = 2
+        const b = 2
+        return [a, b]
+    }(a)
+    """
+
+    testCase """
+    auto const inner if parens
+    ---
+    "civet auto-const"
+    if a = 1
+      a = 2
+    else if b = 2 then c = 3
+    else if d = 3
+      a = 4
+    else
+      e = 5
+    a = 6
+    ---
+    let a, b, c, d
+    if (a = 1) {
+      a = 2
+    }
+    else if (b = 2) c = 3;
+    else if (d = 3) {
+      a = 4
+    }
+    else {
+      const e = 5
+    }
+    a = 6
+    """
+
+    testCase """
+    auto const embedded
+    ---
+    "civet auto-const"
+    a1 = 1
+    a2.b = 1
+    [a3] = 1
+    {a4} = 1
+    a5 = b5 = 1
+    a6.b = b6 = 1
+    b7 = a7.b = 1
+    ---
+    const a1 = 1
+    a2.b = 1;
+    const [a3] = 1;
+    let a4
+    ({a4} = 1)
+    let a5, b5
+    a5 = b5 = 1
+    let b6
+    a6.b = b6 = 1
+    const b7 = a7.b = 1
+    """


### PR DESCRIPTION
This is about 80% of auto-const by modifying the existing auto-let.

When the assignment appears in an expression it may be very difficult to actually enforce it as const without possibly heavily rewriting the parse tree.

There are still some simple cases that we could improve for both auto-let and auto-const.

This will work great for common situations.

Fixes #527 