### PR TITLE
Remove common indentation of triple quotes

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -124,6 +124,8 @@ type FunctionNode = FunctionExpression | ArrowFunction | MethodDefinition
 
 type Predicate = (node: Exclude<ASTNode, undefined>) => boolean
 
+type TabConfig = number | undefined
+
 /**
  * Adds parent pointers to all nodes in the AST. Elements within
  * arrays of nodes receive the closest non-array object parent.
@@ -455,87 +457,105 @@ function constructPipeStep(fn, arg, returning) {
   return [constructInvocation(fn, arg), null]
 }
 
-// Split out leading newlines from the first indented line
-const initialSpacingRe = /^(?:\r?\n|\n)*((?:\r?\n|\n)\s+)/
+// Given a string of spaces and tabs, and the current tab size
+// (where `undefined` means "tabs are the same width as 1 space"),
+// compute the indentation level counted as spaces.
+// NOTE: Currently, tabs are treated as the specified number of spaces,
+// no matter their location (no round-to-next-multiple behavior).
+function getIndentLevel(str: string, tab: TabConfig)
+  if tab? and tab != 1
+    tabs := str.match /\t/g
+    numTabs := tabs ? tabs.length : 0
+    numTabs * tab + /*spaces*/ (str.length - numTabs)
+  else
+    str.length
 
-function dedentBlockString({ $loc, token: str }: ASTLeaf, spacing, trim = true) {
+// Given an indentation string (spaces and tabs), reduces the leading
+// indentation by the specified amount of spaces. If removing a tab reduced
+// the indentation too much, replaces it with the appropriate number of spaces.
+function reduceIndentLevel(str: string, dedent: number, tab: TabConfig)
+  if tab? and tab != 1
+    for each char, i of str
+      unless dedent  // finished removing indentation
+        return str[i..]
+      if char == '\t'
+        dedent -= tab  // one tab removed
+        if dedent < 0  // removed too much; add some spaces back
+          return ''.padStart(-dedent, ' ') + str[i+1..]
+      else
+        dedent--  // one space removed
+    ''  // removed all indentation (and maybe wanted to remove more)
+  else
+    str[dedent..]
+
+indentRe := ///
+  \n        // indent starts after newline (possibly preceded by \r)
+  ([ \t]*)  // capture indentation as $1
+  (?! [ \t] | \r?\n | $ )  // ignore blank lines
+///g
+
+// Gets the indentation level (number of spaces) shared by all indentations
+// after the first newline.
+function getIndentOfBlockString(str: string, tab: TabConfig)
+  minLevel .= Infinity
+  while match := indentRe.exec str
+    level := getIndentLevel match[1], tab
+    minLevel = level if level < minLevel
+  minLevel = 0 if minLevel == Infinity
+  minLevel
+
+function dedentBlockString({ $loc, token: str }: ASTLeaf, tab: TabConfig, dedent: number | undefined, trimStart = true, trimEnd = true)
   // If string begins with a newline then indentation assume that it should be removed for all lines
-  if (spacing == null) spacing = str.match(initialSpacingRe)
+  if not dedent? and /^[ \t]*\r?\n/.test str
+    // Remove remaining shared indentation
+    dedent = getIndentOfBlockString str, tab
+  if dedent
+    str = str.replace /(\n)([ \t]*)/g, (_, newline, indent) =>
+      newline + reduceIndentLevel indent, dedent as number, tab
 
-  if (spacing) {
-    str = str.replaceAll(spacing[1], "\n")
-    const l = spacing.length
-    $loc.pos += l
-    $loc.length -= l
-  }
-
-  if (trim) {
-    // Remove leading newline
-    str = str.replace(/^(\r?\n|\n)/, "")
-      // Remove trailing newline
-      .replace(/(\r?\n|\n)[ \t]*$/, "")
-  }
+  // Remove leading newline
+  str = str.replace /^[ \t]*\r?\n/, "" if trimStart
+  // Remove trailing newline
+  str = str.replace /(\r?\n|\n)[ \t]*$/, "" if trimEnd
 
   // escape unescaped backticks and `${`
-  str = str.replace(/(\\.|`|\$\{)/g, (s) => {
-    if (s[0] === "\\") {
-      return s
-    }
-    return `\\${s}`
-  })
+  str = str.replace /(\\.|`|\$\{)/g, (s) =>
+    if s[0] === "\\"
+      s
+    else
+      `\\${s}`
 
-  return {
-    $loc,
-    token: str,
-  }
-}
+  { $loc, token: str }
 
-function dedentBlockSubstitutions($0) {
-  const [s, strWithSubstitutions, e] = $0
+function dedentBlockSubstitutions($0: [ASTLeaf, (ASTLeaf | (ASTNode[] & {token: never}))[], ASTLeaf], tab: TabConfig)
+  [s, strWithSubstitutions, e] := $0
 
-  if (strWithSubstitutions.length === 0) {
-    return $0
-  }
+  return $0 unless strWithSubstitutions.length
 
-  let initialSpacing, i = 0, l = strWithSubstitutions.length, results = [s]
-  // Get initial spacing from the first string token if it is not a substitution
-  const { token } = strWithSubstitutions[0]
+  // Compute shared indentation of all string parts, concatenated
+  stringPart :=
+    for each part of strWithSubstitutions
+      part.token ?? "s"  // put "s" in place of substitutions
+  .join ''
+  dedent :=
+    if /^[ \t]*\r?\n/.test stringPart
+      getIndentOfBlockString stringPart, tab
+    else
+      false
 
-  if (token) {
-    initialSpacing = token.match(initialSpacingRe)
-  } else {
-    initialSpacing = false
-  }
+  // Dedent the string parts
+  results: ASTNode[] .= [s]
+  for each let part, i of strWithSubstitutions
+    if part.token?
+      part = dedentBlockString part as ASTLeaf, tab, dedent,
+        i === 0, i === strWithSubstitutions.length - 1
+    results.push part
+  results.push e
 
-  while (i < l) {
-    let segment = strWithSubstitutions[i]
+  type: "TemplateLiteral"
+  children: results
 
-    if (segment.token) {
-      segment = dedentBlockString(segment, initialSpacing, false)
-      if (i === 0) {
-        // Trim leading newline
-        segment.token = segment.token.replace(/^(\r?\n|\n)/, "")
-      }
-      if (i === l - 1) {
-        // Trim trailing newline
-        segment.token = segment.token.replace(/(\r?\n|\n)[ \t]*$/, "")
-      }
-      results.push(segment)
-    } else {
-      results.push(segment)
-    }
-
-    i++
-  }
-
-  results.push(e)
-  return {
-    type: "TemplateLiteral",
-    children: results,
-  }
-}
-
-function deepCopy(node: ASTNode) {
+function deepCopy(node: ASTNode): ASTNode {
   if (node == null) return node
   if (typeof node !== "object") return node
 
@@ -549,7 +569,7 @@ function deepCopy(node: ASTNode) {
     Object.entries(node).map(([key, value]) => {
       return [key, deepCopy(value)]
     })
-  )
+  ) as any
 }
 
 function expressionizeIfClause(clause, b, e) {
@@ -3757,7 +3777,7 @@ module.exports = {
   gatherRecursive,
   gatherRecursiveAll,
   gatherRecursiveWithinFunction,
-  getIndent,
+  getIndentLevel,
   getTrimmingSpace,
   hasAwait,
   hasYield,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -17,6 +17,7 @@ const {
   expressionizeIfClause,
   forRange,
   gatherBindingCode,
+  getIndentLevel,
   getTrimmingSpace,
   hasAwait,
   hasYield,
@@ -4733,7 +4734,7 @@ RegularExpressionFlags
 # NOTE: Simplified template grammar
 TemplateLiteral
   TripleTick ( TemplateBlockCharacters / TemplateSubstitution )* TripleTick ->
-    return dedentBlockSubstitutions($0)
+    return dedentBlockSubstitutions($0, module.config.tab)
 
   Backtick ( TemplateCharacters / TemplateSubstitution )* Backtick ->
     return {
@@ -4741,9 +4742,9 @@ TemplateLiteral
       children: $0,
     }
 
-  # NOTE: actual CoffeeScript """ string behaviors are pretty weird, this is simplifed
+  # NOTE: actual CoffeeScript """ string behaviors are pretty weird, this is simplified
   TripleDoubleQuote ( TripleDoubleStringCharacters / CoffeeStringSubstitution )* TripleDoubleQuote ->
-    return dedentBlockSubstitutions($0)
+    return dedentBlockSubstitutions($0, module.config.tab)
 
   # NOTE: ''' don't have interpolation so could be converted into a regular
   # String, but currently we use `template`s so the output looks similar to
@@ -4752,7 +4753,7 @@ TemplateLiteral
   TripleSingleQuote:s TripleSingleStringCharacters:str TripleSingleQuote:e ->
     return {
       type: "TemplateLiteral",
-      children: [s, dedentBlockString(str), e]
+      children: [s, dedentBlockString(str, module.config.tab), e]
     }
 
   # CoffeeScript Interpolation is enabled when "civet coffee-compat" or "civet coffee-interpolation" directive is present
@@ -6942,14 +6943,7 @@ Init
 # pushed value.
 Indent
   /[ \t]*/ ->
-    let level
-    if (module.config.tab) {
-      const tabs = $0.match(/\t/g)
-      const numTabs = tabs ? tabs.length : 0
-      level = numTabs * module.config.tab + /*spaces*/ ($0.length - numTabs)
-    } else {
-      level = $0.length
-    }
+    const level = getIndentLevel($0, module.config.tab)
 
     return {
       $loc,

--- a/test/block-strings.civet
+++ b/test/block-strings.civet
@@ -175,3 +175,63 @@ describe "block strings", ->
         \\${3 + 4}
       </div>`
     """
+
+  describe "mixed indentation", ->
+    testCase """
+      single quote
+      ---
+      x = '''
+            this
+          is
+             text
+      '''
+      ---
+      x = `  this
+      is
+         text`
+    """
+
+    testCase '''
+      double quote
+      ---
+      "civet coffeeCompat"
+      x = """
+            #{this}
+          #{isNot}
+              #{text}
+      """
+      ---
+      var x;
+      x = `  ${this}
+      ${isNot}
+          ${text}`
+    '''
+
+    testCase """
+      tabs
+      ---
+      "civet tab=2"
+      x = '''
+        \tthis
+      \tis
+      \t  \ttext
+      '''
+      ---
+      x = `\tthis
+      is
+        \ttext`
+    """
+
+    testCase """
+      partial tabs
+      ---
+      "civet tab=8"
+      x = '''
+        test
+      \ttext
+      '''
+      ---
+      x = `test
+            text`
+    """
+

--- a/test/template-literal.civet
+++ b/test/template-literal.civet
@@ -124,3 +124,17 @@ describe "template literal", ->
     ---
     `A number # ${n.toFixed(4)}\n\n${bye}`
   """
+
+  testCase '''
+    mixed indentation
+    ---
+    ```
+          ${this}
+        ${isNot}
+            ${text}
+    ```
+    ---
+    `  ${this}
+    ${isNot}
+        ${text}`
+  '''


### PR DESCRIPTION
Previously, indentation was removed from triple quoted strings based on the first indented line. Now it follows CoffeeScript's policy of removing the indentation shared by all lines. This is a little tricky in the case of tabs.

Once this gets released and we upgrade, it should fix the output of `civet --help`:

```
⟫ civet --help                          (quote-indentation ?$)
▄▄· ▪   ▌ ▐·▄▄▄ .▄▄▄▄▄
          ▐█ ▌▪██ ▪█·█▌▀▄.▀·•██       _._     _,-'""`-._
          ██ ▄▄▐█·▐█▐█•▐▀▀▪▄ ▐█.▪    (,-.`._,'(       |\`-/|
          ▐███▌▐█▌ ███ ▐█▄▄▌ ▐█▌·        `-.-' \ )-`( , o o)
          ·▀▀▀ ▀▀▀. ▀   ▀▀▀  ▀▀▀               `-    \`_`"'-


    Usage:
```