### PR TITLE
Add esbuild unplugin to Vite's optimizeDeps

### DIFF
--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -437,6 +437,14 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
       config(config: UserConfig) {
         rootDir = path.resolve(process.cwd(), config.root ?? '');
 
+        config.optimizeDeps ??= {};
+        config.optimizeDeps.esbuildOptions ??= {};
+        config.optimizeDeps.esbuildOptions.plugins ??= [];
+        config.optimizeDeps.esbuildOptions.plugins.push(
+          // @ts-ignore esbuild types from Vite might not match our esbuild
+          unplugin.esbuild({...options, js: undefined, ts: 'preserve'})
+        );
+
         if (implicitExtension) {
           config.resolve ??= {};
           config.resolve.extensions ??= [];
@@ -481,4 +489,5 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
   };
 };
 
-export default createUnplugin(rawPlugin)
+var unplugin = createUnplugin(rawPlugin)
+export default unplugin

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -442,7 +442,14 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         config.optimizeDeps.esbuildOptions.plugins ??= [];
         config.optimizeDeps.esbuildOptions.plugins.push(
           // @ts-ignore esbuild types from Vite might not match our esbuild
-          unplugin.esbuild({...options, js: undefined, ts: 'preserve'})
+          unplugin.esbuild({
+            ...options,
+            js: undefined,
+            ts: 'preserve',
+            dts: undefined,
+            emitDeclaration: false,
+            typecheck: false,
+          })
         );
 
         if (implicitExtension) {


### PR DESCRIPTION
Something about the absolute paths in #1046 broke Vite in dev mode. The problem seems to be that we're now triggering the [dep optimization phase](https://vitejs.dev/config/dep-optimization-options.html). I don't know exactly how it works, but I observe that it uses esbuild, and lo', we have an esbuild plugin. Installing that automatically in Vite config seems to fix the problem.