### PR TITLE
Fix spread bug extracted from lib.civet

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -3992,9 +3992,8 @@ function reorderBindingRestProperty(props) {
     }
 
     // JS forbids trailing comma after rest property
-    if (rest.delim?.-1?.token === ",") {
+    if Array.isArray(rest.delim) and rest.delim.-1?.token is ","
       rest.delim.pop()
-    }
 
     const children = [...props, ...after, rest]
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -55,6 +55,20 @@ describe "object", ->
   """
 
   testCase """
+    content after spread
+    ---
+    {
+      ...target
+      token: target.token
+    }
+    ---
+    ({
+      ...target,
+      token: target.token
+    })
+  """
+
+  testCase """
     single line literal
     ---
     a: b


### PR DESCRIPTION
We discovered that Civet currently can't be built by the latest version of Civet. This test is a MWE extracted from `insertTrimmingSpace`, plus a fix.