### PR TITLE
Omit obviously unreachable breaks from switch

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -1449,8 +1449,8 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
       return
     // NOTE: "CaseClause"s don't get a return statements inserted
     case "WhenClause":
-      // Remove inserted `break;`
-      node.children.splice(node.children.indexOf(node.break), 1)
+      // Remove inserted `break;` if it hasn't already been removed
+      node.children.splice node.children.indexOf(node.break), 1 if node.break
       if node.block.expressions.length
         insertReturn(node.block)
       else
@@ -1594,6 +1594,18 @@ function isWhitespaceOrEmpty(node): boolean {
   if (typeof node === "string") return node.match(/^\s*$/)
   if (Array.isArray(node)) return node.every(isWhitespaceOrEmpty)
 }
+
+/**
+ * Does this statement force exit from normal flow, implying that the
+ * line after this one can never execute?
+ */
+function isExit(node: ASTNode): boolean
+  node?.type is in [
+    "ReturnStatement",
+    "ThrowStatement",
+    "BreakStatement",
+    "ContinueStatement"
+  ]
 
 function gatherRecursiveWithinFunction(node, predicate) {
   return gatherRecursive(node, predicate, isFunction)
@@ -3011,6 +3023,15 @@ function processPatternMatching(statements, ReservedWord): void {
     .forEach((s: SwitchStatement) => {
       const { caseBlock } = s
       const { clauses } = caseBlock
+
+      // Remove inserted `break;` in `when` clauses that don't need them
+      for c of clauses
+        if c.type is "WhenClause" and c.break
+          last := c.block?.expressions?.at(-1)?[1]
+          // [1] extracts statement from [indent, statement, delim]
+          if isExit last
+            c.children.splice c.children.indexOf(c.break), 1
+            c.break = undefined
 
       let errors = false
       let isPattern = false

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -293,6 +293,46 @@ describe "switch", ->
   """
 
   testCase """
+    when skips break if unnecessary
+    ---
+    switch x
+      when 1
+        return y
+      when 2
+        break
+      when 3
+        continue
+      when 4
+        throw e
+      when 5
+        throw e
+        break
+        continue
+        console.log 'maybe'
+    ---
+    switch(x) {
+      case 1: {
+        return y
+      }
+      case 2: {
+        break
+      }
+      case 3: {
+        continue
+      }
+      case 4: {
+        throw e
+      }
+      case 5: {
+        throw e
+        break
+        continue
+        console.log('maybe');break;
+      }
+    }
+  """
+
+  testCase """
     declaration condition in pattern matching
     ---
     switch data := x()


### PR DESCRIPTION
Fixes #870

We could do better, e.g. detecting unreachable code in a situation like this:

```coffee
switch x
  when 1
    if y > 0
      return +1
    else
      return -1
```

We can continue to extend `isExit` if this is needed.