### PR TITLE
unplugin calls addWatchFile

### DIFF
--- a/integration/unplugin/examples/esbuild/esbuild.js
+++ b/integration/unplugin/examples/esbuild/esbuild.js
@@ -1,0 +1,16 @@
+import * as esbuild from 'esbuild'
+import civetEsbuildPlugin from '@danielx/civet/esbuild'
+
+const options = {
+  entryPoints: ['src/main.civet'],
+  bundle: true,
+  outfile: 'dist/main.js',
+  plugins: [civetEsbuildPlugin()],
+}
+
+if (process.argv.includes('--watch')) {
+  const ctx = await esbuild.context(options)
+  await ctx.watch()
+} else {
+  await esbuild.build(options)
+}

--- a/integration/unplugin/examples/esbuild/package.json
+++ b/integration/unplugin/examples/esbuild/package.json
@@ -1,0 +1,11 @@
+{
+  "type": "module",
+  "scripts": {
+    "build": "node esbuild.js",
+    "watch": "node esbuild.js --watch"
+  },
+  "devDependencies": {
+    "@danielx/civet": "*",
+    "esbuild": "*"
+  }
+}

--- a/integration/unplugin/examples/esbuild/src/main.civet
+++ b/integration/unplugin/examples/esbuild/src/main.civet
@@ -1,0 +1,3 @@
+{a} from "./module.civet"
+
+console.log a

--- a/integration/unplugin/examples/esbuild/src/module.civet
+++ b/integration/unplugin/examples/esbuild/src/module.civet
@@ -1,0 +1,1 @@
+export a = "a"

--- a/integration/unplugin/examples/rollup/package.json
+++ b/integration/unplugin/examples/rollup/package.json
@@ -1,7 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "build": "npx rollup --config rollup.config.js"
+    "build": "npx rollup --config rollup.config.js",
+    "watch": "npx rollup --config rollup.config.js --watch"
   },
   "devDependencies": {
     "@danielx/civet": "*"

--- a/integration/unplugin/examples/webpack/package.json
+++ b/integration/unplugin/examples/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "build": "npx webpack build"
+    "build": "npx webpack build",
+    "watch": "npx webpack build --watch"
   },
   "devDependencies": {
     "@danielx/civet": "*",

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -177,6 +177,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
         process.cwd(),
         path.resolve(path.dirname(importer ?? ''), id)
       );
+      this.addWatchFile(relativeId);
       const relativePath = relativeId + outExt;
 
       return relativePath;

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -187,7 +187,6 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
 
       if (isCivetTranspiled(id)) return relativeId.replace(/\?transform$/, '');
 
-      this.addWatchFile(relativeId);
       const relativePath = relativeId + outExt;
 
       return relativePath;
@@ -200,6 +199,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
 
       const filename = path.resolve(process.cwd(), id.slice(0, -outExt.length));
       const code = await fs.promises.readFile(filename, 'utf-8');
+      this.addWatchFile(filename);
 
       // Ideally this should have been done in a `transform` step
       // but for some reason, webpack seems to be running them in the order


### PR DESCRIPTION
Together with https://github.com/unjs/unplugin/pull/345, this will fix eventually #773.

I have tested this (`yarn link`ing to my unplugin fork), using the new esbuild example code.

For now, it might fix watch mode on other build systems. But I wasn't able to test because e.g. Vite dev mode is currently broken (#775).

Update: The types don't work until the unplugin PR gets merged. So maybe we should wait for that.