### PR TITLE
Import attributes

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1498,7 +1498,7 @@ You can also omit quotes around most filenames.
 <Playground>
 fs from fs
 {basename, dirname} from path
-metadata from ./package.json assert type: 'json'
+metadata from ./package.json with type: 'json'
 </Playground>
 
 ### Import Like Object Destructuring

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4542,9 +4542,11 @@ FromClause
 
 # https://github.com/tc39/proposal-import-assertions
 # https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#import-assertions
-# NOTE: Forbid newline before `assert` which could mean a function call
+# https://github.com/tc39/proposal-import-attributes
+# https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#import-attributes
+# NOTE: Forbid newline before `with` which could mean a function call
 ImportAssertion
-  _? "assert" NonIdContinue _? ObjectLiteral
+  _? ( "with" / "assert" ) NonIdContinue _? ObjectLiteral
 
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier

--- a/test/import.civet
+++ b/test/import.civet
@@ -253,72 +253,74 @@ describe "import", ->
       fetch = () => import("./x.js")
     """
 
-  describe "import assertions", ->
-    testCase """
-      standard style
-      ---
-      import json from "./foo.json" assert { type: "json" }
-      ---
-      import json from "./foo.json" assert { type: "json" }
-    """
+  for keyword of ['assert', 'with']
+    describe `import ${if keyword == 'assert' then 'assertions' else 'attributes'}`, ->
+      testCase ```
+        standard style
+        ---
+        import json from "./foo.json" ${keyword} { type: "json" }
+        ---
+        import json from "./foo.json" ${keyword} { type: "json" }
+      ```
 
-    testCase """
-      shorthand object literal
-      ---
-      import json from "./foo.json" assert type: "json"
-      ---
-      import json from "./foo.json" assert {type: "json"}
-    """
+      testCase ```
+        shorthand object literal
+        ---
+        import json from "./foo.json" ${keyword} type: "json"
+        ---
+        import json from "./foo.json" ${keyword} {type: "json"}
+      ```
 
-    testCase """
-      nested implicit object literal
-      ---
-      import json from "./foo.json" assert
-        type: "json"
-      ---
-      import json from "./foo.json" assert {
-        type: "json",
-      }
-    """
+      testCase ```
+        nested implicit object literal
+        ---
+        import json from "./foo.json" ${keyword}
+          type: "json"
+        ---
+        import json from "./foo.json" ${keyword} {
+          type: "json",
+        }
+      ```
 
-    testCase """
-      from shorthand
-      ---
-      json from ./foo.json assert type: "json"
-      ---
-      import json from "./foo.json" assert {type: "json"}
-    """
+      testCase ```
+        from shorthand
+        ---
+        json from ./foo.json ${keyword} type: "json"
+        ---
+        import json from "./foo.json" ${keyword} {type: "json"}
+      ```
 
-    testCase """
-      side-effect import
-      ---
-      import "./foo.json" assert type: "json"
-      ---
-      import "./foo.json" assert {type: "json"}
-    """
+      testCase ```
+        side-effect import
+        ---
+        import "./foo.json" ${keyword} type: "json"
+        ---
+        import "./foo.json" ${keyword} {type: "json"}
+      ```
 
-    testCase """
-      dynamic import
-      ---
-      import("./foo.json", { assert: { type: "json" }})
-      ---
-      import("./foo.json", { assert: { type: "json" }})
-    """
+      testCase ```
+        dynamic import
+        ---
+        import("./foo.json", { ${keyword}: { type: "json" }})
+        ---
+        import("./foo.json", { ${keyword}: { type: "json" }})
+      ```
 
-    testCase """
-      dynamic import shorthand
-      ---
-      foo := import "./foo.json", assert: type: "json"
-      ---
-      const foo = import("./foo.json", {assert: {type: "json"}})
-    """
+      testCase ```
+        dynamic import shorthand
+        ---
+        foo := import "./foo.json", ${keyword}: type: "json"
+        ---
+        const foo = import("./foo.json", {${keyword}: {type: "json"}})
+      ```
 
-    testCase """
-      assert function call
-      ---
-      import "./foo.json"
-      assert type: "json"
-      ---
-      import "./foo.json"
-      assert({type: "json"})
-    """
+      unless keyword is 'with'  // 'with' isn't a valid function name
+        testCase ```
+          ${keyword} function call
+          ---
+          import "./foo.json"
+          ${keyword} type: "json"
+          ---
+          import "./foo.json"
+          ${keyword}({type: "json"})
+        ```


### PR DESCRIPTION
[TypeScript 5.3](https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/) introduces support for [stage-3 import attributes](https://github.com/tc39/proposal-import-attributes) such as

```ts
import obj from "./something.json" with { type: "json" };
```

This is a replacement for `assert`, but I think for compatibility we should support both, at least for now.