### PR TITLE
Fix unplugin emitDeclaration and Windows behavior

### DIFF
--- a/integration/unplugin/examples/esbuild/esbuild.js
+++ b/integration/unplugin/examples/esbuild/esbuild.js
@@ -4,9 +4,10 @@ import civetEsbuildPlugin from '@danielx/civet/esbuild'
 const options = {
   entryPoints: ['src/main.civet'],
   bundle: true,
-  outfile: 'dist/main.js',
+  outdir: 'dist',
   plugins: [civetEsbuildPlugin({
     ts: 'esbuild',
+    emitDeclaration: true,
   })],
 }
 

--- a/integration/unplugin/examples/esbuild/src/main.civet
+++ b/integration/unplugin/examples/esbuild/src/main.civet
@@ -1,3 +1,6 @@
 {a} from "./module"
 
 console.log a
+
+export b = a
+export * from "./module.civet"

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -197,14 +197,18 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
         }
 
         if (options.emitDeclaration) {
+          // Removed duplicate slashed (`\`) versions of the same file for emit
+          for (const file of fsMap.keys()) {
+            const slashed = slash(file);
+            if (file !== slashed) {
+              fsMap.delete(slashed);
+            }
+          }
           for (const file of fsMap.keys()) {
             const sourceFile = program.getSourceFile(file)!;
             program.emit(
               sourceFile,
-              async (filePath, content) => {
-                const dir = path.dirname(filePath);
-                await fs.promises.mkdir(dir, { recursive: true });
-
+              (filePath, content) => {
                 const pathFromDistDir = path.relative(
                   compilerOptions.outDir ?? process.cwd(),
                   filePath
@@ -273,18 +277,18 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}) => {
           sourceMap: true,
         });
 
+        const resolved = path.resolve(process.cwd(), id);
         sourceMaps.set(
-          path.resolve(process.cwd(), id),
+          resolved,
           compiledTS.sourceMap as SourceMap
         );
 
         if (transformTS) {
-          const resolved = path.resolve(process.cwd(), id);
           fsMap.set(resolved, compiledTS.code);
           // Vite and Rollup normalize filenames to use `/` instead of `\`.
           // We give the TypeScript VFS both versions just in case.
           const slashed = slash(resolved);
-          if (resolved !== slashed) fsMap.set(slashed, rawCivetSource);
+          if (resolved !== slashed) fsMap.set(slashed, compiledTS.code);
         }
 
         switch (options.ts) {


### PR DESCRIPTION
Implement @imm's [suggestions](https://github.com/DanielXMoore/Civet/issues/893) for fixing `emitDeclaration`:
* Remove `mkdir` preceding `this.emitFile`; `this.emitFile` should do this already (indeed, unplugin does it explicitly for esbuild)
* Switch `emit` call from `async` to synchronous.
* Add warning when using esbuild and no `outdir` option (as our example was doing), which prevents us (technically, unplugin) from emitting declarations because don't know where to put them.

Additionally, I realized there were bugs specific to Windows, which I was seeing but @imm wasn't (presumably not being on Windows):
* `fsMap` was getting the wrong code for slashed versions of filenames: the Civet source instead of the compiled TS! So I was getting error messages like `main.civet.jsx:1:5 - error TS1434: Unexpected keyword or identifier.`, despite things seeming to also work (but probably not very well).
* `this.emitFile` was getting called on both original and slashed versions of files. This was leading to double emits, with error messages like `(!) The emitted file "main.civet.d.ts" overwrites a previously emitted file of the same name.` To fix this, I removed the duplicates from `fsMap` in the emit phase.

I've tested esbuild and rollup and this seems to work much better.