### PR TITLE
Recognize indentation of type alias

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6596,7 +6596,7 @@ TypeDeclarationRest
 
 TypeAliasDeclaration
   # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
-  TypeKeyword _? IdentifierName:id TypeParameters? OptionalEquals ( ( _? Type ) / ( __ Type ) ) ->
+  TypeKeyword _? IdentifierName:id TypeParameters? OptionalEquals ( MaybeIndentedType / ( __ Type ) ) ->
     return {
       type: "TypeDeclaration",
       id,
@@ -6604,7 +6604,7 @@ TypeAliasDeclaration
       ts: true,
     }
 
-  InsertType IdentifierName:id TypeParameters? __ TypeAssignment ( ( _? Type ) / ( __ Type ) ) ->
+  InsertType IdentifierName:id TypeParameters? __ TypeAssignment ( MaybeIndentedType / ( __ Type ) ) ->
     return {
       type: "TypeDeclaration",
       id,
@@ -6991,7 +6991,7 @@ TypePrimary
   _? TypeTuple ->
     return { ...$2, children: [ $1, ...$2.children ] }
   InterfaceBlock
-  _? FunctionType
+  _? TypeFunction
   _? InlineInterfaceLiteral
   _? ImportType:t ->
     return {
@@ -7019,7 +7019,7 @@ TypePrimary
       raw: [$2.name, ...$3.map(([dot, id]) => dot.token + id.name), ].join(''),
       args,
     }
-  # NOTE: Check FunctionType before parenthesized in order to distinguish between (a: T) => U and
+  # NOTE: Check TypeFunction before parenthesized in order to distinguish between (a: T) => U and
   # A parenthesized inline interface (a: T) ---> ({a: T})
   # NOTE: Check Type before ( EOS Type ) to find implicit nested interfaces first. EOS would swallow the
   # newline so Nested wouldn't match otherwise.
@@ -7153,7 +7153,7 @@ TypeBinaryOp
   "&" ->
     return { $loc, token: "&" }
 
-FunctionType
+TypeFunction
   ( ( Abstract _? )? New _? )? Parameters __ TypeArrowFunction ReturnType?:type ->
     if (type) {
       return $0

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -41,6 +41,24 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    deeply nested braceless type
+    ---
+    type Point =
+      coords:
+        x: number
+        y: number
+      color: string
+    ---
+    type Point = {
+      coords: {
+        x: number
+        y: number
+      }
+      color: string
+    }
+  """
+
+  testCase """
     nested braceless type, no equals
     ---
     type Point
@@ -85,6 +103,22 @@ describe "[TS] type declaration", ->
       x: {a: number, b: number,}
       y: {c: [string], d: ()=>void}
     }
+  """
+
+  testCase """
+    nested array
+    ---
+    type Foo
+      [
+        (x: string) => number
+        (x: number) => number | string
+      ]
+    ---
+    type Foo =
+      [
+        (x: string) => number,
+        (x: number) => number | string
+      ]
   """
 
   testCase """


### PR DESCRIPTION
Based on #1018 discussion.

I actually couldn't come up with a test where this mattered. But probably a step in the right direction for future reduced use of `__`...

There's currently still a `__` for cases like:

```ts
type Foo =
string
```

We could probably replace that with `Nested` (indented the same level)...