### PR TITLE
++= concat assignment

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -388,6 +388,19 @@ a ++ b ++ c
 [1,2,3] ⧺ rest
 </Playground>
 
+You can use `++` to concatenate arrays or strings,
+or your own types by providing a `concat` method.
+Remember that
+[`Array.prototype.concat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat)
+appends a single item unless it is an array
+(or has the [`Symbol.isConcatSpreadable` property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable)),
+in which case it flattens it into the target array.
+Civet's assignment operator behaves the same:
+
+<Playground>
+a ++= b
+</Playground>
+
 ### Assignment Operators
 
 <Playground>

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -1235,24 +1235,34 @@ function replaceBlockExpression(node: BlockStatement, child: ASTNodeBase, replac
  * which is useful for working with e.g. the `expressions` property.
  * Returns -1 if `child` cannot be found.
  */
-function findChildIndex(parent, child) {
-  const children = Array.isArray(parent) ? parent : parent.children
-  const len = children.length
-  for (let i = 0; i < len; i++) {
-    const c = children[i]
-    if (c === child || (Array.isArray(c) && arrayRecurse(c)))
+function findChildIndex(parent, child)
+  children := Array.isArray(parent) ? parent : parent.children
+  for each c, i of children
+    if c is child or (Array.isArray(c) and arrayRecurse(c))
       return i
-  }
-  function arrayRecurse(array) {
-    const len = array.length
-    for (let i = 0; i < len; i++) {
-      const c = array[i]
-      if (c === child || (Array.isArray(c) && arrayRecurse(c)))
+  function arrayRecurse(array)
+    for each c, i of array
+      if c is child or (Array.isArray(c) and arrayRecurse(c))
         return true
-    }
-  }
   return -1
-}
+
+/**
+ * Replace this node with another, by modifying its parent's children.
+ */
+function replaceNode(node: ASTNodeBase, newNode: ASTNodeBase): void
+  unless node.parent?
+    throw new Error "replaceNode failed: node has no parent"
+  function recurse(children: ASTNode[]): boolean
+    for each child, i of children
+      if child is node
+        children[i] = newNode
+        return true
+      else if Array.isArray child
+        return true if recurse child
+    return false
+  unless recurse node.parent.children
+    throw new Error "replaceNode failed: didn't find child node in parent"
+  newNode.parent = node.parent
 
 /**
  * Find nearest strict `ancestor` that satisfies predicate,
@@ -2593,21 +2603,18 @@ function processAssignments(statements): void {
     .forEach((exp) => {
       let { lhs: $1, exp: $2 } = exp, tail = [], i = 0, len = $1.length
 
-      // identifier=
-      if ($1.some((left) => left[left.length - 1].special)) {
-        if ($1.length !== 1) {
-          throw new Error("Only one assignment with id= is allowed")
-        }
-        const [, lhs, , op] = $1[0]
-        const { call } = op
-        // Replace id= with =
-        op[op.length - 1] = "="
+      // identifier=, xor=, ++=
+      if $1.some((left) => left[left.length - 1].special)
+        if ($1.length !== 1) throw new Error("Only one assignment with id= is allowed")
+        [, lhs, , op] := $1[0]
+        { call, omitLhs } := op
         // Wrap right-hand side with call
-        const index = exp.children.indexOf($2)
+        index := exp.children.indexOf($2)
         if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
-        exp.children.splice(index, 1,
-          exp.exp = $2 = [call, "(", lhs, ", ", $2, ")"])
-      }
+        exp.children.splice index, 1,
+          exp.exp = $2 = [call, "(", lhs, ", ", $2, ")"]
+        if omitLhs
+          replaceNode exp, $2
 
       // Force parens around destructuring object assignments
       // Walk from left to right the minimal number of parens are added and enclose all destructured assignments

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7200,9 +7200,16 @@ Reset
         })
       },
       concatAssign(ref) {
+        const typeSuffix = {
+          ts: true,
+          children: [
+            ": <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A",
+          ]
+        }
         module.prelude.push({
           children: [
-            preludeVar, ref, " = <B, I, A extends {push: (this: A, b: B) => void} | (B extends Array<I> ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B): A => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push(...rhs as any) : (lhs as any).push(rhs as any), lhs);\n"
+            preludeVar, ref, typeSuffix,
+            " = (lhs, rhs) => ((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ? (lhs", asAny, ").push(...rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
           ]
         })
       },

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7209,7 +7209,7 @@ Reset
         module.prelude.push({
           children: [
             preludeVar, ref, typeSuffix,
-            " = (lhs, rhs) => ((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ? (lhs", asAny, ").push(...rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
+            " = (lhs, rhs) => ((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
           ]
         })
       },

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3124,12 +3124,16 @@ WAssignmentOp
 AssignmentOp
   AssignmentOpSymbol _? ->
     if ($2?.length) {
+      if (typeof $1 !== "string") {
+        return { ...$1, children: [...$1.children, $2] }
+      }
       return {
         token: $1,
         children: [$1, ...$2]
       }
     }
 
+    if (typeof $1 !== "string") return $1
     return { $loc, token: $1 }
 
 # NOTE: x foo= y expands to x = foo(x, y)
@@ -3160,6 +3164,13 @@ AssignmentOpSymbol
   "*="
   "/="
   "%="
+  ( "++" / "⧺" ) Equals ->
+    return {
+      special: true,
+      call: module.getRef("concatAssign"),
+      omitLhs: true,
+      children: [$2],
+    }
   "+="
   "-="
   "<<="
@@ -7186,6 +7197,13 @@ Reset
           children: [
             preludeVar, ref, " = Symbol(\"return\")';\n",
           ],
+        })
+      },
+      concatAssign(ref) {
+        module.prelude.push({
+          children: [
+            preludeVar, ref, " = <B, I, A extends {push: (this: A, b: B) => void} | (B extends Array<I> ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B): A => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push(...rhs as any) : (lhs as any).push(rhs as any), lhs);\n"
+          ]
         })
       },
       JSX(jsxRef) {

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -574,6 +574,6 @@ describe "assignment", ->
       ---
       x ++= y
       ---
-      var concatAssign = <B, I, A extends {push: (this: A, b: B) => void} | (B extends Array<I> ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B): A => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push(...rhs as any) : (lhs as any).push(rhs as any), lhs);
+      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push(...rhs as any) : (lhs as any).push(rhs), lhs);
       concatAssign(x, y)
     """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -574,6 +574,6 @@ describe "assignment", ->
       ---
       x ++= y
       ---
-      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push(...rhs as any) : (lhs as any).push(rhs), lhs);
+      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
       concatAssign(x, y)
     """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -567,3 +567,13 @@ describe "assignment", ->
       ---
       x(!(min= y))
     """
+
+  describe "++=", ->
+    testCase """
+      ++=
+      ---
+      x ++= y
+      ---
+      var concatAssign = <B, I, A extends {push: (this: A, b: B) => void} | (B extends Array<I> ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B): A => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push(...rhs as any) : (lhs as any).push(rhs as any), lhs);
+      concatAssign(x, y)
+    """


### PR DESCRIPTION
Add `++=` assignment operator that acts like `concat`: multi-push if given an array, single push if not. Thanks to Beberka for pointing out the [isConcatSpreadable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable) interface.

Here's [verification of the `concatAssign` typing](https://www.typescriptlang.org/play?#code/G4QwTgBAxg9gdlEAXAggZzQSwOZwFwQA8AQgDQQoQCmAHklXACZoQDeADgK5oAWBAFEh6Y0BFOQBGBYgEoIAXgB8EYDEyMAvhAA+EfsWp0GzCJzgBrODADucANoBdCAH42XXgKEix5AHT+pCFkFZVV1LQI4KmAqMBlFfgAbHlEKcjAU6TklCgU9ZLR0lOzlfn4MlhBKuABPGWdfOwBlGoBbCRhE3xEAYXhEJCb2MCoQRhAJRKonVySUiCqF2plfdx5fEHZ2RJq5wogKheq6iAECo6W61e4ecuLyApkAbgAoF9gEZHQsXH47AEZSAAmUgAZgc5AALDJ3v0vhgcHA-oCQeDyHZIaQAKwOGEfAbfRHI4FgiEQABEEjG5LxcNQCN+AJJaIgdkp1NxQA).

I imagine the TypeScript could use less `any`s, but it's tricky because there are two cases.
