### PR TITLE
Allow enums on one line

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6707,15 +6707,14 @@ EnumBlock
     }
 
 NestedEnumProperties
-  PushIndent NestedEnumProperty*:props PopIndent ->
-    const flatProps = props.flat()
-    if (!flatProps.length) return $skip
+  PushIndent NestedEnumPropertyLine*:props PopIndent ->
+    if (!props.length) return $skip
     return {
-      properties: flatProps.map((p) => p.property),
+      properties: props.flat().map((p) => p.property),
       children: $0,
     }
 
-NestedEnumProperty
+NestedEnumPropertyLine
   ( Nested EnumProperty ) ( _? EnumProperty )* ->
     return [$1, ...$2].map(pair => ({
       property: pair[1],

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6708,18 +6708,19 @@ EnumBlock
 
 NestedEnumProperties
   PushIndent NestedEnumProperty*:props PopIndent ->
-    if (!props.length) return $skip
+    const flatProps = props.flat()
+    if (!flatProps.length) return $skip
     return {
-      properties: props.map((p) => p.property),
+      properties: flatProps.map((p) => p.property),
       children: $0,
     }
 
 NestedEnumProperty
-  Nested? EnumProperty _? ->
-    return {
-      property: $2,
-      children: $0,
-    }
+  ( Nested EnumProperty ) ( _? EnumProperty )* ->
+    return [$1, ...$2].map(pair => ({
+      property: pair[1],
+      children: pair,
+    }))
 
 EnumProperty
   Identifier:name ( __ Equals ExtendedExpression )?:initializer ObjectPropertyDelimiter ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6715,7 +6715,7 @@ NestedEnumProperties
     }
 
 NestedEnumProperty
-  Nested EnumProperty ->
+  Nested? EnumProperty _? ->
     return {
       property: $2,
       children: $0,

--- a/test/types/enum.civet
+++ b/test/types/enum.civet
@@ -1,4 +1,4 @@
-{testCase} from ../helper.civet
+{testCase, throws} from ../helper.civet
 
 describe "[TS] enum", ->
   // Examples from https://www.typescriptlang.org/docs/handbook/enums.html#computed-and-constant-members
@@ -47,6 +47,27 @@ describe "[TS] enum", ->
     enum Direction {
       Up, Down, Left, Right,
     }
+  """
+
+  testCase """
+    indented two lines
+    ---
+    enum Direction
+      Up, Down
+      Left, Right
+    ---
+    enum Direction {
+      Up, Down,
+      Left, Right,
+    }
+  """
+
+  throws """
+    mismatched indentation
+    ---
+    enum Direction
+      Up, Down
+        Left, Right
   """
 
   testCase.js """

--- a/test/types/enum.civet
+++ b/test/types/enum.civet
@@ -38,6 +38,17 @@ describe "[TS] enum", ->
     }
   """
 
+  testCase """
+    indented one line
+    ---
+    enum Direction
+      Up, Down, Left, Right
+    ---
+    enum Direction {
+      Up, Down, Left, Right,
+    }
+  """
+
   testCase.js """
     no initializers
     ---


### PR DESCRIPTION
Fixes #978

I made the `Nested` part of `NestedEnumProperty` optional, allowing it to be on the same line as the previous enum property. I also had to add `_?` or else it didn't allow whitespace after the commas.

I tried to make sure this doesn't inadvertently allow anything it shouldn't, like

```civet
enum E
  A B // look ma, no comma!
```

still causes a syntax error. But there may have been something I forgot to check.