### PR TITLE
Add # length shorthand #909

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -241,6 +241,7 @@ json.'long property'
 json.`${movie} name`
 matrix.0.0
 array.-1
+array.#
 ```
 
 ```ts
@@ -304,6 +305,13 @@ url |> fetch |> await
 |> .json() |> await
 ||> (json) => console.log "json:", json
 |> callback
+```
+
+```ts
+// this.length shorthand
+@[#] = item
+@[index %% #]
+floor # / 2
 ```
 
 </div>

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -313,6 +313,36 @@ console.log ```
 ```
 </Playground>
 
+## Length Shorthand
+
+`.#` in a property acces is short for `.length`
+
+<Playground>
+array.#
+"a string also".#
+</Playground>
+
+When used on its own as `#` it is `this.length`
+
+<Playground>
+function push(item)
+  @[#] = item
+</Playground>
+
+<Playground>
+function wrap(index)
+  @[index %% #]
+</Playground>
+
+When used with `in` it is a check for the `"length"` property.
+
+<Playground>
+# in x
+</Playground>
+
+It looks and behaves similary to [private fields](#private-fields) with the exception that `.length` is not private.
+
+
 ## Regular Expressions
 
 Civet supports JavaScript regular expression literals `/.../`, provided the

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -975,14 +975,27 @@ ThisLiteral
       thisShorthand: true,
     }
   AtThis
-  PrivateThis
+  HashThis
 
 # Adds a #id -> this.#id shorthand as a "PrivateThis" literal in most cases
 # with the exception of keeping `#a in b` as is for branded in checks.
 # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in#using_the_in_operator_to_implement_branded_checks
 # This is slightly different from how https://262.ecma-international.org/#sec-relational-operators handles relational operators
 # grammatically but should be equivalent in practice
-PrivateThis
+HashThis
+  LengthShorthand:id ( &( _+ ( ( Not __ In ) / In ) ) "" )?:beforeIn ->
+    if (beforeIn != null) return [ '"', id.name, '"' ]
+
+    return {
+      type: "MemberExpression",
+      children: ["this", {
+        type: "PropertyAccess",
+        name: id.name,
+        children: [".", id],
+      }],
+      thisShorthand: true,
+    }
+
   PrivateIdentifier:id &( _+ ( ( Not __ In ) / In ) ) ->
     return id
 
@@ -996,6 +1009,19 @@ PrivateThis
       }],
       privateShorthand: true,
       privateId: id,
+    }
+
+LengthShorthand
+  Hash NonIdContinue ->
+    const id = "length"
+    return {
+      type: "Identifier",
+      name: id,
+      names: [id],
+      children: [{
+        $loc: $loc,
+        token: id,
+      }],
     }
 
 # NOTE: Added '@' as a 'this' shorthand from CoffeeScript
@@ -1255,7 +1281,7 @@ PropertyAccess
       { type: "Call", children: [ "(", neg, num, ")" ] },
     ]
 
-  AccessStart:access InlineComment*:comments ( IdentifierName / PrivateIdentifier ):id ->
+  AccessStart:access InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
     const children = [access, ...comments, ...id.children]
 
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -977,7 +977,7 @@ ThisLiteral
   AtThis
   HashThis
 
-# Adds a #id -> this.#id shorthand as a "PrivateThis" literal in most cases
+# Adds a #id -> this.#id shorthand as a "HashThis" literal in most cases
 # with the exception of keeping `#a in b` as is for branded in checks.
 # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in#using_the_in_operator_to_implement_branded_checks
 # This is slightly different from how https://262.ecma-international.org/#sec-relational-operators handles relational operators

--- a/test/length-shorthand.civet
+++ b/test/length-shorthand.civet
@@ -1,0 +1,35 @@
+{ testCase } from ./helper.civet
+
+
+describe "length shorthand", ->
+  testCase """
+    #
+    ---
+    #
+    ---
+    this.length
+  """
+
+  testCase """
+    # in x
+    ---
+    # in x
+    ---
+    "length" in x
+  """
+
+  testCase """
+    property access
+    ---
+    array.#
+    ---
+    array.length
+  """
+
+  testCase """
+    property access chain
+    ---
+    array.#.toString()
+    ---
+    array.length.toString()
+  """


### PR DESCRIPTION
This add `x.#` as a shorthand for `x.length`. It doesn't support without the `.` because our current implementation of private identifiers doesn't support that yet either. We can add it for both at some point in the future.

See #909 