### PR TITLE
Conditional types via if/unless

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1458,6 +1458,19 @@ function f(x?: string)?: string
   x
 </Playground>
 
+### Conditional Types
+
+TypeScript's ternary types can be written using `if`/`unless` expressions,
+with optional `else` blocks:
+
+<Playground>
+let verb:
+  if Civet extends Animal
+    if Civet extends Cat then "meow"
+  else
+    string
+</Playground>
+
 ### Import
 
 <Playground>

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1469,6 +1469,8 @@ let verb:
     if Civet extends Cat then "meow"
   else
     string
+let breed: unless Civet extends Animal
+  then undefined else string
 </Playground>
 
 ### Import

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -638,22 +638,24 @@ function expressionizeIfClause(clause, b, e)
   }
 
 function expressionizeTypeIf([ifOp, condition, t, e])
-  if ifOp.token is "unless"
-    condition = [
-      "!"
-      parenthesizeType insertTrimmingSpace condition, ""
-    ]
   children := [
     "("
-    condition
+    insertTrimmingSpace condition, ""
     "?"
-    t
   ]
-  if e
-    // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
-    children.push e[0], ":", ...e[2..]
-  else
-    children.push ":never"
+  unless ifOp.negated // if
+    children.push t
+    if e
+      // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
+      children.push e[0], ":", ...e[2..]
+    else
+      children.push ":never"
+  else // unless
+    if e
+      children.push ...e[2..], e[0], ":"
+    else
+      children.push "never:"
+    children.push t
   children.push ")"
   children
 

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -637,6 +637,26 @@ function expressionizeIfClause(clause, b, e)
     children,
   }
 
+function expressionizeTypeIf([ifOp, condition, t, e])
+  if ifOp.token is "unless"
+    condition = [
+      "!"
+      parenthesizeType insertTrimmingSpace condition, ""
+    ]
+  children := [
+    "("
+    condition
+    "?"
+    t
+  ]
+  if e
+    // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
+    children.push e[0], ":", ...e[2..]
+  else
+    children.push ":never"
+  children.push ")"
+  children
+
 function expressionizeIteration(exp): void
   const { async, subtype, block, children, statement } = exp
   const i = children.indexOf(statement)
@@ -2088,6 +2108,13 @@ function makeExpressionStatement(expression: ASTNode): ASTNode
   else
     expression
 
+/**
+ * Parenthesize type if it might need it in some contexts.
+ */
+function parenthesizeType(type)
+  // TODO: avoid parens in some cases
+  ["(", type, ")"]
+
 // Adjust a parsed string by escaping newlines
 function modifyString(str) {
   // Replace non-escaped newlines with escaped newlines
@@ -2173,9 +2200,8 @@ function convertOptionalType(suffix: TypeSuffix | ReturnTypeAnnotation): void
     getTrimmingSpace suffix.t
     wrap and "("
     // TODO: avoid parens if unnecessary
-    "undefined | ("
-    insertTrimmingSpace suffix.t, ""
-    ")"
+    "undefined | "
+    parenthesizeType insertTrimmingSpace suffix.t, ""
     wrap and ")"
   ]
 
@@ -4064,6 +4090,7 @@ module.exports = {
   dedentBlockSubstitutions,
   deepCopy,
   expressionizeIfClause,
+  expressionizeTypeIf,
   findAncestor,
   forRange,
   gatherBindingCode,

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -637,8 +637,9 @@ function expressionizeIfClause(clause, b, e)
     children,
   }
 
-function expressionizeTypeIf([ifOp, condition, t, e])
+function expressionizeTypeIf([ws, ifOp, condition, t, e])
   children := [
+    ws
     "("
     insertTrimmingSpace condition, ""
     "?"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6697,8 +6697,8 @@ NestedType
   Nested TypeElement ArrayElementDelimiter
 
 TypeConditional
-  /(?=if|unless)/ TypeIfThenElse ->
-    return expressionizeTypeIf($2)
+  _? /(?=if|unless)/ TypeIfThenElse ->
+    return [$1, expressionizeTypeIf($3)]
   # NOTE: TypeCondition without ternary currently used for e.g. T<X extends Y>
   TypeCondition ( __ QuestionMark Type __ Colon Type )? ->
     if (!$2) return $1
@@ -6709,8 +6709,8 @@ TypeCondition
   TypeBinary NotDedented Extends Type
 
 TypeIfThenElse
-  ( If / Unless ) ( OpenParen TypeCondition CloseParen ) TypeBlock TypeElse?
-  ( If / Unless ) TypeCondition TypeBlock TypeElse?
+  _? ( If / Unless ) ( OpenParen TypeCondition CloseParen ) TypeBlock TypeElse?
+  _? ( If / Unless ) TypeCondition TypeBlock TypeElse?
 
 TypeElse
   NotDedented Else TypeBlock

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -15,6 +15,7 @@ const {
   dedentBlockString,
   dedentBlockSubstitutions,
   expressionizeIfClause,
+  expressionizeTypeIf,
   forRange,
   gatherBindingCode,
   getIndentLevel,
@@ -6520,7 +6521,7 @@ TypeIndex
 # parse both (?!).  For simplicity, we allow either in all cases.
 # In some cases (e.g. let/const), we transpile them away later.
 TypeSuffix
-  _? QuestionMark?:optional _? Colon Type:t -> {
+  _? QuestionMark?:optional _? Colon MaybeIndentedType:t -> {
     type: "TypeSuffix",
     ts: true,
     optional,
@@ -6536,7 +6537,7 @@ TypeSuffix
   # TypeScript has a special error for ! without : ("Declarations with definite
   # assignment assertions must also have type annotations.") but we parse it
   # so that the user can get this more useful error message.
-  NonNullAssertion _? (Colon Type)?:ct ->
+  NonNullAssertion _? (Colon MaybeIndentedType)?:ct ->
     const [colon, t] = ct ?? []
     return {
       type: "TypeSuffix",
@@ -6544,6 +6545,12 @@ TypeSuffix
       t,
       children: [ $1, $2, colon, t ],
     }
+
+MaybeIndentedType
+  PushIndent ( Nested Type )? PopIndent ->
+    if (!$2) return $skip
+    return $2
+  Type
 
 ReturnTypeSuffix
   _? QuestionMark?:optional _? Colon ReturnType:t ->
@@ -6688,9 +6695,30 @@ NestedType
   Nested TypeElement ArrayElementDelimiter
 
 TypeConditional
-  TypeBinary ( __ "extends" NonIdContinue Type ( __ QuestionMark Type __ Colon Type )? )? ->
-    if ($2) return $0
-    return $1
+  /(?=if|unless)/ TypeIfThenElse ->
+    return expressionizeTypeIf($2)
+  # NOTE: TypeCondition without ternary currently used for e.g. T<X extends Y>
+  TypeCondition ( __ QuestionMark Type __ Colon Type )? ->
+    if (!$2) return $1
+    return $0
+  TypeBinary
+
+TypeCondition
+  TypeBinary NotDedented Extends Type
+
+TypeIfThenElse
+  ( If / Unless ) ( OpenParen TypeCondition CloseParen ) TypeBlock TypeElse?
+  ( If / Unless ) TypeCondition TypeBlock TypeElse?
+
+TypeElse
+  NotDedented Else TypeBlock
+
+TypeBlock
+  Then Type -> $2
+  !EOS Type -> $2
+  PushIndent (Nested Type)? PopIndent ->
+    if (!$2) return $skip
+    return $2
 
 TypeTemplateSubstitution
   SubstitutionStart Type __ CloseBrace

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5599,7 +5599,7 @@ Typeof
 
 Unless
   "unless" NonIdContinue ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, negated: true }
 
 Until
   "until" NonIdContinue ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6547,6 +6547,8 @@ TypeSuffix
     }
 
 MaybeIndentedType
+  # NOTE: Let InterfaceBlock take first crack at an indented block
+  InterfaceBlock
   PushIndent ( Nested Type )? PopIndent ->
     if (!$2) return $skip
     return $2

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -57,3 +57,24 @@ describe "[TS] let declaration", ->
     let n  : undefined | (number)
   """
 
+  testCase """
+    let with indented type
+    ---
+    let x:
+      number | string
+  """
+
+  testCase """
+    let with indented conditional type
+    ---
+    let x:
+      if T extends Animal
+        string
+      else
+        number
+    ---
+    let x:
+      (T extends Animal?
+        string
+      : number)
+  """

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -68,6 +68,14 @@ describe "[TS] let declaration", ->
   """
 
   testCase """
+    let with one-line conditional type
+    ---
+    let x: if T extends Animal then string else number
+    ---
+    let x: (T extends Animal? string : number)
+  """
+
+  testCase """
     let with indented conditional type
     ---
     let x:

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -62,6 +62,9 @@ describe "[TS] let declaration", ->
     ---
     let x:
       number | string
+    ---
+    let x:
+      number | string
   """
 
   testCase """
@@ -76,5 +79,6 @@ describe "[TS] let declaration", ->
     let x:
       (T extends Animal?
         string
-      : number)
+      :
+        number)
   """

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -214,7 +214,7 @@ describe "[TS] type declaration", ->
       ---
       type Example1 = unless Dog extends Animal then number else string
       ---
-      type Example1 = (!(Dog extends Animal)? number : string)
+      type Example1 = (Dog extends Animal? string : number)
     """
 
     testCase """
@@ -251,6 +251,14 @@ describe "[TS] type declaration", ->
       type Example1 = if Dog extends Animal then number
       ---
       type Example1 = (Dog extends Animal? number:never)
+    """
+
+    testCase """
+      one-line unless no-else
+      ---
+      type Example1 = unless Dog extends Animal then number
+      ---
+      type Example1 = (Dog extends Animal?never: number)
     """
 
     testCase """

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -200,6 +200,107 @@ describe "[TS] type declaration", ->
     type Example1 = Dog extends Animal<infer U> ? U : string
   """
 
+  describe "if/else conditional", ->
+    testCase """
+      one-line
+      ---
+      type Example1 = if Dog extends Animal then number else string
+      ---
+      type Example1 = (Dog extends Animal? number : string)
+    """
+
+    testCase """
+      one-line unless
+      ---
+      type Example1 = unless Dog extends Animal then number else string
+      ---
+      type Example1 = (!(Dog extends Animal)? number : string)
+    """
+
+    testCase """
+      two-line
+      ---
+      type Example1 = if Dog extends Animal then number
+      else string
+      ---
+      type Example1 = (Dog extends Animal? number
+      : string)
+    """
+
+    testCase """
+      one-line parenthesized
+      ---
+      type Example1 = if (Dog extends Animal) number else string
+      ---
+      type Example1 = ((Dog extends Animal)? number : string)
+    """
+
+    testCase """
+      two-line parenthesized
+      ---
+      type Example1 = if (Dog extends Animal) number
+      else string
+      ---
+      type Example1 = ((Dog extends Animal)? number
+      : string)
+    """
+
+    testCase """
+      one-line no-else
+      ---
+      type Example1 = if Dog extends Animal then number
+      ---
+      type Example1 = (Dog extends Animal? number:never)
+    """
+
+    testCase """
+      multi-line indented
+      ---
+      type Example1 = if Dog extends Animal
+        number
+      else
+        string
+      ---
+      type Example1 = (Dog extends Animal?
+        number
+      :
+        string)
+    """
+
+    testCase """
+      multi-line extra indented
+      ---
+      type Example1 =
+        if Dog extends Animal
+          number
+        else
+          string
+      ---
+      type Example1 =
+        (Dog extends Animal?
+          number
+        :
+          string)
+    """
+
+    testCase """
+      else matching
+      ---
+      type Example1 =
+        if Dog extends Animal
+          if Dog extends Cat
+            number
+        else
+          string
+      ---
+      type Example1 =
+        (Dog extends Animal?
+          (Dog extends Cat?
+            number:never)
+        :
+          string)
+    """
+
   testCase """
     parens
     ---


### PR DESCRIPTION
As suggested by @esthedebeste on Discord, this PR allows for conditional (ternary) types to be given by `if`/`else` and `unless`/`else` expressions, with the usual support for then conditions (with condition delimited by parentheses, or then clause indented, or explicit `then`).

The `else` clause is optional, with a default value of `never`, which I find to be very common when writing conditional types.

Also added support for indenting a type specification in `let`.