### PR TITLE
`!op` shorthand for `not op`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -369,6 +369,8 @@ a and b
 a or b
 a not in b
 a not instanceof b
+a !in b
+a !instanceof b
 a?
 </Playground>
 
@@ -452,6 +454,7 @@ a <? "string"
 a !<? "string"
 a instanceof "number"
 a not instanceof "number"
+a !instanceof "number"
 </Playground>
 
 ### Logical XOR Operator
@@ -817,6 +820,7 @@ You can "bless" an existing function to behave as an infix operator
 operator contains
 x contains y
 x not contains y
+x !contains y
 </Playground>
 
 You can combine this with a [variable declaration](#variable-declaration):

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -230,7 +230,7 @@ ForbiddenImplicitCalls
   Identifier:id !"(" ->
     if (module.operators.has(id.name)) return $0
     return $skip
-  Not _? Identifier:id ->
+  OmittedNegation _? Identifier:id ->
     if (module.operators.has(id.name)) return $0
     return $skip
   # `x ... y` is reserved for a range, but `x ...y` is an implicit call
@@ -3316,7 +3316,7 @@ _BinaryOp
       call: id,
       special: true,
     }
-  Not __ Identifier:id ->
+  OmittedNegation __ Identifier:id ->
     if (!module.operators.has(id.name)) return $skip
     return {
       call: id,
@@ -3416,7 +3416,7 @@ BinaryOpSymbol
       special: true, // for typeof shorthand
     }
   CoffeeOfEnabled CoffeeOfOp:op -> op
-  Not __ NotOp:op ->
+  OmittedNegation __ NotOp:op ->
     return { ...op, $loc }
   ( Is __ In ) / "∈" ->
     return {
@@ -3438,7 +3438,7 @@ BinaryOpSymbol
       special: true,
       negated: true,
     }
-  ( Is __ Not __ In ) / "∉" ->
+  ( Is __ OmittedNegation __ In ) / "∉" ->
     return {
       method: "includes",
       relational: true,
@@ -3484,14 +3484,14 @@ CoffeeOfOp
       suffix: " >= 0",
       special: true,
     }
-  Not __ Of NonIdContinue ->
+  OmittedNegation __ Of NonIdContinue ->
     return {
       $loc,
       token: "in",
       special: true,
       negated: true,
     }
-  Not __ In ->
+  OmittedNegation __ In ->
     return {
       call: [module.getRef("indexOf"), ".call"],
       relational: true,

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -106,10 +106,12 @@ describe "binary operations", ->
     a !<? "string"
     a instanceof "string"
     a not instanceof "string"
+    a !instanceof "string"
     ---
     typeof a === "string"
     typeof a !== "string"
     typeof a === "string"
+    typeof a !== "string"
     typeof a !== "string"
   """
 
@@ -217,6 +219,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    !in operator
+    ---
+    a !in b
+    ---
+    !(a in b)
+  """
+
+  testCase """
     not in after logical
     ---
     v and v.type is not in ["CallExpression", "MemberExpression", "Identifier"]
@@ -262,6 +272,14 @@ describe "binary operations", ->
     is not in operator
     ---
     a is not in b
+    ---
+    !b.includes(a)
+  """
+
+  testCase """
+    is !in operator
+    ---
+    a is !in b
     ---
     !b.includes(a)
   """
@@ -516,6 +534,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    !instanceof
+    ---
+    a !instanceof b
+    ---
+    !(a instanceof b)
+  """
+
+  testCase """
     comma operator outside parens
     ---
     f(), g()
@@ -747,6 +773,16 @@ describe "custom identifier infix operators", ->
     ---
     operator foo
     x not foo y
+    ---
+
+    !foo(x, y)
+  """
+
+  testCase """
+    ! operator
+    ---
+    operator foo
+    x !foo y
     ---
 
     !foo(x, y)

--- a/test/compat/coffee-of.civet
+++ b/test/compat/coffee-of.civet
@@ -32,6 +32,16 @@ describe "coffeeOf", ->
   """
 
   testCase """
+    !in
+    ---
+    "civet coffee-compat"
+    a !in b
+    ---
+    var indexOf: <T>(this: T[], searchElement: T) => number = [].indexOf as any;
+    indexOf.call(b, a) < 0
+  """
+
+  testCase """
     indexOf doesn't collide with other refs
     ---
     "civet coffee-compat"
@@ -89,6 +99,15 @@ describe "coffeeOf", ->
     ---
     "civet coffee-compat"
     a not of b
+    ---
+    !(a in b)
+  """
+
+  testCase """
+    a !of b
+    ---
+    "civet coffee-compat"
+    a !of b
     ---
     !(a in b)
   """


### PR DESCRIPTION
On Discord, we've had a request for a `!in` operator as shorthand for `not in`.

I've added `!op` support wherever we had support for `not op` (assuming I didn't miss any).