### PR TITLE
Fix #714

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -680,11 +680,14 @@ function processCallMemberExpression(node) {
           throw new Error("Glob pattern cannot have method definition")
         }
         if (part.value && !["CallExpression", "MemberExpression", "Identifier"].includes(part.value.type)) {
-          throw new Error("Glob pattern must have call or member expression value")
+          throw new Error(`Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`)
         }
         let value = part.value ?? part.name
         const wValue = getTrimmingSpace(part.value)
-        value = prefix.concat(insertTrimmingSpace(value, ""))
+        if value.privateShorthand
+          value = prefix.concat(value.children[1].children[1])
+        else
+          value = prefix.concat(insertTrimmingSpace(value, ""))
         if (wValue) value.unshift(wValue)
         if (part.type === "SpreadProperty") {
           parts.push({

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -649,9 +649,37 @@ function processBinaryOpExpression($0) {
 }
 
 /**
+ * This adjusts #x.y().z and @x.y().z when used inside Object glob expressions
+ * to remove `this.` where necessary.
+ *
+ * [See More](../test/object.civet)
+ */
+function handleThisPrivateShorthands(value)
+  if value.privateShorthand
+    value = value.children[1].children[1]
+
+    return [value, false]
+
+  if value.type is "MemberExpression" or value.type is "CallExpression"
+    suppressPrefix .= value.thisShorthand
+    value = {
+      ...value,
+      children: value.children.map (c, i) =>
+        if i is 0
+          [c, s] = handleThisPrivateShorthands c
+          suppressPrefix ||= s
+
+        c
+    }
+
+    return [value, suppressPrefix]
+
+  return [value, value.thisShorthand]
+
+/**
  * Process globs and bind shorthand in Call/MemberExpression
  */
-function processCallMemberExpression(node) {
+function processCallMemberExpression(node)
   const { children } = node
   for (let i = 0; i < children.length; i++) {
     const glob = children[i]
@@ -676,17 +704,18 @@ function processCallMemberExpression(node) {
       prefix = prefix.concat(glob.dot)
 
       for (const part of glob.object.properties) {
-        if (part.type === "MethodDefinition") {
+        if part.type is "MethodDefinition"
           throw new Error("Glob pattern cannot have method definition")
-        }
-        if (part.value && !["CallExpression", "MemberExpression", "Identifier"].includes(part.value.type)) {
+        if part.value and !["CallExpression", "MemberExpression", "Identifier"].includes(part.value.type)
           throw new Error(`Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`)
-        }
-        let value = part.value ?? part.name
-        const wValue = getTrimmingSpace(part.value)
-        if value.privateShorthand
-          value = prefix.concat(value.children[1].children[1])
-        else
+
+        suppressPrefix .= false
+        value .= part.value ?? part.name
+        wValue := getTrimmingSpace part.value
+
+        [value, suppressPrefix] = handleThisPrivateShorthands value
+
+        if !suppressPrefix // Don't prefix @ shorthand
           value = prefix.concat(insertTrimmingSpace(value, ""))
         if (wValue) value.unshift(wValue)
         if (part.type === "SpreadProperty") {
@@ -757,7 +786,6 @@ function processCallMemberExpression(node) {
     }
   }
   return node
-}
 
 function wrapIterationReturningResults(statement, outerRef): void {
   if (statement.type === "DoStatement") {

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -666,6 +666,7 @@ function handleThisPrivateShorthands(value)
       ...value,
       children: value.children.map (c, i) =>
         if i is 0
+          let s
           [c, s] = handleThisPrivateShorthands c
           suppressPrefix ||= s
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -862,6 +862,7 @@ PrivateThis
         name: id.name,
         children: [".", id],
       }],
+      privateShorthand: true,
     }
 
 # NOTE: Added '@' as a 'this' shorthand from CoffeeScript
@@ -2555,11 +2556,15 @@ PropertyDefinition
       if (!name) return $skip
     }
 
+    // Private name becomes public
+    if (name[0] === "#") name = name.slice(1)
+
     return {
       type: "Property",
       children: [ws, name, ": ", value],
-      name, value,
+      name,
       names: [],
+      value,
       hoistDec,
     }
   # NOTE: basic identifiers are now part of the rule above

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -841,6 +841,7 @@ ThisLiteral
         name: id,
         children: [".", id],
       }],
+      thisShorthand: true,
     }
   AtThis
   PrivateThis
@@ -2449,16 +2450,6 @@ ObjectPropertyDelimiter
 # https://262.ecma-international.org/#prod-PropertyDefinition
 # NOTE: Must start on same line
 PropertyDefinition
-  # NOTE: Added CoffeeScript {@id} -> {id: this.id} shorthand
-  _?:ws AtThis:at IdentifierReference:id ->
-    const value = [at, ".", id]
-    return {
-      type: "Property",
-      children: [ws, id, ": ", ...value],
-      name: id,
-      names: id.names,
-      value,
-    }
   _?:ws NamedProperty:prop ->
     return {
       ...prop,

--- a/test/object.civet
+++ b/test/object.civet
@@ -1002,11 +1002,19 @@ describe "object", ->
     """
 
     testCase """
+      this shorthand
+      ---
+      x.{@a, @a.b, @a.x(), @a.x().y}
+      ---
+      ({a:this.a, b:this.a.b, x:this.a.x(), y:this.a.x().y})
+    """
+
+    testCase """
       private identifier
       ---
-      x.{#a}
+      x.{#a, #a.b, #a.x(), #a.x().y}
       ---
-      ({a:x.#a})
+      ({a:x.#a, b:x.#a.b, x:x.#a.x(), y:x.#a.x().y})
     """
 
     testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -1002,6 +1002,14 @@ describe "object", ->
     """
 
     testCase """
+      private identifier
+      ---
+      x.{#a}
+      ---
+      ({a:x.#a})
+    """
+
+    testCase """
       assignment
       ---
       obj.{ a, b: c, d : e } = x


### PR DESCRIPTION
This adds support for the following:

#714 Properly supporting private identifiers in object globs:

```civet
x.{#a, #a.b, #a.x(), #a.x().y}
---
({a:x.#a, b:x.#a.b, x:x.#a.x(), y:x.#a.x().y})
```

Also letting `@a` shorthand be the `this.a` in scope instead of `x.this.a`. It allows for a neat hybrid object effect when mixed with the prefixed properties. This behavior could still be considered experimental for now.
```civet
x.{@a, @a.b, @a.x(), @a.x().y}
---
({a:this.a, b:this.a.b, x:this.a.x(), y:this.a.x().y})
```