### PR TITLE
Fix unplugin Typescript builds and update API

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -141,6 +141,6 @@ for format of ["esm", "cjs"]
     outdir: 'dist'
     outExtension: { ".js": if format == "esm" then ".mjs" else ".js" }
     plugins: [
-      civetPlugin({ dts: true })
+      civetPlugin({ emitDeclaration: true })
     ]
   }).catch -> process.exit 1

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -160,7 +160,7 @@ esbuild.build({
       // Options and their defaults:
       // emitDeclaration: false,         // generate .d.ts files?
       // outputExtension: '.civet.tsx',  // replaces .civet in output
-      // ts: 'civet',                    // use Civet's TS -> JS transpiler?
+      // ts: 'civet',                    // TS -> JS transpilation mode
     })
   ]
 }).catch(() => process.exit(1))

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -158,9 +158,9 @@ esbuild.build({
   plugins: [
     civetPlugin({
       // Options and their defaults:
-      // dts: false,                     // generate .d.ts files?
+      // emitDeclaration: false,         // generate .d.ts files?
       // outputExtension: '.civet.tsx',  // replaces .civet in output
-      // js: false,                      // use Civet's TS -> JS transpiler?
+      // ts: 'civet',                    // use Civet's TS -> JS transpiler?
     })
   ]
 }).catch(() => process.exit(1))
@@ -186,9 +186,11 @@ import civetPlugin from '@danielx/civet/esbuild';
 
 export default defineConfig({
   entryPoints: ['main.civet'],
-  esbuildPlugins: [civetPlugin({
-    // options
-  })],
+  esbuildPlugins: [
+    civetPlugin({
+      // options
+    }),
+  ],
 });
 ```
 

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -51,6 +51,7 @@ To use TypeScript for type checking, create a `tsconfig.json` file. For example:
     "strict": true,
     "jsx": "preserve",
     "lib": ["es2021"],
+    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "esModuleInterop": true

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -139,7 +139,7 @@ To transpile within a CommonJS NodeJS app
 To transpile in the browser, you can load the browser build `dist/browser.js`
 via a `<script>` tag, and access the global variable `Civet`, as in
 `Civet.compile`.
-Alternatively, if you're using a build system, you can import `"danielx/civet"`
+Alternatively, if you're using a build system, you can import `"@danielx/civet"`
 normally, but you'll need to mark `"fs"` as an external dependency
 (see e.g. [esbuild instructions](https://esbuild.github.io/api/#external>)
 and [Vite instructions](https://vitejs.dev/guide/build#library-mode)).

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -84,18 +84,16 @@ interface PluginOptions {
 }
 ```
 
-- `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false` (Requires installing `typescript`)
+- `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`. (Requires installing `typescript`.)
 - `typecheck`: Whether to run type checking on the generated code. Default: `false`.
-- `outputExtension`: Output filename extension to use. Default: `".civet.tsx"`, or uses `".civet.jsx"` if `js` is `true`.
-- `ts`: Mode of transpilation of TS->JS source code. Default: `"civet"`. Options:
-
-  - `"civet"`: Use Civet's JS mode (Not all TS features supported)
-  - `"esbuild"`: Use esbuild's transpiler (Requires installing `esbuild`)
-  - `"tsc"`: Use the typescript compiler (Requires installing `typescript`)
+- `outputExtension`: Output filename extension to use. Default: `".civet.tsx"`, or uses `".civet.jsx"` if `ts` is `"preserve"`.
+- `ts`: Mode for transpiling TypeScript features into JavaScript. Default: `"civet"`. Options:
+  - `"civet"`: Use Civet's JS mode. (Not all TS features supported.)
+  - `"esbuild"`: Use esbuild's transpiler. (Fast and more complete. Requires installing `esbuild`.)
+  - `"tsc"`: Use the TypeScript compiler. (Slow but complete. Requires installing `typescript`.)
   - `"preserve"`: Don't transpile TS code.
-
-    Some bundlers like esbuild and Vite can handle TS directly. Also useful when using `transformOutput` to handle TS code, or using a plugin that modifies TS AST.
-
-    **Note** that this would require additional plugins for bundlers that can't handle TS. For example, for Webpack, you would need to install `ts-loader` and add it to your webpack config. This will **not** work for Rollup.
-
+    Some bundlers, like esbuild and Vite, can handle TS directly. Also useful when using `transformOutput` to handle TS code, or using a plugin that modifies TS AST.
+    Note that some bundlers require additional plugins to handle TS.
+    For example, for Webpack, you would need to install `ts-loader` and add it to your webpack config.
+    Unfortunately, Rollup's TypeScript plugin is incompatible with this plugin, so you need to set `ts` to another option.
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -88,8 +88,14 @@ interface PluginOptions {
 - `typecheck`: Whether to run type checking on the generated code. Default: `false`.
 - `outputExtension`: Output filename extension to use. Default: `".civet.tsx"`, or uses `".civet.jsx"` if `js` is `true`.
 - `ts`: Mode of transpilation of TS->JS source code. Default: `"civet"`. Options:
-  - `civet`: Use Civet's JS mode (Not all TS features supported)
-  - `esbuild`: Use esbuild's transpiler (Requires installing `"esbuild"`)
-  - `tsc`: Use the typescript compiler (Requires installing `"typescript"`)
-  - `preserve`: Don't transpile TS code (Some bundlers like esbuild and vite can handle TS directly. Note that this would require additional plugins for bundlers that can't handle TS)
+
+  - `"civet"`: Use Civet's JS mode (Not all TS features supported)
+  - `"esbuild"`: Use esbuild's transpiler (Requires installing `esbuild`)
+  - `"tsc"`: Use the typescript compiler (Requires installing `typescript`)
+  - `"preserve"`: Don't transpile TS code.
+
+    Some bundlers like esbuild and Vite can handle TS directly. Also useful when using `transformOutput` to handle TS code, or using a plugin that modifies TS AST.
+
+    **Note** that this would require additional plugins for bundlers that can't handle TS. For example, for Webpack, you would need to install `ts-loader` and add it to your webpack config. This will **not** work for Rollup.
+
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -84,12 +84,12 @@ interface PluginOptions {
 }
 ```
 
-- `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`
+- `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false` (Requires installing `typescript`)
 - `typecheck`: Whether to run type checking on the generated code. Default: `false`.
-- `outputExtension`: Output filename extension to use. Default: `.civet.tsx`, or uses `.civet.jsx` if `js` is `true`.
-- `ts`: Mode of transpilation of TS->JS source code. Default: `civet`. Options:
-  - `civet`: Use Civet's JS mode.
-  - `esbuild`: Use esbuild's transpiler. (Requires installing `esbuild`)
-  - `tsc`: Use the typescript compiler. (Requires installing `typescript`)
-  - `preserve`: Don't transpile TS code.
+- `outputExtension`: Output filename extension to use. Default: `".civet.tsx"`, or uses `".civet.jsx"` if `js` is `true`.
+- `ts`: Mode of transpilation of TS->JS source code. Default: `"civet"`. Options:
+  - `civet`: Use Civet's JS mode (Not all TS features supported)
+  - `esbuild`: Use esbuild's transpiler (Requires installing `"esbuild"`)
+  - `tsc`: Use the typescript compiler (Requires installing `"typescript"`)
+  - `preserve`: Don't transpile TS code (Some bundlers like esbuild and vite can handle TS directly. Note that this would require additional plugins for bundlers that can't handle TS)
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -73,9 +73,9 @@ module.exports = {
 
 ```ts
 interface PluginOptions {
-  dts?: boolean;
+  emitDeclaration?: boolean;
   outputExtension?: string;
-  js?: boolean;
+  ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
   typecheck?: boolean;
   transformOutput?: (
     code: string,
@@ -84,8 +84,12 @@ interface PluginOptions {
 }
 ```
 
-- `dts`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`
+- `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`
 - `typecheck`: Whether to run type checking on the generated code. Default: `false`.
 - `outputExtension`: Output filename extension to use. Default: `.civet.tsx`, or uses `.civet.jsx` if `js` is `true`.
-- `js`: Whether to transpile to JS or TS. Default: `false`.
+- `ts`: Mode of transpilation of TS->JS source code. Default: `civet`. Options:
+  - `civet`: Use Civet's JS mode.
+  - `esbuild`: Use esbuild's transpiler. (Requires installing `esbuild`)
+  - `tsc`: Use the typescript compiler. (Requires installing `typescript`)
+  - `preserve`: Don't transpile TS code.
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/examples/nextjs/tsconfig.json
+++ b/integration/unplugin/examples/nextjs/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/integration/unplugin/examples/rollup/rollup.config.js
+++ b/integration/unplugin/examples/rollup/rollup.config.js
@@ -8,7 +8,7 @@ export default {
   },
   plugins: [
     civetRollupPlugin({
-      dts: true,
+      emitDeclaration: true,
     }),
   ],
 };

--- a/integration/unplugin/examples/rollup/tsconfig.json
+++ b/integration/unplugin/examples/rollup/tsconfig.json
@@ -4,7 +4,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "noEmit": false,
     "checkJs": false,
     "declarationMap": false,

--- a/integration/unplugin/examples/vite-lib/tsconfig.json
+++ b/integration/unplugin/examples/vite-lib/tsconfig.json
@@ -4,7 +4,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "noEmit": false,
     "checkJs": false,
     "declarationMap": false,

--- a/integration/unplugin/examples/vite-lib/vite.config.js
+++ b/integration/unplugin/examples/vite-lib/vite.config.js
@@ -9,5 +9,5 @@ export default defineConfig({
       formats: ['cjs', 'es'],
     },
   },
-  plugins: [civetVitePlugin({ dts: true })],
+  plugins: [civetVitePlugin({ emitDeclaration: true })],
 });

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -310,7 +310,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
 
             if (options.ts == undefined) {
               console.log(
-                'WARNING: You are using the default mode for `options.ts` which is `civet`. This mode does not support all TS features. If this is intentional, you should explicitly set `options.ts` to `civet`, or choose a different mode.'
+                'WARNING: You are using the default mode for `options.ts` which is `"civet"`. This mode does not support all TS features. If this is intentional, you should explicitly set `options.ts` to `"civet"`, or choose a different mode.'
               );
             }
 

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -278,6 +278,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
           case 'esbuild': {
             const esbuildTransform = (await import('esbuild')).transform;
             const result = await esbuildTransform(compiledTS.code, {
+              jsx: 'preserve',
               loader: 'tsx',
               sourcefile: id,
               sourcemap: 'external',

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -13,18 +13,10 @@ import {
 } from '@danielx/civet/ts-diagnostic';
 import * as fs from 'fs';
 import path from 'path';
-import ts from 'typescript';
+import type { FormatDiagnosticsHost, Diagnostic, System } from 'typescript';
 import * as tsvfs from '@typescript/vfs';
 import type { UserConfig } from 'vite';
 import os from 'os';
-
-const formatHost: ts.FormatDiagnosticsHost = {
-  getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
-  getNewLine: () => ts.sys.newLine,
-  getCanonicalFileName: ts.sys.useCaseSensitiveFileNames
-    ? f => f
-    : f => f.toLowerCase(),
-};
 
 export type PluginOptions = {
   outputExtension?: string;
@@ -32,30 +24,20 @@ export type PluginOptions = {
     code: string,
     id: string
   ) => TransformResult | Promise<TransformResult>;
-} & ( // Eliminates the possibility of having both `dts` and `js` set to `true`
-  | {
-      dts?: false;
-      typecheck?: false;
-      js?: false | true;
-    }
-  | {
-      dts?: true;
-      typecheck?: true;
-      js?: false;
-    }
-);
+  emitDeclaration?: boolean;
+  typecheck?: boolean;
+  ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
+};
 
-const isCivet = (id: string) => /\.civet$/.test(id);
-const isCivetTranspiled = (id: string) =>
-  /\.civet\.[jt]sx(\?transform)?$/.test(id);
-const isCivetTranspiledTS = (id: string) => /\.civet\.tsx$/.test(id);
-const postfixRE = /(\.[jt]sx)?[?#].*$/s;
+const isCivet = (id: string) => /\.civet([?#].*)?$/.test(id);
+const isCivetTranspiled = (id: string) => /\.civet\.[jt]sx([?#].*)?$/.test(id);
+const postfixRE = /[?#].*$/s;
 const isWindows = os.platform() === 'win32';
 const windowsSlashRE = /\\/g;
 
 // removes query string, hash and tsx/jsx extension
 function cleanCivetId(id: string): string {
-  return id.replace(postfixRE, '');
+  return id.replace(postfixRE, '').replace(/\.[jt]sx$/, '');
 }
 
 function tryStatSync(file: string): fs.Stats | undefined {
@@ -91,29 +73,37 @@ function resolveAbsolutePath(rootDir: string, id: string) {
 }
 
 const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
-  if (options.dts && options.js) {
-    throw new Error("Can't have both `dts` and `js` be set to `true`.");
-  }
-
-  if (options.typecheck && options.js) {
-    throw new Error("Can't have both `typecheck` and `js` be set to `true`.");
-  }
-
-  const transpileToJS = options.js ?? false;
-  // When Civet's js option is better, we could consider a different default:
-  //const transpileToJS = options.js ?? !(options.dts || options.typecheck);
-  const outExt = options.outputExtension ?? (transpileToJS ? '.jsx' : '.tsx');
+  const transformTS = options.emitDeclaration || options.typecheck;
+  const outExt =
+    options.outputExtension ?? (options.ts === 'preserve' ? '.tsx' : '.jsx');
 
   let fsMap: Map<string, string> = new Map();
   const sourceMaps = new Map<string, SourceMap>();
   let compilerOptions: any;
   let rootDir = process.cwd();
 
+  const tsPromise =
+    transformTS || options.ts === 'tsc'
+      ? import('typescript').then(m => m.default)
+      : null;
+  const getTS = () => tsPromise!;
+  const getFormatHost = (sys: System): FormatDiagnosticsHost => {
+    return {
+      getCurrentDirectory: () => sys.getCurrentDirectory(),
+      getNewLine: () => sys.newLine,
+      getCanonicalFileName: sys.useCaseSensitiveFileNames
+        ? f => f
+        : f => f.toLowerCase(),
+    };
+  };
+
   return {
     name: 'unplugin-civet',
     enforce: 'pre',
     async buildStart() {
-      if (options.dts || options.typecheck) {
+      if (transformTS || options.ts === 'tsc') {
+        const ts = await getTS();
+
         const configPath = ts.findConfigFile(process.cwd(), ts.sys.fileExists);
 
         if (!configPath) {
@@ -126,7 +116,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
         );
 
         if (error) {
-          console.error(ts.formatDiagnostic(error, formatHost));
+          console.error(ts.formatDiagnostic(error, getFormatHost(ts.sys)));
           throw error;
         }
 
@@ -143,8 +133,10 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
         fsMap = new Map();
       }
     },
-    buildEnd() {
-      if (options.dts || options.typecheck) {
+    async buildEnd() {
+      if (transformTS) {
+        const ts = await tsPromise!;
+
         const system = tsvfs.createFSBackedSystem(fsMap, process.cwd(), ts);
         const host = tsvfs.createVirtualCompilerHost(
           system,
@@ -157,7 +149,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
           host: host.compilerHost,
         });
 
-        const diagnostics: ts.Diagnostic[] = ts
+        const diagnostics: Diagnostic[] = ts
           .getPreEmitDiagnostics(program)
           .map(diagnostic => {
             const file = diagnostic.file;
@@ -185,11 +177,14 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
 
         if (diagnostics.length > 0) {
           console.error(
-            ts.formatDiagnosticsWithColorAndContext(diagnostics, formatHost)
+            ts.formatDiagnosticsWithColorAndContext(
+              diagnostics,
+              getFormatHost(ts.sys)
+            )
           );
         }
 
-        if (options.dts) {
+        if (options.emitDeclaration) {
           for (const file of fsMap.keys()) {
             const sourceFile = program.getSourceFile(file)!;
             program.emit(
@@ -238,26 +233,86 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
       if (!isCivetTranspiled(id)) return null;
 
       const filename = path.resolve(process.cwd(), id.slice(0, -outExt.length));
-      const code = await fs.promises.readFile(filename, 'utf-8');
+      const rawCivetSource = await fs.promises.readFile(filename, 'utf-8');
       this.addWatchFile(filename);
 
-      // Ideally this should have been done in a `transform` step
-      // but for some reason, webpack seems to be running them in the order
-      // of `resolveId` -> `loadInclude` -> `transform` -> `load`
-      // so we have to do transformation here instead
-      const compiled = civet.compile(code, {
-        // inlineMap: true,
-        filename: id,
-        js: transpileToJS,
-        sourceMap: true,
-      });
+      let compiled: {
+        code: string;
+        sourceMap: SourceMap | string;
+      } = undefined!;
 
-      sourceMaps.set(path.resolve(process.cwd(), id), compiled.sourceMap);
+      if (options.ts === 'civet' && !transformTS) {
+        compiled = civet.compile(rawCivetSource, {
+          filename: id,
+          js: true,
+          sourceMap: true,
+        });
+      } else {
+        const compiledTS = civet.compile(rawCivetSource, {
+          filename: id,
+          js: false,
+          sourceMap: true,
+        });
 
-      const jsonSourceMap = compiled.sourceMap.json(
-        path.basename(id.replace(/\.[jt]sx$/, '')),
-        path.basename(id)
-      );
+        sourceMaps.set(
+          path.resolve(process.cwd(), id),
+          compiledTS.sourceMap as SourceMap
+        );
+
+        if (transformTS) {
+          const resolved = path.resolve(process.cwd(), id);
+          fsMap.set(resolved, compiledTS.code);
+          // Vite and Rollup normalize filenames to use `/` instead of `\`.
+          // We give the TypeScript VFS both versions just in case.
+          const slashed = slash(resolved);
+          if (resolved !== slashed) fsMap.set(slashed, rawCivetSource);
+        }
+
+        switch (options.ts) {
+          case 'esbuild': {
+            const esbuildTransform = (await import('esbuild')).transform;
+            const result = await esbuildTransform(compiledTS.code, {
+              loader: 'tsx',
+              sourcefile: id,
+              sourcemap: 'external',
+            });
+
+            compiled = { code: result.code, sourceMap: result.map };
+            break;
+          }
+          case 'tsc': {
+            const tsTranspile = (await getTS()).transpileModule;
+            const result = tsTranspile(compiledTS.code, { compilerOptions });
+
+            compiled = {
+              code: result.outputText,
+              sourceMap: result.sourceMapText ?? '',
+            };
+            break;
+          }
+          case 'preserve': {
+            compiled = compiledTS;
+            break;
+          }
+          case 'civet':
+          default: {
+            compiled = civet.compile(compiledTS.code, {
+              filename: id,
+              js: true,
+              sourceMap: true,
+            });
+            break;
+          }
+        }
+      }
+
+      const jsonSourceMap =
+        typeof compiled.sourceMap == 'string'
+          ? compiled.sourceMap
+          : compiled.sourceMap.json(
+              path.basename(id.replace(/\.[jt]sx$/, '')),
+              path.basename(id)
+            );
 
       let transformed: TransformResult = {
         code: compiled.code,
@@ -269,37 +324,9 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
 
       return transformed;
     },
-    transformInclude(id) {
-      return isCivetTranspiledTS(id);
-    },
-    transform(code, id) {
-      if (!isCivetTranspiledTS(id)) return null;
-
-      if (options.dts || options.typecheck) {
-        const resolved = path.resolve(process.cwd(), id);
-        fsMap.set(resolved, code);
-        // Vite and Rollup normalize filenames to use `/` instead of `\`.
-        // We give the TypeScript VFS both versions just in case.
-        const slashed = slash(resolved);
-        if (resolved !== slashed) fsMap.set(slashed, code);
-      }
-
-      return null;
-    },
     vite: {
-      config(config: UserConfig, { command }: { command: string }) {
+      config(config: UserConfig) {
         rootDir = path.resolve(process.cwd(), config.root ?? '');
-        // Ensure esbuild runs on .civet files
-        if (command === 'build') {
-          return {
-            esbuild: {
-              include: [/\.civet$/],
-              loader: 'tsx',
-            },
-          };
-        }
-
-        return null;
       },
       async transformIndexHtml(html) {
         return html.replace(/<!--[^]*?-->|<[^<>]*>/g, tag =>

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -27,9 +27,9 @@ export type PluginOptions = {
   emitDeclaration?: boolean;
   typecheck?: boolean;
   ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
-  // @deprecated
+  /** @deprecated Use "ts" option instead */
   js?: boolean;
-  // @deprecated
+  /** @deprecated Use "emitDeclaration" instead */
   dts?: boolean;
 };
 

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -301,6 +301,11 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
               js: true,
               sourceMap: true,
             });
+          }
+          case undefined: {
+            console.log(
+              'WARNING: You are using the default mode for `options.ts` which is `civet`. This mode does not support all TS features. If this is intentional, you should explicitly set `options.ts` to `civet`, or choose a different mode.'
+            );
             break;
           }
         }

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -307,11 +307,13 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
               js: true,
               sourceMap: true,
             });
-          }
-          case undefined: {
-            console.log(
-              'WARNING: You are using the default mode for `options.ts` which is `civet`. This mode does not support all TS features. If this is intentional, you should explicitly set `options.ts` to `civet`, or choose a different mode.'
-            );
+
+            if (options.ts == undefined) {
+              console.log(
+                'WARNING: You are using the default mode for `options.ts` which is `civet`. This mode does not support all TS features. If this is intentional, you should explicitly set `options.ts` to `civet`, or choose a different mode.'
+              );
+            }
+
             break;
           }
         }

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -302,7 +302,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
           }
           case 'civet':
           default: {
-            compiled = civet.compile(compiledTS.code, {
+            compiled = civet.compile(rawCivetSource, {
               filename: id,
               js: true,
               sourceMap: true,

--- a/integration/unplugin/tsup.config.ts
+++ b/integration/unplugin/tsup.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
     'typescript',
     '@typescript/vfs',
     'unplugin',
+    'esbuild',
   ],
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "ES2020",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "nodenext",                      /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "ES2020",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "nodenext",                      /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
This PR:
- Changes the basic `js: boolean` option to a more configurable `ts: civet | esbuild | tsc | preserve` option instead. I feel like changing `js` to `ts` here makes more sense—we're configuring the transformation of _typescript_ source instead of js.

  The esbuild and tsc option both require a peer dependency which is lazily loaded if the option is used.
- Renames `dts` to `emitDeclaration`. With js renamed to ts, `dts` might be confusing naming. `emitDeclaration` follows naming similar to Typescript's compiler options which have `emitDeclarationOnly`