### PR TITLE
Default type for `return` declaration

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -3391,69 +3391,67 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
  * for changing automatic return value of function.
  * Returns whether any present (so shouldn't do implicit return).
  */
-function processReturnValue(func) {
-  const { block } = func
-  const values = gatherRecursiveWithinFunction(block,
-    ({ type }) => type === "ReturnValue")
-  if (!values.length) return false
+function processReturnValue(func: FunctionNode)
+  { block } := func
+  values: ASTNodeBase[] := (gatherRecursiveWithinFunction block,
+    ({ type }) => type === "ReturnValue") as ASTNodeBase[]
+  return false unless values.length
 
-  const ref = makeRef("ret")
+  ref := makeRef "ret"
 
-  let declared
-  values.forEach((value) => {
+  let declaration
+  values.forEach (value) =>
     value.children = [ref]
 
     // Check whether return.value already declared within this function
-    const { ancestor } = findAncestor(value,
+    { ancestor, child } := findAncestor(value,
       ({ type }) => type === "Declaration",
       isFunction)
-    if (ancestor) declared = true
-  })
+    declaration ??= child if ancestor  // remember binding
 
-  // Add declaration of return.value after {
-  if (!declared) {
-    let returnType = func.returnType ?? func.signature?.returnType
-    if (returnType) {
-      const { t } = returnType
-      if (t.type === "TypePredicate") {
+  // Compute default return type
+  returnType .= func.returnType ?? func.signature?.returnType
+  if returnType
+    { t } := returnType
+    switch t.type
+      "TypePredicate"
         returnType = ": boolean"
-      } else if (t.type === "AssertsType") {
+      "AssertsType"
         returnType = undefined
-      }
-    }
-    block.expressions.unshift([
-      getIndent(block.expressions[0]),
-      {
-        type: "Declaration",
-        children: ["let ", ref, returnType],
-        names: [],
-      },
+
+  // Modify existing declaration, or add declaration of return.value after {
+  if declaration
+    unless declaration.suffix?
+      declaration.children[1] = declaration.suffix = returnType
+  else
+    block.expressions.unshift [
+      getIndent block.expressions[0]
+    ,
+      type: "Declaration"
+      children: ["let ", ref, returnType]
+      names: []
+    ,
       ";"
-    ])
-  }
+    ]
 
   // Transform existing `return` -> `return ret`
-  gatherRecursiveWithinFunction(block,
-    (r) => r.type === "ReturnStatement" && !r.expression)
-    .forEach((r) => {
-      r.expression = ref
-      r.children.splice(-1, 1, " ", ref)
-    })
+  gatherRecursiveWithinFunction block,
+    (r) => r.type is "ReturnStatement" and not r.expression
+  .forEach (r) =>
+    r.expression = ref
+    r.children.splice -1, 1, " ", ref
 
   // Implicit return before }
-  if (block.children.at(-2)?.type !== "ReturnStatement") {
-    block.expressions.push([
-      [getIndent(block.expressions.at(-1))],
-      {
-        type: "ReturnStatement",
-        expression: ref,
-        children: ["return ", ref]
-      }
-    ])
-  }
+  unless block.children.at(-2)?.type is "ReturnStatement"
+    block.expressions.push [
+      [getIndent(block.expressions.at(-1))]
+    ,
+      type: "ReturnStatement",
+      expression: ref,
+      children: ["return ", ref]
+    ]
 
   return true
-}
 
 function processUnaryExpression(pre, exp, post) {
   if (!(pre.length || post)) return exp

--- a/test/function.civet
+++ b/test/function.civet
@@ -1852,6 +1852,18 @@ describe "function", ->
     """
 
     testCase """
+      return .= with type
+      ---
+      function f: Number
+        return: number .= 0
+      ---
+      function f(): Number {
+        let ret: number = 0
+        return ret
+      }
+    """
+
+    testCase """
       let return
       ---
       function f
@@ -1884,6 +1896,24 @@ describe "function", ->
       function f(): number {
         let ret: number;
         ret = 5
+        return ret
+      }
+    """
+
+    testCase """
+      return.value typed by function with arguments
+      ---
+      function dupem(thing: Record<string, string>): Record<string, string>
+        return := {}
+        for key, value in thing
+          return.value[key] = value + value
+      ---
+      function dupem(thing: Record<string, string>): Record<string, string> {
+        const ret: Record<string, string> = {}
+        for (const key in thing) {
+          const value = thing[key];
+          ret[key] = value + value
+        }
         return ret
       }
     """


### PR DESCRIPTION
Fixes #765

Also Civetify `processReturnValue` (though no types yet).