### PR TITLE
Nested vs. implicit vs. inline object literals

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2325,12 +2325,11 @@ NonSingleBracedBlock
   ImplicitNestedBlock
 
   # Immediate nested object literal
-  InsertOpenBrace &EOS ObjectLiteral:s InsertCloseBrace ->
+  InsertOpenBrace NestedImplicitObjectLiteral:s InsertCloseBrace ->
     return {
       type: "BlockStatement",
       expressions: [s],
-      // Remove &EOS assertion
-      children: [$1, s, $3],
+      children: $0,
     }
 
 DeclarationOrStatement
@@ -2687,6 +2686,7 @@ ElementListRest
 ArrayElementExpression
   # NOTE: Prevent multiple JSX tags from combining implicitly into a fragment
   JSXTag
+  ImplicitObjectLiteral &ArrayElementDelimiter -> $1
   # NOTE: Allow for postfix splat like CoffeeScript
   # NOTE: Allow empty exp spread for destructuring
   ExtendedExpression?:exp __:ws DotDotDot:dots &ArrayElementDelimiter ->
@@ -2780,8 +2780,11 @@ BracedObjectLiteralContent
       return [...prop.slice(0, prop.length-1), last]
     })
 
+# NOTE: Nested implicit object literal starts with an indentation.
+# All properties can be spaced out and must have a colon.
 NestedImplicitObjectLiteral
-  InsertOpenBrace NestedImplicitPropertyDefinitions:properties InsertNewline InsertIndent InsertCloseBrace ->
+  InsertOpenBrace PushIndent NestedImplicitPropertyDefinitions?:properties PopIndent InsertNewline InsertIndent InsertCloseBrace ->
+    if (!properties) return $skip
     return {
       type: "ObjectExpression",
       properties,
@@ -2789,8 +2792,7 @@ NestedImplicitObjectLiteral
     }
 
 NestedImplicitPropertyDefinitions
-  PushIndent NestedImplicitPropertyDefinition*:defs PopIndent ->
-    if(!defs.length) return $skip
+  NestedImplicitPropertyDefinition+:defs ->
     return defs.flat()
 
 NestedImplicitPropertyDefinition
@@ -2827,8 +2829,12 @@ NestedPropertyDefinition
       return prop
     })
 
-InlineObjectLiteral
-  InsertInlineOpenBrace:open SnugNamedProperty:first ( ImplicitInlineObjectPropertyDelimiter NamedProperty )*:rest ( _? Comma &Dedented )?:trailing InsertCloseBrace:close ->
+# NOTE: Implicit object literals are intended for beginnings of lines,
+# but where the indentation has already been consumed.
+# They can span multiple lines at the same indentation level.
+# They must start with a snug property, and all properties must have a colon.
+ImplicitObjectLiteral
+  InsertInlineOpenBrace:open SnugNamedProperty:first ( ImplicitObjectPropertyDelimiter NamedProperty )*:rest ( _? Comma )?:trailing InsertCloseBrace:close ->
     return {
       type: "ObjectExpression",
       children: [open, first, ...rest, trailing, close],
@@ -2836,9 +2842,22 @@ InlineObjectLiteral
 
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
 # Instead we see if the next line matches a NamedProperty and if so we insert a comma
-ImplicitInlineObjectPropertyDelimiter
+ImplicitObjectPropertyDelimiter
   _? Comma ( NotDedented / _? )
-  &( Nested NamedProperty ) InsertComma ( Nested / _? ) -> [$2, $3]
+  &( Nested NamedProperty ) InsertComma Nested -> [$2, $3]
+
+# NOTE: Inline object literals are intended for within expressions.
+# They can only go onto another line if there's a trailing comma.
+# They must start with a snug property, and all properties must have a colon.
+InlineObjectLiteral
+  InsertInlineOpenBrace:open SnugNamedProperty:first ( InlineObjectPropertyDelimiter NamedProperty )*:rest ( _? Comma &Dedented )?:trailing InsertCloseBrace:close ->
+    return {
+      type: "ObjectExpression",
+      children: [open, first, ...rest, trailing, close],
+    }
+
+InlineObjectPropertyDelimiter
+  _? Comma ( NotDedented / _? )
 
 ObjectPropertyDelimiter
   _? Comma
@@ -3628,6 +3647,10 @@ ModuleItem
 # https://262.ecma-international.org/#prod-StatementListItem
 StatementListItem
   Declaration
+  # NOTE: Allow multi-line implicit object literals as top-level statements.
+  # Leave $: for Svelte labels though.
+  !"$:" ImplicitObjectLiteral ->
+    return makeLeftHandSideExpression($2)
   # NOTE: Added postfix conditionals/loops
   PostfixedStatement
 
@@ -4923,7 +4946,7 @@ TypeAndNamedExports
 NamedExports
   OpenBrace ExportSpecifier* (__ Comma )? __ CloseBrace
   # Unbraced version: export x, y
-  InsertInlineOpenBrace:open ImplicitExportSpecifier:first ( ImplicitInlineObjectPropertyDelimiter ImplicitExportSpecifier )*:rest InsertCloseBrace:close &( StatementDelimiter / ( __ From )) ->
+  InsertInlineOpenBrace:open ImplicitExportSpecifier:first ( ImplicitObjectPropertyDelimiter ImplicitExportSpecifier )*:rest InsertCloseBrace:close &( StatementDelimiter / ( __ From )) ->
     return [open, first, ...rest, close]
 
 # https://262.ecma-international.org/#prod-ExportSpecifier

--- a/test/object.civet
+++ b/test/object.civet
@@ -278,6 +278,29 @@ describe "object", ->
   """
 
   testCase """
+    mix of top-level and inline
+    ---
+    signature: modifier: {}
+    children: []
+    ---
+    ({signature: {modifier: {}},
+    children: []})
+  """
+
+  testCase """
+    mix of nested and inline
+    ---
+    x =
+      signature: modifier: {}
+      children: []
+    ---
+    x = {
+      signature: {modifier: {}},
+      children: [],
+    }
+  """
+
+  testCase """
     expression values
     ---
     x =
@@ -520,7 +543,7 @@ describe "object", ->
   """
 
   testCase """
-    braceless inline object
+    braceless object
     ---
     a: 1
     ---
@@ -528,7 +551,7 @@ describe "object", ->
   """
 
   testCase """
-    braceless inline object with multiple keys
+    braceless object with multiple keys
     ---
     a: 1, b: 2
     ---
@@ -536,7 +559,7 @@ describe "object", ->
   """
 
   testCase """
-    braceless inline object with multiple keys per line
+    braceless object with multiple keys per line
     ---
     a: 1, b: 2
     c: 3, d: 4
@@ -545,21 +568,26 @@ describe "object", ->
     c: 3, d: 4})
   """
 
-  throws """
-    braceless inline object with trailing comma
+  testCase """
+    braceless object with trailing comma
     ---
     a: 1,
-  """
-
-  throws """
-    2-element braceless inline object with trailing comma
     ---
-    a: 1,
-    b: 2,
+    ({a: 1,})
   """
 
   testCase """
-    braceless inline object with function values
+    2-element braceless object with trailing comma
+    ---
+    a: 1,
+    b: 2,
+    ---
+    ({a: 1,
+    b: 2,})
+  """
+
+  testCase """
+    braceless object with function values
     ---
     obj =
       a: => 1
@@ -572,7 +600,7 @@ describe "object", ->
   """
 
   testCase """
-    braceless inline object with function calls
+    braceless object with function calls
     ---
     obj =
       a: f 1
@@ -585,7 +613,7 @@ describe "object", ->
   """
 
   testCase """
-    indented 2-element braceless inline object with trailing comma
+    indented 2-element braceless object with trailing comma
     ---
     if x
       a: 1,
@@ -623,7 +651,7 @@ describe "object", ->
   """
 
   testCase """
-    postfix within inline braceless object, 1 prop
+    postfix within braceless object, 1 prop
     ---
     f a: 1 if call
     ---
@@ -631,7 +659,7 @@ describe "object", ->
   """
 
   testCase """
-    postfix within inline braceless object, 2 props
+    postfix within braceless object, 2 props
     ---
     function f()
       a: 1 if hasA
@@ -645,9 +673,11 @@ describe "object", ->
 
   """
     async
+    break
     class
     catch
     const
+    continue
     declare
     default
     delete
@@ -686,7 +716,7 @@ describe "object", ->
     yield
   """.split('\n').forEach (line) ->
     testCase ```
-      braceless inline object with ${line} as key
+      braceless object with ${line} as key
       ---
       ${line}: 1
       ---
@@ -694,7 +724,7 @@ describe "object", ->
     ```
 
     testCase ```
-      coffee compat braceless inline object with ${line} as key
+      coffee compat braceless object with ${line} as key
       ---
       "civet coffeeCompat"
       ${line}: 1
@@ -703,11 +733,42 @@ describe "object", ->
     ```
 
   testCase """
+    braceless object with continue as key in loop
+    ---
+    loop
+      continue: 1
+    ---
+    while(true) {
+      ({continue: 1})
+    }
+  """
+
+  testCase """
     braceless inline object in function call
     ---
     f a: 1, b: 2, c, d
     ---
     f({a: 1, b: 2}, c, d)
+  """
+
+  testCase """
+    multiline inline object in function call
+    ---
+    f a: 1,
+    b: 2
+    ---
+    f({a: 1,
+    b: 2})
+  """
+
+  testCase """
+    failed braceless inline object in function call
+    ---
+    f a: 1
+    b: 2
+    ---
+    f({a: 1});
+    ({b: 2})
   """
 
   testCase """


### PR DESCRIPTION
Fixes #968 as well as related [weird behaviors](https://civet.dev/playground?code=ZnVuYyBmb286IDEKYmFyOiAy):
```coffee
func foo: 1
bar: 2
↓↓↓
func({ foo: 1, bar: 2 });
```

The issue is that the following parses as an `InlineObjectLiteral` thus `ObjectLiteral` thus `PrimaryExpression`:

```coffee
foo: 1
bar: 2
```

---

This PR splits **implicit object literals** from two to three notions:
* `NestedImplicitObjectLiteral` (AS BEFORE): starts with an indent, arbitrary spacing
* `ImplicitObjectLiteral` (NEW): indentation already consumed, but can have multiple lines at same indentation level — assumed to be used only at beginning of lines
* `InlineObjectLiteral` (MODIFIED): can appear anywhere in an expression, so generally spans only one line, except that explicit trailing commas let you go to next line (as in CoffeeScript)

Previously, `InlineObjectLiteral` acted like `ImplicitObjectLiteral` and that was a problem because it could be used anywhere, not just at beginnings of lines. The main challenge was figuring out where we wanted to add `ImplicitObjectLiteral` in addition to general expressions which included `InlineObjectLiteral`.

Also fixed bugs like the following which [didn't parse](https://civet.dev/playground?code=bG9vcAogIGNvbnRpbnVlOiB4) because there was no check for object literals first, so `continue` matched all by itself:

```coffee
loop
  continue: 1
```