### PR TITLE
LSP Build refactor

### DIFF
--- a/lsp/.gitignore
+++ b/lsp/.gitignore
@@ -1,2 +1,3 @@
+*.metafile
 *.vsix
 open-vsx-token

--- a/lsp/.vscode/launch.json
+++ b/lsp/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
   "version": "0.2.0",
   "configurations": [
+
     {
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}"

--- a/lsp/NOTES.md
+++ b/lsp/NOTES.md
@@ -32,3 +32,15 @@ In VSCode "Run and Debug" --> "Launch Extension"
 Then in the `chrome://inspect` page you should see: `Remote Target #LOCALHOST` with `/home/daniel/apps/civet/lsp/dist/server.js` and a link to "inspect"
 
 When the DevTools page is open `debugger` statements will work.
+
+Extension Bundle Size
+---
+
+Use [esbuild Bundle Size Analyzer](https://esbuild.github.io/analyze/)
+
+Drop in either:
+
+- `server.metafile`
+- `extension.metafile`
+
+To se what was bundled and why.

--- a/lsp/build/build.civet
+++ b/lsp/build/build.civet
@@ -2,13 +2,16 @@
 civetPlugin from @danielx/civet/esbuild
 
 minify := false // !watch or process.argv.includes '--minify'
-sourcemap := false
+sourcemap := true
 
 build({
+  +metafile
   entryPoints: ['source/extension.civet']
   tsconfig: "./tsconfig.json"
   bundle: true
-  external: ['vscode']
+  external: [
+    'vscode'
+  ]
   format: "cjs"
   sourcemap
   minify
@@ -19,19 +22,33 @@ build({
   outfile: 'dist/extension.js'
 }).catch ->
   process.exit 1
+.then ({metafile}) ->
+  { writeFileSync } := await import('fs')
+  writeFileSync 'extension.metafile', JSON.stringify(metafile)
 
 build({
-  entryPoints: ['source/server.mts']
+  +metafile
+  entryPoints: ['source/server.mts'] //, 'source/lib/previewer.mts', 'source/lib/typescript-service.mts', 'source/lib/util.mts' ]
+  outdir: 'dist'
   tsconfig: "./tsconfig.json"
-  bundle: true
   format: "cjs"
-  external: ['vscode']
+  +bundle
+  external: [
+    '@danielx/civet'
+    'typescript'
+    'vscode'
+    'vscode-languageclient'
+    'vscode-languageserver'
+    'vscode-languageserver-textdocument'
+  ]
   sourcemap
   minify
   platform: 'node'
   plugins: [
     civetPlugin()
   ]
-  outfile: 'dist/server.js'
 }).catch ->
   process.exit 1
+.then ({metafile}) ->
+  { writeFileSync } := await import('fs')
+  writeFileSync 'server.metafile', JSON.stringify(metafile)

--- a/lsp/build/build.sh
+++ b/lsp/build/build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 rm -rf dist
 
-node --loader ts-node/esm --loader ../dist/esm.mjs build/build.civet
+node_modules/.bin/civet build/build.civet
 
-mkdir dist/lib
+mkdir -p dist/lib
 cp node_modules/typescript/lib/lib.*.d.ts dist/lib

--- a/lsp/integration/project-test/.civet/coffee-plugin.mjs
+++ b/lsp/integration/project-test/.civet/coffee-plugin.mjs
@@ -1,4 +1,6 @@
 // Rudimentary CoffeeScript plugin
+import { compile as coffeeCompile } from "coffeescript"
+
 function compile(path, source) {
   const { js, sourceMap } = coffeeCompile(source, {
     bare: true,

--- a/lsp/integration/project-test/.civet/coffee-plugin.mjs
+++ b/lsp/integration/project-test/.civet/coffee-plugin.mjs
@@ -1,0 +1,58 @@
+// Rudimentary CoffeeScript plugin
+function compile(path, source) {
+  const { js, sourceMap } = coffeeCompile(source, {
+    bare: true,
+    filename: path,
+    header: false,
+    sourceMap: true
+  })
+
+  const convertedSourceMap = convertCoffeeScriptSourceMap(sourceMap)
+
+  console.log("COFFEE SOURCE MAP", sourceMap, convertedSourceMap)
+
+  return {
+    code: js,
+    sourceMap: {
+      data: {
+        lines: convertedSourceMap
+      }
+    }
+  }
+}
+
+function convertCoffeeScriptSourceMap(sourceMap) {
+  const lines = []
+  let columnDelta = 0
+
+  for (const entry of sourceMap.lines) {
+    if (!entry) {
+      lines.push([])
+    } else {
+      let lastColumn = columnDelta = 0
+      let lastSourceColumn = -1
+      lines.push(entry.columns.filter(x => x).map(function ({ column, sourceLine, sourceColumn }) {
+        // Gross Hack to prevent coffeescript mapping punctuation to the start of the line
+        if (sourceColumn <= lastSourceColumn) {
+          return [0]
+        }
+        lastSourceColumn = sourceColumn
+
+        columnDelta = column - lastColumn
+        lastColumn = column
+
+        return [columnDelta, 0, sourceLine, sourceColumn]
+      }))
+    }
+  }
+
+  return lines
+}
+
+export default {
+  transpilers: [{
+    extension: ".coffee",
+    target: ".js",
+    compile,
+  }],
+}

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -16,7 +16,6 @@
   },
   "activationEvents": [
     "onLanguage:civet",
-    "onLanguage:coffeescript",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
@@ -76,7 +75,7 @@
     ],
     "loader": [
       "ts-node/esm",
-      "../dist/esm.mjs"
+      "@danielx/civet/esm"
     ],
     "reporter": "spec",
     "recursive": true,
@@ -91,25 +90,25 @@
     "test": "mocha",
     "watch": "node build.mjs --watch"
   },
+  "dependencies": {
+    "@danielx/civet": "0.6.38",
+    "typescript": "^5.2.2",
+    "vscode-languageclient": "^8.0.2",
+    "vscode-languageserver": "^8.0.2",
+    "vscode-languageserver-textdocument": "^1.0.7"
+  },
   "devDependencies": {
-    "@danielx/civet": "link:..",
     "@danielx/hera": "^0.7.12",
-    "@types/coffeescript": "^2.5.2",
     "@types/mocha": "^9",
     "@types/node": "^14.17.0",
     "@types/vscode": "^1.63.0",
     "@vscode/test-electron": "^2.1.2",
     "@vscode/vsce": "^2.19.0",
-    "coffeescript": "^2.7.0",
     "esbuild": "^0.19.2",
     "esbuild-visualizer": "^0.3.1",
     "mocha": "^10",
     "nyc": "^15.1.0",
     "source-map-support": "^0.5.21",
-    "ts-node": "^10.6.0",
-    "typescript": "^5.2.2",
-    "vscode-languageclient": "^8.0.2",
-    "vscode-languageserver": "^8.0.2",
-    "vscode-languageserver-textdocument": "^1.0.7"
+    "ts-node": "^10.6.0"
   }
 }

--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -2,8 +2,8 @@ import assert from "assert"
 import path from "path"
 
 import type {
-	SourceMap as CivetSourceMap,
-	CompileOptions,
+  SourceMap as CivetSourceMap,
+  CompileOptions,
 } from "@danielx/civet"
 import BundledCivetModule from "@danielx/civet"
 import BundledCivetConfigModule from "@danielx/civet/config"
@@ -29,9 +29,6 @@ const {
 import { createRequire } from "module"
 import { fileURLToPath, pathToFileURL } from "url"
 import { TextDocument } from "vscode-languageserver-textdocument"
-// TODO: project Coffee version?
-import { compile as coffeeCompile } from "coffeescript"
-import { convertCoffeeScriptSourceMap } from "./util.mjs"
 
 // Import version from package.json
 import * as pkg from "../../package.json" assert { type: 'json' }
@@ -40,7 +37,7 @@ const { version } = pkg
 // HACK to get __dirname working in tests with ts-node
 // ts-node needs everything to be modules for .civet files to work
 // and modules don't have __dirname
-var dir : string
+var dir: string
 try {
   dir = __dirname
 } catch (e) {
@@ -296,7 +293,7 @@ function TSHost(compilationSettings: CompilerOptions, initialFileNames: string[]
       // The source document is ahead of the transpiled document
       if (source && sourceDocVersion > transpiledDoc.version) {
         const transpiledCode = doTranspileAndUpdateMeta(transpiledDoc, sourceDocVersion, transpiler, sourcePath, source)
-        if(transpiledCode !== undefined) {
+        if (transpiledCode !== undefined) {
           snapshot = ScriptSnapshot.fromString(transpiledCode)
         }
       }
@@ -409,10 +406,6 @@ function TSService(projectURL = "./") {
     extension: ".civet" as const,
     target: ".tsx" as ts.Extension,
     compile: transpileCivet,
-  }, {
-    extension: ".coffee",
-    target: ".js" as ts.Extension,
-    compile: transpileCoffee,
   }].map<[string, Transpiler]>(def => [def.extension, def])
 
   const transpilers = new Map<string, Transpiler>(transpilerDefinitions)
@@ -459,7 +452,7 @@ function TSService(projectURL = "./") {
       // One day it would be nice to load plugins that could be transpiled but that is a whole can of worms.
       // VSCode Node versions, esm loaders, etc.
       const pluginFiles = civetFiles.filter(file => file.endsWith("plugin.mjs"))
-      .map(file => pathToFileURL(file).toString())
+        .map(file => pathToFileURL(file).toString())
 
       for (const filePath of pluginFiles) {
         console.info("Loading plugin", filePath)
@@ -487,28 +480,6 @@ function TSService(projectURL = "./") {
       filename: path,
       sourceMap: true,
     })
-  }
-}
-
-function transpileCoffee(path: string, source: string) {
-  const { js, sourceMap } = coffeeCompile(source, {
-    bare: true,
-    filename: path,
-    header: false,
-    sourceMap: true
-  })
-
-  const convertedSourceMap = convertCoffeeScriptSourceMap(sourceMap)
-
-  console.log("COFFEE SOURCE MAP", sourceMap, convertedSourceMap)
-
-  return {
-    code: js,
-    sourceMap: {
-      data: {
-        lines: convertedSourceMap
-      }
-    }
   }
 }
 

--- a/lsp/source/lib/util.mts
+++ b/lsp/source/lib/util.mts
@@ -10,21 +10,19 @@ import {
   SymbolTag,
 } from 'vscode-languageserver'
 
-import { SourceMap } from '@danielx/civet'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import assert from 'assert'
 import {
-  SourcemapLines,
+  type SourcemapLines,
   remapRange,
   rangeFromTextSpan,
 } from '@danielx/civet/ts-diagnostic'
 
 export {
   remapPosition,
-  SourcemapLines,
+  type SourcemapLines,
   convertDiagnostic,
   flattenDiagnosticMessageText,
-  diagnosticCategoryToSeverity,
 } from '@danielx/civet/ts-diagnostic';
 
 // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts#L63
@@ -327,35 +325,4 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
 
   // console.warn(`couldn't forward map src position: ${[origLine, origOffset]}`)
   return position
-}
-
-import type { SourceMap as CoffeeSourceMap } from "coffeescript"
-export function convertCoffeeScriptSourceMap(sourceMap: CoffeeSourceMap): SourceMap["data"]["lines"] {
-  const lines: SourceMap["data"]["lines"] = []
-  let columnDelta = 0
-
-  debugger
-
-  for (const entry of sourceMap.lines) {
-    if (!entry) {
-      lines.push([])
-    } else {
-      let lastColumn = columnDelta = 0
-      let lastSourceColumn = -1
-      lines.push(entry.columns.filter(x => x).map(function ({ column, sourceLine, sourceColumn }) {
-        // Gross Hack to prevent coffeescript mapping punctuation to the start of the line
-        if (sourceColumn <= lastSourceColumn) {
-          return [0]
-        }
-        lastSourceColumn = sourceColumn
-
-        columnDelta = column - lastColumn
-        lastColumn = column
-
-        return [columnDelta, 0, sourceLine, sourceColumn]
-      }))
-    }
-  }
-
-  return lines
 }

--- a/lsp/test/util.civet
+++ b/lsp/test/util.civet
@@ -2,7 +2,6 @@
 { intersectRanges, containsRange, makeRange, remapPosition, forwardMap, convertCoffeeScriptSourceMap } from ../source/lib/util.mjs
 assert from assert
 Civet from @danielx/civet
-{compile as coffeeCompile} from coffeescript
 
 describe "util", ->
   it "should intersect ranges", ->
@@ -79,59 +78,3 @@ describe "util", ->
 
     [0, 1, 2, 3, 4, 5, 6, 7].forEach (i) ->
       forwardMap(sourceMap.data.lines, {line: 20 + i, character: 5})
-
-  it "should convert CoffeeScript source maps", ->
-    src := """
-      {parse} = require "./parser"
-      {prune} = gen = require "./generate"
-      {SourceMap} = util = require "./util"
-
-      defaultOptions = {}
-
-      module.exports =
-        parse: parse
-        compile: (src, options=defaultOptions) ->
-          ast = prune parse(src, {
-            filename: options.filename
-          })
-
-          if options.sourceMap
-            sm = SourceMap(src)
-            options.updateSourceMap = sm.updateSourceMap
-            code = gen ast, options
-            return {
-              code,
-              sourceMap: sm
-            }
-
-          gen ast, options
-        generate: gen
-        util: util
-    """
-
-    {js, sourceMap} := coffeeCompile src,
-      bare: true
-      filename: "test.coffee"
-      header: false
-      sourceMap: true
-
-    convertedMap := convertCoffeeScriptSourceMap(sourceMap)
-    {sourceMap: sm2} := Civet.compile "x",
-      sourceMap: true
-
-    // Hack to generate a source map json for testing
-    sm2.data.lines = convertedMap
-    srcMapJSON := sm2.json("yo.coffee", "yo.js")
-    //@ts-ignore
-    srcMapJSON.sourcesContent = [src]
-
-    // console.log src, code
-
-    // console.dir sm.data,
-    //   depth: 8
-
-    base64Encode := (src) ->
-      return Buffer.from(src).toString('base64')
-
-    // Use this to log the code + sourcemap which can be pasted into https://evanw.github.io/source-map-visualization/ see how it works
-    // console.log `${js}\n//# sourceMappingURL=data:application/json;base64,${base64Encode JSON.stringify(srcMapJSON)}`

--- a/lsp/yarn.lock
+++ b/lsp/yarn.lock
@@ -22,32 +22,6 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.13.tgz#6aff7b350a1e8c3e40b029e46cbe78e24a913483"
   integrity sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==
 
-"@babel/compat-data@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.19.0.tgz#2a592fd89bacb1fcde68de31bee4f2f2dacb0e86"
-  integrity sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==
-
-"@babel/core@^7.1.15":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.0.tgz#d2f5f4f2033c00de8096be3c9f45772563e150c3"
-  integrity sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==
-  dependencies:
-    "@ampproject/remapping" "^2.1.0"
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.0"
-    "@babel/helper-compilation-targets" "^7.19.0"
-    "@babel/helper-module-transforms" "^7.19.0"
-    "@babel/helpers" "^7.19.0"
-    "@babel/parser" "^7.19.0"
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.0"
-    "@babel/types" "^7.19.0"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.2"
-    json5 "^2.2.1"
-    semver "^6.3.0"
-
 "@babel/core@^7.7.5":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.13.tgz#9be8c44512751b05094a4d3ab05fc53a47ce00ac"
@@ -78,31 +52,12 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.0.tgz#785596c06425e59334df2ccee63ab166b738419a"
-  integrity sha512-S1ahxf1gZ2dpoiFgA+ohK9DIpz50bJ0CWs7Zlzb54Z4sG8qmdIrGrVqmy1sAtTVRb+9CU6U8VqT9L0Zj7hxHVg==
-  dependencies:
-    "@babel/types" "^7.19.0"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    jsesc "^2.5.1"
-
 "@babel/helper-compilation-targets@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz#69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf"
   integrity sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==
   dependencies:
     "@babel/compat-data" "^7.18.8"
-    "@babel/helper-validator-option" "^7.18.6"
-    browserslist "^4.20.2"
-    semver "^6.3.0"
-
-"@babel/helper-compilation-targets@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz#537ec8339d53e806ed422f1e06c8f17d55b96bb0"
-  integrity sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==
-  dependencies:
-    "@babel/compat-data" "^7.19.0"
     "@babel/helper-validator-option" "^7.18.6"
     browserslist "^4.20.2"
     semver "^6.3.0"
@@ -119,14 +74,6 @@
   dependencies:
     "@babel/template" "^7.18.6"
     "@babel/types" "^7.18.9"
-
-"@babel/helper-function-name@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
-  integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/types" "^7.19.0"
 
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
@@ -155,20 +102,6 @@
     "@babel/template" "^7.18.6"
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
-
-"@babel/helper-module-transforms@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz#309b230f04e22c58c6a2c0c0c7e50b216d350c30"
-  integrity sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.18.6"
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.0"
-    "@babel/types" "^7.19.0"
 
 "@babel/helper-simple-access@^7.18.6":
   version "7.18.6"
@@ -208,15 +141,6 @@
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
 
-"@babel/helpers@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.19.0.tgz#f30534657faf246ae96551d88dd31e9d1fa1fc18"
-  integrity sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==
-  dependencies:
-    "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.0"
-    "@babel/types" "^7.19.0"
-
 "@babel/highlight@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
@@ -230,11 +154,6 @@
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
   integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
-
-"@babel/parser@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.0.tgz#497fcafb1d5b61376959c1c338745ef0577aa02c"
-  integrity sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==
 
 "@babel/template@^7.18.10", "@babel/template@^7.18.6":
   version "7.18.10"
@@ -261,35 +180,10 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.0.tgz#eb9c561c7360005c592cc645abafe0c3c4548eed"
-  integrity sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.0"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.19.0"
-    "@babel/types" "^7.19.0"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
 "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
   integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
-  dependencies:
-    "@babel/helper-string-parser" "^7.18.10"
-    "@babel/helper-validator-identifier" "^7.18.6"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
-  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
     "@babel/helper-validator-identifier" "^7.18.6"
@@ -302,9 +196,14 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@link:..":
-  version "0.0.0"
-  uid ""
+"@danielx/civet@0.6.38":
+  version "0.6.38"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.6.38.tgz#a9c2537bd67624eb4dcd94843a5fd38c7dcb4e7f"
+  integrity sha512-R63YGIfvV4DQianNPUfMfBX60ozlv5htnRXI1wK3Pg6+d4NZ2V3RifFRH0NkmXXoFkRcULzJ+9BzVeI2/yX+yA==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.1"
+    "@typescript/vfs" "^1.5.0"
+    unplugin "^1.4.0"
 
 "@danielx/hera@^0.7.12":
   version "0.7.12"
@@ -509,13 +408,6 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
-
-"@types/coffeescript@^2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@types/coffeescript/-/coffeescript-2.5.2.tgz#6e8c40f49c01612dc3b99580942112ae60ad630a"
-  integrity sha512-uXfyTfLGQIneVvFuo8jcDSTVjOdiaLZkdkqgZZLy1jhpQqeDetqIBlNtwHzo31bI+krpayapirQjIxXzNtxUxA==
-  dependencies:
-    "@babel/core" "^7.1.15"
 
 "@types/mocha@^9":
   version "9.1.1"
@@ -917,11 +809,6 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
-
-coffeescript@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/coffeescript/-/coffeescript-2.7.0.tgz#a43ec03be6885d6d1454850ea70b9409c391279c"
-  integrity sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==
 
 color-convert@^1.9.0:
   version "1.9.3"


### PR DESCRIPTION
Using dependencies instead of bundling for the lsp's actual dependencies Added @danielx/civet and TypeScript to dependencies Using published @danielx/civet rather than linked
Sped up build by removing ts-node from build step
Removed CoffeeScript support (moved to plugin)
Greatly reduced bundle size by removing CoffeeScript (it pulled in babel which was > 5MB) Struggled to improve breakpoints from VS Code (still doesn't work but connecting Dev Tools debugger does)