### PR TITLE
Update xor typing

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6967,12 +6967,21 @@ Reset
         module.prelude.push(["", [preludeVar, xorRef, typeSuffix, " = (a, b) => (a ? !b && a : b)", asAny, ";", "\n"]])
       },
       xnor(xnorRef) {
+        const Falsy = module.getRef("Falsy")
         const typeSuffix = {
           ts: true,
-          children: [": (a: unknown, b: unknown) => boolean"]
+          children: [
+            ": <A, B>(a: A, b: B) => A & ",
+            Falsy,
+            " extends never ? B : (true | (B extends ",
+            Falsy,
+            " ? never : A) | (A extends ",
+            Falsy,
+            " ? never : B))"
+          ]
         }
         // [indent, statement]
-        module.prelude.push(["", [preludeVar, xnorRef, typeSuffix, " = (a, b) => a ? b : !b || a;", "\n"]])
+        module.prelude.push(["", [preludeVar, xnorRef, typeSuffix, " = (a, b) => (a ? b : !b || a)", asAny, ";", "\n"]])
       },
       returnSymbol(ref) {
         module.prelude.push({

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6951,13 +6951,20 @@ Reset
         // [indent, statement]
         module.prelude.push(["", [preludeVar, moduloRef, typeSuffix, " = (a, b) => (a % b + b) % b;", "\n"]])
       },
+      Falsy(FalsyRef) {
+        module.prelude.push(["", [{
+          ts: true,
+          children: ["type ", FalsyRef, " = false | 0 | '' | 0n | null | undefined;", "\n"]
+        }]])
+      },
       xor(xorRef) {
+        const Falsy = module.getRef("Falsy")
         const typeSuffix = {
           ts: true,
-          children: [": (a: unknown, b: unknown) => boolean"]
+          children: [": <A, B>(a: A, b: B) => A extends ", Falsy, " ? B : B extends ", Falsy, " ? (A | B) : (A | B | false)"]
         }
         // [indent, statement]
-        module.prelude.push(["", [preludeVar, xorRef, typeSuffix, " = (a, b) => a ? !b && a : b;", "\n"]])
+        module.prelude.push(["", [preludeVar, xorRef, typeSuffix, " = (a, b) => (a ? !b && a : b)", asAny, ";", "\n"]])
       },
       xnor(xnorRef) {
         const typeSuffix = {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6961,7 +6961,17 @@ Reset
         const Falsy = module.getRef("Falsy")
         const typeSuffix = {
           ts: true,
-          children: [": <A, B>(a: A, b: B) => A extends ", Falsy, " ? B : B extends ", Falsy, " ? (A | B) : (A | B | false)"]
+          children: [
+            ": <A, B>(a: A, b: B) => A extends ",
+            Falsy,
+            " ? B : B extends ",
+            Falsy,
+            " ? A : (false | (A & ",
+            Falsy,
+            " extends never ? never : B) | (B & ",
+            Falsy,
+            " extends never ? never : A))"
+          ]
         }
         // [indent, statement]
         module.prelude.push(["", [preludeVar, xorRef, typeSuffix, " = (a, b) => (a ? !b && a : b)", asAny, ";", "\n"]])

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -388,7 +388,8 @@ describe "assignment", ->
     a !^= b
     a !^^= b
     ---
-    var xnor: (a: unknown, b: unknown) => boolean = (a, b) => a ? b : !b || a;
+    type Falsy = false | 0 | '' | 0n | null | undefined;
+    var xnor: <A, B>(a: A, b: B) => A & Falsy extends never ? B : (true | (B extends Falsy ? never : A) | (A extends Falsy ? never : B)) = (a, b) => (a ? b : !b || a) as any;
     a = xnor(a, b)
     a = xnor(a, b)
     a = xnor(a, b)

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -375,7 +375,8 @@ describe "assignment", ->
     a xor= b
     a ^^= b
     ---
-    var xor: (a: unknown, b: unknown) => boolean = (a, b) => a ? !b && a : b;
+    type Falsy = false | 0 | '' | 0n | null | undefined;
+    var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? (A | B) : (A | B | false) = (a, b) => (a ? !b && a : b) as any;
     a = xor(a, b)
     a = xor(a, b)
   """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -376,7 +376,7 @@ describe "assignment", ->
     a ^^= b
     ---
     type Falsy = false | 0 | '' | 0n | null | undefined;
-    var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? (A | B) : (A | B | false) = (a, b) => (a ? !b && a : b) as any;
+    var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? A : (false | (A & Falsy extends never ? never : B) | (B & Falsy extends never ? never : A)) = (a, b) => (a ? !b && a : b) as any;
     a = xor(a, b)
     a = xor(a, b)
   """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -306,7 +306,8 @@ describe "binary operations", ->
     a !^^ b
     a xnor b
     ---
-    var xnor: (a: unknown, b: unknown) => boolean = (a, b) => a ? b : !b || a;
+    type Falsy = false | 0 | '' | 0n | null | undefined;
+    var xnor: <A, B>(a: A, b: B) => A & Falsy extends never ? B : (true | (B extends Falsy ? never : A) | (A extends Falsy ? never : B)) = (a, b) => (a ? b : !b || a) as any;
     xnor(a,b)
     xnor(a,b)
     xnor(a, b)

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -283,7 +283,8 @@ describe "binary operations", ->
     a ^^ b
     a xor b
     ---
-    var xor: (a: unknown, b: unknown) => boolean = (a, b) => a ? !b && a : b;
+    type Falsy = false | 0 | '' | 0n | null | undefined;
+    var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? (A | B) : (A | B | false) = (a, b) => (a ? !b && a : b) as any;
     xor(a,b)
     xor(a, b)
     xor(a, b)

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -284,7 +284,7 @@ describe "binary operations", ->
     a xor b
     ---
     type Falsy = false | 0 | '' | 0n | null | undefined;
-    var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? (A | B) : (A | B | false) = (a, b) => (a ? !b && a : b) as any;
+    var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? A : (false | (A & Falsy extends never ? never : B) | (B & Falsy extends never ? never : A)) = (a, b) => (a ? !b && a : b) as any;
     xor(a,b)
     xor(a, b)
     xor(a, b)


### PR DESCRIPTION
(Marking as Draft for now until I update xnor as well)

This PR corrects the typing of the xor operator to reflect the fact that it returns one of the arguments unless they're both truthy, as discussed on Discord.

The Discord discussion originally suggested to make it output:

```ts
var xor = <A, B>(a: A, b: B) => (a ? !b && a : b) as unknown as A extends Falsy ? B : B extends Falsy ? (A | B) : (A | B | false);
```

However, interleaving the types and code like this makes the hera code significantly harder to read, and there's already precedent for using `as any` (e.g. `is` being `Object.is as any`).