### PR TITLE
Typed ampersand function improvements

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -204,6 +204,28 @@ function makeNode(node: ASTNode): ASTNode
   updateParentPointers node
   node
 
+function makeAmpersandFunction(bodyAfterRef = []): ASTNode
+  ref := makeRef("$")
+  body := [ref, ...bodyAfterRef]
+  parameters :=
+    type: "Parameters"
+    children: [ref]
+    names: []
+  block :=
+    expressions: body
+
+  return {
+    type: "ArrowFunction"
+    signature:
+      modifier: {}
+    children: [parameters, " => ", body]
+    ref
+    body
+    ampersandBlock: true
+    block
+    parameters
+  }
+
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   expressions := [
     ...post.blockPrefix or []
@@ -4211,6 +4233,7 @@ export {
   makeEmptyBlock,
   makeExpressionStatement,
   makeGetterMethod,
+  makeAmpersandFunction,
   makeLeftHandSideExpression,
   makeRef,
   maybeRef,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -625,17 +625,12 @@ PipelineExpression
     if (head.token === "&") {
       const ref = makeRef("$")
 
-      const arrowBody = {
-        type: "PipelineExpression",
-        children: [ws, ref, body]
-      }
-
       const parameters = {
         type: "Parameters",
         children: [ref],
         names: [],
       }
-      const expressions = [arrowBody]
+      const expressions = [ref]
       const block = {
         bare: true,
         expressions,
@@ -644,7 +639,7 @@ PipelineExpression
 
       const children = [ parameters, " => ", block ]
 
-      return {
+      head = {
         type: "ArrowFunction",
         signature: {
           modifier: {
@@ -653,10 +648,24 @@ PipelineExpression
         },
         children,
         ref,
-        body: [arrowBody],
+        body: expressions,
         ampersandBlock: true,
         parameters,
         block,
+      }
+    }
+
+    if (head.type === "ArrowFunction" && head.ampersandBlock) {
+      const expressions = [ {
+        type: "PipelineExpression",
+        children: [ ws, head.block.expressions[0], body ],
+      } ]
+      const block = { ...head.block, expressions, children: [expressions] }
+      return {
+        ...head,
+        block,
+        body: expressions,
+        children: [ ...head.children.slice(0, -1), block ],
       }
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -31,6 +31,7 @@ import {
   makeEmptyBlock,
   makeExpressionStatement,
   makeGetterMethod,
+  makeAmpersandFunction,
   makeLeftHandSideExpression,
   makeRef,
   maybeRef,
@@ -439,12 +440,16 @@ UnaryPostfix
   TypePostfix+ -> { ts: true, children: $0 }
 
 TypePostfix
-  _:ws As:as ExclamationPoint?:ex Type:type ->
+  _:ws NWTypePostfix:postfix ->
+    return [ws, ...postfix]
+
+NWTypePostfix
+  As:as ExclamationPoint?:ex Type:type ->
     if (ex) {
-      return [{ $loc: ex.$loc, token: " as unknown" }, ws, as, type]
+      return [{ $loc: ex.$loc, token: "as unknown " }, as, type]
     }
-    return [ws, as, type]
-  _ Satisfies Type
+    return [as, type]
+  Satisfies Type
 
 # https://262.ecma-international.org/#prod-UpdateExpression
 UpdateExpression
@@ -623,36 +628,7 @@ ShortCircuitExpression
 PipelineExpression
   _?:ws PipelineHeadItem:head ( NotDedented Pipe __ PipelineTailItem )+:body ->
     if (head.token === "&") {
-      const ref = makeRef("$")
-
-      const parameters = {
-        type: "Parameters",
-        children: [ref],
-        names: [],
-      }
-      const expressions = [ref]
-      const block = {
-        bare: true,
-        expressions,
-        children: [expressions],
-      }
-
-      const children = [ parameters, " => ", block ]
-
-      head = {
-        type: "ArrowFunction",
-        signature: {
-          modifier: {
-            children: []
-          }
-        },
-        children,
-        ref,
-        body: expressions,
-        ampersandBlock: true,
-        parameters,
-        block,
-      }
+      head = makeAmpersandFunction()
     }
 
     if (head.type === "ArrowFunction" && head.ampersandBlock) {
@@ -685,6 +661,8 @@ PipelineTailItem
   Await
   Yield
   Return
+  NWTypePostfix TypePostfix* ->
+    return makeAmpersandFunction([" ", $1, ...$2])
   AmpersandFunctionExpression
   !Ampersand PipelineHeadItem -> $2
 
@@ -1859,29 +1837,7 @@ FunctionExpression
   # Identity function shorthand
   # NOTE: Currently shadows (&) binary & operator, we might want to revisit
   "(&)" ->
-    const ref = makeRef("$"), body = [ref]
-
-    const parameters = {
-      type: "Parameters",
-      children: [ref],
-      names: [],
-    }
-    const block = {
-      expressions: [ref],
-    }
-
-    return {
-      type: "ArrowFunction",
-      signature: {
-        modifier: {},
-      },
-      children: [parameters, " => ", body],
-      ref,
-      body,
-      ampersandBlock: true,
-      block,
-      parameters,
-    }
+    return makeAmpersandFunction()
 
   # BinaryOp function shorthand
   OpenParen:open BinaryOp:op CloseParen:close ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2001,13 +2001,7 @@ AmpersandFunctionExpression
     if (!rhs) {
       body = ref = makeRef("$")
     } else {
-      // &? gets wrapped in UnaryExpression and ParenthesizedExpression;
-      // descend into `expression` property until `ref` is defined
-      let exp = rhs
-      while (!exp.ref && exp.expression) {
-        exp = exp.expression
-      }
-      ({ref, typeSuffix} = exp)
+      ({ref, typeSuffix} = rhs)
       if (!ref) {
         throw new Error("Could not find ref in ampersand shorthand block")
       }
@@ -2106,7 +2100,7 @@ AmpersandTypeSuffix
   &( _? QuestionMark? _? Colon ) TypeSuffix -> $2
 
 AmpersandBlockRHSBody
-  AmpersandTypeSuffix?:typeSuffix (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( WAssignmentOp ( NotDedented UpdateExpression WAssignmentOp )* NonPipelineExtendedExpression )?:assign ( ![&] BinaryOpRHS+ )?:binopRHS ->
+  AmpersandTypeSuffix?:typeSuffix (!_ CallExpressionRest+ )?:callExpRest UnaryPostfix?:unaryPostfix ( WAssignmentOp ( NotDedented UpdateExpression WAssignmentOp )* NonPipelineExtendedExpression )?:assign ( ![&] BinaryOpRHS+ )?:binopRHS ->
     if (!typeSuffix && !callExpRest && !binopRHS && !unaryPostfix) return $skip
     const ref = makeRef("$")
 
@@ -2115,7 +2109,6 @@ AmpersandBlockRHSBody
       children: [ref],
       names: [],
       ref,
-      typeSuffix,
     }
 
     if (callExpRest) {
@@ -2140,18 +2133,18 @@ AmpersandBlockRHSBody
         lhs,
         assigned: exp,
         exp: rhs,
-        ref,
-        typeSuffix,
       }
     }
 
     if (binopRHS) {
       exp = {
         children: processBinaryOpExpression([exp, binopRHS[1]]),
-        ref,
-        typeSuffix,
       }
     }
+
+    // Put at top level for AmpersandFunctionExpression to process
+    exp.ref = ref
+    exp.typeSuffix = typeSuffix
 
     return exp
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1986,7 +1986,7 @@ AmpersandFunctionExpression
   UnaryOp*:prefix ( Ampersand / ( !NumericLiteral &( QuestionMark? Dot !Dot ) ) ) AmpersandBlockRHS?:rhs ->
     if (!prefix.length && !rhs) return $skip
 
-    let body, ref
+    let body, ref, typeSuffix
 
     // Only unary ops
     if (!rhs) {
@@ -1998,7 +1998,7 @@ AmpersandFunctionExpression
       while (!exp.ref && exp.expression) {
         exp = exp.expression
       }
-      ({ref} = exp)
+      ({ref, typeSuffix} = exp)
       if (!ref) {
         throw new Error("Could not find ref in ampersand shorthand block")
       }
@@ -2013,7 +2013,7 @@ AmpersandFunctionExpression
 
     const parameters = {
       type: "Parameters",
-      children: [ref],
+      children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref],
       names: [],
     }
     const expressions = [body]
@@ -2093,9 +2093,12 @@ AmpersandBlockRHS
     if (!$2) return $skip
     return $2
 
+AmpersandTypeSuffix
+  &( _? QuestionMark? _? Colon ) TypeSuffix -> $2
+
 AmpersandBlockRHSBody
-  (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( WAssignmentOp ( NotDedented UpdateExpression WAssignmentOp )* NonPipelineExtendedExpression )?:assign ( ![&] BinaryOpRHS+ )?:binopRHS ->
-    if (!callExpRest && !binopRHS && !unaryPostfix) return $skip
+  AmpersandTypeSuffix?:typeSuffix (!_ CallExpressionRest+ )?:callExpRest QuestionMark?:unaryPostfix ( WAssignmentOp ( NotDedented UpdateExpression WAssignmentOp )* NonPipelineExtendedExpression )?:assign ( ![&] BinaryOpRHS+ )?:binopRHS ->
+    if (!typeSuffix && !callExpRest && !binopRHS && !unaryPostfix) return $skip
     const ref = makeRef("$")
 
     let exp = {
@@ -2103,6 +2106,7 @@ AmpersandBlockRHSBody
       children: [ref],
       names: [],
       ref,
+      typeSuffix,
     }
 
     if (callExpRest) {
@@ -2128,6 +2132,7 @@ AmpersandBlockRHSBody
         assigned: exp,
         exp: rhs,
         ref,
+        typeSuffix,
       }
     }
 
@@ -2135,6 +2140,7 @@ AmpersandBlockRHSBody
       exp = {
         children: processBinaryOpExpression([exp, binopRHS[1]]),
         ref,
+        typeSuffix,
       }
     }
 

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -403,6 +403,31 @@ describe "&. function block shorthand", ->
     bar($ => $.foo)
   """
 
+  describe "typed &", ->
+    testCase """
+      identity
+      ---
+      &: number
+      ---
+      ($: number) => $
+    """
+
+    testCase """
+      optional
+      ---
+      &?: number
+      ---
+      ($?: number) => $
+    """
+
+    testCase """
+      with operator
+      ---
+      &: number + 1
+      ---
+      ($: number) => $ + 1
+    """
+
 describe "(op) shorthand", ->
   testCase """
     binary op

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -372,6 +372,14 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    type cast
+    ---
+    arr.map & as any
+    ---
+    arr.map($ => $ as any)
+  """
+
+  testCase """
     null
     ---
     arr.filter !&?

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -400,7 +400,7 @@ describe "&. function block shorthand", ->
     ---
     &.foo |> bar
     ---
-    bar($ => $.foo)
+    $ => bar($.foo)
   """
 
   describe "typed &", ->
@@ -426,6 +426,14 @@ describe "&. function block shorthand", ->
       &: number + 1
       ---
       ($: number) => $ + 1
+    """
+
+    testCase """
+      with pipe
+      ---
+      &: number |> foo
+      ---
+      ($: number) => foo($)
     """
 
 describe "(op) shorthand", ->

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -228,6 +228,14 @@ describe "pipe", ->
       x |> & |> f
     """
 
+    testCase """
+      typed
+      ---
+      &: number |> (+ 1) |> &/2 |> Math.ceil
+      ---
+      ($: number) => Math.ceil(($+ 1)/2)
+    """
+
   describe "thicc", ->
     testCase """
       basic

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -149,6 +149,17 @@ describe "pipe", ->
     return fn(a)
   """
 
+  testCase """
+    as T in pipeline
+    ---
+    fetch()
+    |> as Response
+    |> .json()
+    |> as! MyRecord
+    ---
+    ((fetch() as Response).json()) as unknown as MyRecord
+  """
+
   // TODO: reduce excess parens
   testCase """
     no nested pipelines in implicit arguments


### PR DESCRIPTION
## Precedence change:

* `&.foo |> bar` changed to mean `$ => bar($.foo)` instead of current behavior of `bar($ => $.foo)`. Motivations:
  * `& |> bar` already means `$ => bar($)`, so this seems far more symmetric
  * `-> foo |> bar` already puts `bar(foo)` inside function body (see #949 for mismatch with `=>`, but I think that's a bug)
  * Generally, probably more useful to work with values than functions in a pipeline, until we introduce a composition operator
  * Examples below

## New features:

* `&: T` prefix allows you specify a type for `$` argument.  For example:
  * `&: number` is an identity only for `number`s
  * `&: number + 1` is a more explicit increment
  * `&: number |> Math.floor` is where things get more interesting (TS sadly doesn't usually infer in cases like this)
    * Note: This required changing precedence as above, because `&: number` is already an identity function.
* `& as T` for type casting, especially for:
* `as T` in pipeline: shorthand for `& as T`.  For example:
  * `foo |> bar |> as any`