### PR TITLE
Fix concatAssign for arrays

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7510,7 +7510,7 @@ Reset
         module.prelude.push({
           children: [
             preludeVar, ref, typeSuffix,
-            " = (lhs, rhs) => ((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
+            " = (lhs, rhs) => (((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
           ]
         })
       },

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -584,6 +584,6 @@ describe "assignment", ->
       ---
       x ++= y
       ---
-      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => ((rhs as any)?.[Symbol.isConcatSpreadable] ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
+      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
       concatAssign(x, y)
     """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -1,4 +1,4 @@
-{testCase, throws} from ./helper.civet
+{evalsTo, testCase, throws} from ./helper.civet
 
 describe "assignment", ->
   testCase """
@@ -587,3 +587,18 @@ describe "assignment", ->
       var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
       concatAssign(x, y)
     """
+
+    evalsTo """
+      x := [1, 2]
+      x ++= [3, 4]
+      x ++= 5
+      x ++=
+        [Symbol.isConcatSpreadable]: true,
+        0: 6
+        1: 7
+        length: 2
+      x ++=
+        0: 8
+        length: 1
+      x
+    """, [1, 2, 3, 4, 5, 6, 7, {0: 8, length: 1}]

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -108,7 +108,7 @@ evalsTo := (src: string, value: any) ->
   result := eval compile src, {
     js: true
   }
-  assert.equal result, value, """
+  assert.deepEqual result, value, """
 
     --- Source   ---
     #{src}


### PR DESCRIPTION
I made a small mistake when originally writing `concatAssign`: the value of `Array.prototype[Symbol.isConcatSpreadable]` is `undefined`, not `true`. Setting the value to `false` does make it no longer concat-spreadable, but if it's `undefined` we need to *also* check if it's an Array.

[Relevant section of the ECMAScript specification](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-isconcatspreadable):

> 1. If *O* [is not an Object](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-object-type), return **false**.
> 2. Let *spreadable* be ? [Get](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-get-o-p)(*O*, [@@isConcatSpreadable](https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-well-known-symbols)).
> 3. If *spreadable* is not **undefined**, return [ToBoolean](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toboolean)(*spreadable*).
> 4. Return ? [IsArray](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-isarray)(*O*).