### PR TITLE
Fix #1047 - Properly escape newlines in multi-line strings

### DIFF
--- a/source/parser/string.civet
+++ b/source/parser/string.civet
@@ -137,12 +137,14 @@ function processCoffeeInterpolation(s, parts, e, $loc)
   }
 
 /**
-Adjust a parsed string by escaping newlines
+Adjust a parsed string by escaping unescaped newlines.
 */
 function modifyString(str: string)
-  // Replace non-escaped newlines with escaped newlines
-  // taking into account the possibility of a preceding escaped backslash
-  return str.replace(/(^.?|[^\\]{2})(\\\\)*\n/g, '$1$2\\n')
+  str.replace /((?:\\.|[^\r\n])*)(\r\n|\n|\r)?/gsu, (_, chars, nl) ->
+    if nl
+      chars + '\\n'
+    else
+      chars
 
 /**
 Add quotes around a string to make it a valid JavaScript string,

--- a/test/strings.civet
+++ b/test/strings.civet
@@ -57,6 +57,36 @@ describe "strings", ->
   """
 
   testCase """
+    two newlines
+    ---
+    "a\nb\nc"
+    "\n\n"
+    ---
+    "a\\nb\\nc"
+    "\\n\\n"
+  """
+
+  testCase """
+    windows newlines
+    ---
+    "a\r\nb\r\nc"
+    "\r\n\r\n"
+    ---
+    "a\\nb\\nc"
+    "\\n\\n"
+  """
+
+  testCase """
+    old mac newlines
+    ---
+    "a\rb\rc"
+    "\r\r"
+    ---
+    "a\\nb\\nc"
+    "\\n\\n"
+  """
+
+  testCase """
     escaped backslash then non-escaped backslash then newline
     ---
     x = "a\\\\\\


### PR DESCRIPTION
I converted `\r\n|\n|\r` all to `\n`. It seems like the right thing to do.