### PR TITLE
Fix #947 - Better const function semantics

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1951,16 +1951,6 @@ FunctionExpression
     }
 
   AmpersandFunctionExpression
-  Identifier:id __ ConstAssignment _*:ws ThinArrowFunction:fn ->
-    return {
-      ...fn,
-      id,
-      children: [
-        ...fn.children.slice(0, 3),
-        insertTrimmingSpace(ws, " "), id,
-        ...fn.children.slice(3)
-      ]
-    }
 
   # Ruby/Crystal style block shorthand
 AmpersandFunctionExpression

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -163,7 +163,7 @@ describe "examples (from real life)", ->
         default // number, boolean, undefined
           String(mapping)
     ---
-    function compileStructuralHandler(mapping: StructuralHandling, source: any, single=false, offset=-1): string {
+    const compileStructuralHandler = function(mapping: StructuralHandling, source: any, single=false, offset=-1): string {
       switch(typeof mapping) {
         case "string": {
           return JSON.stringify(mapping)
@@ -285,7 +285,7 @@ describe "examples (from real life)", ->
     ---
     const outer = 1
 
-    function changeNumbers() {
+    const changeNumbers = function() {
       const inner = 1
       const outer = 10;
     }
@@ -314,7 +314,7 @@ describe "examples (from real life)", ->
     resolveModuleNames := (moduleNames: string[], containingFile: string) ->
       resolvedModules := []
     ---
-    function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError: (message: string) => void ) {
+    const getSourceFile = function(fileName: string, languageVersion: ScriptTarget, onError: (message: string) => void ) {
       const sourceText = sys.readFile(fileName)
 
       if (sourceText != undefined) {
@@ -323,7 +323,7 @@ describe "examples (from real life)", ->
       return
     }
 
-    function resolveModuleNames(moduleNames: string[], containingFile: string) {
+    const resolveModuleNames = function(moduleNames: string[], containingFile: string) {
       const resolvedModules = [];return resolvedModules
     }
   """

--- a/test/export.civet
+++ b/test/export.civet
@@ -22,7 +22,7 @@ describe "export", ->
     ---
     export default x:= ->
     ---
-    export default function x() {}
+    const x= function() {};export default x
   """
 
   testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -82,7 +82,7 @@ describe "function", ->
     ---
     x :=-> a
     ---
-    function x() { return a }
+    const x =function() { return a }
   """
 
   testCase """
@@ -93,7 +93,7 @@ describe "function", ->
         x
     ---
     (function() {
-      function fn2() {
+      const fn2 = function() {
         return x
       };return fn2
     })
@@ -104,7 +104,7 @@ describe "function", ->
     ---
     defaultLoad := async ->
     ---
-    async function defaultLoad() {}
+    const defaultLoad = async function() {}
   """
 
   testCase """
@@ -174,7 +174,7 @@ describe "function", ->
       f := ->
         await 5
       ---
-      async function f() {
+      const f = async function() {
         return await 5
       }
     """
@@ -209,10 +209,10 @@ describe "function", ->
       g := <T>(x: T) ->
         yield x
       ---
-      function* f() {
+      const f = function*() {
         return yield 5
       }
-      function* g<T>(x: T) {
+      const g = function*<T>(x: T) {
         return yield x
       }
     """
@@ -907,7 +907,7 @@ describe "function", ->
         ...rest
       ) -> null
       ---
-      function foo(
+      const foo = function(
         x,
         ...rest
       ) { return null }
@@ -921,7 +921,7 @@ describe "function", ->
         rest...
       ) -> null
       ---
-      function foo(
+      const foo = function(
         x,
         ...rest
       ) { return null }

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -339,7 +339,7 @@ describe "Indentation-based JSX", ->
     ---
     function Counter() {
       const [count, setCount] = createSignal(1)
-      function increment() { return setCount(count() + 1) }
+      const increment = function() { return setCount(count() + 1) }
       return <button type="button" onClick={increment}>
         {count()}
       </button>


### PR DESCRIPTION
Removing our transform of const declarations to function to keep them consistent with const semantics.

If people really want function semantics they can use the `function` declaration.