### PR TITLE
Update more parent pointers along the way

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -12,7 +12,7 @@ type ASTNodeBase =
   children: ASTNode[]
   blockPrefix?: unknown
   names?: string[]
-  parent: ASTNodeBase | undefined
+  parent?: ASTNodeBase | undefined
 
 type ASTError =
   type: "Error"
@@ -130,50 +130,46 @@ type TabConfig = number | undefined
  * Adds parent pointers to all nodes in the AST. Elements within
  * arrays of nodes receive the closest non-array object parent.
  */
-function addParentPointers(node: ASTNode, parent?: ASTNodeBase): void {
-  if (node == null) return
+function addParentPointers(node: ASTNode, parent?: ASTNodeBase): void
+  if (not node?) return
   if (typeof node !== "object") return
 
   // NOTE: Arrays are transparent and skipped when traversing via parent
-  if (Array.isArray(node)) {
-    for (const child of node) {
+  if Array.isArray(node)
+    for child of node
       addParentPointers(child, parent)
-    }
     return
-  }
 
+  node = node as ASTNodeBase
   node.parent = parent
-  if (node.children) {
-    for (const child of node.children) {
+  if node.children
+    for child of node.children
       addParentPointers(child, node)
-    }
-  }
-}
 
 /**
  * Just update parent pointers for the children of a node,
  * recursing into arrays but not objects.  More efficient version of
  * `addParentPointers` when just injecting one new node.
  */
-function updateParentPointers(node: ASTNode, parent?: ASTNodeBase, depth = 1): void {
-  if (node == null) return
+function updateParentPointers(node: ASTNode, parent?: ASTNodeBase, depth = 1): void
+  if (not node?) return
   if (typeof node !== "object") return
 
   // NOTE: Arrays are transparent and skipped when traversing via parent
-  if (Array.isArray(node)) {
-    for (const child of node) {
+  if Array.isArray(node)
+    for child of node
       updateParentPointers(child, parent, depth)
-    }
     return
-  }
 
-  if (parent != null) node.parent = parent
-  if (depth && node.children) {
-    for (const child of node.children) {
+  node = node as ASTNodeBase
+  if (parent?) node.parent = parent
+  if depth and node.children
+    for child of node.children
       updateParentPointers(child, node, depth-1)
-    }
-  }
-}
+
+function makeNode(node: ASTNode): ASTNode
+  updateParentPointers node
+  node
 
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   expressions := [
@@ -181,7 +177,7 @@ function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
     ["", statement]
   ]
 
-  block := {
+  block := makeNode {
     type: "BlockStatement"
     children: [" { ", expressions, " }"]
     expressions
@@ -192,10 +188,9 @@ function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   // This removes trailing whitespace for easier testing
   if (!isWhitespaceOrEmpty(ws)) children.push(ws)
 
-  post = { ...post, children, block }
-  if (post.type === "IfStatement") {
+  post = makeNode { ...post, children, block }
+  if post.type === "IfStatement"
     post.then = block
-  }
   return post
 
 /**
@@ -330,8 +325,8 @@ assert := {
  *
  * @returns the duplicated block with prefix statements attached or the unchanged block.
  */
-function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: BlockStatement) {
-  if (prefixStatements && prefixStatements.length) {
+function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: BlockStatement)
+  if prefixStatements && prefixStatements.length
     const indent = getIndent(block.expressions[0])
     // Match prefix statements to block indent level
     if indent
@@ -340,6 +335,8 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
         [indent, ...statement.slice(1)]
 
     const expressions = [...prefixStatements, ...block.expressions]
+    // blockPrefix wasn't previously a child, so now needs parent pointers
+    addParentPointers prefixStatements, block
 
     block = {
       ...block,
@@ -348,15 +345,14 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
         block.children.map((c) => c === block.expressions ? expressions : c),
     }
     // Add braces if block lacked them
-    if (block.bare) {
+    if block.bare
       // Now copied, so mutation is OK
       block.children = [[" {"], ...block.children, "}"]
       block.bare = false
-    }
-  }
+
+    updateParentPointers block
 
   return block
-}
 
 function closest(node: ASTNodeBase, types: string[]) {
   do {
@@ -391,8 +387,9 @@ function constructInvocation(fn, arg) {
 
     ref.type = "PipedExpression"
     ref.children = [makeLeftHandSideExpression(arg)]
+    updateParentPointers ref
 
-    return {
+    return makeNode {
       type: "UnwrappedExpression",
       children: [skipIfOnlyWS(fn.leadingComment), body, skipIfOnlyWS(fn.trailingComment)],
     }
@@ -607,19 +604,18 @@ function expressionizeIfClause(clause, b, e)
     children,
   }
 
-function expressionizeIteration(exp): void {
+function expressionizeIteration(exp): void
   const { async, subtype, block, children, statement } = exp
   const i = children.indexOf(statement)
-  if (i < 0) {
+  if i < 0
     throw new Error("Could not find iteration statement in iteration expression")
-  }
 
-  if (subtype === "DoStatement") {
+  if subtype === "DoStatement"
     // Just wrap with IIFE
     insertReturn(block)
     children.splice(i, 1, ...wrapIIFE(["", statement, undefined], async))
+    updateParentPointers exp
     return
-  }
 
   const resultsRef = makeRef("results")
 
@@ -636,7 +632,7 @@ function expressionizeIteration(exp): void {
       ["", wrapWithReturn(resultsRef)],
     ], async)
   )
-}
+  updateParentPointers exp
 
 function processBinaryOpExpression($0)
   expandedOps := expandChainedComparisons($0)
@@ -961,14 +957,13 @@ function insertPush(node, ref): void {
   node.push(")")
 }
 
-function wrapWithReturn(expression) {
+function wrapWithReturn(expression?: ASTNode): ASTNode
   const children = expression ? ["return ", expression] : ["return"]
 
-  return {
+  return makeNode {
     type: "ReturnStatement",
     children,
   }
-}
 
 function isExistence(exp) {
   if (exp.type === "ParenthesizedExpression" && exp.implicit) {
@@ -1343,6 +1338,8 @@ function insertHoistDec(block, node, dec): void {
     const indent = expressions[index][0]
     expressions.splice(index, 0, [indent, dec, ";"])
   }
+  // hoistDec wasn't previously a child, so now needs parent pointers
+  addParentPointers dec, block
 }
 
 function patternAsValue(pattern) {
@@ -1379,42 +1376,38 @@ function patternAsValue(pattern) {
 }
 
 // [indent, statement, semicolon]
-function insertReturn(node): void {
+function insertReturn(node: ASTNode): void
   if (!node) return
   // TODO: unify this with the `exp` switch
-  switch (node.type) {
+  switch node.type
     case "BlockStatement":
-      if (node.expressions.length) {
+      if node.expressions.length
         const last = node.expressions[node.expressions.length - 1]
         insertReturn(last)
-      } else {
+      else
         // NOTE: Kind of hacky but I'm too much of a coward to make `->` add an implicit return
-        if (node.parent.type === "CatchClause") {
+        if node.parent.type is "CatchClause"
           node.expressions.push(["return"])
-        }
-      }
       return
     // NOTE: "CaseClause"s don't get a return statements inserted
     case "WhenClause":
       // Remove inserted `break;`
       node.children.splice(node.children.indexOf(node.break), 1)
-      if (node.block.expressions.length) {
+      if node.block.expressions.length
         insertReturn(node.block)
-      } else {
+      else
         node.block.expressions.push(wrapWithReturn())
-      }
       return
     case "DefaultClause":
       insertReturn(node.block)
       return
-  }
   if (!Array.isArray(node)) return
 
   const [, exp, semi] = node
-  if (semi?.type === "SemicolonDelimiter") return
+  if (semi?.type is "SemicolonDelimiter") return
   if (!exp) return
 
-  switch (exp.type) {
+  switch (exp.type)
     case "BreakStatement":
     case "ContinueStatement":
     case "DebuggerStatement":
@@ -1423,18 +1416,20 @@ function insertReturn(node): void {
     case "ThrowStatement":
       return
     case "Declaration":
-      exp.children.push(["", {
+      exp.children.push ["", {
         type: "ReturnStatement",
         children: [";return ", patternAsValue(exp.bindings.at(-1).pattern)],
-      }])
+        parent: exp
+      }]
       return
     case "FunctionExpression":
       // Add return after function declaration if it has an id to not interfere with hoisting
       if (exp.id)
-        exp.children.push(["",
+        exp.children.push ["",
           type: "ReturnStatement"
           children: [";return ", exp.id]
-        ])
+          parent: exp
+        ]
         return
       /* c8 ignore next 3 */
       // This is currently never hit because anonymous FunctionExpressions are already wrapped in parens by this point
@@ -1454,11 +1449,12 @@ function insertReturn(node): void {
       // else block
       if (exp.else) insertReturn(exp.else[2])
       // Add explicit return after if block if no else block
-      else exp.children.push(["", {
-        type: "ReturnStatement",
+      else exp.children.push ["", {
+        type: "ReturnStatement"
         // NOTE: add a prefixed semi-colon because the if block may not be braced
-        children: [";return"],
-      }])
+        children: [";return"]
+        parent: exp
+      }]
       return
     case "PatternMatchingStatement":
       insertReturn(exp.children[0][0])
@@ -1470,7 +1466,6 @@ function insertReturn(node): void {
       exp.blocks.forEach((block) => insertReturn(block))
       // NOTE: do not insert a return in the finally block
       return
-  }
 
   // Don't add return if there's a trailing semicolon
   if (node[node.length - 1]?.type === "SemicolonDelimiter") return
@@ -1478,7 +1473,6 @@ function insertReturn(node): void {
   // Insert return after indentation and before expression
   const returnStatement = wrapWithReturn(node[1])
   node.splice(1, 1, returnStatement)
-}
 
 // insert a return in each when/else/default block
 // case blocks don't get implicit returns
@@ -1940,8 +1934,8 @@ function braceBlock(block: BlockStatement)
  * More generally wrap in parentheses if necessary.
  * (Consider renaming and making parentheses depend on context.)
  */
-function makeLeftHandSideExpression(expression) {
-  switch (expression.type) {
+function makeLeftHandSideExpression(expression)
+  switch (expression.type)
     case "Ref":
     case "AmpersandRef":
     case "Identifier":
@@ -1956,15 +1950,13 @@ function makeLeftHandSideExpression(expression) {
     case "ThrowExpression": // wrapIIFE
     case "TryExpression": // wrapIIFE
       return expression
-    default:
-      return {
-        type: "ParenthesizedExpression",
-        children: ["(", expression, ")"],
-        expression,
-        implicit: true,
-      }
+
+  makeNode {
+    type: "ParenthesizedExpression"
+    children: ["(", expression, ")"]
+    expression
+    implicit: true
   }
-}
 
 // Adjust a parsed string by escaping newlines
 function modifyString(str) {
@@ -2215,7 +2207,7 @@ function processCoffeeInterpolation(s, parts, e, $loc) {
   }
 }
 
-function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
+function processAssignmentDeclaration(decl, id, suffix, ws, assign, e)
   // Adjust position to space before assignment to make TypeScript remapping happier
   decl = {
     ...decl,
@@ -2225,13 +2217,13 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
     }
   }
 
-  let [splices, thisAssignments] = gatherBindingCode(id)
+  [splices, thisAssignments] .= gatherBindingCode(id)
 
   splices = splices.map((s) => [", ", s])
   thisAssignments = thisAssignments.map((a) => ["", a, ";"])
 
   const initializer = [ws, assign, e]
-  const binding = {
+  const binding = makeNode {
     type: "Binding",
     pattern: id,
     initializer,
@@ -2243,7 +2235,7 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
 
   const children = [decl, binding]
 
-  return {
+  makeNode {
     type: "Declaration",
     names: id.names,
     decl,
@@ -2252,9 +2244,8 @@ function processAssignmentDeclaration(decl, id, suffix, ws, assign, e) {
     thisAssignments,
     children,
   }
-}
 
-function processDeclarationCondition(condition, rootCondition): void
+function processDeclarationCondition(condition, rootCondition, parent): void
   return unless condition.type is "DeclarationCondition"
   ref := makeRef()
 
@@ -2272,6 +2263,9 @@ function processDeclarationCondition(condition, rootCondition): void
       names: []
     pattern: pattern
     ref: ref
+  // condition wasn't previously a child, so now needs parent pointers
+  addParentPointers condition, parent
+
   Object.assign rootCondition,
     blockPrefix: [
       ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
@@ -2295,7 +2289,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   switch expression
     {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]}
       expression = expression2
-  processDeclarationCondition expression, condition.expression
+  processDeclarationCondition expression, condition.expression, s
 
   { ref, pattern } := expression
 
@@ -2347,18 +2341,18 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
         expression: ref
         parent: s
       s.children[1] = s.condition
+      updateParentPointers s
 
       // wraps the entire switch statement
       block := blockWithPrefix [["", [{
         type: "Declaration",
         children: ["let ", ...condition.expression.children],
       }], ";"], ...blockPrefix], makeEmptyBlock()
+      updateParentPointers block, s.parent
 
       replaceBlockExpression(s.parent as BlockStatement, s, block)
       block.expressions.push ["", s]
       s.parent = block
-
-  addParentPointers(s, s.parent)
 
 // Add implicit block unless followed by a method/function of the same name,
 // or block is within an ExportDeclaration.
@@ -2424,9 +2418,8 @@ function processAssignments(statements): void {
     .forEach((exp) => {
       function extractAssignment(lhs) {
         let expr = lhs
-        while (expr.type === "ParenthesizedExpression") {
+        while expr.type === "ParenthesizedExpression"
           expr = expr.expression
-        }
         if (expr.type === "AssignmentExpression" ||
           expr.type === "UpdateExpression") {
           if (expr.type === "UpdateExpression" &&
@@ -3813,7 +3806,7 @@ function wrapIIFE(expressions: StatementTuple[], async): ASTNode[] {
       type: "Await"
       children: ["await "]
 
-  block := {
+  block := makeNode {
     type: "BlockStatement",
     expressions,
     children: ["{", expressions, "}"],
@@ -3830,7 +3823,7 @@ function wrapIIFE(expressions: StatementTuple[], async): ASTNode[] {
       async: !!async
     returnType: undefined
 
-  fn := {
+  fn := makeNode {
     type: "ArrowFunction",
     signature
     parameters
@@ -3841,9 +3834,7 @@ function wrapIIFE(expressions: StatementTuple[], async): ASTNode[] {
     children: [async, parameters, "=>", block]
   }
 
-  updateParentPointers(block, fn)
-
-  exp :=
+  exp := makeNode
     type: "CallExpression"
     children: [ makeLeftHandSideExpression(fn), "()" ]
 


### PR DESCRIPTION
After the initial parse and parent pointer setting, we modify the AST a lot, and rarely do we update the parent pointers.  This PR is a step in the right direction, in particular refining the `addParentPointers` call just added in #792.

This PR adds a lot of missing `updateParentPointers` (a shallow operation that just looks at immediate object children), including via a new helper `makeNode` that we should probably call every time we make a new AST node that has `children` set to something with objects.

> Note: An alternative would be to merge `updateParentPointers` and `makeNode`, by having `updateParentPointers` always return the node. Let me know if you have a preference!

At the more subtle level, I found some missing `addParentPointers` that are needed when we pull part of an AST from a property like `blockPrefix` or `hoistDec` into `children`, so they weren't previously in the actual tree of `children`, so didn't get visited by the original `addParentPointers` pass. This is fundamentally why an `addParentPointers` is needed in a case like declaration conditions, but it can be applied a little more shallowly than #792.