### PR TITLE
Omit return with Iterator/Generator<*, void> type

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -1527,7 +1527,7 @@ function insertSwitchReturns(exp): void
   exp.caseBlock.clauses.forEach (clause) =>
     insertReturn clause
 
-function isEmptyBareBlock(node) {
+function isEmptyBareBlock(node): boolean {
   if (node?.type !== "BlockStatement") return false
   const { bare, expressions } = node
   return bare &&
@@ -1536,7 +1536,7 @@ function isEmptyBareBlock(node) {
         expressions[0][1]?.type === "EmptyStatement"))
 }
 
-function isFunction(node) {
+function isFunction(node): boolean {
   const { type } = node
   return type === "FunctionExpression" || type === "ArrowFunction" ||
     type === "MethodDefinition" || node.async
@@ -1546,22 +1546,28 @@ function isFunction(node) {
 /**
  * Returns true if the StringLiteral node is a template literal.
  */
-function isTemplateLiteral(node) {
+function isTemplateLiteral(node): boolean {
   let s = node
   while (s && s[0] && !s.token) s = s[0]
   return s.token?.startsWith?.('`')
 }
 
-function isVoidType(t?: ReturnTypeAnnotation) {
+function isVoidType(t?: ReturnTypeAnnotation): boolean {
   return t?.type === "LiteralType" && t.t.type === "VoidType"
 }
 
-function isPromiseVoidType(t) {
+function isPromiseVoidType(t): boolean {
   return t?.type === "IdentifierType" && t.raw === "Promise" &&
     t.args?.types?.length === 1 && isVoidType(t.args.types[0])
 }
 
-function isWhitespaceOrEmpty(node) {
+function isGeneratorVoidType(t): boolean {
+  return t?.type === "IdentifierType" and
+    (t.raw === "Iterator" || t.raw === "Generator") and
+    t.args?.types?.length >= 2 and isVoidType(t.args.types[1])
+}
+
+function isWhitespaceOrEmpty(node): boolean {
   if (!node) return true
   if (node.type === "Ref") return false
   if (node.token) return node.token.match(/^\s*$/)
@@ -2464,11 +2470,12 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
   if (!processReturnValue(f) and implicitReturns)
     { signature, block } := f
     { modifier, name, returnType } := signature
-    { async, set } := modifier
+    { async, generator, set } := modifier
     isMethod := f.type is "MethodDefinition"
     isConstructor := isMethod and name is "constructor"
     isVoid := isVoidType(returnType?.t) or
-      (async && isPromiseVoidType(returnType?.t))
+      (async and isPromiseVoidType(returnType?.t)) or
+      (not async and generator and isGeneratorVoidType(returnType?.t))
     isBlock := block?.type === "BlockStatement"
     if !isVoid and !set and !isConstructor and isBlock
       insertReturn(block)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2871,7 +2871,7 @@ MethodDefinition
   MethodSignature:signature !PropertyAccess BracedBlock?:block ->
     let children = $0
     let generatorPos = 0
-    const { modifier } = signature
+    let { modifier } = signature
 
     if (hasAwait(block)) {
       generatorPos++
@@ -2887,6 +2887,8 @@ MethodDefinition
       } else {
         // Insert implicit async
         children.unshift("async ")
+        modifier = { ...modifier, async: true }
+        signature = { ...signature, modifier }
       }
     }
 
@@ -2904,6 +2906,8 @@ MethodDefinition
       } else {
         // Insert implicit generator
         children.splice(generatorPos, 0, "*")
+        modifier = { ...modifier, generator: true }
+        signature = { ...signature, modifier }
       }
     }
 
@@ -3007,7 +3011,7 @@ MethodModifier
       async: true,
       get: false,
       set: false,
-      generator: !!$1,
+      generator: !!$2,
       children: $0,
     }
   Star __ ->

--- a/test/function.civet
+++ b/test/function.civet
@@ -1296,6 +1296,50 @@ describe "function", ->
     """
 
     testCase """
+      implicit * Iterator<*, void>
+      ---
+      (x): Iterator<any, void, any> ->
+        yield x
+      ---
+      (function*(x): Iterator<any, void, any> {
+        yield x
+      })
+    """
+
+    testCase """
+      implicit * Generator<*, void> longhand
+      ---
+      function(x): Generator<any, void>
+        yield x
+      ---
+      (function*(x): Generator<any, void> {
+        yield x
+      })
+    """
+
+    testCase """
+      no * Iterator<*, void>
+      ---
+      (x): Iterator<any, void> ->
+        fetch x
+      ---
+      (function(x): Iterator<any, void> {
+        return fetch(x)
+      })
+    """
+
+    testCase """
+      no * Generator<*, void> longhand
+      ---
+      function(x): Generator<any, void>
+        fetch x
+      ---
+      (function(x): Generator<any, void> {
+        return fetch(x)
+      })
+    """
+
+    testCase """
       nested anonymous function
       ---
       (x) ->


### PR DESCRIPTION
Fixes #862

Also fix some bugs in `generator` attributes (not actually tested here, but they were needed for a removed addition of "don't implicit return in async generators").