### PR TITLE
LSP pass on more completion info

### DIFF
--- a/lsp/source/lib/util.mts
+++ b/lsp/source/lib/util.mts
@@ -197,7 +197,7 @@ function shouldIncludeEntry(item: NavigationTree | NavigationBarItem): boolean {
   return !!(item.text && item.text !== '<function>' && item.text !== '<class>');
 }
 
-function parseKindModifier(kindModifiers: string): Set<string> {
+export function parseKindModifier(kindModifiers: string): Set<string> {
   return new Set(kindModifiers.split(/,|\s+/g));
 }
 


### PR DESCRIPTION
I ported over more of [TypeScript's completion code](https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts), resulting in these minor improvements:

* Show source of imports in completion description
* Optional completions get `?` suffix (e.g. completing `x.y` when `x` has type `{ y?: ... }`
* Deprecated completions get some kind of deprecation flag
* Respect `filterText`, `sortText`, `isRecommended`, `replacementSpan` (not sure if these are used though)

My original goal was #922, but I got kind of lost how to create a custom completion command to execute a follow-up query (`completionEntryDetails`) and get the additional edits to do. Do you know how to create a command ([`registerCommand`](https://github.com/microsoft/vscode/blob/e244acbb172c428cb219717a07bf55d2737492ca/extensions/typescript-language-features/src/commands/commandManager.ts#L26)) in this context? Can it even be done in a service, or is it supposed to be in `extension.civet`?