### PR TITLE
Parenthesize if expressions, remove other excess parens

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -1,5 +1,5 @@
 /**
- * lib.js holds functions that are used inside parser.hera
+ * lib.civet holds functions that are used inside parser.hera
  *
  * The rules inside parser.hera should be simple and short.
  * Most of the helpers/transforms should make their way into
@@ -572,22 +572,35 @@ function deepCopy(node: ASTNode): ASTNode {
   ) as any
 }
 
-function expressionizeIfClause(clause, b, e) {
-  const children = clause.children.slice(1) // Remove 'if'
-  children.push("?", b) // Add ternary
-  if (e) {
-    // Remove 'else'
-    children.push(e[0], ":", ...e.slice(2))
-  }
-  else {
-    children.push(":void 0")
-  }
+// Negate expression inside condition
+function negateCondition(condition)
+  { expression } .= condition
+  children := condition.children.slice()
+  i := children.indexOf(expression)
+  if i < 0
+    throw new Error `Could not find expression in condition`
+  children[i] = expression = ["!", makeLeftHandSideExpression(expression)]
+  { ...condition, expression, children }
 
-  return {
+function expressionizeIfClause(clause, b, e)
+  { condition } := clause  // remove 'if'
+  [ ...condRest, closeParen ] := condition.children  // separate ')'
+  children := [
+    ...condRest
+    "?"
+    b
+  ]
+  if e
+    // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
+    children.push e[0], ":", ...e[2..]
+  else
+    children.push ":void 0"
+  children.push closeParen
+
+  {
     type: "IfExpression",
     children,
   }
-}
 
 function expressionizeIteration(exp): void {
   const { async, subtype, block, children, statement } = exp
@@ -1911,6 +1924,7 @@ function makeLeftHandSideExpression(expression) {
     case "CallExpression":
     case "MemberExpression":
     case "ParenthesizedExpression":
+    case "IfExpression": // already wrapped in parens
     case "DebuggerExpression": // wrapIIFE
     case "SwitchExpression": // wrapIIFE
     case "ThrowExpression": // wrapIIFE
@@ -3799,6 +3813,7 @@ module.exports = {
   maybeRef,
   modifyString,
   needsRef,
+  negateCondition,
   processAssignmentDeclaration,
   processBinaryOpExpression,
   processCallMemberExpression,

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -579,7 +579,12 @@ function negateCondition(condition)
   i := children.indexOf(expression)
   if i < 0
     throw new Error `Could not find expression in condition`
-  children[i] = expression = ["!", makeLeftHandSideExpression(expression)]
+  children[i] = expression =
+    type: "UnaryExpression"
+    children: [
+      "!"
+      makeLeftHandSideExpression expression
+    ]
   { ...condition, expression, children }
 
 function expressionizeIfClause(clause, b, e)
@@ -1406,7 +1411,6 @@ function insertReturn(node): void {
 
   const [, exp, semi] = node
   if (semi?.type === "SemicolonDelimiter") return
-  let indent = getIndent(node)
   if (!exp) return
 
   switch (exp.type) {
@@ -2228,7 +2232,7 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
   }
 }
 
-function processDeclarationCondition(condition): void
+function processDeclarationCondition(condition, rootCondition): void
   return unless condition.type is "DeclarationCondition"
   ref := makeRef()
 
@@ -2237,21 +2241,20 @@ function processDeclarationCondition(condition): void
   binding := bindings[0]
   { pattern, suffix, initializer, splices, thisAssignments } := binding
 
-  initCondition :=
+  Object.assign condition,
     type: "AssignmentExpression"
     children: [ref, initializer]
     hoistDec:
       type: "Declaration"
       children: ["let ", ref, suffix]
       names: []
+    pattern: pattern
+    ref: ref
+  Object.assign rootCondition,
     blockPrefix: [
       ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
       ...thisAssignments
     ]
-    pattern: pattern
-    ref: ref
-
-  Object.assign(condition, initCondition)
 
 function processDeclarationConditions(node: ASTNode): void
   gatherRecursiveAll node, (n) =>
@@ -2265,9 +2268,14 @@ function processDeclarationConditions(node: ASTNode): void
 function processDeclarationConditionStatement(s: IfStatement | IterationStatement | SwitchStatement): void
   { condition } := s
   return unless condition?.expression
-  processDeclarationCondition(condition.expression)
+  { expression } .= condition
+  // Support for negated conditions built by unless/until
+  switch expression
+    {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]}
+      expression = expression2
+  processDeclarationCondition expression, condition.expression
 
-  { ref, pattern } := condition.expression
+  { ref, pattern } := expression
 
   if pattern
     conditions .= []

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -32,6 +32,7 @@ const {
   makeRef,
   maybeRef,
   modifyString,
+  negateCondition,
   processAssignmentDeclaration,
   processBinaryOpExpression,
   processCallMemberExpression,
@@ -3305,10 +3306,11 @@ UnlessClause
     kind.token += getTrimmingSpace(condition)
     condition = insertTrimmingSpace(condition, '')
 
+    condition = negateCondition(condition)
+
     return {
       type: "IfStatement",
-      // TODO: Don't add unnecessary parens
-      children: [kind, ["(!", condition, ")"]],
+      children: [kind, condition],
       condition,
     }
 
@@ -3474,19 +3476,13 @@ WhileStatement
 WhileClause
   ( While / Until ):kind _?:ws Condition:condition ->
     if (kind.token === "until") {
-      kind.token = "while"
-
-      // TODO: Don't add unnecessary parens
-      return {
-        type: "IterationStatement",
-        children: [kind, ...ws, ["(!", ...condition.children, ")"]],
-        condition,
-      }
+      kind = { ...kind, token: "while" }
+      condition = negateCondition(condition)
     }
 
     return {
       type: "IterationStatement",
-      children: [kind, ...ws, ...condition.children],
+      children: [kind, ws, condition],
       condition,
     }
 

--- a/test/array.civet
+++ b/test/array.civet
@@ -249,7 +249,7 @@ describe "array", ->
     ---
     [
       1,
-      (x)?1:void 0
+      (x?1:void 0)
     ]
   """
 
@@ -262,7 +262,7 @@ describe "array", ->
     ]
     ---
     [
-      (x)?1:void 0,
+      (x?1:void 0),
       a
     ]
   """
@@ -275,7 +275,7 @@ describe "array", ->
     ]
     ---
     [
-      ...(x)?a:void 0
+      ...(x?a:void 0)
     ]
   """
 

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -367,12 +367,12 @@ describe "binary operations", ->
         throw new Error
     ---
     const name = optionalName ??
-      (loaded)?(
+      (loaded?(
         file.name
       )
       :(
         (()=>{throw new Error})()
-      )
+      ))
   """
 
   testCase """

--- a/test/class.civet
+++ b/test/class.civet
@@ -331,7 +331,7 @@ describe "class", ->
     class A extends if x then B else C
       x: number
     ---
-    class A extends ((x)? B : C) {
+    class A extends (x? B : C) {
       x: number
     }
   """

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -47,10 +47,10 @@ describe "example code", ->
     tag =
       (colon || (prev != null) &&
          (indexOf.call(['.', '?.', '::', '?::'], prev[0]) >= 0 ||
-         !prev.spaced && prev[0] === '@'))?
+         !prev.spaced && prev[0] === '@')?
         'PROPERTY'
       :
-        'IDENTIFIER'
+        'IDENTIFIER')
   """
 
   testCase """
@@ -111,14 +111,14 @@ describe "example code", ->
     ---
     var val, indentRegex;
     val =
-      (!(this.fromSourceString))?
+      (!this.fromSourceString?
         val
-      : (heredoc)?(
-        (this.indent)?indentRegex = RegExp(`\\\\n${this.indent}`, "g"):void 0,
+      : (heredoc?(
+        (this.indent?indentRegex = RegExp(`\\\\n${this.indent}`, "g"):void 0),
 
-        (indentRegex)?val = val.replace(indentRegex, '\\n'):void 0,
-        (this.initialChunk)?val = val.replace(LEADING_BLANK_LINE,  ''):void 0,
-        (this.finalChunk)?val = val.replace(TRAILING_BLANK_LINE, ''):void 0,
+        (indentRegex?val = val.replace(indentRegex, '\\n'):void 0),
+        (this.initialChunk?val = val.replace(LEADING_BLANK_LINE,  ''):void 0),
+        (this.finalChunk?val = val.replace(TRAILING_BLANK_LINE, ''):void 0),
         val
       )
       :(
@@ -131,7 +131,7 @@ describe "example code", ->
             return ' '
           }
         })
-      )
+      )))
   """
 
   testCase """
@@ -296,7 +296,7 @@ describe "example code", ->
     var code;
     if (olen === 0) {
       code = value.compileToFragments(o)
-      return (o.level >= LEVEL_OP)? this.wrapInParentheses(code) : code
+      return (o.level >= LEVEL_OP? this.wrapInParentheses(code) : code)
     }
   """
 

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -298,7 +298,7 @@ describe "examples (from real life)", ->
     ---
     date := if x==1 then "a" else "b"
     ---
-    const date = (x==1)? "a" : "b"
+    const date = (x==1? "a" : "b")
   """
 
   testCase """

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -452,10 +452,10 @@ describe "function application", ->
     else
       c
     ---
-    x((3)?
+    x((3?
       b
     :
-      c)
+      c))
   """
 
   // Beyond CoffeeScript

--- a/test/function.civet
+++ b/test/function.civet
@@ -1323,7 +1323,7 @@ describe "function", ->
       ---
       (x) => a if x
       ---
-      (x) =>(x)? a:void 0
+      (x) =>(x? a:void 0)
     """
 
     testCase """
@@ -1339,7 +1339,7 @@ describe "function", ->
       ---
       (x) => if x then a else b
       ---
-      (x) => (x)? a : b
+      (x) => (x? a : b)
     """
 
     testCase """
@@ -1451,7 +1451,7 @@ describe "function", ->
           a
       ---
       (function(x) {
-        if(!(x)) {
+        if(!x) {
           return a
         };return
       })
@@ -1742,7 +1742,7 @@ describe "function", ->
       function f(arg) {
         let ret;
         ret = 'default'
-        if(!(arg)) { return ret }
+        if(!arg) { return ret }
         ret = arg
         return ret
       }

--- a/test/if.civet
+++ b/test/if.civet
@@ -237,7 +237,7 @@ describe "if", ->
     unless x
       return y
     ---
-    if(!(x)) {
+    if(!x) {
       return y
     }
   """
@@ -261,7 +261,7 @@ describe "if", ->
     else
       return z
     ---
-    if(!(x)) {
+    if(!x) {
       return y
     }
     else {
@@ -308,7 +308,7 @@ describe "if", ->
     ---
     return true unless x
     ---
-    if(!(x)) { return true }
+    if(!x) { return true }
   """
 
   testCase """
@@ -443,10 +443,10 @@ describe "if", ->
       else
         "b"
       ---
-      x = (y)?
+      x = (y?
         "a"
       :
-        "b"
+        "b")
     """
 
     testCase """
@@ -459,10 +459,10 @@ describe "if", ->
         "b"
       ---
       x =
-      (y)?
+      (y?
         "a"
       :
-        "b"
+        "b")
     """
 
     testCase """
@@ -472,9 +472,9 @@ describe "if", ->
         "a"
       else "b"
       ---
-      x = (y)?
+      x = (y?
         "a"
-      : "b"
+      : "b")
     """
 
     testCase """
@@ -483,8 +483,8 @@ describe "if", ->
       x = if (y)
         "a"
       ---
-      x = (y)?
-        "a":void 0
+      x = (y?
+        "a":void 0)
     """
 
     testCase """
@@ -498,14 +498,14 @@ describe "if", ->
       else
         "c"
       ---
-      x = (y)?(
-        (z)?
+      x = (y?(
+        (z?
           "a"
         :
-          "b"
+          "b")
       )
       :
-        "c"
+        "c")
     """
 
     testCase """
@@ -516,12 +516,12 @@ describe "if", ->
       else
         c; d
       ---
-      x = (y)?(
+      x = (y?(
         a, b
       )
       :(
         c, d
-      )
+      ))
     """
 
     testCase """
@@ -532,12 +532,12 @@ describe "if", ->
       else
         /*c*/ c; /*d*/ d
       ---
-      x = (y)?(
+      x = (y?(
         /*a*/ a, /*b*/ b
       )
       :(
         /*c*/ c, /*d*/ d
-      )
+      ))
     """
 
     testCase """
@@ -548,11 +548,11 @@ describe "if", ->
       else
         "b"
       ---
-      x = (y)?(
+      x = (y?(
         (()=>{throw new Error})()
       )
       :
-        "b"
+        "b")
     """
 
     testCase """
@@ -563,11 +563,11 @@ describe "if", ->
       else
         "b"
       ---
-      x = (y)?(
+      x = (y?(
         (()=>{debugger})()
       )
       :
-        "b"
+        "b")
     """
 
     testCase """
@@ -578,10 +578,10 @@ describe "if", ->
       else
         "b"
       ---
-      x = (!(y))?
+      x = (!y?
         "a"
       :
-        "b"
+        "b")
     """
 
     testCase """
@@ -589,7 +589,7 @@ describe "if", ->
       ---
       x = (a if y)
       ---
-      x = ((y)?a:void 0)
+      x = ((y?a:void 0))
     """
 
     testCase """
@@ -597,7 +597,7 @@ describe "if", ->
       ---
       x = (a if y) + 1
       ---
-      x = ((y)?a:void 0) + 1
+      x = ((y?a:void 0)) + 1
     """
 
     testCase """
@@ -605,7 +605,7 @@ describe "if", ->
       ---
       x = (a unless y)
       ---
-      x = ((!(y))?a:void 0)
+      x = ((!y?a:void 0))
     """
 
     testCase """
@@ -614,9 +614,9 @@ describe "if", ->
       x = if y
         {}
       ---
-      x = (y)?(
+      x = (y?(
         {}
-      ):void 0
+      ):void 0)
     """
 
     testCase """
@@ -625,9 +625,9 @@ describe "if", ->
       x = if (y)
         {}
       ---
-      x = (y)?(
+      x = (y?(
         {}
-      ):void 0
+      ):void 0)
     """
 
     testCase """
@@ -641,11 +641,25 @@ describe "if", ->
         .say 'hello'
       ---
       greeting =
-        ((x)?
+        (x?
           y
         :
           z)
         .say('hello')
+    """
+
+    testCase """
+      unary operator prefix
+      ---
+      void if x
+        y
+      else
+        z
+      ---
+      void (x?
+        y
+      :
+        z)
     """
 
   describe "return if expression", ->
@@ -654,7 +668,7 @@ describe "if", ->
       ---
       return if y then 1 else 0
       ---
-      return (y)? 1 : 0
+      return (y? 1 : 0)
     """
 
     testCase """
@@ -664,8 +678,8 @@ describe "if", ->
       then 1
       else 0
       ---
-      return (y)? 1
-      : 0
+      return (y? 1
+      : 0)
     """
 
     testCase """
@@ -676,10 +690,10 @@ describe "if", ->
       else
         0
       ---
-      return (y)?
+      return (y?
         1
       :
-        0
+        0)
     """
 
   describe "DeclarationCondition", ->

--- a/test/if.civet
+++ b/test/if.civet
@@ -790,6 +790,18 @@ describe "if", ->
     """
 
     testCase """
+      declaration with unless
+      ---
+      unless x := getBool()
+        console.log "falsey", x
+      ---
+      let ref;if(!(ref = getBool())) {
+        const  x = ref;
+        console.log("falsey", x)
+      }
+    """
+
+    testCase """
       longhand const
       ---
       if const match = regex.exec string

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -64,7 +64,7 @@ describe "braced JSX attributes", ->
     ---
     <Component n={null} u={undefined} t={true} f={false} i={100} bi={1_000_000n}
      a={[1, 2, 3]} o={{a, b}} id={foo} r={/[a-zA-Z]+/}
-     t={`string ${interpolation}`} p={((cond)? 1 : 2)} />
+     t={`string ${interpolation}`} p={((cond? 1 : 2))} />
   """
 
   throws """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -577,12 +577,12 @@ describe "Unbraced function children in JSX", ->
     ---
     <>
       {
-        (loggedIn)?(
+        (loggedIn?(
           <LogoutButton />
         )
         :(
           <LoginButton />
-        )
+        ))
       }
     </>
   """

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -74,7 +74,7 @@ describe "JSX", ->
     ---
     <h1>{if x < 10 then "Hello" else "Goodbye"}</h1>
     ---
-    <h1>{(x < 10)? "Hello" : "Goodbye"}</h1>
+    <h1>{(x < 10? "Hello" : "Goodbye")}</h1>
   """
 
   testCase """
@@ -82,7 +82,7 @@ describe "JSX", ->
     ---
     <h1>{"Hello" if x < 10}</h1>
     ---
-    <h1>{(x < 10)?"Hello":void 0}</h1>
+    <h1>{(x < 10?"Hello":void 0)}</h1>
   """
 
   testCase """
@@ -90,7 +90,7 @@ describe "JSX", ->
     ---
     <h1 title={if x < 10 then "Hello" else "Goodbye"}/>
     ---
-    <h1 title={(x < 10)? "Hello" : "Goodbye"}/>
+    <h1 title={(x < 10? "Hello" : "Goodbye")}/>
   """
 
   testCase """
@@ -98,7 +98,7 @@ describe "JSX", ->
     ---
     <h1 title={"Hello" if x < 10}/>
     ---
-    <h1 title={(x < 10)?"Hello":void 0}/>
+    <h1 title={(x < 10?"Hello":void 0)}/>
   """
 
   throws """

--- a/test/object.civet
+++ b/test/object.civet
@@ -559,7 +559,7 @@ describe "object", ->
       a: 1 if hasA
     ---
     f({
-      a:(hasA)? 1:void 0,
+      a:(hasA? 1:void 0),
     })
   """
 
@@ -571,8 +571,8 @@ describe "object", ->
       b: 2 if hasB
     ---
     f({
-      a:(hasA)? 1:void 0,
-      b:(hasB)? 2:void 0,
+      a:(hasA? 1:void 0),
+      b:(hasB? 2:void 0),
     })
   """
 
@@ -592,8 +592,8 @@ describe "object", ->
       b: 2 if hasB
     ---
     function f() {
-      return ({a:(hasA)? 1:void 0,
-      b:(hasB)? 2:void 0})
+      return ({a:(hasA? 1:void 0),
+      b:(hasB? 2:void 0)})
     }
   """; // TODO: thinks next triple quote is a call expression
 

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -165,7 +165,7 @@ describe "[TS] function", ->
       throw new Error "falsey" unless value
     ---
     assert = function(value: unknown): asserts value {
-      if(!(value)) { throw new Error("falsey") };return
+      if(!value) { throw new Error("falsey") };return
     }
   """
 

--- a/test/while.civet
+++ b/test/while.civet
@@ -57,7 +57,7 @@ describe "while", ->
     ---
     x() until y
     ---
-    while (!(y)) { x() }
+    while (!y) { x() }
   """
 
   testCase """
@@ -73,7 +73,7 @@ describe "while", ->
     ---
     x() until y;
     ---
-    while (!(y)) { x() };
+    while (!y) { x() };
   """
 
   describe "iteration results", ->

--- a/test/while.civet
+++ b/test/while.civet
@@ -103,9 +103,21 @@ describe "while", ->
       while {x, y} := next()
         x++
       ---
-      let ref;while (ref = next()) {
+      let ref;while ((ref = next()) && 'x' in ref && 'y' in ref) {
         const {x, y} = ref;
         x++
+      }
+    """
+
+    testCase """
+      until
+      ---
+      until item := next()
+        console.log "falsey", item
+      ---
+      let ref;while (!(ref = next())) {
+        const item = ref;
+        console.log("falsey", item)
       }
     """
 
@@ -118,13 +130,12 @@ describe "while", ->
       ---
       x = 0
       let ref;
-      while (ref = next()) {
+      while ((ref = next()) && 'x' in ref && 'y' in ref) {
         const {x, y} = ref;
         x++
       }
     """
 
-    // TODO: better indentation handling
     testCase """
       while inside function
       ---
@@ -135,7 +146,7 @@ describe "while", ->
       ---
       f = function() {
         let ref;
-        while (ref = next()) {
+        while ((ref = next()) && 'x' in ref && 'y' in ref) {
           const {x, y} = ref;
           x++
         }
@@ -155,7 +166,7 @@ describe "while", ->
       f = function() {
         a
         let ref;
-        while (ref = next()) {
+        while ((ref = next()) && 'x' in ref && 'y' in ref) {
           const {x, y} = ref;
           x++
         }


### PR DESCRIPTION
Fixes #757

This ended up also fixing some `while` pattern matching tests, though I can't say I exactly understand why. 😅 (probably the old unwrapping of `condition.children`)