### PR TITLE
Support x?.-1 and other optional fancy accesses

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -3815,20 +3815,21 @@ function reorderBindingRestProperty(props) {
 /**
  * Replace all nodes that match predicate with replacer(node)
  */
-function replaceNodes(root, predicate, replacer) {
-  if (root == null) return root
-  const array = Array.isArray(root) ? root : root.children
-  if (!array) return root
-  array.forEach((node, i) => {
-    if (node == null) return
-    if (predicate(node)) {
-      array[i] = replacer(node, root)
-    } else {
-      replaceNodes(node, predicate, replacer)
-    }
-  })
+function replaceNodes(root, predicate, replacer)
+  return root unless root?
+  array := Array.isArray(root) ? root : root.children
+  unless array
+    if predicate root
+      return replacer root, root
+    else
+      return root
+  for each node, i of array
+    return unless node?
+    if predicate node
+      array[i] = replacer node, root
+    else
+      replaceNodes node, predicate, replacer
   return root
-}
 
 /**
  * Used to ignore the result of __ if it is only whitespace

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1052,28 +1052,6 @@ MemberBracketContent
       expression,
     }
 
-  # NOTE: Added shorthand x."string" -> x["string"]
-  # NOTE: Added shorthand x.3 -> x[3]
-  Dot:dot ( TemplateLiteral / StringLiteral / IntegerLiteral ):literal ->
-    // Possessive dots are arrays where the first item is the dot
-    if (Array.isArray(dot)) dot = dot[0]
-    return {
-      type: "Index",
-      children: [
-        { token: "[", $loc: dot.$loc },
-        literal,
-        "]",
-      ]
-    }
-
-  # NOTE: Added shorthand x.-1 -> x.at(-1)
-  Dot:dot "-":neg IntegerLiteral:num ->
-    return [
-      { type: "PropertyAccess", children: [dot, "at"] },
-        // not including `name` so that `{x.-1}` doesn't use it
-      { type: "Call", children: [ "(", neg, num, ")" ] },
-    ]
-
 SliceParameters
   ExtendedExpression:start __:ws ( DotDotDot / DotDot ):sep ExtendedExpression?:end ->
     const inclusive = sep.token === ".."
@@ -1141,6 +1119,28 @@ PropertyAccessModifier
   NonNullAssertion
 
 PropertyAccess
+  # NOTE: Added shorthand x."string" -> x["string"]
+  # NOTE: Added shorthand x.3 -> x[3]
+  AccessStart:dot ( TemplateLiteral / StringLiteral / IntegerLiteral ):literal ->
+    dot = replaceNodes(deepCopy(dot), (node) => node.token === ".",
+      (node) => ({ token: "[", $loc: node.$loc }))
+    return {
+      type: "Index",
+      children: [
+        dot,
+        literal,
+        "]",
+      ]
+    }
+
+  # NOTE: Added shorthand x.-1 -> x.at(-1)
+  AccessStart:dot "-":neg IntegerLiteral:num ->
+    return [
+      { type: "PropertyAccess", children: [dot, "at"] },
+        // not including `name` so that `{x.-1}` doesn't use it
+      { type: "Call", children: [ "(", neg, num, ")" ] },
+    ]
+
   AccessStart:access InlineComment*:comments ( IdentifierName / PrivateIdentifier ):id ->
     const children = [access, ...comments, ...id.children]
 

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -202,6 +202,30 @@ describe "property access", ->
     """
 
     testCase """
+      optional decimal
+      ---
+      x?.1
+      ---
+      x?[1]
+    """
+
+    testCase """
+      possessive decimal
+      ---
+      x's 1
+      ---
+      x[1]
+    """
+
+    testCase """
+      optional possessive decimal
+      ---
+      x?'s 1
+      ---
+      x?[1]
+    """
+
+    testCase """
       decimal with separators
       ---
       x.1_000_000
@@ -237,6 +261,22 @@ describe "property access", ->
       negative
       ---
       x.-1
+      ---
+      x.at(-1)
+    """
+
+    testCase """
+      optional negative
+      ---
+      x?.-1
+      ---
+      x?.at(-1)
+    """
+
+    testCase """
+      possessive negative
+      ---
+      x's -1
       ---
       x.at(-1)
     """


### PR DESCRIPTION
I noticed that `x?.-1` doesn't work when writing this code:

https://github.com/DanielXMoore/Civet/blob/5d990f690f778f9a39225f69647bc7a4992739c5/source/lib.civet#L3030