### PR TITLE
Shorthand for type indexed access

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1568,6 +1568,29 @@ enum Direction
   Right = 2 * Left
 </Playground>
 
+### Indexing Types
+
+[Indexed access types](https://www.typescriptlang.org/docs/handbook/2/indexed-access-types.html)
+can be written with a `.` when accessing a string, template, or number:
+
+<Playground>
+type Age = Person."age"
+type First = TupleType.0
+type Data = T.`data-${keyof Person}`
+</Playground>
+
+Note that `T.x` is reserved for
+[TypeScript namespaces](https://www.typescriptlang.org/docs/handbook/namespaces.html),
+so you need to add quotes around `x` for indexed access.
+
+You can also enable [CoffeeScript prototype style](#coffeescript-operators)
+indexed access:
+
+<Playground>
+"civet coffeePrototype"
+type Age = Person::age
+</Playground>
+
 ### Assertions
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6723,6 +6723,22 @@ TypeUnaryOp
 
 TypeIndexedAccess
   OpenBracket Type? __ CloseBracket
+  # NOTE: Added shorthand T."string" -> T["string"] and T.0 -> T[0]
+  Dot:dot ( TemplateLiteral / StringLiteral / IntegerLiteral ):literal ->
+    const open = { ...dot, token: "[" }
+    return [
+      open,
+      literal,
+      "]"
+    ]
+  # NOTE: Extension of coffeePrototype syntax: T::x -> T["x"]
+  CoffeePrototypeEnabled DoubleColon:p IdentifierName?:id ->
+    const open = { ...p, token: '["' }
+    return [
+      open,
+      id,
+      '"]'
+    ]
 
 UnknownAlias
   "???" ->

--- a/test/types/shorthand-const.civet
+++ b/test/types/shorthand-const.civet
@@ -1,6 +1,6 @@
 {testCase} from ../helper.civet
 
-describe "[TS] shortand const", ->
+describe "[TS] shorthand const", ->
   testCase """
     works with types
     ---

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -471,6 +471,40 @@ describe "[TS] type declaration", ->
     type Age = Person["age"]
   """
 
+  describe "indexed access shorthand", ->
+    testCase """
+      dot string
+      ---
+      type Age = Person."age"
+      ---
+      type Age = Person["age"]
+    """
+
+    testCase """
+      dot template
+      ---
+      type Age = Person.`age${x}`
+      ---
+      type Age = Person[`age${x}`]
+    """
+
+    testCase """
+      dot number
+      ---
+      type Age = Person.0
+      ---
+      type Age = Person[0]
+    """
+
+    testCase """
+      coffeePrototype
+      ---
+      "civet coffeePrototype"
+      type Age = Person::age
+      ---
+      type Age = Person["age"]
+    """
+
   testCase """
     index signature
     ---


### PR DESCRIPTION
Mainly this adds `T."x"` and related access to types, paralleling our existing support for this notation in expressions.

For consideration, I also added `T::x` shorthand for `T["x"]` when `coffeePrototype` is enabled. I think this intuitive for those who have this flag on (think of `T` as a class), though of course there isn't an actual notion of prototype here. I could also remove this if you think it's not ideal. (It still leaves our options for `::` open when `coffeePrototype` is off. I also don't think this conflicts with any of our current intentions for `::`.)