### PR TITLE
TypeScript's `import ... = require(...)` and `export = ...`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4703,6 +4703,18 @@ MaybeNestedExpression
 
 # https://262.ecma-international.org/#prod-ImportDeclaration
 ImportDeclaration
+  # NOTE: TypeScript's CommonJS import syntax
+  # https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require
+  Import _ Identifier _? Equals __ "require" NonIdContinue Arguments ->
+    // Replace `import` with `const` in JS output
+    const imp = [
+      { ...$1, ts: true },
+      { ...$1, token: "const", js: true },
+    ]
+    return {
+      type: "ImportDeclaration",
+      children: [imp, $0.slice(1)],
+    }
   Import __ TypeKeyword __ ImportClause __ FromClause ImportAssertion? -> { type: "ImportDeclaration", ts: true, children: $0 }
   Import __ ImportClause __ FromClause ImportAssertion? -> { type: "ImportDeclaration", children: $0 }
   Import __ ModuleSpecifier ImportAssertion? -> { type: "ImportDeclaration", children: $0 }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4872,6 +4872,18 @@ ImportedBinding
 
 # https://262.ecma-international.org/#prod-ExportDeclaration
 ExportDeclaration
+  # NOTE: TypeScript's CommonJS export syntax
+  # https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require
+  Export _? Equals ExtendedExpression ->
+    // Replace `export` with `module.exports` in JS output
+    const exp = [
+      { ...$1, ts: true },
+      { ...$1, token: "module.exports", js: true },
+    ]
+    return {
+      type: "ExportDeclaration",
+      children: [exp, $0.slice(1)],
+    }
   # NOTE: Using ExtendedExportDeclaration to allow If/Switch expressions
   Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / ExtendedExpression ):declaration ->
     return { type: "ExportDeclaration", declaration, children: $0 }

--- a/test/types/export.civet
+++ b/test/types/export.civet
@@ -1,0 +1,19 @@
+{testCase} from ../helper.civet
+
+describe "[TS] export", ->
+  // https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require
+  testCase """
+    export =
+    ---
+    export = fs.readFileSync "..."
+    ---
+    export = fs.readFileSync("...")
+  """
+
+  testCase.js """
+    export =, JS output
+    ---
+    export = fs.readFileSync "..."
+    ---
+    module.exports = fs.readFileSync("...")
+  """

--- a/test/types/import.civet
+++ b/test/types/import.civet
@@ -66,3 +66,23 @@ describe "[TS] import", ->
     function adopt(p: import("./module")) {
     }
   """
+
+  testCase """
+    import = require
+    ---
+    import fs = require("fs")
+    import fs2 = require "fs"
+    ---
+    import fs = require("fs")
+    import fs2 = require("fs")
+  """
+
+  testCase.js """
+    import = require, JS output
+    ---
+    import fs = require("fs")
+    import fs2 = require "fs"
+    ---
+    const fs = require("fs")
+    const fs2 = require("fs")
+  """

--- a/test/types/import.civet
+++ b/test/types/import.civet
@@ -67,6 +67,7 @@ describe "[TS] import", ->
     }
   """
 
+  // https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require
   testCase """
     import = require
     ---


### PR DESCRIPTION
This is necessary for working with TypeScript + CommonJS.  See https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require

Fixes #971 in a certain sense, in particular https://github.com/DanielXMoore/Civet/issues/971#issuecomment-1936853962