### PR TITLE
CLI import rewriting, --civet option, cleanup

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,4 +1,4 @@
-{ compile } from ./main.civet
+{ compile, parse } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
 function version: string
@@ -36,6 +36,7 @@ if process.argv.includes "--help"
       -o / --output XX Specify output directory and/or extension, or filename
       -c / --compile   Compile input files to TypeScript (or JavaScript)
       --config XX      Specify a config file (default scans for a config.civet, civet.json, civetconfig.civet or civetconfig.json file, optionally in a .config directory, or starting with a .)
+      --civet XX       Specify civet compiler flag, as in "civet XX" prologue
       --no-config      Don't scan for a config file
       --js             Strip out all type annotations; default to .jsx extension
       --ast            Print the AST instead of the compiled code
@@ -43,6 +44,9 @@ if process.argv.includes "--help"
       --no-cache       Disable compiler caching (slow, for debugging)
 
     You can use - to read from stdin or (prefixed by -o) write to stdout.
+
+    By default, .civet imports get rewritten to use the output extension.
+    You can override this behavior via: --civet rewriteCivetImports=.ext
 
 
   """
@@ -109,6 +113,11 @@ function parseArgs(args: string[]): ParsedArgs
         options.config = args[++i]
       when '--no-config'
         options.config = false
+      when '--civet'
+        Object.assign options.parseOptions ??= {},
+          parse `civet ${args[++i]}`,
+            startRule: 'CivetPrologueContent'
+          |> .config
       when '--ast'
         options.ast = true
       when '--no-cache'

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -56,13 +56,13 @@ path from "path"
 
 // TODO: Once the types are exported within the Civet source code,
 // we should import them directly here, instead of looking at an old release.
-type { ParseOptions } from "@danielx/civet"
+type { CompileOptions } from "@danielx/civet"
 
-interface Options
+interface Options extends CompileOptions
   run?: boolean
   compile?: boolean
   output?: string
-  config?: string | boolean | undefined | ParseOptions
+  config?: string | boolean | undefined
   ast?: boolean
   noCache?: boolean
   inlineMap?: boolean
@@ -260,6 +260,32 @@ function cli
 
   return repl options if options.repl
 
+  // Parse `output` option into forced directory, extension, and/or full path
+  let outputDir?: string, outputExt?: string, outputPath?: path.ParsedPath
+  if options.output
+    optionsPath := path.parse options.output
+    let stat: Stats | null
+    try
+      stat = await fs.stat options.output
+    catch
+      stat = null
+    if stat?.isDirectory() or options.output.endsWith(path.sep) or
+                              options.output.endsWith('/')
+      // -o dir writes outputs into that directory with default name
+      outputDir = options.output
+    else if /^(\.[^.]+)+$/.test optionsPath.base
+      // -o .js or .ts or .civet.js or .civet.ts etc. to control extension
+      outputExt = optionsPath.base
+      // Can also be prefixed by a directory name
+      outputDir = optionsPath.dir if optionsPath.dir
+    else
+      // -o filename fully specifies the output filename
+      // (don't use this with multiple input files)
+      outputPath = optionsPath
+    // For CLI compilations, default to rewriting imports to output extension
+    (options.parseOptions ??= {}).rewriteCivetImports ??=
+      outputExt ?? '.civet' + if options.js then ".jsx" else ".tsx"
+
   for await {filename, error, content, stdin} of readFiles filenames
     if error
       console.error `${filename} failed to load:`
@@ -281,39 +307,24 @@ function cli
       if (stdin and not options.output) or options.output is '-'
         process.stdout.write output
       else
-        outputPath: path.FormatInputPathObject .= path.parse filename
-        delete outputPath.base  // use name and ext
+        targetPath: path.FormatInputPathObject .= path.parse filename
+        delete targetPath.base  // use name and ext
+        // Default extension
         if options.js
-          outputPath.ext += ".jsx"
+          targetPath.ext += ".jsx"
         else
-          outputPath.ext += ".tsx"
-        if options.output
-          optionsPath := path.parse options.output
-          let stat: Stats | null
-          try
-            stat = await fs.stat options.output
-          catch
-            stat = null
-          if stat?.isDirectory() or options.output.endsWith(path.sep) or
-                                    options.output.endsWith('/')
-            // -o dir writes outputs into that directory with default name
-            outputPath.dir = options.output
-          else if /^(\.[^.]+)+$/.test optionsPath.base
-            // -o .js or .ts or .civet.js or .civet.ts etc. to control extension
-            outputPath.ext = optionsPath.base
-            // Can also be prefixed by a directory name
-            outputPath.dir = optionsPath.dir if optionsPath.dir
-          else
-            // -o filename fully specifies the output filename
-            // (don't use this with multiple input files)
-            outputPath = optionsPath
+          targetPath.ext += ".tsx"
+        // `output` option overrides
+        targetPath.dir = outputDir if outputDir?
+        targetPath.ext = outputExt if outputExt?
+        targetPath = outputPath if outputPath?
         // Make output directory in case it doesn't already exist
-        fs.mkdir outputPath.dir, recursive: true if outputPath.dir
-        outputFilename := path.format outputPath
+        fs.mkdir targetPath.dir, recursive: true if targetPath.dir
+        targetFilename := path.format targetPath
         try
-          await fs.writeFile outputFilename, output
+          await fs.writeFile targetFilename, output
         catch error
-          console.error `${outputFilename} failed to write:`
+          console.error `${targetFilename} failed to write:`
           console.error error
     else // run
       esm := /^\s*(import|export)\b/m.test output

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -292,8 +292,9 @@ function cli
       // (don't use this with multiple input files)
       outputPath = optionsPath
     // For CLI compilations, default to rewriting imports to output extension
-    (options.parseOptions ??= {}).rewriteCivetImports ??=
-      outputExt ?? '.civet' + if options.js then ".jsx" else ".tsx"
+    if options.output is not '-'
+      (options.parseOptions ??= {}).rewriteCivetImports ??=
+        outputExt ?? '.civet' + if options.js then ".jsx" else ".tsx"
 
   for await {filename, error, content, stdin} of readFiles filenames
     if error

--- a/source/config.civet
+++ b/source/config.civet
@@ -4,7 +4,7 @@ fs from fs/promises
 
 // TODO: Once the types are exported within the Civet source code,
 // we should import them directly here, instead of looking at an old release.
-type { ParseOptions } from "@danielx/civet"
+type { CompileOptions } from "@danielx/civet"
 
 configFileNames := new Set [
   "🐈.json"
@@ -44,7 +44,7 @@ export function findConfig(startDir: string): Promise<string | undefined>
 
   return
 
-export function loadConfig(path: string): Promise<ParseOptions>
+export function loadConfig(path: string): Promise<CompileOptions>
   config := await fs.readFile path, "utf8"
 
   if path.endsWith ".json"

--- a/source/main.civet
+++ b/source/main.civet
@@ -1,5 +1,4 @@
-import parser from "./parser.hera"
-{ parse } := parser
+import { parse } from "./parser.hera"
 import generate, { prune } from "./generate.civet"
 import * as lib from "./lib.civet"
 import * as util from "./util.civet"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4833,15 +4833,20 @@ ModuleExportName
 # https://262.ecma-international.org/#prod-ModuleSpecifier
 ModuleSpecifier
   UnprocessedModuleSpecifier ->
-    if (!module.config.rewriteTsImports) return $1
-
-    // Workaround to fix:
-    // https://github.com/microsoft/TypeScript/issues/42151
-    // import t.ts
-    // "An import path cannot end with a '.ts' extension. Consider importing './t.js' instead."
-    const { token } = $1
-    // convert .[mc]?ts to .[mc]?js
-    return { $loc, token: token.replace(/\.([mc])?ts(['"])$/, ".$1js$2") }
+    let { token } = $1
+    if (module.config.rewriteTsImports) {
+      // Workaround to fix:
+      // https://github.com/microsoft/TypeScript/issues/42151
+      // import t.ts
+      // "An import path cannot end with a '.ts' extension. Consider importing './t.js' instead."
+      // convert .[mc]?ts to .[mc]?js
+      token = token.replace(/\.([mc])?ts(['"])$/, ".$1js$2")
+    }
+    if (module.config.rewriteCivetImports) {
+      token = token.replace(/\.civet(['"])$/,
+        `${module.config.rewriteCivetImports.replace(/\$/g, '$$')}$1`)
+    }
+    return { ...$1, token }
 
 UnprocessedModuleSpecifier
   StringLiteral

--- a/test/import.civet
+++ b/test/import.civet
@@ -107,6 +107,19 @@ describe "import", ->
     import t from "./t.cjs"
   """
 
+  testCase """
+    rewrite .civet to .jsx if requested
+    ---
+    "civet rewrite-civet-imports=.jsx"
+    import t from "./t.civet"
+    import t from './t.civet'
+    import t from ./t.civet
+    ---
+    import t from "./t.jsx"
+    import t from './t.jsx'
+    import t from "./t.jsx"
+  """
+
   describe "unquoted module specifier", ->
     testCase """
       default import

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -23,6 +23,7 @@ declare module "@danielx/civet" {
     react: boolean
     solid: boolean
     client: boolean
+    rewriteCivetImports: string
     rewriteTsImports: boolean
     server: boolean
     tab: number


### PR DESCRIPTION
* Add `"civet rewriteCivetImports=.ext"` compiler option to rewrite `.civet` imports to `.ext`. This is useful when manually compiling everything.
* Set default CLI behavior (with `civet -c`) to rewrite to the extension for output files. (As specified by `-o`, or defaulting to `.civet.tsx`/`.civet.jsx`.) This should benefit those not using fancier build systems; it makes built code actually runnable.
* Add `--civet` command-line option to specify compiler flags, which e.g. makes it possible to override this extension rewriting behavior. (Also a lightweight alternative to config files.) This was fun because I wrote it by calling a small rule in the Hera compiler!
* Cleanup: I finally understand how config files are supposed to work: flags like `coffeeCompat` are supposed to go in a `compilerOptions` field. I didn't realize that before, so the typing was all wrong. Should be fixed now.