### PR TITLE
Color tweaks to improve contrast

### DIFF
--- a/civet.dev/.vitepress/theme/custom.css
+++ b/civet.dev/.vitepress/theme/custom.css
@@ -24,17 +24,25 @@
   --shadow-text: 2px 2px 0 rgba(0, 0, 0, 0.125);
   --shadow-vertical: 0 2px rgba(0, 0, 0, 0.125);
 
+  --color-primary: #CE1CAE;
+  --color-secondary: #6C0E97;
   --color-bg: #fdfdfd;
 
   --vp-home-hero-name-color: var(--color-primary);
   --vp-c-bg: var(--color-bg);
   --vp-nav-bg-color: var(--color-bg);
   --vp-c-bg-alt: #fafafa;
+
+  --vp-c-brand-1: var(--color-primary);
+  --vp-c-brand-2: var(--color-secondary);
+
+  --vp-button-brand-bg: var(--color-primary);
+  --vp-button-brand-hover-bg: var(--color-secondary);
 }
 
 .dark {
   --color-primary: #F224CC;
-  --color-primary-dark: #6C0E97;
+  --color-secondary: #A233D6;
   --color-bg: hsl(239 49% 9.5% / 1);
 
   --shadow-extreme: 8px 8px 0 rgba(0, 0, 0, 0.75);
@@ -43,10 +51,6 @@
   --shadow-vertical: 0 2px rgba(0, 0, 0, 0.75);
 
   --vp-c-bg-alt: hsl(239 49% 4% / 1);
-  --vp-c-brand-1: var(--color-primary);
-  --vp-c-brand-2: var(--color-primary-dark);
-
-  --vp-button-brand-hover-bg: var(--color-primary-dark);
 
 }
 


### PR DESCRIPTION
I unified light and dark mode a bit; #871 introduced custom color branding for dark mode, but not light mode. I also tweaked the primary and secondary colors to be consistently light or dark to improve contrast.

Dark:

![image](https://github.com/DanielXMoore/Civet/assets/2218736/647dd60d-60cf-4b8a-893c-7d41841ccd9c)

Light:

![image](https://github.com/DanielXMoore/Civet/assets/2218736/e84d64d2-b78c-498a-98dc-c61c3bc784ae)
