### PR TITLE
Fix go to definition

### DIFF
--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -56,7 +56,7 @@ interface ResolvedModuleWithFailedLookupLocations extends ts.ResolvedModuleWithF
   failedLookupLocations: string[];
 }
 
-interface FileMeta {
+export interface FileMeta {
   sourcemapLines: SourceMap["data"]["lines"] | undefined
   transpiledDoc: TextDocument | undefined
   parseErrors: Error[] | undefined

--- a/lsp/source/lib/util.mts
+++ b/lsp/source/lib/util.mts
@@ -19,7 +19,9 @@ import {
 } from '@danielx/civet/ts-diagnostic'
 
 export {
+  rangeFromTextSpan,
   remapPosition,
+  remapRange,
   type SourcemapLines,
   convertDiagnostic,
   flattenDiagnosticMessageText,


### PR DESCRIPTION
This continues from lsp build refactor.

Now we reverse map the definitions after forward mapping to look them up in transpiled files.