### PR TITLE
Fix #564 Implement basic const enums in --js mode

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5831,8 +5831,11 @@ EnumDeclaration
       ts: true,
       children: $0,
     }
-    // const enums do not generate any JavaScript code
-    if (isConst) return ts
+    // In TypeScript const enums do not generate any JavaScript code
+    // but we don't yet do the same post-processing to completely
+    // erase the enum from the output. So we just use a simpler
+    // but less optimized output for raw js.
+    // if (isConst) return ts
     // Generate JS output for enum similar to how TypeScript does
     const names = new Set(block.properties.map(p => p.name.name))
     return [ts,

--- a/test/types/enum.civet
+++ b/test/types/enum.civet
@@ -131,6 +131,15 @@ describe "[TS] enum", ->
       Down
       Left
       Right
-    ---
 
+    Direction.Up
+    ---
+    let Direction = {};
+    Direction[Direction["Up"] = 0] = "Up";
+    Direction[Direction["Down"] = Direction["Up"] + 1] = "Down";
+    Direction[Direction["Left"] = Direction["Down"] + 1] = "Left";
+    Direction[Direction["Right"] = Direction["Left"] + 1] = "Right";
+
+
+    Direction.Up
   """


### PR DESCRIPTION
Since we're not following up the enum erasure with replacing with the literal values we should generate them in JS too in the meantime.