### PR TITLE
Warning-free hack for ergonomic require of cjs esbuild plugin

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -61,6 +61,10 @@ rewriteCivetImports = {
       rewriteCivetImports
       civetPlugin()
     ]
+    footer: if name == 'esbuild-plugin'
+      # Rewrite default export as CJS exports object,
+      # so require('esbuild-plugin') gives the plugin.
+      js: 'module.exports = module.exports.default;'
   }).catch -> process.exit 1
 
 # esm needs to be a module for import.meta

--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -130,11 +130,4 @@ defaultPlugin := civet()
 // Default zero-config plugin
 civet.setup = defaultPlugin.setup
 
-// Hack to hybrid export for esbuild cjs and ts-node esm
-// this causes a warning in esbuild
-if typeof module !== 'undefined'
-  // So we can `civetPlugin = require "@danielx/civet/esbuild-plugin"`
-  module.exports = civet
-  module.exports.default = civet
-// So ts-node can `import ./source/esbuild-plugin.civet`
 export default civet


### PR DESCRIPTION
It's still a bit hacky, but at least it doesn't cause esbuild to generate a loud warning.

Tested:
* `require('./dist/esbuild-plugin.js')` in `node` CLI (produces function)
* `import plugin from './dist/esbuild-plugin.js'` in a file `test.mjs` (produces function)
* `yarn test`

Based on https://github.com/egoist/tsup/issues/572#issuecomment-1060599574. Also, it looks like if we used `tsup` for this (we already do for the unplugin), there's a cleaner solution: https://tsup.egoist.dev/#interop-with-commonjs