### PR TITLE
Consistent arrow vs. pipe precedence

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -585,13 +585,16 @@ FatArrow
     return [ $1, "=>" ]
 
 TrailingDeclaration
-  ( _? ( ConstAssignment / LetAssignment ) )
+  _? ( ConstAssignment / LetAssignment )
+
+TrailingPipe
+  _? Pipe
 
 # NOTE Different from
 # https://262.ecma-international.org/#prod-ConciseBody
 FatArrowBody
   # If same-line single expression, avoid wrapping in braces
-  !EOS NonPipelinePostfixedExpression:exp !TrailingDeclaration !SemicolonDelimiter ->
+  !EOS NonPipelinePostfixedExpression:exp !TrailingDeclaration !TrailingPipe !SemicolonDelimiter ->
     // Ensure object literal is wrapped in parens
     if (exp.type === "ObjectExpression") {
       return makeLeftHandSideExpression(exp)

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -186,6 +186,23 @@ describe "pipe", ->
   """
 
   testCase """
+    pipeline within thin arrow function
+    ---
+    -> import("../package.json") |> await |> .version
+    ---
+    (async function() { return (await import("../package.json")).version })
+  """
+
+  // This example doesn't need to be wrapped in braces, but thicc pipes do
+  testCase """
+    pipeline within fat arrow function
+    ---
+    => import("../package.json") |> await |> .version
+    ---
+    async () => { return (await import("../package.json")).version }
+  """
+
+  testCase """
     nested pipelines within nested arguments
     ---
     func |> .call @,
@@ -397,6 +414,14 @@ describe "pipe", ->
         let ref;
         return (a.add((ref = x + 1)),ref)
       })
+    """
+
+    testCase """
+      within fat arrow function
+      ---
+      => import("../package.json") |> await ||> .init()
+      ---
+      async () => { let ref; return ((ref = await import("../package.json")).init(),ref) }
     """
 
   describe "|>= assignment", ->


### PR DESCRIPTION
Makes `=>` and `->` behave the same with respect to pipes: pipelines go inside the function.

Fixes #949