### PR TITLE
Avoid double semicolon in then clause

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -213,17 +213,14 @@ function insertPush(node, ref): void
   // TODO: unify this with the `exp` switch
   switch (node.type) {
     case "BlockStatement":
-      if (node.expressions.length) {
-        const last = node.expressions[node.expressions.length - 1]
-        insertPush(last, ref)
-      } else {
+      if node.expressions.length
+        insertPush(node.expressions.-1, ref)
+      else
         node.expressions.push([ref, ".push(void 0);"])
-      }
       return
     case "CaseBlock":
-      node.clauses.forEach((clause) => {
+      node.clauses.forEach (clause) =>
         insertPush(clause, ref)
-      })
       return
     // NOTE: "CaseClause"s don't push
     case "WhenClause":
@@ -268,8 +265,8 @@ function insertPush(node, ref): void
     case "IfStatement":
       // if block
       insertPush(exp.then, ref)
-      if (exp.then.bare)
-        exp.then.children.push(";")
+      if exp.then.bare and not exp.then.semicolon
+        exp.then.children.push exp.then.semicolon = ";"
       // else block
       if (exp.else) insertPush(exp.else[2], ref)
       // Add else block pushing undefined if no else block
@@ -410,14 +407,12 @@ function insertSwitchReturns(exp): void
     insertReturn clause
 
 function wrapIterationReturningResults(statement, outer, outerRef?): void
-  if (statement.type is "DoStatement") {
-    if (outerRef) {
+  if statement.type is "DoStatement"
+    if outerRef
       insertPush(statement.block, outerRef)
-    } else {
+    else
       insertReturn(statement.block, outer)
-    }
     return
-  }
 
   const resultsRef = makeRef("results")
 
@@ -429,11 +424,10 @@ function wrapIterationReturningResults(statement, outer, outerRef?): void
   insertPush(statement.block, resultsRef)
 
   outer.children.unshift(declaration)
-  if (outerRef) {
+  if outerRef
     statement.children.push(";", outerRef, ".push(", resultsRef, ");")
-  } else {
+  else
     statement.children.push(";return ", resultsRef, ";")
-  }
 
 function processParams(f): void
   const { type, parameters, block } = f

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -502,12 +502,10 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
       block := blockWithPrefix(condition.expression.blockPrefix, s.then)
       s.then = block
 
-      toAdd := [block]
+      if block.bare and e and not block.semicolon
+        block.children.push block.semicolon = ";"
 
-      if block.bare and e
-        toAdd.push ";"
-
-      s.children.splice(2, 1, ...toAdd)
+      s.children.splice(2, 1, block)
 
       // Update parent pointers since declaration conditions have expanded
       updateParentPointers(block, s)

--- a/test/for.civet
+++ b/test/for.civet
@@ -556,6 +556,20 @@ describe "for", ->
     """
 
     testCase """
+      if then else
+      ---
+      check :=
+        for i of [0..7]
+          if true then 'yes' else 'no'
+      ---
+      const check =
+        (()=>{const results=[];for (let i1 = 0; i1 <= 7; ++i1) {
+          const i = i1;
+          if (true) results.push('yes'); else results.push('no')
+        }return results})()
+    """
+
+    testCase """
       pushing switch results
       ---
       x = for (let i = 0; i < 10; i++)


### PR DESCRIPTION
Fixes #1040

I actually can't remember why we check for this in two different places. Perhaps one of them can be removed, and this code can be simplified? But not remembering why they're actually necessary, I left them both in and just made them interact better.