### PR TITLE
`T?` → `T | undefined`; `T??` → `T | undefined | null`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1458,6 +1458,14 @@ function f(x?: string)?: string
   x
 </Playground>
 
+More generally, `T?` allows for `undefined` and
+`T??` additionally allows for `null`:
+
+<Playground>
+let i: number?
+let x: string??
+</Playground>
+
 ### Conditional Types
 
 TypeScript's ternary types can be written using `if`/`unless` expressions,

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2112,11 +2112,20 @@ function makeExpressionStatement(expression: ASTNode): ASTNode
   else
     expression
 
+const typeNeedsNoParens = new Set [
+  "IdentifierType"
+  "ImportType"
+  "LiteralType"
+  "TupleType"
+  "ParenthesizedType"
+  "UnaryType"
+]
+
 /**
  * Parenthesize type if it might need it in some contexts.
  */
-function parenthesizeType(type)
-  // TODO: avoid parens in some cases
+function parenthesizeType(type: ASTNodeBase)
+  return type if typeNeedsNoParens.has type.type
   ["(", type, ")"]
 
 // Adjust a parsed string by escaping newlines
@@ -3410,7 +3419,7 @@ function processPipelineExpressions(statements): void {
 
 function processTypes(node: ASTNode)
   // T? -> T | undefined; T?? -> T | undefined | null
-  gatherRecursiveAll node, (n) => n.type is "TypeUnary"
+  gatherRecursiveAll node, (n) => n.type is "UnaryType"
   // @ts-ignore
   .forEach (unary: ASTNodeBase): void =>
     let last: ASTNode

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -14,7 +14,7 @@ type ASTNodeBase =
   names?: string[]
   parent?: ASTNodeBase | undefined
 
-type ASTError =
+type ASTError = ASTNodeBase &
   type: "Error"
   message: string
 
@@ -22,7 +22,7 @@ type Loc =
   pos: number
   length: number
 
-type ASTLeaf =
+type ASTLeaf = ASTNodeBase &
   $loc: Loc
   token: string
 
@@ -70,7 +70,7 @@ type LabeledStatement
 
 type ElseToken = { $loc: Loc, token: "else" }
 
-type ASTRef =
+type ASTRef = ASTNodeBase &
   type: "Ref"
   base: string
   id: string
@@ -1282,7 +1282,7 @@ function findChildIndex(parent, child)
 /**
  * Replace this node with another, by modifying its parent's children.
  */
-function replaceNode(node: ASTNodeBase, newNode: ASTNodeBase): void
+function replaceNode(node: ASTNodeBase, newNode: ASTNode): void
   unless node.parent?
     throw new Error "replaceNode failed: node has no parent"
   function recurse(children: ASTNode[]): boolean
@@ -1295,7 +1295,8 @@ function replaceNode(node: ASTNodeBase, newNode: ASTNodeBase): void
     return false
   unless recurse node.parent.children
     throw new Error "replaceNode failed: didn't find child node in parent"
-  newNode.parent = node.parent
+  if newNode <? "object" and not Array.isArray newNode
+    newNode.parent = node.parent
 
 /**
  * Find nearest strict `ancestor` that satisfies predicate,
@@ -3407,6 +3408,38 @@ function processPipelineExpressions(statements): void {
     })
 }
 
+function processTypes(node: ASTNode)
+  // T? -> T | undefined; T?? -> T | undefined | null
+  gatherRecursiveAll node, (n) => n.type is "TypeUnary"
+  // @ts-ignore
+  .forEach (unary: ASTNodeBase): void =>
+    let last: ASTNode
+    count .= 0
+    while unary.suffix.length and unary.suffix.-1?.token is "?"
+      last = unary.suffix.pop()
+      count++
+    return unless count
+    if unary.parent?.type is "TypeTuple"
+      // Leave one ? inside a type tuple
+      if count is 1
+        unary.suffix.push last
+        return
+      replaceNode unary, [
+        getTrimmingSpace unary
+        "("
+        parenthesizeType insertTrimmingSpace unary, ""
+        " | null)"
+        last
+      ]
+    else
+      replaceNode unary, [
+        getTrimmingSpace unary
+        "("
+        parenthesizeType insertTrimmingSpace unary, ""
+        count is 1 ? " | undefined" : " | undefined | null"
+        ")"
+      ]
+
 function processProgram(root: BlockStatement, config, m, ReservedWord): void {
   // invariants
   assert.equal(m.forbidBracedApplication.length, 1, "forbidBracedApplication")
@@ -3420,6 +3453,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord): void {
 
   const { expressions: statements } = root
 
+  processTypes(statements)
   processDeclarationConditions(statements)
   processPipelineExpressions(statements)
   processDeclarations(statements)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6604,7 +6604,7 @@ TypeUnary
   ( __ TypeUnaryOp NonIdContinue )*:prefix TypePrimary:t TypeUnarySuffix*:suffix ->
     if (!prefix.length && !suffix.length) return t
     return {
-      type: "TypeUnary",
+      type: "UnaryType",
       prefix,
       suffix,
       t,
@@ -6668,7 +6668,7 @@ TypePrimary
   _? OpenParen ( Type / ( EOS Type ) ) __ CloseParen ->
     return {
       type: "ParenthesizedType",
-      chidren: $0,
+      children: $0,
     }
 
 ImportType

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6601,9 +6601,16 @@ TypeBinary
     return [optionalPrefix, t, ops]
 
 TypeUnary
-  ( __ TypeUnaryOp NonIdContinue )* TypePrimary TypeUnarySuffix* ->
-    if (!$1.length && !$3.length) return $2
-    return [...$1, $2, ...$3]
+  ( __ TypeUnaryOp NonIdContinue )*:prefix TypePrimary:t TypeUnarySuffix*:suffix ->
+    if (!prefix.length && !suffix.length) return t
+    return {
+      type: "TypeUnary",
+      prefix,
+      suffix,
+      t,
+      // omit empty prefix for trimming space
+      children: prefix.length ? $0 : [t, suffix],
+    }
 
 TypeUnarySuffix
   TypeIndexedAccess
@@ -6623,11 +6630,17 @@ UnknownAlias
     return { $loc, token: "unknown" }
 
 TypePrimary
-  _? TypeTuple
+  _? TypeTuple ->
+    return { ...$2, children: [ $1, ...$2.children ] }
   InterfaceBlock
   _? FunctionType
   _? InlineInterfaceLiteral
-  _? ImportType
+  _? ImportType:t ->
+    return {
+      type: "ImportType",
+      t,
+      children: $0,
+    }
   _? TypeLiteral:t ->
     return {
       type: "LiteralType",
@@ -6652,7 +6665,11 @@ TypePrimary
   # A parenthesized inline interface (a: T) ---> ({a: T})
   # NOTE: Check Type before ( EOS Type ) to find implicit nested interfaces first. EOS would swallow the
   # newline so Nested wouldn't match otherwise.
-  _? OpenParen ( Type / ( EOS Type ) ) __ CloseParen
+  _? OpenParen ( Type / ( EOS Type ) ) __ CloseParen ->
+    return {
+      type: "ParenthesizedType",
+      chidren: $0,
+    }
 
 ImportType
   "import" OpenParen __ StringLiteral __ CloseParen ( Dot IdentifierName )? TypeArguments?
@@ -6660,8 +6677,11 @@ ImportType
   "import" InsertOpenParen Trimmed_ StringLiteral InsertCloseParen
 
 TypeTuple
-  OpenBracket NestedTypeList __ CloseBracket
-  OpenBracket TypeList? __ CloseBracket
+  OpenBracket ( NestedTypeList / TypeList? ) __ CloseBracket ->
+    return {
+      type: "TypeTuple",
+      children: $0,
+    }
 
 TypeList
   TypeElement (__ Comma TypeElement)*

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -80,7 +80,7 @@ describe "[TS] function", ->
     function x(a: number, b?: number) ?: number
       return a + b
     ---
-    function x(a: number, b?: number) : (undefined | (number)) {
+    function x(a: number, b?: number) : (undefined | number) {
       return a + b
     }
   """
@@ -175,7 +175,7 @@ describe "[TS] function", ->
     const x = (a: number, b?: number) ?: number ->
       return a + b
     ---
-    const x = function(a: number, b?: number) : (undefined | (number)) {
+    const x = function(a: number, b?: number) : (undefined | number) {
       return a + b
     }
   """

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -38,7 +38,7 @@ describe "[TS] let declaration", ->
     ---
     let n?: number
     ---
-    let n: undefined | (number)
+    let n: undefined | number
   """
 
   testCase """
@@ -46,7 +46,7 @@ describe "[TS] let declaration", ->
     ---
     n?: number .= undefined
     ---
-    let n: undefined | (number) = undefined
+    let n: undefined | number = undefined
   """
 
   testCase """
@@ -54,7 +54,7 @@ describe "[TS] let declaration", ->
     ---
     let n ? : number
     ---
-    let n  : undefined | (number)
+    let n  : undefined | number
   """
 
   testCase """

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -506,6 +506,14 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    tuples with optionals
+    ---
+    type Point = [number, number, number?]
+    ---
+    type Point = [number, number, number?]
+  """
+
+  testCase """
     named tuples
     ---
     type Point = [x: number, y: number, z?: number]
@@ -544,3 +552,28 @@ describe "[TS] type declaration", ->
     ---
     type Test = [...nums: number[], ...strings: string[]]
   """
+
+  describe "| undefined shorthand", ->
+    testCase """
+      ?
+      ---
+      type Name = string?
+      ---
+      type Name = ((string) | undefined)
+    """
+
+    testCase """
+      ??
+      ---
+      type Name = string??
+      ---
+      type Name = ((string) | undefined | null)
+    """
+
+    testCase """
+      ?? in tuple
+      ---
+      type Names = [string??]
+      ---
+      type Names = [((string) | null)?]
+    """

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -559,7 +559,7 @@ describe "[TS] type declaration", ->
       ---
       type Name = string?
       ---
-      type Name = ((string) | undefined)
+      type Name = (string | undefined)
     """
 
     testCase """
@@ -567,7 +567,7 @@ describe "[TS] type declaration", ->
       ---
       type Name = string??
       ---
-      type Name = ((string) | undefined | null)
+      type Name = (string | undefined | null)
     """
 
     testCase """
@@ -575,5 +575,5 @@ describe "[TS] type declaration", ->
       ---
       type Names = [string??]
       ---
-      type Names = [((string) | null)?]
+      type Names = [(string | null)?]
     """


### PR DESCRIPTION
Fixes #144 according to recent proposal in Discord. Do we like it? `T?` → `T | undefined` is nicely consistent with TypeScript's other optional types, but `T??` → `T | undefined | null` corresponds to our runtime `x?` operator. Maybe the closest we can get, though.

Also remove some excess parentheses (finally) in this type manipulation.

I notice that our rules are of the form `TypeUnary` but our AST node `type` strings are of the form `UnaryType`. Not sure whether we should fix this...