### PR TITLE
Fix 'not in' after logical binop

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -967,19 +967,19 @@ function expandChainedComparisons([first, binops]: [unknown, [unknown, ASTLeaf, 
 
   return results
 
-  function processChains(op) {
+  function processChains(op): void
     if first and isRelationalOp op
       first = expandExistence first
 
-    if (chains.length > 1) {
-      chains.forEach((index, k) => {
+    if chains.length > 1
+      chains.forEach (index, k) =>
         if (k > 0) {
           // NOTE: Inserting ws tokens to keep even operator spacing in the resulting array
           results.push(" ", "&&", " ")
         }
 
         binop := binops[index]
-        let [ , , , exp] = binop
+        [ , , , exp] .= binop
         exp = binop[3] = expandExistence(exp)
 
         let endIndex
@@ -992,18 +992,13 @@ function expandChainedComparisons([first, binops]: [unknown, [unknown, ASTLeaf, 
         results.push(first, ...binops.slice(start, endIndex).flat())
         first = [exp].concat(binops.slice(index + 1, endIndex))
         start = endIndex
-      })
-    } else {
+    else
       // Advance start if there was no chain
-      if first
-        results.push(first, ...binops.slice(start, i + 1).flat())
-      else
-        results.push(...binops.slice(start, i + 1).flat())
+      results.push first if first
+      results.push ...binops[start...i + 1].flat()
       start = i + 1
-    }
 
     chains.length = 0
-  }
 
   function expandExistence(exp)
     // Expand existence operator like x?

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -579,8 +579,8 @@ function expressionizeIteration(exp): void {
   )
 }
 
-function processBinaryOpExpression($0) {
-  const expandedOps = expandChainedComparisons($0)
+function processBinaryOpExpression($0)
+  expandedOps := expandChainedComparisons($0)
 
   // Expanded ops is [a, __, op1, __, b, __, op2, __, c, __, op3, __, d], etc.
   // NOTE: all operators of higher precedence than relational have been merged into the operand expressions
@@ -646,7 +646,6 @@ function processBinaryOpExpression($0) {
   }
 
   return expandedOps
-}
 
 /**
  * This adjusts #x.y().z and @x.y().z when used inside Object glob expressions
@@ -931,7 +930,7 @@ function isRelationalOp(op)
 * binops is an array of [__, op, __, exp] tuples
 * first is an expression
 */
-function expandChainedComparisons([first, binops]) {
+function expandChainedComparisons([first, binops]: [unknown, [unknown, ASTLeaf, unknown, unknown][]])
   // TODO: add refs to ensure middle expressions are evaluated only once
 
   // short circuit/bitwise ops have lower precedence than comparison ops
@@ -960,7 +959,7 @@ function expandChainedComparisons([first, binops]) {
     else if lowerPrecedenceOps.includes op.token
       // end of the chain
       processChains op
-      first = []
+      first = undefined
 
     i++
 
@@ -969,7 +968,9 @@ function expandChainedComparisons([first, binops]) {
   return results
 
   function processChains(op) {
-    first = expandExistence(first) if isRelationalOp op
+    if first and isRelationalOp op
+      first = expandExistence first
+
     if (chains.length > 1) {
       chains.forEach((index, k) => {
         if (k > 0) {
@@ -977,8 +978,8 @@ function expandChainedComparisons([first, binops]) {
           results.push(" ", "&&", " ")
         }
 
-        const binop = binops[index]
-        let [pre, op, post, exp] = binop
+        binop := binops[index]
+        let [ , , , exp] = binop
         exp = binop[3] = expandExistence(exp)
 
         let endIndex
@@ -994,23 +995,25 @@ function expandChainedComparisons([first, binops]) {
       })
     } else {
       // Advance start if there was no chain
-      results.push(first, ...binops.slice(start, i + 1).flat())
+      if first
+        results.push(first, ...binops.slice(start, i + 1).flat())
+      else
+        results.push(...binops.slice(start, i + 1).flat())
       start = i + 1
     }
 
     chains.length = 0
   }
 
-  function expandExistence(exp) {
+  function expandExistence(exp)
     // Expand existence operator like x?
     const existence = isExistence(exp)
-    if (existence) {
+    if existence
       results.push(existence, " ", "&&", " ")
       return existence.expression
-    }
+
     return exp
-  };
-}
+  ;
 
 function processParams(f): void {
   const { type, parameters, block } = f

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -187,6 +187,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    not in after logical
+    ---
+    v and v.type is not in ["CallExpression", "MemberExpression", "Identifier"]
+    ---
+    v && !["CallExpression", "MemberExpression", "Identifier"].includes(v.type)
+  """
+
+  testCase """
     branded in
     ---
     #a in b


### PR DESCRIPTION
I went to try

```civet
x and y is not in z
```

and found out it was busted.

Here's the fix.