### PR TITLE
Typechecking CLI

### DIFF
--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -150,6 +150,35 @@ normally, but you'll need to mark `"fs"` as an external dependency
 (see e.g. [esbuild instructions](https://esbuild.github.io/api/#external>)
 and [Vite instructions](https://vitejs.dev/guide/build#library-mode)).
 
+## Typechecking
+
+You can ask Civet to run TypeScript to check for type errors in your Civet code
+(the analog of `tsc`):
+
+```sh
+civet --typecheck src/**/*.civet
+```
+
+Be sure to specify all the files you want to check.
+This command returns an error code if there are any type errors,
+so you can use it in an NPM script and in CI.
+
+You can typecheck and generate JavaScript/TypeScript files at the same time.
+This could be a good NPM `build` script, for example.
+Note that JavaScript/TypeScript files will be generated
+even if there are type errors.
+
+```sh
+civet -c --typecheck src/**/*.civet
+```
+
+You can also use TypeScript to generate `.d.ts` declaration files
+(if there are no type errors):
+
+```sh
+civet --emit-declaration src/**/*.civet
+```
+
 ## Building a project
 
 Use Civet's built-in [unplugin](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin) to integrate with many

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -90,7 +90,8 @@ function implicitCivet(file: string): string | undefined {
   return
 }
 
-const civetUnplugin = createUnplugin((options: PluginOptions = {}, meta) => {
+export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
+(options: PluginOptions = {}, meta) => {
   if (options.dts) options.emitDeclaration = options.dts;
   if (options.js) options.ts = 'civet';
 
@@ -202,6 +203,7 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}, meta) => {
           });
 
         if (diagnostics.length > 0) {
+          // TODO: Map diagnostics to original file via sourcemap
           console.error(
             ts.formatDiagnosticsWithColorAndContext(
               diagnostics,
@@ -450,6 +452,6 @@ const civetUnplugin = createUnplugin((options: PluginOptions = {}, meta) => {
       },
     },
   };
-});
+};
 
-export default civetUnplugin;
+export default createUnplugin(rawPlugin)

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -420,7 +420,7 @@ function cli
           console.error error
           process.exit 1
 
-  process.exitCode = errors
+  process.exitCode = Math.min 255, errors
   if unplugin?
     try
       await unplugin.buildEnd.call {
@@ -429,7 +429,7 @@ function cli
       }
     catch error
       if match := (error as Error).message.match /Aborting build because of (\d+) TypeScript diagnostic/
-        process.exitCode = +match[1]
+        process.exitCode = Math.min 255, errors + +match[1]
       else
         process.exitCode = 1
         throw error

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -50,7 +50,7 @@ if process.argv.includes "--help"
       --inline-map     Generate a sourcemap
       --no-cache       Disable compiler caching (slow, for debugging)
       --typecheck      Run TypeScript and output diagnostics
-      --emit-declaration  Run TypeScript and emit .d.ts declaration files
+      --emit-declaration  Run TypeScript and emit .d.ts files (if no errors)
 
     You can use - to read from stdin or (prefixed by -o) write to stdout.
 

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,6 +1,13 @@
 { compile, parse } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
+// unplugin ends up getting installed in the same dist directory
+{rawPlugin} from ./unplugin
+let unplugin:
+  buildStart: () => void
+  buildEnd: (this: {emitFile: (data: {source: string, fileName: string, type: string}) => void}) => void
+  load: (this: {addWatchFile: (filename: string) => void}, filename: string) => Promise<{code: string, map: unknown}>
+
 function version: string
   require("../package.json").version
 
@@ -42,6 +49,8 @@ if process.argv.includes "--help"
       --ast            Print the AST instead of the compiled code
       --inline-map     Generate a sourcemap
       --no-cache       Disable compiler caching (slow, for debugging)
+      --typecheck      Run TypeScript and output diagnostics
+      --emit-declaration  Run TypeScript and emit .d.ts declaration files
 
     You can use - to read from stdin or (prefixed by -o) write to stdout.
 
@@ -70,10 +79,11 @@ interface Options extends CompileOptions
   ast?: boolean
   noCache?: boolean
   inlineMap?: boolean
-  js?: boolean
   hits?: string
   trace?: string
   repl?: boolean
+  typecheck?: boolean
+  emitDeclaration?: boolean
 
 interface ParsedArgs
   filenames: string[]
@@ -83,7 +93,7 @@ interface ParsedArgs
 function parseArgs(args: string[]): ParsedArgs
   options: Options := {}
   Object.defineProperty options, 'run',
-    get: (this: Options) -> not (@ast or @compile)
+    get: (this: Options) -> not (@ast or @compile or @typecheck or @emitDeclaration)
   filenames: string[] := []
   scriptArgs: string[] .= []
   i .= 0
@@ -130,6 +140,10 @@ function parseArgs(args: string[]): ParsedArgs
         options.hits = args[++i]
       when '--trace'
         options.trace = args[++i]
+      when '--typecheck'
+        options.typecheck = true
+      when '--emit-declaration', '--emitDeclaration'
+        options.emitDeclaration = true
       when '--'
         endOfArgs ++i  // remaining arguments are filename and/or arguments
       else
@@ -262,6 +276,14 @@ function cli
       options.compile = true
       filenames = ['-']
 
+  if options.typecheck or options.emitDeclaration
+    unplugin = rawPlugin {
+      ...options
+      ts: if options.js then 'civet' else 'preserve'
+      outputExtension: '.tsx'
+    }, framework: 'civet-cli'
+    unplugin.buildStart()
+
   // In run mode, compile to JS with source maps
   if options.run
     options.js = true
@@ -296,19 +318,29 @@ function cli
       (options.parseOptions ??= {}).rewriteCivetImports ??=
         outputExt ?? '.civet' + if options.js then ".jsx" else ".tsx"
 
+  errors .= 0
   for await {filename, error, content, stdin} of readFiles filenames
     if error
       console.error `${filename} failed to load:`
       console.error error
+      errors++
       continue
 
     // Transpile
     let output: string
     try
-      output = compile content!, {...options, filename}
+      if unplugin?
+        output = unplugin.load.call {
+          addWatchFile();
+        }, `${filename}.tsx`
+        |> await
+        |> .code
+      else
+        output = compile content!, {...options, filename}
     catch error
       //console.error `${filename} failed to transpile:`
       console.error error
+      errors++
       continue
 
     if options.ast
@@ -336,7 +368,8 @@ function cli
         catch error
           console.error `${targetFilename} failed to write:`
           console.error error
-    else // run
+          errors++
+    else if options.run
       esm := /^\s*(import|export)\b/m.test output
       if esm
         // Run ESM code via `node --loader @danielx/civet/esm` subprocess
@@ -386,5 +419,19 @@ function cli
           console.error `${filename} crashed while running in CJS mode:`
           console.error error
           process.exit 1
+
+  process.exitCode = errors
+  if unplugin?
+    try
+      await unplugin.buildEnd.call {
+        emitFile({source, fileName})
+          fs.writeFile fileName, source
+      }
+    catch error
+      if match := (error as Error).message.match /Aborting build because of (\d+) TypeScript diagnostic/
+        process.exitCode = +match[1]
+      else
+        process.exitCode = 1
+        throw error
 
 cli() if require.main is module

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7,6 +7,7 @@ declare module "@danielx/civet" {
     coffeeBooleans: boolean
     coffeeClasses: boolean
     coffeeComment: boolean
+    coffeeCompat: boolean
     coffeeDo: boolean
     coffeeEq: boolean
     coffeeForLoops: boolean


### PR DESCRIPTION
Following up on https://github.com/DanielXMoore/Civet/issues/61#issuecomment-1921882118, I realized that we don't need to duplicate the functionality of the unplugin: we can call the unplugin directly from the CLI!  (with a small amount of unplugin emulation)

![image](https://github.com/DanielXMoore/Civet/assets/2218736/0798045a-ca50-4e4d-a0e0-965562f04e83)

* New `--typecheck` option runs the TypeScript compiler on all specified source files and outputs all diagnostics.
  * No sourcemapping to the original files; this is a missing feature in the unplugin. Added a TODO.
  * You need to specify all `.civet` files in one command line to check everything. So something like `civet --typecheck src/**/*.civet`.
  * Should `-t` be an alias for this? It seems important, but we might also eventually have a `--ts` feature to mirror the unplugin `ts` option, so maybe better to save it.
* New `--emit-declaration` option generates `.d.ts` files for all input `.civet` files. Actually only emits if `--typecheck` doesn't produce error diagnostics.
* Note that `-c`/`--compile` is orthogonal to the above options. If specified, we compile to `.tsx`/`.jsx` files, and this happens even if `--typecheck` emits error diagnostics. But you can also run typechecking without outputting any files, via `civet --typecheck`.
* I guess this fixes #61, though it's unresolved whether there should be a separate `bin` called `civetsc`/`tscivet`. Perhaps more crucially, we're missing a "typecheck everything" command that respects an `include`/`exclude` feature like `tsc` and `tsconfig.json`. That said, I imagine anyone using the CLI would be explicitly listing `.civet` files anyway for compilation, so maybe this is sufficient?
