### PR TITLE
 Fix vscode extension not loaded

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "publisher": "DanielX",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version to publish vscode extension again

## Problem

VSCode is electron based application which not support `esm` extension.

In previous version `0.3.8` #706 I mistakenly write `type: module`

which fix in [bc3df868a6c12704563a50de2c609c3617b11518](https://github.com/DanielXMoore/Civet/commit/bc3df868a6c12704563a50de2c609c3617b11518#diff-27789350cda9e8a79d0a95ea08e89a9c6c292a847d061198b8ee8790babb7b25) by remove it to revert to default behavior use `type: commonjs` as fallback

But that Fixed! version not publish yet in [marketplace](https://marketplace.visualstudio.com/items?itemName=DanielX.civet), so patch a version to help easier publish it.

<img width="761" alt="image" src="https://github.com/DanielXMoore/Civet/assets/19445033/703d9bac-5a37-4bfb-9dd7-9ae4110aad11">
