### PR TITLE
Support "Error" nodes in Playground

### DIFF
--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "switch", ->
   testCase """
@@ -334,6 +334,18 @@ describe "switch", ->
     while (true) {
       CODE
     }
+  """
+
+  throws """
+    mixed when and pattern matching
+    ---
+    switch x
+      when 1
+        ;
+      2
+        ;
+      else
+        ;
   """
 
   testCase """


### PR DESCRIPTION
* `"Error"` nodes in TS generation now display the error(s). (Not very pretty, but functional.) Fixes #979
* JavaScript-specific `"Error"` nodes don't crash until you click "Run"; then they log the specific error messages to our virtual console.

