### PR TITLE
Support extends shorthand in type parameters

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7166,7 +7166,7 @@ TypeArgumentDelimiter
   TypeParameterDelimiter
 
 TypeParameters
-  _? OpenAngleBracket TypeParameter+:parameters __ CloseAngleBracket ->
+  OpenAngleBracket TypeParameter+:parameters __ CloseAngleBracket ->
     return {
       type: "TypeParameters",
       parameters,
@@ -7178,7 +7178,7 @@ TypeParameter
   __ ( "const" _? )? Identifier TypeConstraint? TypeInitializer? TypeParameterDelimiter
 
 TypeConstraint
-  __ "extends" NonIdContinue Type
+  __ ExtendsToken Type
 
 TypeInitializer
   __ "=" Type

--- a/test/class.civet
+++ b/test/class.civet
@@ -271,6 +271,15 @@ describe "class", ->
   """
 
   testCase """
+    ambiguous extends vs. type params
+    ---
+    class A<B<T>
+    ---
+    class A<B extends T> {
+    }
+  """
+
+  testCase """
     extends with braces
     ---
     class A extends B {


### PR DESCRIPTION
Fixes #1013

However, fixing this requires:
* There are some ambiguous situations like `class X<Y<Z>`; it could mean `class X extends Y<Z>` or `class X<Y extends Z>`. But I guess you're asking for trouble in this situation. Currently it means the latter because greedy.
* Forbidding space between a type and its parameters: `T<X>` is valid, but `T <X>` is invalid. This is contrary to TypeScript, but in line with our usual rules about whitespace I think? Potentially controversial, though TS documentation seems to consistently have no space.
* Alternatively, we could still allow spaces, but then `class X < Y<Z>` does not parse how we'd expect.
