### PR TITLE
Allow arguments to property bind

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1318,11 +1318,12 @@ PropertyGlob
 
 PropertyBind
   # NOTE: foo@.bar and foo@bar shorthand for foo.bar.bind(foo)
-  PropertyAccessModifier?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id ->
+  PropertyAccessModifier?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id Arguments?:args ->
     return {
       type: "PropertyBind",
       name: id.name,
       children: [modifier, dot, id],  // omit `@` from children
+      args: args?.children.slice(1, -1) ?? [], // remove the parens from the arg list, or give an empty list
     }
 
 SuperProperty

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -325,7 +325,14 @@ function processCallMemberExpression(node)
           {
             ...glob,
             type: "PropertyAccess",
-            children: [...glob.children, ".bind(", prefix, ")"]
+            children: [
+              ...glob.children,
+              ".bind(",
+              prefix,
+              ...glob.args.length > 0 ? [", "] : [],
+              ...glob.args,
+              ")",
+            ]
           },
           ...children.slice(i + 1)
         ]

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -388,6 +388,28 @@ describe "property access", ->
       f(this.x.bind(this))
     """
 
+    testCase """
+      bind with argument
+      ---
+      x@y z
+      ---
+      x.y.bind(x, z)
+    """
+
+    testCase """
+      bind with indented argument list
+      ---
+      foo@bar
+        a
+        b
+        c
+      ---
+      foo.bar.bind(foo, 
+        a,
+        b,
+        c,)
+    """
+
   describe "possessive form", ->
     testCase """
       's


### PR DESCRIPTION
Title. A weird side effect is that `x@y()` is now equivalent to `x@y`.

Closes #954 