### PR TITLE
Added (+) binary op to function shorthand

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1777,6 +1777,7 @@ FunctionExpression
       block,
     }
   # Identity function shorthand
+  # NOTE: Currently shadows (&) binary & operator, we might want to revisit
   "(&)" ->
     const ref = makeRef("$"), body = [ref]
 
@@ -1794,8 +1795,36 @@ FunctionExpression
       signature: {
         modifier: {},
       },
-      children: [ref, " => ", body],
+      children: [parameters, " => ", body],
       ref,
+      body,
+      ampersandBlock: true,
+      block,
+      parameters,
+    }
+
+  # BinaryOp function shorthand
+  OpenParen:open !Identifier !Not BinaryOp:op CloseParen:close ->
+    const refA = makeRef("a")
+      refB = makeRef("b"),
+      body = [refA, op, refB]
+
+    const parameters = {
+      type: "Parameters",
+      children: [open, refA, ",", refB, close],
+      names: [],
+    }
+
+    const block = {
+      expressions: [[refA, op, refB]],
+    }
+
+    return {
+      type: "ArrowFunction",
+      signature: {
+        modifier: {},
+      },
+      children: [parameters, " => ", body],
       body,
       ampersandBlock: true,
       block,

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -34,6 +34,18 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    binary op
+    ---
+    items.reduce (+), 0
+    items.reduce (&&), true
+    items.reduce (||), false
+    ---
+    items.reduce((a,b) => a+b, 0)
+    items.reduce((a1,b1) => a1&&b1, true)
+    items.reduce((a2,b2) => a2||b2, false)
+  """
+
+  testCase """
     omit & with ?
     ---
     x.map ?.name


### PR DESCRIPTION
This was pretty simple to add but currently `(&)` as the `$=>$` shorthand is shadowing `(&)` as the binary operator.

It's probably fine to keep it for now but we may want to revisit the identity function shorthand or allow it to be the binary `&`.