### PR TITLE
Assignments in & functions

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -524,6 +524,12 @@ url |> fetch |> await
 |> callback
 </Playground>
 
+<Playground>
+document.createElement('div')
+||> .className = 'civet'
+||> .appendChild document.createTextNode 'Civet'
+</Playground>
+
 Unicode forms:
 
 <Playground>
@@ -724,6 +730,12 @@ You can also omit `&` when starting with a `.` or `?.` property access:
 <Playground>
 x.map .name
 x.map ?.profile?.name[0...3]
+</Playground>
+
+You can also assign properties:
+
+<Playground>
+x.map .name = "Civet" + i++
 </Playground>
 
 ### Functions as Infix Operators

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1793,7 +1793,7 @@ AmpersandBlockRHS
     return $2
 
 AmpersandBlockRHSBody
-  (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( ![&] BinaryOpRHS+ )?:binopRHS ->
+  (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( WAssignmentOp ( NotDedented UpdateExpression WAssignmentOp )* NonPipelineExtendedExpression )?:assign ( ![&] BinaryOpRHS+ )?:binopRHS ->
     if (!callExpRest && !binopRHS && !unaryPostfix) return $skip
     const ref = makeRef("$")
 
@@ -1812,8 +1812,26 @@ AmpersandBlockRHSBody
       exp = processUnaryExpression([], exp, unaryPostfix)
     }
 
+    if (assign) {
+      // Based on ActualAssignment
+      const [op1, more, rhs] = assign
+      const lhs = [
+        [undefined, exp, ...op1],
+        ...more.map((x) => [x[0], x[1], ...x[2]]),
+      ]
+      exp = {
+        type: "AssignmentExpression",
+        children: [lhs, rhs],
+        names: null,
+        lhs,
+        assigned: exp,
+        exp: rhs,
+        ref,
+      }
+    }
+
     if (binopRHS) {
-      return {
+      exp = {
         children: processBinaryOpExpression([exp, binopRHS[1]]),
         ref,
       }

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -90,6 +90,22 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    assignment
+    ---
+    x.map .name = "foo"
+    ---
+    x.map($ => $.name = "foo")
+  """
+
+  testCase """
+    multiple assignment
+    ---
+    x.map .name = name += "foo"
+    ---
+    x.map($ => $.name = name += "foo")
+  """
+
+  testCase """
     addition
     ---
     x.map &+1
@@ -167,6 +183,14 @@ describe "&. function block shorthand", ->
     x.map &.foo is in a
     ---
     x.map($ => a.includes($.foo))
+  """
+
+  testCase """
+    assignment and binary operator
+    ---
+    x.map &.name = 'name' + i++
+    ---
+    x.map($ => $.name = 'name' + i++)
   """
 
   testCase """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -289,6 +289,16 @@ describe "pipe", ->
     """
 
     testCase """
+      multi-line with assignments
+      ---
+      document.createElement('div')
+      ||> .className = 'civet'
+      ||> .appendChild document.createTextNode 'Civet'
+      ---
+      let ref;(ref = document.createElement('div')).className = 'civet',ref.appendChild(document.createTextNode('Civet')),ref
+    """
+
+    testCase """
       ref with implicit return
       ---
       ->


### PR DESCRIPTION
As discussed in Discord, it's nice to be able to assign to properties in a pipeline, especially fat, as an alternative to `..` cascade notation.  The DOM manipulation example at the top of reference.md is particularly compelling.