### PR TITLE
Support comments before directives

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6925,7 +6925,7 @@ Reset
     }
 
 Init
-  Shebang? TripleSlashDirective* DirectivePrologue*:directives ->
+  Shebang? ( TripleSlashDirective / ( ( JSSingleLineComment / JSMultiLineComment ) EOS ) / DirectivePrologue )*:directives ->
     directives.forEach((directive) => {
       if (directive.type === "CivetPrologue") {
         Object.assign(module.config, directive.config)

--- a/test/prologues.civet
+++ b/test/prologues.civet
@@ -19,3 +19,25 @@ describe "Triple Slash directives", ->
     /// <reference path="..." />
     x = 1
   """
+
+  testCase """
+    mixing comments and directives
+    ---
+    #!/usr/bin/env node
+    // @ts-nocheck
+    "use strict"
+    /* longer
+       comment */
+    /// <reference path="..." />
+    "civet coffeeCompat"
+    x = 1
+    ---
+    #!/usr/bin/env node
+    // @ts-nocheck
+    "use strict"
+    /* longer
+       comment */
+    /// <reference path="..." />
+    var x;
+    x = 1
+  """


### PR DESCRIPTION
In particular this lets `// @ts-nocheck` (which needs to come first) come before `"civet coffeeCompat"`, which was recently requested by @bbrk24.