### PR TITLE
Automatic TS jsx setting in unplugin and CLI

### DIFF
--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -153,6 +153,9 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           ...configContents.options,
           target: ts.ScriptTarget.ESNext,
         };
+        // We use .tsx extensions when type checking, so need to enable
+        // JSX mode even if the user doesn't request/use it.
+        compilerOptions.jsx ??= "preserve";
         compilerOptionsWithSourceMap = {
           ...compilerOptions,
           sourceMap: true,


### PR DESCRIPTION
The unplugin and CLI `--typecheck` use `.tsx` extension for type checking, because Civet's output is generally in TSX syntax. But TypeScript issues an error in this case when importing and the user didn't set a `compilerOptions.jsx` option in `tsconfig.json`:

```
test.civet.tsx:2:17 - error TS6142: Module './yes.civet' was resolved to 'C:/Users/edemaine/Projects/Civet/yes.civet.tsx', but '--jsx' is not set.

2 import yes from './yes.civet'
```

This PR forces a `jsx` setting in tsconfig if the user didn't specify one, removing this stray error.