### PR TITLE
Report error nodes in LSP

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "publisher": "DanielX",
   "repository": {
     "type": "git",
@@ -93,7 +93,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@danielx/civet": "^0.6.50",
+    "@danielx/civet": "^0.6.72",
     "@danielx/hera": "^0.7.12",
     "@types/mocha": "^9",
     "@types/node": "^14.17.0",

--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -19,7 +19,7 @@ import {
 import {
   TextDocument
 } from 'vscode-languageserver-textdocument';
-import TSService, { FileMeta } from './lib/typescript-service.mjs';
+import TSService from './lib/typescript-service.mjs';
 import * as Previewer from "./lib/previewer.mjs";
 import { convertNavTree, forwardMap, getCompletionItemKind, convertDiagnostic, remapPosition, parseKindModifier } from './lib/util.mjs';
 import assert from "assert"

--- a/lsp/yarn.lock
+++ b/lsp/yarn.lock
@@ -268,14 +268,14 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@^0.6.50":
-  version "0.6.50"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.6.50.tgz#22b6c4c834d4a0a30f14f3933becc54dfa860a5d"
-  integrity sha512-fyBnC7BggqLLuACNCs36wRCJYoh2igUzus7FoPJWSg1YmCfmQib/4TThJlvBT7QfGPT2rtSIH7qPDSZRdMEAOA==
+"@danielx/civet@^0.6.72":
+  version "0.6.72"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.6.72.tgz#c5b23d9f7a94a8edb96b2f58eec24d33b0bafcaf"
+  integrity sha512-jumnIbXbdFs0ZiKN62fmD+p8QGi+E0jmtc02dKz9wIIoPkODsa4XXlBrS5BRR5fr3w5d3ah8Vq7gWt+DL9Wa0Q==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
     "@typescript/vfs" "^1.5.0"
-    unplugin "^1.4.0"
+    unplugin "^1.6.0"
 
 "@danielx/hera@^0.7.12":
   version "0.7.12"
@@ -569,15 +569,15 @@ acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
+acorn@^8.11.3:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
 acorn@^8.4.1:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
-
-acorn@^8.9.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 agent-base@6:
   version "6.0.2"
@@ -2427,15 +2427,15 @@ underscore@^1.12.1:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
-unplugin@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.4.0.tgz#b771373aa1bc664f50a044ee8009bd3a7aa04d85"
-  integrity sha512-5x4eIEL6WgbzqGtF9UV8VEC/ehKptPXDS6L2b0mv4FRMkJxRtjaJfOWDd6a8+kYbqsjklix7yWP0N3SUepjXcg==
+unplugin@^1.6.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.7.1.tgz#009571e3128640f4e327f33680d2db27afaf1e11"
+  integrity sha512-JqzORDAPxxs8ErLV4x+LL7bk5pk3YlcWqpSNsIkAZj972KzFZLClc/ekppahKkOczGkwIG6ElFgdOgOlK4tXZw==
   dependencies:
-    acorn "^8.9.0"
+    acorn "^8.11.3"
     chokidar "^3.5.3"
     webpack-sources "^3.2.3"
-    webpack-virtual-modules "^0.5.0"
+    webpack-virtual-modules "^0.6.1"
 
 unzipper@^0.10.11:
   version "0.10.11"
@@ -2525,10 +2525,10 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack-virtual-modules@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
-  integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
+webpack-virtual-modules@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.1.tgz#ac6fdb9c5adb8caecd82ec241c9631b7a3681b6f"
+  integrity sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The LSP now reports parse errors. Unfortunately they don't have location information yet so they will only appear at the top of the file. Eventually we can add location info to error nodes, apply the sourcemapping, update the LSP to check for this location, and then they will appear in the proper place.