### PR TITLE
Unify pattern matching and declaration conditions

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -27,10 +27,23 @@ type ASTLeaf =
   $loc: Loc
   token: string
 
+type Children = ASTNode[]
+
 type StatementDelimiter = ASTNode
 type IndentNode = ASTNode
 
 type StatementTuple = [IndentNode, ASTNode, StatementDelimiter?]
+
+type IfStatement =
+  type: "IfStatement"
+  children: Children
+  condition: IfCondition
+  then: BlockStatement
+  else: [ ASTNode, ElseToken, BlockStatement ] | undefined
+  then: block
+  else: e
+
+type ElseToken = { $loc: Loc, token: "else" }
 
 type ASTRef =
   type: "Ref"
@@ -131,26 +144,18 @@ function updateParentPointers(node: ASTNode, parent?: ASTNodeBase, depth = 1): v
 }
 
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
-  let children, expressions
-
-  prefix := post.blockPrefix or post.condition?.expression.blockPrefix
-
-  if prefix?.length
-    indent := prefix[0][0]
-    expressions = [...prefix, [indent, statement]]
-    children = [" {\n", ...expressions, "\n", indent?.slice?.(0, -2), "}"]
-  else
-    expressions = [["", statement]]
-    children = [" { ", ...expressions, " }"]
+  expressions := [
+    ...post.blockPrefix or []
+    ["", statement]
+  ]
 
   block := {
     type: "BlockStatement"
-    children
+    children: [" { ", expressions, " }"]
     expressions
   }
 
-  children = [...post.children]
-  children.push(block)
+  children := [...post.children, block]
 
   // This removes trailing whitespace for easier testing
   if (!isWhitespaceOrEmpty(ws)) children.push(ws)
@@ -2039,6 +2044,57 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
   }
 }
 
+function processDeclarationCondition(condition): void
+  return unless condition.type is "DeclarationCondition"
+  ref := makeRef()
+
+  { decl, bindings } := condition.declaration
+  // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
+  binding := bindings[0]
+  { pattern, suffix, initializer, splices, thisAssignments } := binding
+
+  initCondition :=
+    type: "AssignmentExpression"
+    children: [ref, initializer]
+    hoistDec:
+      type: "Declaration"
+      children: ["let ", ref, suffix]
+      names: []
+    blockPrefix: [
+      ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
+      ...thisAssignments
+    ]
+
+  Object.assign(condition, initCondition)
+
+function processDeclarationConditions(node: ASTNode): void
+  gatherRecursiveAll node, (n) =>
+    n.type is "IfStatement" or n.type is "IterationStatement"
+  .forEach processDeclarationConditionStatement
+
+function processDeclarationConditionStatement(s: IfStatement | WhileStatement): void
+  { condition } := s
+  return unless condition
+  processDeclarationCondition(condition.expression)
+
+  switch s.type
+    when "IfStatement"
+      { else: e} := s
+      block := blockWithPrefix(condition.expression.blockPrefix, s.then)
+      s.then = block
+
+      toAdd := [block]
+
+      if block.bare and e
+        toAdd.push ";"
+
+      s.children.splice(2, 1, ...toAdd)
+
+    when "IterationStatement"
+      { children, block } := s
+      newBlock := blockWithPrefix(condition.expression.blockPrefix, block)
+      s.children = s.children.map (c) -> c.type is "BlockStatement" ? newBlock : c
+
 // Add implicit block unless followed by a method/function of the same name,
 // or block is within an ExportDeclaration.
 function implicitFunctionBlock(f): void {
@@ -2838,6 +2894,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord): void {
 
   const { expressions: statements } = root
 
+  processDeclarationConditions(statements)
   processPipelineExpressions(statements)
   processAssignments(statements)
   processPatternMatching(statements, ReservedWord)

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2113,6 +2113,9 @@ function processDeclarationConditionStatement(s: IfStatement | WhileStatement): 
       newBlock := blockWithPrefix(condition.expression.blockPrefix, block)
       s.children = s.children.map (c) -> c.type is "BlockStatement" ? newBlock : c
 
+  // Update parent pointers since declaration conditions have expanded
+  addParentPointers(s, s.parent)
+
 // Add implicit block unless followed by a method/function of the same name,
 // or block is within an ExportDeclaration.
 function implicitFunctionBlock(f): void {

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2108,13 +2108,16 @@ function processDeclarationConditionStatement(s: IfStatement | WhileStatement): 
 
       s.children.splice(2, 1, ...toAdd)
 
+      // Update parent pointers since declaration conditions have expanded
+      updateParentPointers(block, s)
+
     when "IterationStatement"
       { children, block } := s
       newBlock := blockWithPrefix(condition.expression.blockPrefix, block)
-      s.children = s.children.map (c) -> c.type is "BlockStatement" ? newBlock : c
+      s.children = children.map (c) -> c.type is "BlockStatement" ? newBlock : c
 
-  // Update parent pointers since declaration conditions have expanded
-  addParentPointers(s, s.parent)
+      // Update parent pointers since declaration conditions have expanded
+      updateParentPointers(newBlock, s)
 
 // Add implicit block unless followed by a method/function of the same name,
 // or block is within an ExportDeclaration.

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2064,6 +2064,8 @@ function processDeclarationCondition(condition): void
       ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
       ...thisAssignments
     ]
+    pattern: pattern
+    ref: ref
 
   Object.assign(condition, initCondition)
 
@@ -2076,6 +2078,22 @@ function processDeclarationConditionStatement(s: IfStatement | WhileStatement): 
   { condition } := s
   return unless condition
   processDeclarationCondition(condition.expression)
+
+  { ref, pattern } := condition.expression
+
+  if pattern
+    conditions .= []
+    getPatternConditions(pattern, ref, conditions)
+
+    conditions = conditions.filter (c) =>
+      !(c.length is 3 and c[0] is "typeof " and c[1] is ref and c[2] is " === 'object'") and
+      !(c.length is 2 and c[0] is ref and c[1] is " != null")
+
+    if conditions.length
+      condition.children.unshift "("
+      conditions.forEach (c) ->
+        condition.children.push " && ", c
+      condition.children.push ")"
 
   switch s.type
     when "IfStatement"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3172,16 +3172,11 @@ LabelledItem
 IfStatement
   # NOTE: Added paren-less condition
   # NOTE: Block isn't Statement so we can handle implied braces by nesting
-  (IfClause / UnlessClause):clause Block:block ElseClause?:e ->
-    const children = [...clause.children]
-    block = blockWithPrefix(clause.condition.expression.blockPrefix, block)
-    children.push(block)
-    if (block.bare && e) children./**/push(";")
-    if (e) children./**/push(e)
-
+  ( IfClause / UnlessClause ):clause Block:block ElseClause?:e ->
     return {
-      ...clause,
-      children,
+      type: "IfStatement",
+      children: [...clause.children, block, e],
+      condition: clause.condition,
       then: block,
       else: e,
     }
@@ -3367,7 +3362,6 @@ DoStatement
 WhileStatement
   # NOTE: Condition provides optional parens
   WhileClause:clause Block:block ->
-    block = blockWithPrefix(clause.condition.expression.blockPrefix, block)
     return {
       ...clause,
       children: [...clause.children, block],
@@ -3900,31 +3894,13 @@ Condition
     }
 
 DeclarationCondition
-  ForbidIndentedApplication LexicalDeclaration?:dec RestoreIndentedApplication ->
-    if (!dec) return $skip
+  ForbidIndentedApplication LexicalDeclaration?:declaration RestoreIndentedApplication ->
+    if (!declaration) return $skip
 
-    const ref = makeRef()
-
-    const { decl, bindings } = dec
-    // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
-    const binding = bindings[0]
-    const { pattern, suffix, initializer, splices, thisAssignments } = binding
-
-    const initCondition = {
-      type: "AssignmentExpression",
-      children: [ref, initializer],
-      hoistDec: {
-        type: "Declaration",
-        children: ["let ", ref, suffix],
-        names: [],
-      },
-      blockPrefix: [
-        ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
-        ...thisAssignments
-      ],
+    return {
+      type: "DeclarationCondition",
+      declaration,
     }
-
-    return initCondition
 
 ExpressionWithIndentedApplicationForbidden
   ForbidIndentedApplication ForbidNewlineBinaryOp ExtendedExpression?:exp RestoreNewlineBinaryOp RestoreIndentedApplication ->

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -246,9 +246,7 @@ describe "coffeeForLoops", ->
     coffees = (s for s in scripts when s.type in coffeetypes)
     ---
     var coffees;var indexOf: <T>(this: T[], searchElement: T) => boolean = [].indexOf as any;
-    coffees = (()=>{var s;const results=[];for (let i = 0, len = scripts.length; i < len; i++) {
-    s = scripts[i];if (!(indexOf.call(coffeetypes, s.type) >= 0)) continue;results.push(s)
-    }; return results})()
+    coffees = (()=>{var s;const results=[];for (let i = 0, len = scripts.length; i < len; i++) { s = scripts[i];if (!(indexOf.call(coffeetypes, s.type) >= 0)) continue;results.push(s) }; return results})()
   """
 
   testCase """
@@ -430,9 +428,7 @@ describe "coffeeForLoops", ->
     log(a) for own a of b when a != "y"
     ---
     var a;var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
-    for (a in b) {
-    if (!hasProp(b, a)) continue;if (!(a !== "y")) continue;log(a)
-    }
+    for (a in b) { if (!hasProp(b, a)) continue;if (!(a !== "y")) continue;log(a) }
   """
 
   testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -282,9 +282,7 @@ describe "if", ->
     ---
     x if { x } := y
     ---
-    let ref;if (ref = y) {
-    const { x } = ref;x
-    }
+    let ref;if (ref = y) { const { x } = ref;x }
   """
 
   testCase """
@@ -296,15 +294,13 @@ describe "if", ->
       z
     } if w := g()
     ---
-    let ref;if (ref = g()) {
-    const w = ref;if (ref1 = f()) {
+    let ref;if (ref = g()) { const w = ref;if (ref1 = f()) {
       const x = ref1;
       y
     }
     else {
       z
-    }
-    }
+    } }
   """
 
   testCase """
@@ -801,6 +797,18 @@ describe "if", ->
         const [...a] = ref,[b] = a.splice(-1);
         this.a = a;
         console.log(this.a, b)
+      }
+    """
+
+    testCase """
+      pins in declaration
+      ---
+      if {x, ^y} := obj
+        console.log x
+      ---
+      let ref;if ((ref = obj) && "y" in ref && y === ref.y) {
+        const {x, y} = ref;
+        console.log(x)
       }
     """
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -282,7 +282,7 @@ describe "if", ->
     ---
     x if { x } := y
     ---
-    let ref;if (ref = y) { const { x } = ref;x }
+    let ref;if ((ref = y) && 'x' in ref) { const { x } = ref;x }
   """
 
   testCase """
@@ -689,7 +689,7 @@ describe "if", ->
       if [_, s] := s.match(re)
         s
       ---
-      let ref;if (ref = s.match(re)) {
+      let ref;if ((ref = s.match(re)) && Array.isArray(ref) && ref.length === 2) {
         const [_, s] = ref;
         s
       }
@@ -713,7 +713,7 @@ describe "if", ->
       if [_, s]/*left*/:=/*right*/s.match(re)
         s
       ---
-      let ref;if (ref/*left*/=/*right*/s.match(re)) {
+      let ref;if ((ref/*left*/=/*right*/s.match(re)) && Array.isArray(ref) && ref.length === 2) {
         const [_, s] = ref;
         s
       }
@@ -725,7 +725,7 @@ describe "if", ->
       if [_, ...@s] := s.match(re)
         s
       ---
-      let ref;if (ref = s.match(re)) {
+      let ref;if ((ref = s.match(re)) && Array.isArray(ref) && ref.length >= 1) {
         const [_, ...s1] = ref;
         this.s = s1;
         s
@@ -738,7 +738,7 @@ describe "if", ->
       if [...@s, a] := s.match(re)
         s
       ---
-      let ref;if (ref = s.match(re)) {
+      let ref;if ((ref = s.match(re)) && Array.isArray(ref) && ref.length >= 1) {
         const [...s1] = ref, [a] = s1.splice(-1);
         this.s = s1;
         s
@@ -751,7 +751,7 @@ describe "if", ->
       if ([_, s] := s.match(re))
         s
       ---
-      let ref;if (ref = s.match(re)) {
+      let ref;if ((ref = s.match(re)) && Array.isArray(ref) && ref.length === 2) {
         const [_, s] = ref;
         s
       }
@@ -793,7 +793,7 @@ describe "if", ->
       if const [...@a, b] = regex.exec string
         console.log @a, b
       ---
-      let ref;if (ref = regex.exec(string)) {
+      let ref;if ((ref = regex.exec(string)) && Array.isArray(ref) && ref.length >= 1) {
         const [...a] = ref,[b] = a.splice(-1);
         this.a = a;
         console.log(this.a, b)
@@ -806,7 +806,7 @@ describe "if", ->
       if {x, ^y} := obj
         console.log x
       ---
-      let ref;if ((ref = obj) && "y" in ref && y === ref.y) {
+      let ref;if ((ref = obj) && 'x' in ref && 'y' in ref && ref.y === y) {
         const {x, y} = ref;
         console.log(x)
       }

--- a/test/if.civet
+++ b/test/if.civet
@@ -294,7 +294,7 @@ describe "if", ->
       z
     } if w := g()
     ---
-    let ref;if (ref = g()) { const w = ref;if (ref1 = f()) {
+    let ref;if (ref = g()) { const w = ref;let ref1;if (ref1 = f()) {
       const x = ref1;
       y
     }


### PR DESCRIPTION
- [x] Refactor declaration conditions
- [x] Apply pattern matching conditions to declaration conditions

There's some possible follow on discussion/work to do.

Should

```civet
if {x} := y
  ...
```

also add a condition check for x being non-falsey?

What about:

```
if {x, y} := z
  ...
```

Should x and y be non-falsey?