### PR TITLE
Allow arbitrary unary operators before ampersand function notation

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -740,11 +740,16 @@ function search<T>(list: T[]): T | undefined
 
 ### Single-Argument Function Shorthand
 
+`&` (optionally preceding by unary operators) marks the beginning of a
+single-argument function whose argument gets immediately used:
+
 <Playground>
 x.map &.name
 x.map &.profile?.name[0...3]
 x.map &.callback a, b
 x.map +&
+x.map await &.json()
+x.forEach delete &.old
 x.filter (&)
 </Playground>
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -351,6 +351,10 @@ ParenthesizedAssignment
 
 # https://262.ecma-international.org/#prod-UnaryExpression
 UnaryExpression
+  # NOTE: Check for ampersand function expression first,
+  # which can start with UnaryOps that need to be absorbed.
+  AmpersandFunctionExpression
+
   # NOTE: Merged AwaitExpression with UnaryOp
   # https://262.ecma-international.org/#prod-AwaitExpression
   # NOTE: Eliminated left recursion
@@ -1777,8 +1781,8 @@ FunctionExpression
   # Ruby/Crystal style block shorthand
 AmpersandFunctionExpression
   # NOTE: !NumericLiteral is so we don't match on `.1` etc.
-  AmpersandUnaryPrefix?:prefix ( Ampersand / ( !NumericLiteral &( QuestionMark? Dot ) ) ) AmpersandBlockRHS?:rhs ->
-    if (!prefix && !rhs) return $skip
+  UnaryOp*:prefix ( Ampersand / ( !NumericLiteral &( QuestionMark? Dot !Dot ) ) ) AmpersandBlockRHS?:rhs ->
+    if (!prefix.length && !rhs) return $skip
 
     let body, ref
 
@@ -1798,7 +1802,7 @@ AmpersandFunctionExpression
       }
       body = rhs
     }
-    if (prefix) {
+    if (prefix.length) {
       body = {
         type: "UnaryExpression",
         children: [ prefix, body, undefined ]
@@ -1933,9 +1937,6 @@ AmpersandBlockRHSBody
     }
 
     return exp
-
-AmpersandUnaryPrefix
-  [!~+-]+
 
 ThinArrowFunction
   ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:suffix _? Arrow:arrow NoCommaBracedOrEmptyBlock:block ->
@@ -3401,7 +3402,7 @@ Xnor
 UnaryOp
   # Lookahead to prevent unary operators from overriding update operators
   # ++/-- or block unary operator shorthand
-  /(?!\+\+|--)[!~+-](?!\s|[!~+-]*(&|\.[^0-9]))/ ->
+  /(?!\+\+|--)[!~+-](?!\s)/ ->
     return { $loc, token: $0 }
   AwaitOp
   ( Delete / Void / Typeof ) !":" _?

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -218,6 +218,22 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    unary not
+    ---
+    x.map not &
+    ---
+    x.map($ => !$)
+  """
+
+  testCase """
+    unary not not
+    ---
+    x.map not not &
+    ---
+    x.map($ => !!$)
+  """
+
+  testCase """
     unary ~
     ---
     x.map ~&
@@ -239,6 +255,22 @@ describe "&. function block shorthand", ->
     x.map +&
     ---
     x.map($ => +$)
+  """
+
+  testCase """
+    unary delete
+    ---
+    x.forEach delete .old
+    ---
+    x.forEach($ => delete $.old)
+  """
+
+  testCase """
+    unary await
+    ---
+    await.all x.map await .json()
+    ---
+    await Promise.all(x.map(async $ => await $.json()))
   """
 
   testCase """


### PR DESCRIPTION
`not` requested in #854

I replaced a hard-coded negative lookaheads in a regex with an early attempt to match `AmpersandFunctionExpression`. I *think* this works, and should be more robust (and with caching, minimal overhead). As a bonus, we get some fun uses with `delete` and `await` illustrated in the tests and docs.