### PR TITLE
Opt non compat

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -923,15 +923,15 @@ CallExpressionRest
 
 # NOTE: Added shorthand x?(3) -> x?.(3)
 OptionalShorthand
-  MultiLineComment* QuestionMark OptionalDot ->
+  InlineComment* QuestionMark OptionalDot ->
     return {
       type: "Optional",
       children: $0,
     }
 
 OptionalDot
-  MultiLineComment* Dot
-  InsertDot MultiLineComment*
+  InlineComment* Dot
+  InsertDot InlineComment*
 
 NonNullAssertion
   # NOTE: Prevent shadowing !^ xnor operator
@@ -956,7 +956,7 @@ MemberBase
   MetaProperty
 
 MemberExpressionRest
-  MultiLineComment*:comments MemberExpressionRestBody:body ->
+  InlineComment*:comments MemberExpressionRestBody:body ->
     if (Array.isArray(body)) return [...comments, ...body]
     return {
       ...body,
@@ -965,7 +965,7 @@ MemberExpressionRest
 
 MemberExpressionRestBody
   # NOTE: Added shorthand x?[3] -> x?.[3]
-  ( OptionalShorthand / NonNullAssertion )?:dot MultiLineComment*:comments MemberBracketContent:content ->
+  ( OptionalShorthand / NonNullAssertion )?:dot InlineComment*:comments MemberBracketContent:content ->
     if (dot) {
       // Optional followed by a slice expression
       if (dot.type === "Optional" && content.type === "SliceExpression") {
@@ -1105,7 +1105,7 @@ AccessStart
     return $2
 
 PropertyAccess
-  AccessStart:access MultiLineComment*:comments ( IdentifierName / PrivateIdentifier ):id ->
+  AccessStart:access InlineComment*:comments ( IdentifierName / PrivateIdentifier ):id ->
     const children = [access, ...comments, ...id.children]
 
     return {
@@ -1132,7 +1132,7 @@ PropertyAccess
 
 PropertyGlob
   # NOTE: Added shorthand obj.{a,b:c} -> {a: obj.a, c: obj.b}
-  ( ( QuestionMark / NonNullAssertion )? OptionalDot ):dot MultiLineComment* BracedObjectLiteral:object ->
+  ( ( QuestionMark / NonNullAssertion )? OptionalDot ):dot InlineComment* BracedObjectLiteral:object ->
     return {
       type: "PropertyGlob",
       dot,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4799,7 +4799,7 @@ JSSingleLineComment
 MultiLineComment
   JSMultiLineComment
   # NOTE: Added CoffeeScript style ### multiline comments
-  CoffeeMultiLineComment
+  CoffeeCommentEnabled CoffeeMultiLineComment
 
 JSMultiLineComment
   $( "/*" (!"*/" . )* "*/" ) ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4811,12 +4811,9 @@ CoffeeSingleLineComment
     return { type: "Comment", $loc, token: `//${$1}` }
 
 CoffeeMultiLineComment
-  CoffeeHereCommentStart $/[^]*?###/ ->
-    $2 = $2.slice(0, $2.length-3).replace(/\*\//g, "* /")
-    return { type: "Comment", $loc, token: `/*${$2}*/` }
-
-CoffeeHereCommentStart
-  /###(?!#)/
+  /###(?!#)((?:[^#]*|#(?!##))*)###/ ->
+    $1 = $1.replace(/\*\//g, "* /")
+    return { type: "Comment", $loc, token: `/*${$1}*/` }
 
 # InlineComment is a multi-line comment with no line separators
 InlineComment

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4710,7 +4710,7 @@ HeregexComment
   # NOTE: CoffeeScript doesn't treat JS comments as regex comments
   # TODO: this behavior should be toggled by a coffeeCompat directive
   JSSingleLineComment
-  CoffeeSingleLineComment
+  # CoffeeCommentEnabled CoffeeSingleLineComment
 
 # https://262.ecma-international.org/#prod-RegularExpressionBody
 # NOTE: Simplified a little from the spec, ignoring <PS>, <LS>
@@ -4781,14 +4781,16 @@ ReservedWord
 
 # https://262.ecma-international.org/#sec-comments
 Comment
-  MultiLineComment
-  SingleLineComment
+  # MultiLineComment
+  # SingleLineComment
+  /\/\*(?:(?!\*\/).)*\*\/|\/\/(?!\/)[^\r\n]*/ ->
+    return { type: "Comment", $loc, token: $0 }
 
 # https://262.ecma-international.org/#prod-SingleLineComment
 # This is more accurately called "RestOfLineComment"
 SingleLineComment
   JSSingleLineComment
-  CoffeeCommentEnabled CoffeeSingleLineComment
+  # CoffeeCommentEnabled CoffeeSingleLineComment
 
 JSSingleLineComment
   # JS Comments are two slashes not followed by a third (because that is a heregex)
@@ -4799,7 +4801,7 @@ JSSingleLineComment
 MultiLineComment
   JSMultiLineComment
   # NOTE: Added CoffeeScript style ### multiline comments
-  CoffeeCommentEnabled CoffeeMultiLineComment
+  # CoffeeCommentEnabled CoffeeMultiLineComment
 
 JSMultiLineComment
   $( "/*" (!"*/" . )* "*/" ) ->
@@ -4821,7 +4823,8 @@ InlineComment
     return { $loc, token: $0 }
 
 RestOfLine
-  ( NonNewlineWhitespace / Comment )* EOL
+  /(?=((?:[ \t]+|\/\*(?:(?!\*\/).)*\*\/)*))\1(?=((?:\/\/(?!\/)[^\r\n]*)?))\2(?=(\r\n|\r|\n|$))\3/ ->
+    return [$0.slice(0, -1), {$loc: {pos: 0, length: 1} , token: $0.at(-1) }]
 
 # Matches any whitespace optionally followed by a rest of line comment
 # This will always succeed since each part is optional that's why it
@@ -4832,7 +4835,11 @@ TrailingComment
 # Non-newline "white space" (includes inline comments)
 # TODO: Allow for inline Coffee comments when enabled
 _
-  ( NonNewlineWhitespace / InlineComment )+
+  # ( NonNewlineWhitespace / InlineComment )+
+  # Manually optimized regex without CoffeeLineContinuation support
+  /(?:[ \t]+|\/\*(?:(?!\*\/)[^\r\n])*\*\/)+/ ->
+    // TODO: Could unwrap this to avoid creating a new array eventually
+    return [{ $loc, token: $0 }]
 
 NonNewlineWhitespace
   [ \t]+ ->
@@ -4849,7 +4856,9 @@ __
   # Fast path for whitespace without comments
   # /(?!(?=\s|#|\/\/|\/\*))|[\s]+(?!(?:#|\/\/|\/\*))/ ->
   #   return [{ $loc, token: $0 }]
-  ( Whitespace / Comment )*
+  # ( Whitespace / Comment )*
+  /(?:(?=([\s]+))\1|(?:\/\*(?:(?!\*\/).)*\*\/|\/\/(?!\/)[^\r\n]*))*/ ->
+    return [{ $loc, token: $0 }]
 
 Whitespace
   [\s]+ ->
@@ -4880,6 +4889,8 @@ StatementDelimiter
   &( _* ( "}" / ")" / "]" ) )
 
 SemicolonDelimiter
+  # NOTE: This TrailingComment is to keep any post delimiter
+  # comments from leaking outside an implicitly closed block
   _? Semicolon TrailingComment ->
     return {
       type: "SemicolonDelimiter",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4817,11 +4817,11 @@ CoffeeMultiLineComment
 
 # InlineComment is a multi-line comment with no line separators
 InlineComment
-  $( "/*" $(!"*/" [^\r\n] )* "*/" ) ->
-    return { $loc, token: $1 }
+  /\/\*(?:(?!\*\/)[^\r\n])*\*\// ->
+    return { $loc, token: $0 }
 
 RestOfLine
-  (NonNewlineWhitespace / SingleLineComment / MultiLineComment)* EOL
+  ( NonNewlineWhitespace / Comment )* EOL
 
 # Matches any whitespace optionally followed by a rest of line comment
 # This will always succeed since each part is optional that's why it

--- a/test/comment.civet
+++ b/test/comment.civet
@@ -24,13 +24,14 @@ describe "comment", ->
   testCase """
     CoffeeScript style multi-line comments
     ---
+    "civet coffeeComment"
     ###
-    hi
+    # hi
     ###
 
     ---
     /*
-    hi
+    # hi
     */
 
   """
@@ -38,6 +39,7 @@ describe "comment", ->
   testCase """
     escapes */ in ### block comments
     ---
+    "civet coffeeComment"
     ###
     hi */
     ###


### PR DESCRIPTION
Experimental branch with manually optimizing comment/whitespace leaf rules / regexes.

About a ~20% perf boost currently but loses some coffeeCompat options

Ideally these optimizations could be done in Hera automatically but this is a good proof of concept.

- [ ] Allow Hera to compile the parser on the fly, pruning branches based on config (to handle CoffeeCompat)
- [ ] Enhance Hera to merge rules / regex to reduce the number of 
- [ ] Update some Civet handlers to be more robust with the merged whitespace output
- [ ] Simplify Civet AST where possible and defer handlings until after parse

There are also some grammar simplifications that can be cherry picked onto the main branch.

References
----

[Mimic atomic groups](https://blog.stevenlevithan.com/archives/mimic-atomic-groups)