### PR TITLE
Check for existence of absolute path in unplugin

### DIFF
--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -83,10 +83,9 @@ function tryFsResolve(file: string): string | undefined {
 }
 
 function resolveAbsolutePath(rootDir: string, id: string) {
-  const file = cleanCivetId(id);
-  const resolved = tryFsResolve(path.join(rootDir, file));
+  const resolved = tryFsResolve(path.join(rootDir, id));
 
-  if (!resolved) return tryFsResolve(file);
+  if (!resolved) return tryFsResolve(id);
 
   return resolved;
 }


### PR DESCRIPTION
This PR fixes a bug introduced in #786 where all absolute paths were considered to be absolute to project which broke vitest as it instead passed system absolute paths. The plugin now first checks for the existence of the path relative to the project, and then to the system.