### PR TITLE
Fix dts generation for Vite & Rollup

### DIFF
--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -74,7 +74,6 @@ module.exports = {
 interface PluginOptions {
   dts?: boolean;
   outputExtension?: string;
-  js?: boolean;
   typecheck?: boolean;
   transformOutput?: (
     code: string,
@@ -86,5 +85,4 @@ interface PluginOptions {
 - `dts`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`
 - `typecheck`: Whether to run type checking on the generated code. Default: `false`.
 - `outputExtension`: Output filename extension to use. Default: `.civet.tsx`, or uses `.civet.jsx` if `js` is `true`.
-- `js`: Whether to transpile to JS or TS. Default: `false`.
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.


### PR DESCRIPTION
Rollup doesn't support returning non-js source inside the loader, but the previous plugin returned TS from loader if dts or typecheck were enabled, and then added that to typescript vfs map in transform step.
This didn't really help much, so I've moved the transform step to be inside the loader as well. In addition, the loader now always returns JS, and if TS features are enabled, then it does an additional build with TS enabled and uses that for vfs.

I'm not sure how fast civet's compile step is though. Would it be faster if we just did a TS compile with civet, and then transform that to JS with esbuild?