### PR TITLE
Optional let declarations

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1444,6 +1444,16 @@ class Civet
 declare function jsonParse(json: string): ???
 </Playground>
 
+### Optional Types
+
+Similar to function parameters and object properties,
+`let` declarations can be declared optional to allow `undefined`:
+
+<Playground>
+let i?: number
+i?: number .= undefined
+</Playground>
+
 ### Import
 
 <Playground>

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -123,6 +123,13 @@ type FunctionSignature =
   parameters: ParametersNode
   parent: ASTNodeBase | undefined
 
+type TypeSuffix
+  type: "TypeSuffix"
+  ts: true
+  optional?: ASTNode
+  t?: ASTNode
+  children: Children
+
 type ReturnTypeAnnotation =
   t:
     type: string
@@ -2481,18 +2488,30 @@ function processDeclarations(statements: StatementTuple[]): void
   // @ts-ignore
   .forEach ({ bindings }: DeclarationStatement) =>
     bindings?.forEach (binding) =>
-      { initializer } := binding
-      return unless initializer
+      suffix := binding.suffix as TypeSuffix
+      if suffix and suffix.optional and suffix.t
+        // Convert `let x?: T` to `let x: undefined | T`
+        spliceChild suffix, suffix.optional, 1, suffix.optional = undefined
+        ws := getTrimmingSpace suffix.t
+        spliceChild suffix, suffix.t, 1, suffix.t = [
+          ws
+          // TODO: avoid parens if unnecessary
+          "undefined | ("
+          insertTrimmingSpace suffix.t, ""
+          ")"
+        ]
 
-      exp := initializer[2]
-      // Wrap thick pipeline 'x ||> f' => 'f(x),x' with parentheses when inside an initializer
-      if exp?.type is "PipelineExpression"
-        if exp.children.-2 is ","
-          { parent } := exp
-          parenthesizedExpression := makeLeftHandSideExpression(exp)
-          parenthesizedExpression.parent = parent
-          exp.parent = parenthesizedExpression
-          initializer[2] = parenthesizedExpression
+      { initializer } := binding
+      if initializer
+        exp := initializer[2]
+        // Wrap thick pipeline 'x ||> f' => 'f(x),x' with parentheses when inside an initializer
+        if exp?.type is "PipelineExpression"
+          if exp.children.-2 is ","
+            { parent } := exp
+            parenthesizedExpression := makeLeftHandSideExpression(exp)
+            parenthesizedExpression.parent = parent
+            exp.parent = parenthesizedExpression
+            initializer[2] = parenthesizedExpression
 
 // Add implicit block unless followed by a method/function of the same name,
 // or block is within an ExportDeclaration.
@@ -3847,6 +3866,19 @@ function replaceNodes(root, predicate, replacer)
     else
       replaceNodes node, predicate, replacer
   return root
+
+/**
+ * Splice child from children/array, similar to Array.prototype.splice,
+ * but specifying a child instead of an index.  Throw if child not found.
+ */
+function spliceChild(node: ASTNode, child: ASTNode, del, ...replacements)
+  children := node?.children ?? node
+  unless Array.isArray children
+    throw new Error "spliceChild: non-array node has no children field"
+  index := children.indexOf child
+  if index < 0
+    throw new Error "spliceChild: child not found"
+  children.splice index, del, ...replacements
 
 /**
  * Used to ignore the result of __ if it is only whitespace

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6518,25 +6518,32 @@ TypeIndex
 # and class properties, but not let/const) and ! only in some circumstances
 # (let/const and class properties, but not function parameters), and can't
 # parse both (?!).  For simplicity, we allow either in all cases.
+# In some cases (e.g. let/const), we transpile them away later.
 TypeSuffix
-  QuestionMark? _? Colon Type -> {
+  QuestionMark?:optional _? Colon Type:t -> {
     type: "TypeSuffix",
     ts: true,
-    children: $0
+    optional,
+    t,
+    children: $0,
   }
-  QuestionMark _? -> {
+  QuestionMark:optional _? -> {
     type: "TypeSuffix",
     ts: true,
-    children: $0
+    optional,
+    children: $0,
   }
   # TypeScript has a special error for ! without : ("Declarations with definite
   # assignment assertions must also have type annotations.") but we parse it
   # so that the user can get this more useful error message.
-  NonNullAssertion _? (Colon Type)? -> {
-    type: "TypeSuffix",
-    ts: true,
-    children: $0
-  }
+  NonNullAssertion _? (Colon Type)?:ct ->
+    const [colon, t] = ct ?? []
+    return {
+      type: "TypeSuffix",
+      ts: true,
+      t,
+      children: [ $1, $2, colon, t ],
+    }
 
 ReturnTypeSuffix
   _? Colon ReturnType:t ->

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -32,3 +32,19 @@ describe "[TS] let declaration", ->
     ---
     let ref?!
   """
+
+  testCase """
+    let ?: allows for undefined
+    ---
+    let n?: number
+    ---
+    let n: undefined | (number)
+  """
+
+  testCase """
+    shorthand let ?: allows for undefined
+    ---
+    n?: number .= undefined
+    ---
+    let n: undefined | (number) = undefined
+  """


### PR DESCRIPTION
As suggested by unless on Discord:

```js
let x?: T
---
let x: undefined | T
```

...by analogy to function parameters (`f(x?: T)`) and object properties (`{ x?: T }`).

Future work: similarly for function return types (`function f()?: T`).