### PR TITLE
Allow multiple patterns over multiple lines with comma

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4104,7 +4104,7 @@ CaseClause
     }
 
 PatternExpressionList
-  ConditionFragment:first ( _? Comma _? ConditionFragment )*:rest ->
+  ConditionFragment:first ( _? Comma ( Nested / _ )? ConditionFragment )*:rest ->
     return [first, ...rest.map(([, , , p]) => p)]
 
 ConditionFragment

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -470,9 +470,14 @@ describe "switch", ->
       switch x
         1, 2
           console.log "it's one or two"
+        3,
+        4
+          console.log "it's three or four"
       ---
       if(x === 1 || x === 2) {
           console.log("it's one or two")}
+      else if(x === 3 || x === 4) {
+          console.log("it's three or four")}
     """
 
     testCase """


### PR DESCRIPTION
Part of #335, as suggested in #831.

I figured `NotDedented` would be too confusing - then you'd have indentation for both patterns and body. But same indentation level seems very clear.