### PR TITLE
Fix #629: Unary op with late assignment

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -341,7 +341,7 @@ UnaryExpression
   # NOTE: Merged AwaitExpression with UnaryOp
   # https://262.ecma-international.org/#prod-AwaitExpression
   # NOTE: Eliminated left recursion
-  UnaryOp*:pre ( UpdateExpression / NestedNonAssignmentExtendedExpression ):exp UnaryPostfix?:post ->
+  UnaryOp*:pre UnaryBody:exp UnaryPostfix?:post ->
     return processUnaryExpression(pre, exp, post)
 
   # NOTE: This is a little hacky to match CoffeeScript's behavior
@@ -350,6 +350,21 @@ UnaryExpression
     ws = insertTrimmingSpace(ws, "")
     return ["(", ...ws, exp, ")()"]
 
+UnaryWithoutParenthesizedAssignment
+  UnaryOp*:pre UnaryWithoutParenthesizedAssignmentBody:exp UnaryPostfix?:post ->
+    return processUnaryExpression(pre, exp, post)
+
+UnaryBody
+  ParenthesizedAssignment
+  UpdateExpression
+  ExpressionizedStatementWithTrailingCallExpressions
+  NestedNonAssignmentExtendedExpression
+
+UnaryWithoutParenthesizedAssignmentBody
+  UpdateExpression
+  ExpressionizedStatementWithTrailingCallExpressions
+  NestedNonAssignmentExtendedExpression
+
 UnaryPostfix
   QuestionMark
   ( __ ( As / Satisfies ) Type )+ -> { ts: true, children: $0 }
@@ -357,7 +372,7 @@ UnaryPostfix
 # https://262.ecma-international.org/#prod-UpdateExpression
 UpdateExpression
   # NOTE: Not allowing whitespace betwen prefix and postfix increment operators and operand
-  UpdateExpressionSymbol UnaryExpression ->
+  UpdateExpressionSymbol UnaryWithoutParenthesizedAssignment ->
     return {
       type: "UpdateExpression",
       assigned: $2,

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -525,9 +525,9 @@ describe "assignment", ->
     """
 
     testCase """
-      not form isn't an assignment
+      not form is treated as late assignment
       ---
       x not min= y
       ---
-      x(!min)= y
+      x(!(min= y))
     """

--- a/test/unary-expression.civet
+++ b/test/unary-expression.civet
@@ -76,3 +76,19 @@ describe "unary expression", ->
     ---
     (x != null) + (y != null)
   """
+
+  testCase """
+    late assignment
+    ---
+    !x = 1
+    ---
+    !(x = 1)
+  """
+
+  testCase """
+    expressionized statement
+    ---
+    !debugger
+    ---
+    !(()=>{debugger})()
+  """


### PR DESCRIPTION
The previous code generated from `test/assignment.civet` wasn't valid JS so this seems somewhat better.