### PR TITLE
Support TS instantiation expressions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -193,17 +193,17 @@ Arguments
     return $skip
 
 ImplicitArguments
-  ( TypeArguments !ImplementsToken )?:ta ApplicationStart InsertOpenParen:open _?:ws NonPipelineArgumentList:args InsertCloseParen:close ->
+  ApplicationStart InsertOpenParen:open _?:ws NonPipelineArgumentList:args InsertCloseParen:close ->
     // Don't treat as call if this is a postfix for/while/until/if/unless
     if (args.length === 1 && args[0].type === "IterationExpression" &&
         args[0].subtype !== "DoStatement" && !args[0].async &&
         isEmptyBareBlock(args[0].block)) {
       return $skip
     }
-    return [ta?.[0], open, insertTrimmingSpace(ws, ""), args, close]
+    return [open, insertTrimmingSpace(ws, ""), args, close]
 
 ExplicitArguments
-  TypeArguments? OpenParen ArgumentList? ( __ Comma )? __ CloseParen
+  OpenParen ArgumentList? ( __ Comma )? __ CloseParen
 
 # Start of function application, inserts an open parenthesis, maintains spacing and comments when possible
 ApplicationStart
@@ -735,10 +735,8 @@ OmittedNegation
   Not " "? _? -> $3
 
 ExtendsTarget
-  LeftHandSideExpressionWithObjectApplicationForbidden:exp TypeArguments?:ta ->
-    exp = makeLeftHandSideExpression(exp)
-    if (ta) return [exp, ta]
-    return exp
+  LeftHandSideExpressionWithObjectApplicationForbidden:exp ->
+    return makeLeftHandSideExpression(exp)
 
 ImplementsClause
   ImplementsToken ImplementsTarget ( Comma ImplementsTarget )* ->
@@ -950,7 +948,7 @@ LeftHandSideExpression
   # NOTE: Merged in NewExpression
   # NOTE: Changed to CallExpression to handle arguments
   # NOTE: Eliminated left recursion
-  ( New !( "." / ":" ) __ )+ CallExpression TypeArguments?
+  ( New !( "." / ":" ) __ )+ CallExpression
   CallExpression
   # NOTE: OptionalExpression is merged into CallExpression
 
@@ -984,13 +982,16 @@ CallExpression
 
 CallExpressionRest
   MemberExpressionRest
+  # NOTE: TypeScript instantiation expressions
+  # https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#instantiation-expressions
+  # But x<y>z and x<y>0 is a comparison chain.
+  TypeArguments !( IdentifierName / NumericLiteral ) -> $1
   # perf: assertion to exit early
-  /(?=['"`<])/ TypeArguments?:args ( TemplateLiteral / StringLiteral ):literal ->
+  /(?=['"`])/ ( TemplateLiteral / StringLiteral ):literal ->
     if (literal.type === "StringLiteral") {
       literal = "`" + literal.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
     }
-    if (!args) return literal
-    return [args, literal]
+    return literal
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
   OptionalShorthand? ArgumentsWithTrailingMemberExpressions ->
     if (!$1) return $2

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -90,6 +90,16 @@ describe "binary operations", ->
   """
 
   testCase """
+    snug < with literal
+    ---
+    x<y
+    x<y>0
+    ---
+    x<y
+    x<y && y>0
+  """
+
+  testCase """
     typeof shorthand
     ---
     a <? "string"

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -386,6 +386,14 @@ describe "[TS] function", ->
       x<T>(y)
     """
 
+    testCase """
+      instantiation expressions
+      ---
+      y := x<T>
+      ---
+      const y = x<T>
+    """
+
   describe "this type", ->
     testCase """
       interface method

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -390,8 +390,10 @@ describe "[TS] function", ->
       instantiation expressions
       ---
       y := x<T>
+      z
       ---
       const y = x<T>
+      z
     """
 
   describe "this type", ->


### PR DESCRIPTION
Fixes #939

This actually cleaned up the grammar some; before, we had to check for `TypeArguments` in every call scenario. Now it's part of `CallExpression`.

There's some fun ambiguity with tight comparison chains. But note that `x<y>(z)` was already treated like a function call, not a comparison chain. I preserved the working of `x<y>z` and `x<y>0` but there might be other more subtle cases that break...