### PR TITLE
Cleanup non-null assertion handling

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1070,7 +1070,6 @@ OptionalShorthand
       type: "Optional",
       children: $0,
     }
-  NonNullAssertion
 
 OptionalDot
   InlineComment* Dot
@@ -1078,7 +1077,7 @@ OptionalDot
 
 NonNullAssertion
   # NOTE: Prevent shadowing !^ xnor operator
-  "!" !"^" -> { type: "NonNullAssertion", ts: true, children: $1 }
+  ExclamationPoint !"^" -> { type: "NonNullAssertion", ts: true, children: [$1] }
 
 # https://262.ecma-international.org/#prod-MemberExpression
 MemberExpression
@@ -1117,15 +1116,16 @@ MemberExpressionRest
 MemberExpressionRestBody
   # NOTE: Added shorthand x?[3] -> x?.[3]
   OptionalShorthand?:dot InlineComment*:comments MemberBracketContent:content ->
+    if (!dot && !comments.length) return content
     if (dot) {
       // Optional followed by a slice expression
       if (dot.type === "Optional" && content.type === "SliceExpression") {
         // Remove '.' from optional since it is present in '.slice'
         return [...dot.children.slice(0, -1), ...comments, content]
       }
-      return $0.flat()
+      return [dot, ...comments, content]
     }
-    return content
+    return [...comments, content]
   # NOTE: Combined Optional and Property access
   PropertyAccess
   PropertyGlob
@@ -3093,7 +3093,7 @@ MethodDefinition
     }
   # NOTE: Not adding extra validation using PropertySetParameterList
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
-  MethodSignature:signature !(PropertyAccess / UnaryPostfix) BracedBlock?:block ->
+  MethodSignature:signature !(PropertyAccess / UnaryPostfix / NonNullAssertion) BracedBlock?:block ->
     let children = $0
     let generatorPos = 0
     let { modifier } = signature
@@ -6397,16 +6397,17 @@ InlineJSXMemberExpression
 
 # MemberExpressionRest without optional IndentFurther before PropertyAccess
 InlineJSXMemberExpressionRest
-  OptionalShorthand? MemberBracketContent ->
-    if ($1) {
+  OptionalShorthand?:dot InlineComment*:comments MemberBracketContent:content ->
+    if (!dot && !comments.length) return content
+    if (dot) {
       // Optional followed by a slice expression
-      if ($1.type === "Optional" && $2.type === "SliceExpression") {
+      if (dot.type === "Optional" && content.type === "SliceExpression") {
         // Remove '.' from optional since it is present in '.slice'
-        return [$1.children[0], $2]
+        return [...dot.children.slice(0, -1), ...comments, content]
       }
-      return $0
+      return [dot, ...comments, content]
     }
-    return $2
+    return [...comments, content]
   PropertyAccess
   PropertyGlob
   PropertyBind

--- a/test/object.civet
+++ b/test/object.civet
@@ -1007,6 +1007,22 @@ describe "object", ->
     """
 
     testCase """
+      call with non-null assertion
+      ---
+      {f()!.g}
+      ---
+      ({g: f()!.g})
+    """
+
+    testCase """
+      call with double non-null assertion
+      ---
+      {f()!!.g}
+      ---
+      ({g: f()!!.g})
+    """
+
+    testCase """
       prop call
       ---
       {props.x()}

--- a/test/types/non-null-assertion.civet
+++ b/test/types/non-null-assertion.civet
@@ -32,3 +32,11 @@ describe "[TS] non null assertion", ->
     ---
     const a = f!()
   """
+
+  testCase """
+    double assertion
+    ---
+    a := x!!
+    ---
+    const a = x!!
+  """


### PR DESCRIPTION
* Remove `NonNullAssertion` from `OptionalShorthand`, as it was already in `MemberExpressionRest` and thus `CallExpressionRest`.
* Fix some lost comments.
* Prevent `foo()!!.bar` from parsing like a method definition.