### PR TITLE
Force emitting dts files in unplugin

### DIFF
--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -283,6 +283,16 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
                   filePath
                 );
 
+                // Work around unplugin+esbuild bug where it only creates the
+                // root output directory, not any subdirectories.
+                if (meta.framework === 'esbuild') {
+                  fs.mkdirSync(
+                    path.dirname(
+                      path.resolve(esbuildOptions.outdir!, pathFromDistDir)
+                    ), { recursive: true }
+                  );
+                }
+
                 this.emitFile({
                   source: content,
                   fileName: pathFromDistDir,
@@ -290,7 +300,10 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
                 });
               },
               undefined,
-              true
+              true, // emitDtsOnly
+              undefined,
+              // @ts-ignore @internal interface
+              true, // forceDtsEmit
             );
           }
         }


### PR DESCRIPTION
It seems that `emitDeclaration` isn't emitting `.d.ts` files, and hasn't been for some time. (I didn't track down exactly which version of Civet broke this, but it's at least 10 versions ago.) I guess we could really use unplugin tests...

Anyway, TypeScript seems to respond to [an `@internal` interface](https://github.com/microsoft/TypeScript/blob/1c0fd3122345bc342337089beb0b905d0ec0ddba/src/compiler/types.ts#L4727) to `forceDtsEmit`. Adding this fixes `.d.ts` emit.

This revealed a bug in esbuild, where unplugin creates the output directory but doesn't create the subdirectories in the `.d.ts` filenames. E.g., `src/index.civet` generates `dist/src/index.civet`, and unplugin makes the directory `dist` but not `dist/src`. I'll upstream this to unplugin, but meanwhile have a workaround here.