### PR TITLE
Make ts-diagnostic.civet independent of vscode dependencies

### DIFF
--- a/source/ts-diagnostic.civet
+++ b/source/ts-diagnostic.civet
@@ -1,17 +1,12 @@
-type { Diagnostic, DiagnosticMessageChain, TextSpan } from 'typescript'
+type {  DiagnosticMessageChain } from 'typescript'
 
-// Can't import until: https://github.com/microsoft/TypeScript/issues/32949 because
-// it will pull in all 8MB when bundled with esbuild (affected LSP)
-// { DiagnosticCategory } from typescript
-enum DiagnosticCategory
-  Warning = 0
-  Error = 1
-  Suggestion = 2
-  Message = 3
+interface Position
+  line: number
+  character: number
 
-vs, { DiagnosticSeverity, Position, Range } from 'vscode-languageserver'
-
-{ TextDocument } from 'vscode-languageserver-textdocument'
+interface Range
+    start: Position
+    end: Position
 
 type SourceMapping = [number] | [number, number, number, number]
 
@@ -106,38 +101,3 @@ export function flattenDiagnosticMessageText(
       result += flattenDiagnosticMessageText(kid, indent)
 
   return result
-
-export function rangeFromTextSpan(span: TextSpan, document: TextDocument): Range
-  return
-    start: document.positionAt(span.start)
-    end: document.positionAt(span.start + span.length)
-
-export function convertDiagnostic(
-  diagnostic: Diagnostic,
-  document: TextDocument,
-  sourcemapLines?: SourcemapLines
-): vs.Diagnostic
-  return
-    message: flattenDiagnosticMessageText(diagnostic.messageText)
-    range: remapRange(
-      rangeFromTextSpan(
-        {
-          start: diagnostic.start || 0,
-          length: diagnostic.length ?? 1,
-        },
-        document
-      ),
-      sourcemapLines
-    )
-    severity: diagnosticCategoryToSeverity(diagnostic.category)
-    code: diagnostic.code
-    source: diagnostic.source || 'typescript'
-
-function diagnosticCategoryToSeverity(
-  category: DiagnosticCategory
-): DiagnosticSeverity
-  switch category
-    when DiagnosticCategory.Warning then DiagnosticSeverity.Warning
-    when DiagnosticCategory.Error then DiagnosticSeverity.Error
-    when DiagnosticCategory.Suggestion then DiagnosticSeverity.Hint
-    when DiagnosticCategory.Message then DiagnosticSeverity.Information


### PR DESCRIPTION
This PR removes the dependency of `ts-diagnostic.civet` on vscode-specific dependencies as those are only required for the LSP and moves that code back to the lsp dir.