### PR TITLE
Simpler implementation of comments near Civet directives

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6524,10 +6524,8 @@ Shebang
   /#![^\r\n]*/ EOL
 
 CivetPrologue
-  [\t ]* DoubleQuote CivetPrologueContent:content DoubleQuote SimpleStatementDelimiter [ \t]* /\r\n|\r|\n/? EOS?:eos ->
-    return {...content, children: [...content.children, eos]}
-  [\t ]* SingleQuote CivetPrologueContent:content SingleQuote SimpleStatementDelimiter [ \t]* /\r\n|\r|\n/? EOS?:eos ->
-    return {...content, children: [...content.children, eos]}
+  [\t ]* DoubleQuote CivetPrologueContent:content DoubleQuote SimpleStatementDelimiter [ \t]* ( EOL / &RestOfLine ) -> content
+  [\t ]* SingleQuote CivetPrologueContent:content SingleQuote SimpleStatementDelimiter [ \t]* ( EOL / &RestOfLine ) -> content
 
 CivetPrologueContent
   "civet" NonIdContinue CivetOption*:options [\s]* ->

--- a/test/comment.civet
+++ b/test/comment.civet
@@ -239,3 +239,13 @@ describe "comment", ->
     let a = function() { console.log({ hi: true }) }
   """
 
+  testCase """
+    newline after directive preserved
+    ---
+    "civet coffeeCompat"
+
+    console.log 'hi'
+    ---
+
+    console.log('hi')
+  """


### PR DESCRIPTION
This is a followup to #783 implementing the suggestion in https://github.com/DanielXMoore/Civet/pull/783#discussion_r1367750148
I think the code is cleaner, in particular because it doesn't gobble up one or two newlines depending on context.

The new test passes with and without this change, though.