### PR TITLE
Generalize pin expressions to allow x.y and ^x.y

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2746,7 +2746,7 @@ function getPatternConditions(pattern, ref, conditions): void {
       conditions.push([
         ref,
         " === ",
-        pattern.identifier,
+        pattern.expression,
       ])
       break
     case "Literal":

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -986,6 +986,13 @@ MemberExpression
     }
     return $1
 
+ActualMemberExpression
+  MemberBase MemberExpressionRest+:rest ->
+    return processCallMemberExpression({
+      type: "MemberExpression",
+      children: [$1, ...rest].flat(),
+    })
+
 MemberBase
   PrimaryExpression
   SuperProperty
@@ -1409,11 +1416,17 @@ AtIdentifierRef
     return makeRef(id.name)
 
 PinPattern
-  "^" Identifier:identifier ->
+  Caret SingleLineExpressionWithIndentedApplicationForbidden:expression ->
     return {
       type: "PinPattern",
       children: $0,
-      identifier,
+      expression,
+    }
+  ActualMemberExpression:expression ->
+    return {
+      type: "PinPattern",
+      children: [expression],
+      expression,
     }
 
 # https://262.ecma-international.org/#prod-BindingPattern
@@ -1533,7 +1546,7 @@ BindingProperty
       names: value.names,
     }
 
-  _?:ws "^"?:pin BindingIdentifier:binding Initializer?:initializer ->
+  _?:ws Caret?:pin BindingIdentifier:binding Initializer?:initializer ->
     // TODO make this work with pin
     if (binding.type === "AtBinding") {
       return {
@@ -1553,7 +1566,7 @@ BindingProperty
         name: binding,
         value: {
           type: "PinPattern",
-          identifier: binding,
+          expression: binding,
         },
       }
     }
@@ -4238,6 +4251,11 @@ ExpressionWithIndentedApplicationForbidden
     if (exp) return exp
     return $skip
 
+SingleLineExpressionWithIndentedApplicationForbidden
+  ForbidIndentedApplication ForbidNewlineBinaryOp SingleLineAssignmentExpression?:exp RestoreNewlineBinaryOp RestoreIndentedApplication ->
+    if (exp) return exp
+    return $skip
+
 # NOTE: Forbid both explicit (braced) and implicit indented object literals
 # as arguments to implicit function calls.  This is useful in the context of
 # an `if` or `class` line where we don't want to treat the body as an object.
@@ -5183,6 +5201,10 @@ Backtick
 
 By
   "by" NonIdContinue ->
+    return { $loc, token: $1 }
+
+Caret
+  "^" ->
     return { $loc, token: $1 }
 
 Case

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -435,6 +435,36 @@ describe "switch", ->
     """
 
     testCase """
+      enum
+      ---
+      switch x
+        Direction.Up
+          console.log "up"
+        Direction.Down
+          console.log "down"
+      ---
+      if(x === Direction.Up) {
+          console.log("up")}
+      else if(x === Direction.Down) {
+          console.log("down")}
+    """
+
+    testCase """
+      pin enum
+      ---
+      switch x
+        ^Direction.Up
+          console.log "up"
+        ^Direction.Down
+          console.log "down"
+      ---
+      if(x === Direction.Up) {
+          console.log("up")}
+      else if(x === Direction.Down) {
+          console.log("down")}
+    """
+
+    testCase """
       multiple non-binding cases
       ---
       switch x


### PR DESCRIPTION
Fixes #821 (pattern matching on enum values) by allowing two new patterns:

* General pinned expressions: `^x.y`, `^x()`, and more generally `SingleLineExpressionWithIndentedApplicationForbidden` expressions in pins. I can't see why pins need to be identifiers; they can be any expression. I tried to make something that resembles one-liners, though not totally sure I got it perfect.
* `x.y` (a new `ActualMemberExpression` that has at least one member access) acts as the pinned expression `^x.y`. Currently no calls are allowed, which is maybe not ideal. Suggestions for generalization welcome.
