### PR TITLE
properly encoding js import source

### DIFF
--- a/source/config.civet
+++ b/source/config.civet
@@ -50,7 +50,7 @@ export function loadConfig(path: string)
     let exports
 
     try
-      exports = await import `data:text/javascript,${js}`
+      exports = await import `data:text/javascript,${ encodeURIComponent js }`
     catch e
       console.error "Error loading config file", path, e
 


### PR DESCRIPTION
Before:

```
export default `"%20"`
```

gets imported as " "

Now it gets correctly imported as `"%20"`