### PR TITLE
basic parser tracing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,19 @@ You can attach a debugger as follows:
 Then you can step through the parser and see what is going on in practice
 as opposed to in theory.
 
+### Parser Tracing
+
+Sometimes you may want to check exactly what rules are checked in
+detailed order. You can use `--trace tracefile`.
+
+```sh
+dist/civet --trace trace.out < some-small-test.civet
+```
+
+Since this logs every rule entry and exit as well as cache hit
+it can quickly become quite large so it is best to use on as
+minimal a test case as possible.
+
 ### CLI
 
 A quick way to experiment with the parser (after building it with
@@ -120,6 +133,19 @@ Bugs in the compiler can often be caused by caching (which is done in
 [`source/main.coffee`](source/main.coffee)).  You can temporarily disable
 caching to see whether that's the issue, by adding the `--no-cache`
 command-line option.
+
+## Optimizing
+
+A quick way to get an idea of how much work the parser is doing is to
+use the `--hits hitsfile.txt` to get a count of every rule checked.
+
+```sh
+dist/civet --hits hits.out < source/lib.civet
+```
+
+This will output a sorted list of rules that were checked the most.
+Focusing on the rules that have the most checks should have the most
+impact on performance.
 
 ## Asking for Help
 

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -104,6 +104,7 @@ esbuild.build({
   watch
   platform: 'browser'
   outfile: 'dist/browser.js'
+  external: ['fs']
   plugins: [
     resolveExtensions
     heraPlugin

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -95,6 +95,10 @@ parseArgs = (args) ->
         options.inlineMap = true
       when '--js'
         options.js = true
+      when '--hits'
+        options.hits = args[++i]
+      when '--trace'
+        options.trace = args[++i]
       when '--'
         endOfArgs ++i  # remaining arguments are filename and/or arguments
       else

--- a/source/main.civet
+++ b/source/main.civet
@@ -7,8 +7,6 @@ export { parse, generate, util }
 
 import StateCache from "./state-cache.civet"
 
-{ writeFileSync } from fs
-
 // Need to no-cache any rule that directly modifies parser state
 // indentation stack, jsx stack, etc.
 
@@ -65,6 +63,8 @@ export type CompilerOptions
   ast?: boolean
   js?: boolean
   noCache?: boolean
+  hits?: string
+  trace?: string
   parseOptions?:
     coffeeCompat?: boolean
   updateSourceMap?: (output: string, inputPos?: number) => void
@@ -83,9 +83,14 @@ export compile := (src: string, options?: CompilerOptions) ->
   if filename.endsWith('.coffee') and not /^(#![^\r\n]*(\r\n|\n|\r))?\s*['"]civet/.test src
     options.parseOptions.coffeeCompat = true
 
-  let events
-  if !options.noCache
-    events = makeCache()
+  {hits, trace, noCache} := options
+
+  let events: CacheEvents | undefined
+  unless noCache
+    events = makeCache {
+      hits: !!hits
+      trace: !!trace
+    }
 
   let ast
 
@@ -97,9 +102,34 @@ export compile := (src: string, options?: CompilerOptions) ->
       events
     })
   catch err
-    if trace
-      writeFileSync "logs.out", logs.join "\n"
     throw err
+  finally
+    if hits or trace
+      import('fs').then ({ writeFileSync }) ->
+        if { logs } := events?.meta
+          if trace
+            writeFileSync trace, logs.join "\n"
+
+        if hits
+          if hitData := events?.meta.hits
+            total .= 0
+            data := [...hitData.entries()]
+
+            // sort hit count and write to hits.out
+            counts := data
+            .sort ([, a], [, b]) => b - a
+            .map ([k, v]) =>
+              total+=v
+              `${k}: ${v}`
+            .join "\n"
+
+            hitSummary := ```
+              Total: ${total}
+
+              ${counts}
+            ```
+
+            writeFileSync hits, hitSummary
 
   if options.ast
     return ast
@@ -138,17 +168,41 @@ type ParseResult = {
   value: unknown
 } | undefined
 
-trace := false
+type MetaData
+  hits?: Map<string, number>
+  logs?: string[]
 
-logs: unknown[] := []
-makeCache := ->
-  stateCache := new StateCache
+type CacheOptions
+  hits?: boolean | undefined
+  trace?: boolean | undefined
+
+type CacheEvents
+  meta: MetaData
+  enter: (ruleName: string, state: ParseState) => { cache: ParseResult } | undefined
+  exit: (ruleName: string, state: ParseState, result: ParseResult) => void
+
+makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
+  meta: MetaData := {}
+  let hitCount: Map<string, number>
+  if hits
+    hitCount = new Map
+    meta.hits = hitCount
+
+  let logs: string[]
+  if trace
+    logs = []
+    meta.logs = logs
+
+  stateCache := new StateCache<ParseResult>
   getStateKey: () => [number, string] .= null!
 
   stack: string[] := []
 
-  events :=
+  events := {
+    meta
     enter: (ruleName: string, state: ParseState) ->
+      hitCount.set ruleName, (hitCount.get(ruleName) or 0) + 1 if hits
+
       return if uncacheable.has(ruleName)
 
       key: CacheKey := [ruleName, state.pos, ...getStateKey()]
@@ -190,6 +244,7 @@ makeCache := ->
         logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + " " + (if result then "✅" else "❌")
 
       return
+  }
 
   return events
 

--- a/source/main.civet
+++ b/source/main.civet
@@ -101,8 +101,6 @@ export compile := (src: string, options?: CompilerOptions) ->
       filename
       events
     })
-  catch err
-    throw err
   finally
     if hits or trace
       import('fs').then ({ writeFileSync }) ->

--- a/source/main.civet
+++ b/source/main.civet
@@ -7,6 +7,8 @@ export { parse, generate, util }
 
 import StateCache from "./state-cache.civet"
 
+{ writeFileSync } from fs
+
 // Need to no-cache any rule that directly modifies parser state
 // indentation stack, jsx stack, etc.
 
@@ -84,12 +86,19 @@ export compile := (src: string, options?: CompilerOptions) ->
   if !options.noCache
     events = makeCache()
 
-  //@ts-ignore
-  parse.config = options.parseOptions or {}
-  ast := prune parse(src, {
-    filename
-    events
-  })
+  let ast
+
+  try
+    //@ts-ignore
+    parse.config = options.parseOptions or {}
+    ast = prune parse(src, {
+      filename
+      events
+    })
+  catch err
+    if trace
+      writeFileSync "logs.out", logs.join "\n"
+    throw err
 
   if options.ast
     return ast
@@ -128,12 +137,14 @@ type ParseResult = {
   value: unknown
 } | undefined
 
-// logs = []
+trace := false
+
+logs: unknown[] := []
 makeCache := ->
   stateCache := new StateCache
   getStateKey: () => [number, string] .= null!
 
-  // stack = []
+  stack: string[] := []
 
   events :=
     enter: (ruleName: string, state: ParseState) ->
@@ -143,14 +154,16 @@ makeCache := ->
 
       // We cache `undefined` when a rule fails to match so we need to use `has` here.
       if stateCache.has(key)
-        // logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "💰"
+        if trace
+          logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "💰"
         result := stateCache.get(key)
         return {
           cache: if result then { ...result }
         }
 
-      // logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "\u2192"
-      // stack.push(ruleName)
+      if trace
+        logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "\u2192"
+        stack.push ruleName
 
       return
 
@@ -170,8 +183,10 @@ makeCache := ->
       //@ts-ignore
       if parse.config.verbose and result
         console.log `Parsed ${JSON.stringify state.input[state.pos...result.pos]} [pos ${state.pos}-${result.pos}] as ${ruleName}`//, JSON.stringify(result.value)
-      // stack.pop()
-      // logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + " " + (if result then "✅" else "❌")
+
+      if trace
+        stack.pop()
+        logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + " " + (if result then "✅" else "❌")
 
       return
 


### PR DESCRIPTION
It would be nice to be able to output a trace of all the rules including cache hit counts.

This is a start.

- [x] Remove `fs` dep
- [x] Add cache counts
- [x] Figure out output format