### PR TITLE
Unary prefix and postfix in braced literal shorthand

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -124,8 +124,9 @@ Both braced and unbraced literals support shorthand for
 computed property names:
 
 <Playground>
-negate := {-1: 1, 1: -1}
-templated := {`${prefix}${suffix}`: result}
+negate := {-1: +1, +1: -1}
+templated :=
+  `${prefix}${suffix}`: result
 </Playground>
 
 ### Object Globs

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -108,12 +108,23 @@ $: document.title = title
 ### Braced Literals
 
 With braces, the `{x}` shorthand generalizes to any
-sequence of member accesses and/or calls:
+sequence of member accesses and/or calls and/or unary operators:
 
 <Playground>
 another := {person.name, obj?.c?.x}
 computed := {foo(), bar()}
 named := {lookup[x+y]}
+cast := {value as T}
+bool := {!!available}
+</Playground>
+
+### Property Names
+
+Both braced and unbraced literals support shorthand for
+computed property names:
+
+<Playground>
+negate := {-1: 1, 1: -1}
 templated := {`${prefix}${suffix}`: result}
 </Playground>
 

--- a/source/lib.civet
+++ b/source/lib.civet
@@ -2226,6 +2226,7 @@ function quoteString(str) {
 // The return value should have a `name` property (for "Identifier" and
 // "Index"), or have `type` of "Index" (for `[computed]`), or be undefined.
 function lastAccessInCallExpression(exp) {
+  return exp if exp.type is "Identifier"
   let children, i
   do {
     ({ children } = exp)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2926,23 +2926,25 @@ PropertyDefinition
     }
   # NOTE: Added `{x.y?.z()}` shorthand for `{z: x.y?.z()}`
   # NOTE: this needs to be at the bottom to prevent shadowing NamedProperty
-  _?:ws !EOS CallExpression:value ->
-    switch (value.type) {
-      // `{identifier}` remains `{identifier}`, the one shorthand JS supports
-      case "Identifier":
-        return {...value, children: [ws, ...value.children]}
-      // PropertyGlob like x.{a,b} turns into ObjectExpression {a: x.a, b: x.b}
-      // (via `processCallMemberExpression`)
-      case "ObjectExpression":
-        let first = value.properties[0]
-        if (first) {
-          first = {
-            ...first,
-            children: [ws, ...first.children],
-            hoistDec: value.hoistDec
+  _?:ws !EOS UnaryOp*:pre CallExpression:value UnaryPostfix?:post ->
+    if (!pre.length && !post) {
+      switch (value.type) {
+        // `{identifier}` remains `{identifier}`, the one shorthand JS supports
+        case "Identifier":
+          return {...value, children: [ws, ...value.children]}
+        // PropertyGlob like x.{a,b} turns into ObjectExpression {a: x.a, b: x.b}
+        // (via `processCallMemberExpression`)
+        case "ObjectExpression":
+          let first = value.properties[0]
+          if (first) {
+            first = {
+              ...first,
+              children: [ws, ...first.children],
+              hoistDec: value.hoistDec
+            }
           }
-        }
-        return [ first, ...value.properties.slice(1) ]
+          return [ first, ...value.properties.slice(1) ]
+      }
     }
     const last = lastAccessInCallExpression(value)
     if (!last) return $skip
@@ -2993,7 +2995,7 @@ PropertyDefinition
 
     return {
       type: "Property",
-      children: [ws, name, ": ", value],
+      children: [ws, name, ": ", processUnaryExpression(pre, value, post)],
       name,
       names: [],
       value,
@@ -3091,7 +3093,7 @@ MethodDefinition
     }
   # NOTE: Not adding extra validation using PropertySetParameterList
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
-  MethodSignature:signature !PropertyAccess BracedBlock?:block ->
+  MethodSignature:signature !(PropertyAccess / UnaryPostfix) BracedBlock?:block ->
     let children = $0
     let generatorPos = 0
     let { modifier } = signature

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3061,7 +3061,7 @@ ComputedPropertyName
       expression,
       implicit: true,
     }
-  InsertOpenBracket "-" NumericLiteral InsertCloseBracket ->
+  InsertOpenBracket [+-] NumericLiteral InsertCloseBracket ->
     const expression = [ $2, $3 ]
     return {
       type: "ComputedPropertyName",

--- a/test/object.civet
+++ b/test/object.civet
@@ -185,6 +185,18 @@ describe "object", ->
   """
 
   testCase """
+    positive number as computed name
+    ---
+    {
+      +1: 5
+    }
+    ---
+    ({
+      [+1]: 5
+    })
+  """
+
+  testCase """
     computed property name
     ---
     { [x]: 5 }

--- a/test/object.civet
+++ b/test/object.civet
@@ -1066,6 +1066,46 @@ describe "object", ->
       let ref;({[(ref = f(y),ref)]: x[ref]})
     """
 
+    testCase """
+      not
+      ---
+      boolified := {not not exists}
+      ---
+      const boolified = {exists: !!exists}
+    """
+
+    testCase """
+      not call
+      ---
+      boolified := {not not exists()}
+      ---
+      const boolified = {exists: !!exists()}
+    """
+
+    testCase """
+      as T
+      ---
+      cast := {x as T}
+      ---
+      const cast = {x: x as T}
+    """
+
+    testCase """
+      call as T
+      ---
+      cast := {x() as T}
+      ---
+      const cast = {x: x() as T}
+    """
+
+    testCase """
+      await
+      ---
+      asyncComputed := {await asyncFoo()}
+      ---
+      const asyncComputed = {asyncFoo: await asyncFoo()}
+    """
+
     describe "super access", ->
       wrapper """
         class X {


### PR DESCRIPTION
Fixes #1012 by allowing unary prefix and postfix notation in braced literals shorthand properties in most cases. This allows for negation, type casting, and await.

Also add missing support for positive integers as property names.