### PR TITLE
Avoid implicit returns from fat arrows

### DIFF
--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2671,9 +2671,14 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
     isVoid := isVoidType(returnType?.t) or
       (async and isPromiseVoidType(returnType?.t)) or
       (not async and generator and isGeneratorVoidType(returnType?.t))
-    isBlock := block?.type === "BlockStatement"
-    if !isVoid and !set and !isConstructor and isBlock
-      insertReturn(block)
+    if block?.type === "BlockStatement"
+      if isVoid or set or isConstructor
+        if block.bare and block.implicitlyReturned
+          block.children = [ " {", ...block.children, " }" ]
+          block.bare = block.implicitlyReturned = false
+      else
+        unless block.implicitlyReturned
+          insertReturn(block)
 
 function processFunctions(statements, config): void
   gatherRecursiveAll(statements, ({ type }) => type === "FunctionExpression" || type === "ArrowFunction")

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -597,9 +597,16 @@ FatArrowBody
   !EOS NonPipelinePostfixedExpression:exp !TrailingDeclaration !TrailingPipe !SemicolonDelimiter ->
     // Ensure object literal is wrapped in parens
     if (exp.type === "ObjectExpression") {
-      return makeLeftHandSideExpression(exp)
+      exp = makeLeftHandSideExpression(exp)
     }
-    return exp
+    const expressions = [exp]
+    return {
+      type: "BlockStatement",
+      bare: true,
+      expressions,
+      children: [expressions],
+      implicitlyReturned: true,
+    }
   # Otherwise, wrap block body in braces and insert returns
   NoCommaBracedOrEmptyBlock
 

--- a/test/function.civet
+++ b/test/function.civet
@@ -1375,6 +1375,14 @@ describe "function", ->
     """
 
     testCase """
+      one-line fat arrow with void
+      ---
+      (x): void => console.log x
+      ---
+      (x): void => { console.log(x) }
+    """
+
+    testCase """
       nested anonymous function
       ---
       (x) ->

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -109,7 +109,7 @@ describe "[TS] function", ->
     ---
     const ignore = <T, U>(a: T, b: U) : void => null
     ---
-    const ignore = <T, U>(a: T, b: U) : void => null
+    const ignore = <T, U>(a: T, b: U) : void => { null }
   """
 
   testCase """


### PR DESCRIPTION
Fixes #952

Currently, we preserve one-line arrow functions with an expression body, as in `(x) => x+1`, to avoid wrapping with braces and then adding an implicit `return`. But this breaks our promise that `:void` return values do not implicitly return. So this PR wraps those expressions in braces. It's a little weird that `:void => null` ends up returning `undefined` instead of `null`, but it matches the behavior with multi-line arrows.

Note that this behavior only enables when `implicitReturns` is on. If you turn it off, fat arrows act as usual (both implicitly returning for single line, and not implicitly returning for multiline blocks, similar to JS).