### PR TITLE
Fix hasProp type

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7531,7 +7531,7 @@ Reset
       hasProp(hasPropRef) {
         const typeSuffix = {
           ts: true,
-          children: [": <T>(object: T, prop: string) => boolean"]
+          children: [": <T>(object: T, prop: PropertyKey) => boolean"]
         }
         // [indent, statement]
         module.prelude.push(["", [preludeVar, hasPropRef, typeSuffix, " = ({}.constructor", asAny, ").hasOwn;\n"]])

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7531,10 +7531,10 @@ Reset
       hasProp(hasPropRef) {
         const typeSuffix = {
           ts: true,
-          children: [": <T>(object: T, prop: keyof T) => boolean"]
+          children: [": <T>(object: T, prop: string) => boolean"]
         }
         // [indent, statement]
-        module.prelude.push(["", [preludeVar, hasPropRef, typeSuffix, " = {}.constructor.hasOwn", asAny, ";\n"]])
+        module.prelude.push(["", [preludeVar, hasPropRef, typeSuffix, " = ({}.constructor", asAny, ").hasOwn;\n"]])
       },
       is(isRef) {
         // Thanks to @thetarnav for help with this TypeScript magic.

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -414,7 +414,7 @@ describe "coffeeForLoops", ->
     for own a of b
       console.log a
     ---
-    var a;var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+    var a;var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
     for (a in b) {
       if (!hasProp(b, a)) continue;
       console.log(a)
@@ -427,7 +427,7 @@ describe "coffeeForLoops", ->
     "civet coffee-compat"
     log(a) for own a of b when a != "y"
     ---
-    var a;var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+    var a;var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
     for (a in b) { if (!hasProp(b, a)) continue;if (!(a !== "y")) continue;log(a) }
   """
 

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -414,7 +414,7 @@ describe "coffeeForLoops", ->
     for own a of b
       console.log a
     ---
-    var a;var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+    var a;var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
     for (a in b) {
       if (!hasProp(b, a)) continue;
       console.log(a)
@@ -427,7 +427,7 @@ describe "coffeeForLoops", ->
     "civet coffee-compat"
     log(a) for own a of b when a != "y"
     ---
-    var a;var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+    var a;var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
     for (a in b) { if (!hasProp(b, a)) continue;if (!(a !== "y")) continue;log(a) }
   """
 

--- a/test/for.civet
+++ b/test/for.civet
@@ -404,7 +404,7 @@ describe "for", ->
       for own key in object
         console.log key
       ---
-      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
       for (const key in object) {
         if (!hasProp(object, key)) continue;
         console.log(key)
@@ -417,7 +417,7 @@ describe "for", ->
       for own key in getObject()
         console.log key
       ---
-      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
       let ref;for (const key in ref = getObject()) {
         if (!hasProp(ref, key)) continue;
         console.log(key)
@@ -430,7 +430,7 @@ describe "for", ->
       for own key, value in object
         console.log key, value
       ---
-      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
       for (const key in object) {
         if (!hasProp(object, key)) continue;
         const value = object[key];
@@ -444,7 +444,7 @@ describe "for", ->
       for own key, value in getObject()
         console.log key, value
       ---
-      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
       let ref;for (const key in ref = getObject()) {
         if (!hasProp(ref, key)) continue;
         const value = ref[key];
@@ -458,7 +458,7 @@ describe "for", ->
       for own var key, let value in object
         console.log key, value
       ---
-      var hasProp: <T>(object: T, prop: keyof T) => boolean = {}.constructor.hasOwn as any;
+      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
       for (var key in object) {
         if (!hasProp(object, key)) continue;
         let value = object[key];

--- a/test/for.civet
+++ b/test/for.civet
@@ -404,7 +404,7 @@ describe "for", ->
       for own key in object
         console.log key
       ---
-      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+      var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
       for (const key in object) {
         if (!hasProp(object, key)) continue;
         console.log(key)
@@ -417,7 +417,7 @@ describe "for", ->
       for own key in getObject()
         console.log key
       ---
-      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+      var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
       let ref;for (const key in ref = getObject()) {
         if (!hasProp(ref, key)) continue;
         console.log(key)
@@ -430,7 +430,7 @@ describe "for", ->
       for own key, value in object
         console.log key, value
       ---
-      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+      var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
       for (const key in object) {
         if (!hasProp(object, key)) continue;
         const value = object[key];
@@ -444,7 +444,7 @@ describe "for", ->
       for own key, value in getObject()
         console.log key, value
       ---
-      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+      var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
       let ref;for (const key in ref = getObject()) {
         if (!hasProp(ref, key)) continue;
         const value = ref[key];
@@ -458,7 +458,7 @@ describe "for", ->
       for own var key, let value in object
         console.log key, value
       ---
-      var hasProp: <T>(object: T, prop: string) => boolean = ({}.constructor as any).hasOwn;
+      var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
       for (var key in object) {
         if (!hasProp(object, key)) continue;
         let value = object[key];


### PR DESCRIPTION
Allow for checking arbitrary strings, and handle arbitrary `{}.constructor` type.

[TS playground example](https://www.typescriptlang.org/play?#code/G4QwTgBAFiDOAKYD2AHAXBAFAHgCoD5MkAjAKwFMBjAFw1wBoIVl0JFVyxqBPAaXO4BKCAF58EYkiQAbciAB2wkVgDeAXwB0lJPNjUwAVxpJIcCAqEaYsAPIB3eQG4AUM4AmVaeHIRQkEqQYKgAeGPIGALbEnIzcAPxhkdFgaq7autTmotBw7ChEZIwA5MFFgs4QlRAA9NUAenHO6XoS2dZ5BaTF3GUVVbUNTTotlG25LJ3FAF69VTX1cUA)

Fixes #1010; see [TS playground](https://www.typescriptlang.org/play?target=99#code/G4QwTgBAFiDOAKYD2AHAXBAFAHgCoD5MkAjAKwFMBjAFw1wBoIVl0JFVyxqBPAaXO4BKCAF58EYkiQAbciAB2wkVgDeAXwB0lJPNjUwAVxpJIcCAqEaYsAPIB3eQG4AUM8rS4sCADEpAERBqcghyAA8g+QATLwCgiBVnCAgAMylicFEIACIACQBLCABZJABbLJc1V21daggSChpM+XI7H39A8kxBF2dUyExqvQgAawEIPPk6sipqYQSkvOSsAEJrdhQiaZpGUaFhauoJg3IXJMGZcg1pJABzTF3u50qgA).