### PR TITLE
Cleanup Call arguments AST, fix (+) processing

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -819,31 +819,26 @@ function processCallMemberExpression(node)
   // use of the operator. This is useful for e.g. shortcutting (&&).
   if children[0]?.parenthesizedOp?.token and children[1]?.type is "Call"
     op := children[0].parenthesizedOp
-    args := clone children[1]
+    call .= children[1]
+    args := [...call.args] // shallow copy
+    call = { ...call, args }
+    // Remove trailing comma
+    if comma := isComma args.-1
+      comma.token = ''
     // Arguments already start and end with open and close parentheses.
     // Replace each comma with an instance of the operator and matching parens.
-    argSinceComma .= false
     commaCount .= 0
-    let lastComma
-    gatherRecursive args, (n) =>
-      if n.type? and n.type is not "Comment"
-        argSinceComma = true
-      if n.token is ","
-        argSinceComma = false
-        return true
-    .forEach (comma): void =>
-      comma.token = `)${op.token}(`
-      lastComma = comma
-      commaCount++
-    // Ignore trailing comma
-    if not argSinceComma and lastComma?
-      lastComma.token = ''
-      commaCount--
+    for each arg of args
+      if comma := isComma arg
+        comma.token = `)${op.token}(`
+        commaCount++
     // Don't mess with (+)()
-    if commaCount > 0
+    if args.length
       children.splice 0, 2,
-        type: "ParenthesizedExpression",
-        children: ["(", args, ")"]
+        commaCount ?
+          type: "ParenthesizedExpression",
+          children: ["(", call, ")"]
+        : call
 
   // Process globs and bind shorthand
   for (let i = 0; i < children.length; i++) {
@@ -1683,6 +1678,18 @@ function isExit(node: ASTNode): boolean
     "BreakStatement",
     "ContinueStatement"
   ]
+
+/**
+ * Detects Comma, CommaDelimiter, and ParameterElementDelimiter
+ * with an explicit comma, as should be at the top level of
+ * a "Call" node's `args` array.
+ * Returns the node whose `token` is ",", or else undefined.
+ */
+function isComma(node: ASTNode): (ASTLeaf & { token: "," }) | undefined
+  if node?.token is ","
+    node
+  else if Array.isArray(node) and node.-1?.token is ","
+    node.-1
 
 function gatherRecursiveWithinFunction(node, predicate) {
   return gatherRecursive(node, predicate, isFunction)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -202,15 +202,37 @@ Arguments
 ImplicitArguments
   ApplicationStart InsertOpenParen:open _?:ws NonPipelineArgumentList:args InsertCloseParen:close ->
     // Don't treat as call if this is a postfix for/while/until/if/unless
-    if (args.length === 1 && args[0].type === "IterationExpression" &&
-        args[0].subtype !== "DoStatement" && !args[0].async &&
-        isEmptyBareBlock(args[0].block)) {
-      return $skip
+    if (args.length === 1) {
+      let arg0 = args[0]
+      if (Array.isArray(arg0)) arg0 = arg0[1] // skip whitespace
+      if (arg0.type === "IterationExpression" &&
+          arg0.subtype !== "DoStatement" && !arg0.async &&
+          isEmptyBareBlock(arg0.block)) {
+        return $skip
+      }
     }
-    return [open, insertTrimmingSpace(ws, ""), args, close]
+    return {
+      type: "Call",
+      args,
+      children: [open, insertTrimmingSpace(ws, ""), args, close]
+    }
 
 ExplicitArguments
-  OpenParen ArgumentList? ( __ Comma )? __ CloseParen
+  OpenParen:open ( ArgumentList ( __ Comma )? )?:args __:ws CloseParen:close ->
+    if (args) {
+      if (args[1]) { // trailing comma
+        args = [ ...args[0], args[1] ]
+      } else { // no trailing comma
+        args = args[0]
+      }
+    } else { // no arguments
+      args = []
+    }
+    return {
+      type: "Call",
+      args,
+      children: [open, args, ws, close],
+    }
 
 # Start of function application, inserts an open parenthesis, maintains spacing and comments when possible
 ApplicationStart
@@ -238,11 +260,7 @@ ForbiddenImplicitCalls
 
 ArgumentsWithTrailingMemberExpressions
   Arguments:args AllowedTrailingMemberExpressions:trailing ->
-    const call = {
-      type: "Call",
-      children: args,
-    }
-    return [ call, ...trailing ]
+    return [ args, ...trailing ]
 
 TrailingMemberExpressions
   # NOTE: Assert "." to not match "?" or "!" as a member expression on the following line
@@ -265,39 +283,62 @@ CommaDelimiter
   NotDedented Comma
 
 # https://262.ecma-international.org/#prod-ArgumentList
+# NOTE: Return value should always be an array alternating
+#   argument, comma, argument, comma, ..., argument, [comma],
+# where each comma is a Comma token or an array [whitespace, commaToken]
+# (like CommaDelimiter)
 ArgumentList
   # Check for same line arguments then nested arguments
-  ArgumentPart ( CommaDelimiter !EOS ArgumentPart )* ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+
+  ArgumentPart ( CommaDelimiter !EOS ArgumentPart )* ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
+    return [
+      $1,
+      ...$2.flatMap(([comma, eos, arg]) => [comma, arg]),
+      ...$3.flatMap(([comma, args]) =>
+        Array.isArray(args) ? [comma, ...args] : [comma, args]
+      )
+    ]
   # NOTE: Added nested arguments on separate new lines
   NestedImplicitObjectLiteral ->
-    return insertTrimmingSpace($1, '')
+    return [ insertTrimmingSpace($1, '') ]
   NestedArgumentList
   # NOTE: Eliminated left recursion
-  _? ArgumentPart ( CommaDelimiter _? ArgumentPart )* ->
-    return [...($1 || []), $2, ...$3]
+  ( _? ArgumentPart ) ( CommaDelimiter ( _? ArgumentPart ) )* ->
+    return [ $1, ...$2.flat() ]
 
 # NOTE: ArgumentList variant that forbids top-level pipeline operators
 NonPipelineArgumentList
   # Check for same line arguments then nested arguments
-  NonPipelineArgumentPart ( CommaDelimiter !EOS NonPipelineArgumentPart )* ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+
+  NonPipelineArgumentPart ( CommaDelimiter !EOS NonPipelineArgumentPart )* ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
+    return [
+      $1,
+      ...$2.flatMap(([comma, eos, arg]) => [comma, arg]),
+      ...$3.flatMap(([comma, args]) =>
+        Array.isArray(args) ? [comma, ...args] : [comma, args]
+      )
+    ]
   # NOTE: Added nested arguments on separate new lines
   NestedImplicitObjectLiteral ->
-    return insertTrimmingSpace($1, '')
+    return [ insertTrimmingSpace($1, '') ]
   NestedArgumentList
   # NOTE: Eliminated left recursion
-  _? NonPipelineArgumentPart ( CommaDelimiter _? NonPipelineArgumentPart )* ->
-    return [...($1 || []), $2, ...$3]
+  ( _? NonPipelineArgumentPart ) ( CommaDelimiter ( _? NonPipelineArgumentPart ) )* ->
+    return [ $1, ...$2.flat() ]
 
 NestedArgumentList
   PushIndent NestedArgument*:args PopIndent ->
-    if (args.length) return args
-    return $skip
+    if (!args.length) return $skip
+    return args.flat()
 
 NestedArgument
-  Nested SingleLineArgumentExpressions ParameterElementDelimiter
+  Nested:indent SingleLineArgumentExpressions:args ParameterElementDelimiter:comma ->
+    // Attach indentation to first argument in SingleLineArgumentExpressions
+    let [ arg0, ...rest ] = args
+    arg0 = [ indent, ...arg0 ]
+    return [ arg0, ...rest, comma ]
 
 SingleLineArgumentExpressions
-  _? ArgumentPart ( _? Comma _? ArgumentPart )*
+  ( _? ArgumentPart ) ( ( _? Comma ) ( _? ArgumentPart ) )* ->
+    return [ $1, ...$2.flat() ]
 
 ArgumentPart
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
@@ -6224,7 +6265,7 @@ InlineJSXCallExpression
       type: "CallExpression",
       children: [
         $1,
-        { type: "Call", children: args },
+        args,
         ...rest.flat()
       ],
     })
@@ -6233,7 +6274,7 @@ InlineJSXCallExpression
       type: "CallExpression",
       children: [
         $1,
-        { type: "Call", children: args },
+        args,
         ...rest.flat()
       ],
     })
@@ -6256,7 +6297,6 @@ InlineJSXCallExpressionRest
     }
     return $1
   OptionalShorthand? ExplicitArguments:args ->
-    args = { type: "Call", children: args }
     if (!$1) return args
     return [ $1, args ]
 

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -433,6 +433,24 @@ describe "(op) shorthand", ->
   """
 
   testCase """
+    apply binary op with one argument
+    ---
+    (+) 1
+    ---
+    (1)
+  """
+
+  testCase """
+    apply binary op with no arguments
+    ---
+    (+)()
+    (+)( /* comment */ )
+    ---
+    ((a,b) => a+b)();
+    ((a1,b1) => a1+b1)( /* comment */ )
+  """
+
+  testCase """
     apply binary op with many complex arguments
     ---
     (*) x+y, z+w, a**b
@@ -457,11 +475,33 @@ describe "(op) shorthand", ->
   testCase """
     apply binary op with trailing comma
     ---
+    (+)(1, )
     (+)(1, 2, )
     (+)(1, 2, /* comment */ )
     ---
+    (1 );
     ((1)+( 2 ));
     ((1)+( 2 /* comment */ ))
+  """
+
+  testCase """
+    apply binary op with comma operator
+    ---
+    (+)((1, 2), (3, 4))
+    ---
+    (((1, 2))+( (3, 4)))
+  """
+
+  testCase """
+    apply binary op with function call
+    ---
+    (+)
+      f(1, 2)
+      f(3, 4)
+    ---
+    ((
+      f(1, 2))+(
+      f(3, 4)))
   """
 
   testCase """


### PR DESCRIPTION
#948 recursively processed all commas, which leads to some weird behavior:
```js
(+) f(x, y), z
↓↓↓
f(x) + y + z
```

This PR bites the bullet and cleans up all forms of `Arguments` so that you get one array with all the arguments and commas at the top level (similar to processing we do with top-level statements, IIRC). This lets us process commas without recursion.

Currently, whitespace is combined with some arguments and commas, so that the array really alternates between arguments and commas. Alternatively, we could allow whitespace at the top level of the array too. I guess this can be decided later.

I also changed the behavior of `(+)(1)` to expand to just `(1)`. This seems beneficial when you're working with complex nested prefix formulas, and you remove one item, expecting `(and)(cond)` to give `cond` and not crash.