### PR TITLE
Suppress ESLint `no-cond-assign` with `if const` etc

### DIFF
--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -450,8 +450,7 @@ function processDeclarationCondition(condition, rootCondition, parent): void
     // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
     // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
     if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
-      // steal the parens from the parent, forcing them to double up
-      [condition.parent.children.0, ref, initializer, condition.parent.children.-1]
+      ["(", ref, initializer, ")"]
     else
       [ref, initializer]
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -448,22 +448,24 @@ function processDeclarationCondition(condition, rootCondition, parent): void
   children :=
     // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
     // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
-    // @ts-ignore Just because binding.pattern might not have a type at runtime doesn't mean it's unsafe
-    if binding.pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
+    // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
+    if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
       // steal the parens from the parent, forcing them to double up
       [condition.parent.children.0, ref, initializer, condition.parent.children.-1]
     else
       [ref, initializer]
 
-  Object.assign condition,
+  Object.assign condition, {
     type: "AssignmentExpression"
-    children: children
+    children
     hoistDec:
       type: "Declaration"
       children: ["let ", ref, suffix]
       names: []
-    pattern: pattern
-    ref: ref
+    pattern
+    ref
+  }
+
   // condition wasn't previously a child, so now needs parent pointers
   addParentPointers condition, parent
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -2,6 +2,7 @@ import type {
   ASTNode
   ASTRef
   BlockStatement
+  DeclarationStatement
   IfStatement
   IterationStatement
   ParenthesizedExpression
@@ -438,14 +439,25 @@ function processDeclarationCondition(condition, rootCondition, parent): void
   return unless condition.type is "DeclarationCondition"
   ref := makeRef()
 
-  { decl, bindings } := condition.declaration
+  { decl, bindings } := condition.declaration as DeclarationStatement
   // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
   binding := bindings[0]
   { pattern, suffix, initializer, splices, thisAssignments } := binding
 
+  grandparent := condition.parent?.parent
+  children :=
+    // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
+    // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
+    // @ts-ignore Just because binding.pattern might not have a type at runtime doesn't mean it's unsafe
+    if binding.pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
+      // steal the parens from the parent, forcing them to double up
+      [condition.parent.children.0, ref, initializer, condition.parent.children.-1]
+    else
+      [ref, initializer]
+
   Object.assign condition,
     type: "AssignmentExpression"
-    children: [ref, initializer]
+    children: children
     hoistDec:
       type: "Declaration"
       children: ["let ", ref, suffix]

--- a/test/if.civet
+++ b/test/if.civet
@@ -294,7 +294,7 @@ describe "if", ->
       z
     } if w := g()
     ---
-    let ref;if (ref = g()) { const w = ref;let ref1;if (ref1 = f()) {
+    let ref;if ((ref = g())) { const w = ref;let ref1;if ((ref1 = f())) {
       const x = ref1;
       y
     }
@@ -715,7 +715,7 @@ describe "if", ->
       if m: Match := s.match(re)
         s
       ---
-      let ref: Match;if (ref = s.match(re)) {
+      let ref: Match;if ((ref = s.match(re))) {
         const m: Match = ref;
         s
       }
@@ -779,11 +779,11 @@ describe "if", ->
       else if y := 1
         "bye"
       ---
-      let ref;let ref1;if (ref = 0) {
+      let ref;let ref1;if ((ref = 0)) {
         const x = ref;
         "hi"
       }
-      else if (ref1 = 1) {
+      else if ((ref1 = 1)) {
         const y = ref1;
         "bye"
       }
@@ -807,7 +807,7 @@ describe "if", ->
       if const match = regex.exec string
         console.log match
       ---
-      let ref;if (ref = regex.exec(string)) {
+      let ref;if ((ref = regex.exec(string))) {
         const match = ref;
         console.log(match)
       }
@@ -844,7 +844,7 @@ describe "if", ->
       if a := try b
         log a
       ---
-      let ref;if (ref = (()=>{try { return b } catch(e) {return}})()) {
+      let ref;if ((ref = (()=>{try { return b } catch(e) {return}})())) {
         const a = ref;
         log(a)
       }
@@ -859,8 +859,8 @@ describe "if", ->
       else
         b
       ---
-      let ref, y;x = (ref = f())?
-        {y} = ref,a
+      let ref, y;x = ((ref = f()))?
+        ({y} = ref,a)
       :
         b
     """


### PR DESCRIPTION
If the condition to an `if` or `while` statement is just an assignment and nothing else, this trips ESLint's `no-cond-assign` rule. While this should continue to trigger for Civet code like `if x = y`, `if x := y` feels intentional enough that it shouldn't trigger that error. ESLint allows you to suppress the error by doubling up the parens, so this PR doubles the parens in these cases.

The typings -- or, more frequently, lack thereof -- inside the compiler made this a little difficult to navigate at first, but I got there in the end.