### PR TITLE
Add type assignment shorthand

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5064,6 +5064,11 @@ LetAssignment
   ".=" ->
     return { $loc, token: "=" }
 
+
+TypeAssignment
+  "::=" ->
+    return { $loc, token: "=" }
+
 # https://262.ecma-international.org/#prod-LexicalBinding
 # merged with https://262.ecma-international.org/#prod-VariableDeclaration
 LexicalBinding
@@ -6599,6 +6604,14 @@ TypeAliasDeclaration
       ts: true,
     }
 
+  InsertType IdentifierName:id TypeParameters? __ TypeAssignment ( ( _? Type ) / ( __ Type ) ) ->
+    return {
+      type: "TypeDeclaration",
+      id,
+      children: $0,
+      ts: true,
+    }
+
 InterfaceDeclaration
   Interface _? IdentifierName:id TypeParameters? InterfaceExtendsClause? InterfaceBlock ->
     return {
@@ -7347,6 +7360,10 @@ InsertBreak
 InsertVar
   "" ->
     return { $loc, token: "var " }
+
+InsertType
+  "" ->
+    return { $loc, token: "type " }
 
 CoffeeBinaryExistentialEnabled
   "" ->

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -10,6 +10,14 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    assignment shorthand
+    ---
+    x ::= Y
+    ---
+    type x = Y
+  """
+
+  testCase """
     newline
     ---
     type Fred =
@@ -112,6 +120,14 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    type parameters with assignment shorthand
+    ---
+    Z<X, Y> ::= Array<X>
+    ---
+    type Z<X, Y> = Array<X>
+  """
+
+  testCase """
     type parameters with inline interface
     ---
     const map: Map<string, {content: string}> = new Map
@@ -137,6 +153,20 @@ describe "[TS] type declaration", ->
     nested or after newline, no equals
     ---
     type A
+      B |
+      C |
+      D
+    ---
+    type A =
+      B |
+      C |
+      D
+  """
+
+  testCase """
+    nested or after newline, assignment shorthand
+    ---
+    A ::=
       B |
       C |
       D


### PR DESCRIPTION
Fixes #176 

Fairly straightforwards, adds `X ::= Y` as shorthand for `type X = Y`. For the tests I just picked a few existing tests using the `type` keyword and copied them but with `::=` instead.