### PR TITLE
Extends shorthand `<` and negated forms

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1473,6 +1473,14 @@ let breed: unless Civet extends Animal
   then undefined else string
 </Playground>
 
+You can also use [`<` as shorthand for `extends`](#extends),
+and the negated forms `not extends` and `!<`:
+
+<Playground>
+let verb: Civet < Cat ? "meow" : string
+let breed: Civet !< Animal ? undefined : string
+</Playground>
+
 ### Import
 
 <Playground>

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -644,7 +644,7 @@ function expressionizeTypeIf([ws, ifOp, condition, t, e])
     insertTrimmingSpace condition, ""
     "?"
   ]
-  unless ifOp.negated // if
+  unless ifOp.negated xor condition.negated // if
     children.push t
     if e
       // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -695,16 +695,13 @@ ExtendsClause
 
 ExtendsToken
   # NOTE: Added "<" extends shorthand
-  Loc:l __:ws ExtendsShorthand:t " "? ->
-    const children = [ ...ws, t, ]
+  Loc:l _?:ws ExtendsShorthand:t " "? ->
+    return [
+      ws || { $loc: l.$loc, token: " " },
+      t,
+    ]
 
-    if (!ws.length) {
-      children.unshift({ $loc: l.$loc, token: " " })
-    }
-
-    return { children }
-
-  __ Extends
+  _? Extends
 
 ExtendsShorthand
   "<" ->
@@ -6706,7 +6703,7 @@ TypeConditional
   TypeBinary
 
 TypeCondition
-  TypeBinary NotDedented Extends Type
+  TypeBinary IndentedFurther? ExtendsToken Type
 
 TypeIfThenElse
   _? ( If / Unless ) ( OpenParen TypeCondition CloseParen ) TypeBlock TypeElse?

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -696,16 +696,42 @@ ExtendsClause
 ExtendsToken
   # NOTE: Added "<" extends shorthand
   Loc:l _?:ws ExtendsShorthand:t " "? ->
-    return [
-      ws || { $loc: l.$loc, token: " " },
-      t,
-    ]
-
-  _? Extends
+    return {
+      type: "Extends",
+      children: [
+        ws || { $loc: l.$loc, token: " " },
+        t,
+      ],
+    }
+  _? Extends ->
+    return {
+      type: "Extends",
+      children: $0,
+    }
 
 ExtendsShorthand
   "<" ->
     return { $loc, token: "extends " }
+
+NotExtendsToken
+  Loc:l _?:ws1 OmittedNegation:ws2 ExtendsShorthand:t " "? ->
+    const ws = ws1 && ws2 ? [ws1, ws2] : ws1 || ws2 ||
+      { $loc: l.$loc, token: " " }
+    return {
+      type: "Extends",
+      negated: true,
+      children: [ ws, t ],
+    }
+  _? OmittedNegation Extends ->
+    return {
+      type: "Extends",
+      negated: true,
+      children: $0,
+    }
+
+OmittedNegation
+  ExclamationPoint -> ""
+  Not " "? _? -> $3
 
 ExtendsTarget
   LeftHandSideExpressionWithObjectApplicationForbidden:exp TypeArguments?:ta ->
@@ -6696,17 +6722,25 @@ NestedType
 TypeConditional
   _? /(?=if|unless)/ TypeIfThenElse ->
     return [$1, expressionizeTypeIf($3)]
-  # NOTE: TypeCondition without ternary currently used for e.g. T<X extends Y>
-  TypeCondition ( __ QuestionMark Type __ Colon Type )? ->
+  TypeCondition NotDedented QuestionMark Type __ Colon Type ->
+    if ($1.negated) return [ $1, $2, $3, $7, $5, $6, $4 ]
+    return $0
+  # NOTE: `X extends Y` type used for e.g. `T<X extends Y>`
+  TypeBinary ( IndentedFurther? ExtendsToken Type )? ->
     if (!$2) return $1
     return $0
-  TypeBinary
 
 TypeCondition
-  TypeBinary IndentedFurther? ExtendsToken Type
+  TypeBinary IndentedFurther? ( ExtendsToken / NotExtendsToken ) Type ->
+    return {
+      type: "TypeCondition",
+      negated: $3.negated,
+      children: $0,
+    }
 
 TypeIfThenElse
-  _? ( If / Unless ) ( OpenParen TypeCondition CloseParen ) TypeBlock TypeElse?
+  _? ( If / Unless ) ( OpenParen TypeCondition CloseParen ) TypeBlock TypeElse? ->
+    return [ $1, $2, $3[1], $4, $5 ]  // unwrap parentheses
   _? ( If / Unless ) TypeCondition TypeBlock TypeElse?
 
 TypeElse

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -269,6 +269,19 @@ describe "[TS] class", ->
     class A extends B implements I {}
   """
 
+  describe "not extends from type conditions invalid for classes", ->
+    throws """
+      not extends
+      ---
+      class A not extends B
+    """
+
+    throws """
+      !<
+      ---
+      class A !< B
+    """
+
   testCase """
     arrow field definitions
     ---

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -233,6 +233,31 @@ describe "[TS] type declaration", ->
       type Example1 = Dog extends Animal<infer U> ? U : string
     """
 
+  describe "not extends", ->
+    testCase """
+      not extends
+      ---
+      type Example1 = Dog not extends Animal ? number : string
+      ---
+      type Example1 = Dog extends Animal ? string : number
+    """
+
+    testCase """
+      !<
+      ---
+      type Example1 = Dog !< Animal ? number : string
+      ---
+      type Example1 = Dog extends Animal ? string : number
+    """
+
+    testCase """
+      not<
+      ---
+      type Example1 = Dog not< Animal ? number : string
+      ---
+      type Example1 = Dog extends Animal ? string : number
+    """
+
   describe "if/else conditional", ->
     testCase """
       one-line
@@ -251,6 +276,22 @@ describe "[TS] type declaration", ->
     """
 
     testCase """
+      one-line negated
+      ---
+      type Example1 = if Dog not extends Animal then number else string
+      ---
+      type Example1 = (Dog extends Animal? string : number)
+    """
+
+    testCase """
+      one-line negated unless
+      ---
+      type Example1 = unless Dog not extends Animal then number else string
+      ---
+      type Example1 = (Dog extends Animal? number : string)
+    """
+
+    testCase """
       two-line
       ---
       type Example1 = if Dog extends Animal then number
@@ -265,7 +306,7 @@ describe "[TS] type declaration", ->
       ---
       type Example1 = if (Dog extends Animal) number else string
       ---
-      type Example1 = ((Dog extends Animal)? number : string)
+      type Example1 = (Dog extends Animal? number : string)
     """
 
     testCase """
@@ -274,7 +315,7 @@ describe "[TS] type declaration", ->
       type Example1 = if (Dog extends Animal) number
       else string
       ---
-      type Example1 = ((Dog extends Animal)? number
+      type Example1 = (Dog extends Animal? number
       : string)
     """
 

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -200,6 +200,39 @@ describe "[TS] type declaration", ->
     type Example1 = Dog extends Animal<infer U> ? U : string
   """
 
+  describe "extends shorthand", ->
+    testCase """
+      conditional
+      ---
+      type Example1 = Dog < Animal ? number : string
+      ---
+      type Example1 = Dog extends Animal ? number : string
+    """
+
+    testCase """
+      conditional infer
+      ---
+      type Example1 = Dog < Animal<infer U> ? U : string
+      ---
+      type Example1 = Dog extends Animal<infer U> ? U : string
+    """
+
+    testCase """
+      tight conditional
+      ---
+      type Example1 = Dog<Animal ? number : string
+      ---
+      type Example1 = Dog extends Animal ? number : string
+    """
+
+    testCase """
+      tight conditional infer
+      ---
+      type Example1 = Dog<Animal<infer U> ? U : string
+      ---
+      type Example1 = Dog extends Animal<infer U> ? U : string
+    """
+
   describe "if/else conditional", ->
     testCase """
       one-line


### PR DESCRIPTION
As requested by @esthedebeste on Discord, this PR adds:
* `<` shorthand for `extends` in type conditions, matching existing support in classes
* Negated forms `not extends`, `!<`, and `not<` (though the last is a little ugly), via the trick of swapping the then/else clauses.
* Tighten some `__` and change a `NotDedented` from last PR to `IndentedFurther`. Otherwise we accidentally think there is extension going on in e.g. this test:
  ```ts
  type T = undefined
  <div />
  ```

Support for `unless ... not extends ...` is my first legit use of logical `xor`. 😸 