### PR TITLE
Allow more ergonomic require of cjs esbuild plugin

### DIFF
--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -135,5 +135,6 @@ civet.setup = defaultPlugin.setup
 if typeof module !== 'undefined'
   // So we can `civetPlugin = require "@danielx/civet/esbuild-plugin"`
   module.exports = civet
+  module.exports.default = civet
 // So ts-node can `import ./source/esbuild-plugin.civet`
 export default civet

--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -130,7 +130,10 @@ defaultPlugin := civet()
 // Default zero-config plugin
 civet.setup = defaultPlugin.setup
 
+// Hack to hybrid export for esbuild cjs and ts-node esm
+// this causes a warning in esbuild
 if typeof module !== 'undefined'
+  // So we can `civetPlugin = require "@danielx/civet/esbuild-plugin"`
   module.exports = civet
-
+// So ts-node can `import ./source/esbuild-plugin.civet`
 export default civet

--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -130,4 +130,4 @@ defaultPlugin := civet()
 // Default zero-config plugin
 civet.setup = defaultPlugin.setup
 
-export default civet
+module.exports = civet

--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -130,4 +130,7 @@ defaultPlugin := civet()
 // Default zero-config plugin
 civet.setup = defaultPlugin.setup
 
-module.exports = civet
+if typeof module !== 'undefined'
+  module.exports = civet
+
+export default civet


### PR DESCRIPTION
This lets us use `civetPlugin = require "@danielx/civet/esbuild-plugin"` instead of needing to use `.default`.

We can pick it up in `esbuild.civet` after publishing.