### PR TITLE
Support implicit .civet importing unless implicitExtension: false

### DIFF
--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -160,8 +160,10 @@ esbuild.build({
     civetPlugin({
       // Options and their defaults:
       // emitDeclaration: false,         // generate .d.ts files?
-      // outputExtension: '.civet.tsx',  // replaces .civet in output
+      // implicitExtension: true,        // import "./x" checks for x.civet
+      // outputExtension: '.tsx',        // appended to .civet in output
       // ts: 'civet',                    // TS -> JS transpilation mode
+      // typecheck: false,               // check types via tsc
     })
   ]
 }).catch(() => process.exit(1))

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -74,6 +74,7 @@ module.exports = {
 ```ts
 interface PluginOptions {
   emitDeclaration?: boolean;
+  implicitExtension?: boolean;
   outputExtension?: string;
   ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
   typecheck?: boolean;
@@ -86,7 +87,8 @@ interface PluginOptions {
 
 - `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`. (Requires installing `typescript`.)
 - `typecheck`: Whether to run type checking on the generated code. Default: `false`.
-- `outputExtension`: Output filename extension to use. Default: `".civet.tsx"`, or uses `".civet.jsx"` if `ts` is `"preserve"`.
+- `implicitExtension`: Whether to allow importing `filename.civet` via `import "filename"`. Default: `true`.
+- `outputExtension`: Output filename extension to append to `.civet`. Default: `".jsx"`, or `".tsx"` if `ts` is `"preserve"`.
 - `ts`: Mode for transpiling TypeScript features into JavaScript. Default: `"civet"`. Options:
   - `"civet"`: Use Civet's JS mode. (Not all TS features supported.)
   - `"esbuild"`: Use esbuild's transpiler. (Fast and more complete. Requires installing `esbuild`.)

--- a/integration/unplugin/examples/esbuild/src/main.civet
+++ b/integration/unplugin/examples/esbuild/src/main.civet
@@ -1,3 +1,3 @@
-{a} from "./module.civet"
+{a} from "./module"
 
 console.log a

--- a/integration/unplugin/examples/vite/src/main.civet
+++ b/integration/unplugin/examples/vite/src/main.civet
@@ -1,3 +1,3 @@
-{a} from "./module.civet"
+{a} from "./module"
 
 console.log a

--- a/integration/unplugin/examples/webpack/main.civet
+++ b/integration/unplugin/examples/webpack/main.civet
@@ -1,3 +1,3 @@
-{a} from "./module.civet"
+{a} from "./module"
 
 console.log a

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -64,12 +64,14 @@ function tryFsResolve(file: string): string | undefined {
   return undefined;
 }
 
-function resolveAbsolutePath(rootDir: string, id: string) {
-  const resolved = tryFsResolve(path.join(rootDir, id));
-
-  if (!resolved) return tryFsResolve(id);
-
-  return resolved;
+function resolveAbsolutePath(rootDir: string, id: string, implicitExtension: boolean) {
+  const file = path.join(rootDir, id);
+  // Check for existence of resolved file and unsolved id,
+  // without and with implicit .civet extension, and return first existing
+  return tryFsResolve(file) ||
+    (implicitExtension && implicitCivet(file)) ||
+    tryFsResolve(id) ||
+    (implicitExtension && implicitCivet(id));
 }
 
 function implicitCivet(file: string): string | undefined {
@@ -226,7 +228,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
 
       id = cleanCivetId(id);
       const absolutePath = path.isAbsolute(id)
-        ? resolveAbsolutePath(rootDir, id)
+        ? resolveAbsolutePath(rootDir, id, implicitExtension)
         : path.resolve(path.dirname(importer ?? ''), id);
       if (!absolutePath) return null;
 

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -15,6 +15,7 @@ import type { UserConfig } from 'vite';
 import os from 'os';
 
 export type PluginOptions = {
+  implicitExtension?: boolean;
   outputExtension?: string;
   transformOutput?: (
     code: string,
@@ -29,7 +30,6 @@ export type PluginOptions = {
   dts?: boolean;
 };
 
-const isCivet = (id: string) => /\.civet([?#].*)?$/.test(id);
 const isCivetTranspiled = (id: string) => /\.civet\.[jt]sx([?#].*)?$/.test(id);
 const postfixRE = /[?#].*$/s;
 const isWindows = os.platform() === 'win32';
@@ -72,6 +72,13 @@ function resolveAbsolutePath(rootDir: string, id: string) {
   return resolved;
 }
 
+function implicitCivet(file: string): string | undefined {
+  if (tryFsResolve(file)) return
+  const civet = file + '.civet'
+  if (tryFsResolve(civet)) return civet
+  return
+}
+
 const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
   if (options.dts) options.emitDeclaration = options.dts;
   if (options.js) options.ts = 'civet';
@@ -79,6 +86,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
   const transformTS = options.emitDeclaration || options.typecheck;
   const outExt =
     options.outputExtension ?? (options.ts === 'preserve' ? '.tsx' : '.jsx');
+  const implicitExtension = options.implicitExtension ?? true;
 
   let fsMap: Map<string, string> = new Map();
   const sourceMaps = new Map<string, SourceMap>();
@@ -215,7 +223,6 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
     },
     resolveId(id, importer) {
       if (/\0/.test(id)) return null;
-      if (!isCivet(id) && !isCivetTranspiled(id)) return null;
 
       id = cleanCivetId(id);
       const absolutePath = path.isAbsolute(id)
@@ -223,7 +230,15 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
         : path.resolve(path.dirname(importer ?? ''), id);
       if (!absolutePath) return null;
 
-      const relativeId = path.relative(process.cwd(), absolutePath);
+      let relativeId = path.relative(process.cwd(), absolutePath);
+
+      // Implicit .civet extension
+      if (!relativeId.endsWith('.civet')) {
+        if (!implicitExtension) return null;
+        const implicitId = implicitCivet(relativeId)
+        if (!implicitId) return null;
+        relativeId = implicitId
+      }
 
       const relativePath = relativeId + outExt;
       return relativePath;
@@ -337,6 +352,12 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
     vite: {
       config(config: UserConfig) {
         rootDir = path.resolve(process.cwd(), config.root ?? '');
+
+        if (implicitExtension) {
+          config.resolve ??= {};
+          config.resolve.extensions ??= [];
+          config.resolve.extensions.push('.civet');
+        }
       },
       async transformIndexHtml(html) {
         return html.replace(/<!--[^]*?-->|<[^<>]*>/g, tag =>


### PR DESCRIPTION
Most bundlers support implicit `.ts`/`.js`/etc. extensions. It's reasonable to expect that `.civet` will be implicit as well, so this PR adds it as default behavior.  @Mokshit06 suggested there be an option to disable this behavior, though, so you can force explicit extensions via `implicitExtension: false`.

I've tested this in esbuild, Vite, Rollup, and Webpack.