### PR TITLE
`(foo)` for custom operators `foo`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1804,10 +1804,15 @@ FunctionExpression
     }
 
   # BinaryOp function shorthand
-  OpenParen:open !Identifier !Not BinaryOp:op CloseParen:close ->
+  OpenParen:open BinaryOp:op CloseParen:close ->
+    // (foo) doesn't need an arrow wrapper; just foo suffices
+    if (op.special && op.call && !op.negated) return op.call
+
     const refA = makeRef("a")
       refB = makeRef("b"),
-      body = [refA, op, refB]
+      body = processBinaryOpExpression([refA, [
+        [[], op, [], refB] // BinaryOpRHS
+      ]])
 
     const parameters = {
       type: "Parameters",
@@ -1816,7 +1821,7 @@ FunctionExpression
     }
 
     const block = {
-      expressions: [[refA, op, refB]],
+      expressions: [body],
     }
 
     return {

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -719,7 +719,7 @@ describe "custom identifier infix operators", ->
     x (foo) y
     ---
 
-    x((foo)(y))
+    x(foo(y))
   """
 
   testCase """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -54,6 +54,34 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    parenthesized special op
+    ---
+    items.reduce (is in), false
+    ---
+    items.reduce(((a,b) => b.includes(a)), false)
+  """
+
+  testCase """
+    parenthesized custom op
+    ---
+    operator foo
+    items.reduce (foo), 0
+    ---
+
+    items.reduce(foo, 0)
+  """
+
+  testCase """
+    parenthesized negated custom op
+    ---
+    operator foo
+    items.reduce (not foo), false
+    ---
+
+    items.reduce(((a,b) => !foo(a,b)), false)
+  """
+
+  testCase """
     omit & with ?
     ---
     x.map ?.name


### PR DESCRIPTION
Extension of #912 as mentioned in https://github.com/DanielXMoore/Civet/pull/912#discussion_r1441907448

Also fixes complex operators like `is in` which currently crash the compiler.

This completes Level 2 of #791.