### PR TITLE
Use .tsx extension for TypeScript type checking

### DIFF
--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -287,18 +287,21 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}, meta) => {
           sourceMap: true,
         });
 
-        const resolved = path.resolve(process.cwd(), id);
+        const resolved = filename + outExt;
         sourceMaps.set(
           resolved,
           compiledTS.sourceMap as SourceMap
         );
 
         if (transformTS) {
-          fsMap.set(resolved, compiledTS.code);
+          // Force .tsx extension for type checking purposes.
+          // Otherwise, TypeScript complains about types in .jsx files.
+          const tsx = filename + '.tsx';
+          fsMap.set(tsx, compiledTS.code);
           // Vite and Rollup normalize filenames to use `/` instead of `\`.
           // We give the TypeScript VFS both versions just in case.
-          const slashed = slash(resolved);
-          if (resolved !== slashed) fsMap.set(slashed, compiledTS.code);
+          const slashed = slash(tsx);
+          if (tsx !== slashed) fsMap.set(slashed, compiledTS.code);
         }
 
         switch (options.ts) {


### PR DESCRIPTION
When transpiling to JavaScript via `"tsc"` mode, we currently set the extension to `.jsx`, which makes sense, except that it breaks type checking.

Before this PR, we got messages like this:

```
vite v4.5.1 building for production...
✓ 2 modules transformed.
src/main.civet.jsx:3:15 - error TS8010: Type annotations can only be used in TypeScript files.

3 function f(b: number) {
                ~~~~~~
src/module.civet.jsx:1:15 - error TS8010: Type annotations can only be used in TypeScript files.

1 export var a: string = "a"
                ~~~~~~
```

After, we get messages like this:

```
vite v4.5.1 building for production...
✓ 2 modules transformed.
src/main.civet.tsx:7:15 - error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.

7 console.log(f(a))
                ~
```
```