### PR TITLE
Fix Playground around top-level await

### DIFF
--- a/civet.dev/.vitepress/components/PlaygroundFull.vue
+++ b/civet.dev/.vitepress/components/PlaygroundFull.vue
@@ -43,6 +43,11 @@ function onInput(civet: string, js: string) {
 const evalOutput = ref<null | string>(null);
 const evalComplete = ref<boolean>(true);
 
+declare global {
+  interface Window {
+    civetconsole: Record<string, (...args: unknown[]) => void>;
+  }
+}
 window.civetconsole = {};
 Object.keys(console).forEach((key) => {
   window.civetconsole[key] = (...args) => {

--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -8,73 +8,14 @@ onmessage = async (e) => {
   const highlighter = await getHighlighter();
   const inputHtml = highlighter.codeToHtml(code, { lang: 'coffee' });
 
+  let tsCode, ast, errors = []
   try {
-    let ast = Civet.compile(code, { ast: true });
-    const errors = [];
-    let tsCode = Civet.generate(ast, { errors });
+    ast = Civet.compile(code, { ast: true });
+    tsCode = Civet.generate(ast, { errors });
     if (errors.length) {
       // TODO: Better error display; copied from main.civet
       throw new Error(`Parse errors: ${errors.map($ => $.message).join("\n")}`)
     }
-    let jsCode = '';
-
-    if (jsOutput) {
-      // Wrap in IIFE if there's a top-level await
-      const topLevelAwait = Civet.lib.gatherRecursive(ast,
-        (n) => n.type === 'Await',
-        Civet.lib.isFunction
-      ).length > 0
-      if (topLevelAwait) {
-        const prefix = /^(\s*|;|\'([^'\\]|\\.)*\'|\"([^"\\]|\\.)*\"|\/\/.*|\/\*[^]*?\*\/)*/.exec(code)[0]
-        const rest = code.slice(prefix.length)
-        .replace(/\/\/.*|\/\*[^]*?\*\//g, '')
-        const coffee = /['"]civet[^'"]*coffee(Compat|-compat|Do|-do)/.test(prefix)
-        ast = Civet.compile(
-          prefix +
-          (coffee ? 'do ->\n' : 'async do\n') +
-          rest.replace(/^/gm, ' '),
-          { ast: true }
-        );
-      }
-
-      // Convert console to civetconsole for Playground execution
-      Civet.lib.gatherRecursive(ast,
-        (n) => n.type === 'Identifier' && n.children?.token === "console"
-      ).forEach((node) => {
-        node.children.token = "civetconsole"
-      })
-
-      jsCode = Civet.generate(ast, { js: true, errors })
-
-      if (topLevelAwait) {
-        jsCode += `.then((x)=>x!==undefined&&civetconsole.log("[EVAL] "+x))`
-      }
-
-      // Parse errors specific to JS generation
-      if (errors.length) {
-        jsCode = `civetconsole.error("Civet failed to generate JavaScript code:\\n${errors.map($ => $.message.replace(/[\\"]/g, '\\$&')).join("\\n")}")`
-        console.log(jsCode)
-      }
-    }
-
-    if (prettierOutput) {
-      try {
-        tsCode = prettier.format(tsCode, {
-          parser: 'typescript',
-          plugins: prettierPlugins,
-          printWidth: 50,
-        });
-      } catch (err) {
-        console.info('Prettier error. Fallback to raw civet output', {
-          tsCode,
-          err,
-        });
-      }
-    }
-
-    const outputHtml = highlighter.codeToHtml(tsCode, { lang: 'tsx' });
-
-    postMessage({ uid, inputHtml, outputHtml, jsCode });
   } catch (error) {
     if (Civet.isCompileError(error)) {
       console.info('Snippet compilation error!', error);
@@ -89,7 +30,80 @@ onmessage = async (e) => {
       console.error(error)
       postMessage({ uid, inputHtml, outputHtml: error.message, error });
     }
+    return
   }
+
+  let jsCode = '';
+  if (jsOutput) {
+    // Wrap in IIFE if there's a top-level await
+    // Use Civet's async do, so Civet does implicit return of last value
+    try {
+      const topLevelAwait = Civet.lib.gatherRecursive(ast,
+        (n) => n.type === 'Await',
+        Civet.lib.isFunction
+      ).length > 0
+      if (topLevelAwait) {
+        // Eat prologue strings and comments
+        let prefix = /^(\s*|;|\'([^'\\]|\\.)*\'|\"([^"\\]|\\.)*\"|\/\/.*|\/\*[^]*?\*\/)*/.exec(code)[0]
+        // Trim prologue to end at the last newline or semicolon;
+        // otherwise, e.g. "x" |> console.log would eat the "x"
+        prefix = /^[^]*(\n|;)/.exec(prefix)?.[0] ?? ''
+        const rest = code.slice(prefix.length)
+        .replace(/\/\/.*|\/\*[^]*?\*\//g, '');
+        // Civet prologue must end with a newline
+        const coffee = /['"]civet[^'"]*coffee(Compat|-compat|Do|-do)[^'"]*['"][;\s]*?\n/.test(prefix)
+        ast = Civet.compile(
+          prefix +
+          (coffee ? '(do ->\n' : 'async do\n') +
+          rest.replace(/^/gm, ' ') +
+          (coffee ? ')' : ''),
+          { ast: true }
+        );
+      }
+
+      // Convert console to civetconsole for Playground execution
+      Civet.lib.gatherRecursive(ast,
+        (n) => n.type === 'Identifier' && n.children?.token === "console"
+      ).forEach((node) => {
+        node.children.token = "civetconsole"
+      })
+
+      jsCode = Civet.generate(ast, { js: true, errors })
+
+      if (topLevelAwait) {
+        jsCode += `.catch((x)=>civetconsole.log("[THROWN] "+x))`
+        jsCode += `.then((x)=>x!==undefined&&civetconsole.log("[EVAL] "+x))`
+      }
+
+      if (errors.length) {
+        // TODO: Better error display; copied from main.civet
+        throw new Error(`Parse errors: ${errors.map($ => $.message).join("\n")}`)
+      }
+    } catch (error) {
+      // Parse errors specific to JS generation
+      jsCode = `civetconsole.error("Civet failed to generate JavaScript code:\\n${error.message.replace(/[\\"]/g, '\\$&').replace(/\n/g, '\\n')}")`
+      console.log(jsCode)
+    }
+  }
+
+  if (prettierOutput) {
+    try {
+      tsCode = prettier.format(tsCode, {
+        parser: 'typescript',
+        plugins: prettierPlugins,
+        printWidth: 50,
+      });
+    } catch (err) {
+      console.info('Prettier error. Fallback to raw civet output', {
+        tsCode,
+        err,
+      });
+    }
+  }
+
+  const outputHtml = highlighter.codeToHtml(tsCode, { lang: 'tsx' });
+
+  postMessage({ uid, inputHtml, outputHtml, jsCode });
 };
 
 let highlighter;

--- a/source/main.civet
+++ b/source/main.civet
@@ -76,7 +76,8 @@ export compile := (src: string, options?: CompilerOptions) ->
   else
     options = {...options}
 
-  options.parseOptions ?= {}
+  // Handle undefined parseOptions, and avoid mutating the original object
+  options.parseOptions = {...options.parseOptions}
 
   filename := options.filename or "unknown"
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7792,7 +7792,7 @@ Reset
     }
 
 Init
-  Shebang? ( TripleSlashDirective / ( ( JSSingleLineComment / JSMultiLineComment ) EOS ) / DirectivePrologue )*:directives ->
+  Shebang? Prologue:directives ->
     directives.forEach((directive) => {
       if (directive.type === "CivetPrologue") {
         Object.assign(module.config, directive.config)
@@ -7800,6 +7800,13 @@ Init
     })
 
     return $0
+
+Prologue
+  ( TripleSlashDirective / ( ( JSSingleLineComment / JSMultiLineComment ) EOS ) / DirectivePrologue )*
+
+# NOTE: Used by Playground to separate Prologue from rest of program
+ProloguePrefix
+  Prologue /[^]*/
 
 # Indentation
 


### PR DESCRIPTION
* Fix preamble detection to not e.g. eat `"x"` in `"x" |> console.log`
* Fix detection of coffeeCompat mode
* Fix coffeeCompat `do` (needed to be wrapped in parens)
* Catch errors during promise and output them
* Format JS parse errors for output (escape \n)