### PR TITLE
#202 - Don't wrap StatementExpressions in IIFE in declaration

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -49,7 +49,6 @@ import {
   reorderBindingRestProperty,
   replaceNodes,
   typeOfJSX,
-  wrapIIFE,
 } from "./parser/lib.civet"
 
 /**
@@ -4369,11 +4368,11 @@ EmptyCondition
 # NOTE: Added from CoffeeScript
 SwitchExpression
   SwitchStatement:s ->
+    const statement = ["", s]
     return {
-      type: "SwitchExpression",
-      // wrap with IIFE
-      children: wrapIIFE([["", s]]),
-      statement: s
+      type: "StatementExpression",
+      statement: statement,
+      children: [statement],
     }
 
 # https://262.ecma-international.org/#prod-CaseBlock
@@ -4520,11 +4519,12 @@ TryStatement
     }
 
 TryExpression
-  TryStatement:t ->
+  TryStatement:s ->
+    const statement = ["", s]
     return {
-      type: "TryExpression",
-      blocks: t.blocks,
-      children: wrapIIFE([["", t]])
+      type: "StatementExpression",
+      statement: statement,
+      children: [statement],
     }
 
 # https://262.ecma-international.org/#prod-Catch
@@ -4792,16 +4792,20 @@ Debugger
 
 DebuggerExpression
   DebuggerStatement:s ->
+    const statement = ["", s]
     return {
-      type: "DebuggerExpression",
-      children: wrapIIFE([["", s]]),
+      type: "StatementExpression",
+      statement: statement,
+      children: [statement],
     }
 
 ThrowExpression
   ThrowStatement:s ->
+    const statement = ["", s]
     return {
-      type: "ThrowExpression",
-      children: wrapIIFE([["", s]]),
+      type: "StatementExpression",
+      statement: statement,
+      children: [statement],
     }
 
 MaybeNestedExpression

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4371,7 +4371,7 @@ SwitchExpression
     const statement = ["", s]
     return {
       type: "StatementExpression",
-      statement: statement,
+      statement,
       children: [statement],
     }
 
@@ -4523,7 +4523,7 @@ TryExpression
     const statement = ["", s]
     return {
       type: "StatementExpression",
-      statement: statement,
+      statement,
       children: [statement],
     }
 
@@ -4795,7 +4795,7 @@ DebuggerExpression
     const statement = ["", s]
     return {
       type: "StatementExpression",
-      statement: statement,
+      statement,
       children: [statement],
     }
 
@@ -4804,7 +4804,7 @@ ThrowExpression
     const statement = ["", s]
     return {
       type: "StatementExpression",
-      statement: statement,
+      statement,
       children: [statement],
     }
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,4 +1,5 @@
 import type {
+  ASTNode
   ASTNodeBase
   FunctionNode
   LabeledStatement
@@ -209,33 +210,28 @@ function patternAsValue(pattern)
 // does construct an else clause pushing undefined in if statements that lack them
 // and adds to the beginning and the end of the expression's children.
 // Maybe these insertion modifications can be refactored to be more DRY eventually.
-function insertPush(node, ref): void
+function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode) => ASTNode): void
   if (!node) return
   // TODO: unify this with the `exp` switch
-  switch (node.type) {
+  switch node.type
     case "BlockStatement":
       if node.expressions.length
-        insertPush(node.expressions.-1, ref)
+        assignResults(node.expressions.-1, collect)
       else
-        node.expressions.push([ref, ".push(void 0);"])
+        node.expressions.push(["", collect("void 0"), ";"])
       return
     case "CaseBlock":
       node.clauses.forEach (clause) =>
-        insertPush(clause, ref)
+        assignResults(clause, collect)
       return
-    // NOTE: "CaseClause"s don't push
-    case "WhenClause":
-      insertPush(node.block, ref)
+    when "WhenClause", "DefaultClause", "PatternClause"
+      assignResults(node.block, collect)
       return
-    case "DefaultClause":
-      insertPush(node.block, ref)
-      return
-  }
-  if (!Array.isArray(node)) return
+
+  return  unless Array.isArray node
 
   [, exp] .= node
   return unless exp
-  indent := getIndent(node)
 
   outer := exp
   {type} .= exp
@@ -243,7 +239,7 @@ function insertPush(node, ref): void
     exp = (exp as LabeledStatement).statement
     {type} = exp
 
-  switch (exp.type) {
+  switch exp.type
     case "BreakStatement":
     case "ContinueStatement":
     case "DebuggerStatement":
@@ -252,48 +248,49 @@ function insertPush(node, ref): void
     case "ThrowStatement":
       return
     case "Declaration":
-      exp.children.push(["", [";", ref, ".push(",
-        patternAsValue(exp.bindings.-1.pattern), ")"]])
+      exp.children.push([
+        "", [";", collect(patternAsValue(exp.bindings.-1.pattern)) ]
+      ])
       return
     case "ForStatement":
     case "IterationStatement":
     case "DoStatement":
-      wrapIterationReturningResults(exp, outer, ref)
+      wrapIterationReturningResults(exp, outer, collect)
       return
     case "BlockStatement":
-      insertPush(exp.expressions[exp.expressions.length - 1], ref)
+      assignResults(exp.expressions[exp.expressions.length - 1], collect)
       return
     case "IfStatement":
       // if block
-      insertPush(exp.then, ref)
+      assignResults(exp.then, collect)
       if exp.then.bare and not exp.then.semicolon
         exp.then.children.push exp.then.semicolon = ";"
+
       // else block
-      if (exp.else) insertPush(exp.else[2], ref)
-      // Add else block pushing undefined if no else block
-      else exp.children.push([" else {\n", indent, ref, ".push(undefined)\n", indent, "}"])
+      if (exp.else)
+        assignResults(exp.else[2], collect)
+      else // Add else block pushing undefined if no else block
+        exp.children.push([" else {", collect("undefined"), "}"])
       return
     case "PatternMatchingStatement":
-      insertPush(exp.children[0][0], ref)
+      assignResults(exp.children[0][0], collect)
       return
     case "SwitchStatement":
       // insert a results.push in each case block
-      insertPush(exp.children[2], ref)
+      assignResults(exp.children[2], collect)
       return
     case "TryStatement":
       // NOTE: CoffeeScript doesn't add a push to an empty catch block but does add if there is any statement in the catch block
       // we always add a push to the catch block
       // NOTE: does not insert a push in the finally block
-      exp.blocks.forEach((block) => insertPush(block, ref))
+      exp.blocks.forEach((block) => assignResults(block, collect))
       return
-  }
 
   // Don't push if there's a trailing semicolon
-  if (node[node.length - 1]?.type is "SemicolonDelimiter") return
+  return if node.-1?.type is "SemicolonDelimiter"
 
   // Insert push wrapping expression
-  node.splice(1, 0, ref, ".push(")
-  node.push(")")
+  node[1] = collect(node[1])
 
 // [indent, statement, semicolon]
 function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
@@ -407,10 +404,10 @@ function insertSwitchReturns(exp): void
   exp.caseBlock.clauses.forEach (clause) =>
     insertReturn clause
 
-function wrapIterationReturningResults(statement, outer, outerRef?): void
+function wrapIterationReturningResults(statement, outer, collect?: (node: ASTNode) => ASTNode): void
   if statement.type is "DoStatement"
-    if outerRef
-      insertPush(statement.block, outerRef)
+    if collect
+      assignResults(statement.block, collect)
     else
       insertReturn(statement.block, outer)
     return
@@ -422,11 +419,13 @@ function wrapIterationReturningResults(statement, outer, outerRef?): void
     children: ["const ", resultsRef, "=[];"],
   }
 
-  insertPush(statement.block, resultsRef)
+  assignResults statement.block, (node) =>
+    // TODO: real node
+    [ resultsRef, ".push(", node, ")" ]
 
   outer.children.unshift(declaration)
-  if outerRef
-    statement.children.push(";", outerRef, ".push(", resultsRef, ");")
+  if collect
+    statement.children.push ";", collect(resultsRef), ";"
   else
     statement.children.push(";return ", resultsRef, ";")
 
@@ -520,7 +519,9 @@ function expressionizeIteration(exp): void
   const resultsRef = makeRef("results")
 
   // insert `results.push` to gather results array
-  insertPush(block, resultsRef)
+  assignResults block, (node) =>
+    // TODO: real node
+    [ resultsRef, ".push(", node, ")" ]
   braceBlock(block)
 
   // Wrap with IIFE
@@ -537,4 +538,5 @@ function expressionizeIteration(exp): void
 export {
   expressionizeIteration
   processFunctions
+  assignResults
 }

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -43,6 +43,7 @@ import {
   makeRef
   maybeRef
   parenthesizeType
+  updateParentPointers
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
@@ -57,7 +58,11 @@ import {
 
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf } from ./for.civet
-import { processFunctions, expressionizeIteration } from ./function.civet
+import {
+  assignResults,
+  processFunctions,
+  expressionizeIteration
+} from ./function.civet
 import { processDeclarationConditions, processPatternMatching } from ./pattern-matching.civet
 import {
   adjustAtBindings
@@ -573,7 +578,8 @@ function processDeclarations(statements: StatementTuple[]): void
   // @ts-ignore
   gatherRecursiveAll statements, .type is "Declaration"
   // @ts-ignore
-  .forEach ({ bindings }: DeclarationStatement) =>
+  .forEach (statement: DeclarationStatement) =>
+    { bindings } := statement as DeclarationStatement
     bindings?.forEach (binding) =>
       suffix := binding.suffix
       if suffix and suffix.optional and suffix.t
@@ -584,13 +590,33 @@ function processDeclarations(statements: StatementTuple[]): void
       if initializer
         exp := initializer[2]
 
-function processBindingPatternLHS(lhs, tail): void {
+        if exp.type is "StatementExpression"
+          ref := makeRef()
+          statementExp := exp.statement
+
+          // Detach statement and assign results to ref
+          assignResults statementExp, (resultNode) =>
+            makeNode
+              type: "AssignmentExpression",
+              children: [ref, " = ", resultNode]
+
+          initializer[2] = ref
+
+          refDec :=
+            type: "Declaration",
+            children: ["let ", ref, ";"],
+
+          // insert statement before the declaration
+          statement.children.unshift(refDec, statementExp, ";")
+
+          updateParentPointers statementExp, statement
+
+function processBindingPatternLHS(lhs, tail): void
   // Expand AtBindings first before gathering splices
   adjustAtBindings(lhs, true)
   const [splices, thisAssignments] = gatherBindingCode(lhs)
   // TODO: This isn't quite right for compound assignments, may need to wrap with parens and use comma to return the complete value
   tail.push(...splices.map((s) => [", ", s]), ...thisAssignments.map((a) => [", ", a]))
-}
 
 function processAssignments(statements): void {
   // Move assignments/updates within LHS of assignments/updates
@@ -785,6 +811,15 @@ function processTypes(node: ASTNode)
         ")"
       ]
 
+/**
+Wrap any remaining statement expressions in IIFE.
+*/
+function processStatementExpressions(statements: StatementTuple[]): void
+  gatherRecursiveAll(statements, .type is "StatementExpression")
+    .forEach (exp) =>
+      exp.children = wrapIIFE(exp.children)
+
+
 function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule): void {
   // invariants
   assert.equal(m.forbidBracedApplication.length, 1, "forbidBracedApplication")
@@ -803,6 +838,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
   processPipelineExpressions(statements)
   processDeclarations(statements)
   processAssignments(statements)
+  processStatementExpressions(statements)
   processPatternMatching(statements, ReservedWord)
 
   // Modify iteration expressions

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -9,18 +9,19 @@ export type ASTNode =
   | undefined
 
 export type StatementNode = IfStatement | IterationStatement | SwitchStatement | LabeledStatement | BlockStatement | DeclarationStatement | ExpressionNode
-export type ExpressionNode = ParenthesizedExpression | BinaryOp | Identifier | Literal | MethodDefinition | FunctionNode | TypeNode
+export type ExpressionNode = StatementExpression | ParenthesizedExpression | BinaryOp | Identifier | Literal | MethodDefinition | FunctionNode | TypeNode
 
 export type ASTNodeBase = ASTNode &
   parent: ASTNodeBase | undefined
   children: Children
 
-export type Children = ASTNode[] & type?: never
-export type ASTString = string & type?: never
+export type Children = ASTNode[] & (type?: undefined) & (token?: undefined)
+export type ASTString = string & (type?: undefined) & (token?: undefined)
 
 export type ASTError =
   type: "Error"
   message: string
+  token?: undefined
 
 export type Loc =
   pos: number
@@ -40,6 +41,7 @@ export type BinaryOp = (string &
   special?: never
   relational?: never
   assoc?: never
+  type?: undefined
 ) | (ASTLeaf &
   special?: true
   // The following are allowed only when special is true:
@@ -112,6 +114,7 @@ export type ASTRef =
   type: "Ref"
   base: string
   id: string
+  token?: undefined
 
 export type AtBinding =
   type: "AtBinding"
@@ -141,7 +144,7 @@ export type Binding =
   names: string[]
   pattern: BindingIdentifier | BindingPattern
   suffix: TypeSuffix | undefined
-  initializer: [unknown, unknown, ASTNodeBase] | undefined
+  initializer: [unknown, unknown, NonNullable<ASTNode>] | undefined
   splices: unknown[]
   thisAssignments: unknown[]
 
@@ -155,6 +158,11 @@ export type Identifier =
 export type ReturnValue =
   type: "ReturnValue"
   children: Children
+
+export type StatementExpression =
+  type: "StatementExpression"
+  children: Children
+  statement: ASTNode & type: any
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -269,10 +269,6 @@ function makeLeftHandSideExpression(expression)
     case "NewExpression":
     case "ParenthesizedExpression":
     case "IfExpression": // already wrapped in parens
-    case "DebuggerExpression": // wrapIIFE
-    case "SwitchExpression": // wrapIIFE
-    case "ThrowExpression": // wrapIIFE
-    case "TryExpression": // wrapIIFE
     case "StatementExpression": // wrapIIFE
       return expression
 
@@ -423,7 +419,7 @@ function wrapIIFE(expressions: StatementTuple[], async?: string): ASTNode[]
     children: ["{", expressions, "}"],
     bare: false,
     root: false,
-    parent: undefined, // TODO: get parent from expression
+    parent: undefined,
   }
 
   parameters :=

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -3,8 +3,10 @@ import type {
   ASTLeaf
   ASTNode
   ASTNodeBase
+  Literal
   TypeSuffix
   ReturnTypeAnnotation
+  StatementTuple
 } from ./types.civet
 
 import {
@@ -271,6 +273,7 @@ function makeLeftHandSideExpression(expression)
     case "SwitchExpression": // wrapIIFE
     case "ThrowExpression": // wrapIIFE
     case "TryExpression": // wrapIIFE
+    case "StatementExpression": // wrapIIFE
       return expression
 
   makeNode {
@@ -403,7 +406,7 @@ function parenthesizeType(type: ASTNodeBase)
  * uses await, or just adding async if specified.
  * Returns an Array suitable for `children`.
  */
-function wrapIIFE(expressions: StatementTuple[], async): ASTNode[]
+function wrapIIFE(expressions: StatementTuple[], async?: string): ASTNode[]
   let prefix
 
   if async
@@ -419,6 +422,8 @@ function wrapIIFE(expressions: StatementTuple[], async): ASTNode[]
     expressions,
     children: ["{", expressions, "}"],
     bare: false,
+    root: false,
+    parent: undefined, // TODO: get parent from expression
   }
 
   parameters :=

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -670,7 +670,7 @@ describe "examples (from real life)", ->
     ---
     function foo(a) {
       if (bar[a] === 'three') return 3
-      if (a < 0) return (()=>{let m;if(m = bar[-a],m === 'three') { return 3}})()
+      if (a < 0) return(()=>{ let m;if(m = bar[-a],m === 'three') { return 3}})()
       let ret = 9
       ret *= a
       return ret

--- a/test/function.civet
+++ b/test/function.civet
@@ -1928,11 +1928,7 @@ describe "function", ->
       ---
       (function() {
         const results=[];while (x) {
-          if (a) return true; else {
-
-          results.push(undefined)
-
-          }
+          if (a) return true; else {results.push(undefined)}
         };return results;
       })
     """

--- a/test/if.civet
+++ b/test/if.civet
@@ -844,7 +844,7 @@ describe "if", ->
       if a := try b
         log a
       ---
-      let ref;if ((ref = (()=>{try { return b } catch(e) {return}})())) {
+      let ref;if ((ref =(()=>{ try { return b } catch(e) {return}})())) {
         const a = ref;
         log(a)
       }

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1117,13 +1117,13 @@ describe "switch", ->
         else
           4
       ---
-      const y = (()=>{if(x === 1) {
-          return 2}
+      let ref;if(x === 1) {
+          ref = 2}
       else if(x === 2) {
-          return 3}
+          ref = 3}
       else  {
-          return 4
-        }})()
+          ref = 4
+        };const y =ref
     """
 
     testCase """
@@ -1224,16 +1224,16 @@ describe "switch", ->
       ---
       x := switch command.split(" ")
         ["turn", direction]
-          console.log `Turning ${direction}!`
+          `Turning ${direction}!`
         ["move", distance]
-          console.log `Moving ${distance}!`
+          `Moving ${distance}!`
       ---
-      const x = (()=>{let m;if(m = command.split(" "),Array.isArray(m) && m.length === 2 && m[0] === "turn") {
+      let m;let ref;if(m = command.split(" "),Array.isArray(m) && m.length === 2 && m[0] === "turn") {
           const [, direction] = m;
-          return console.log(`Turning ${direction}!`)}
+          ref = `Turning ${direction}!`}
       else if(Array.isArray(m) && m.length === 2 && m[0] === "move") {
           const [, distance] = m;
-          return console.log(`Moving ${distance}!`)}})()
+          ref = `Moving ${distance}!`};const x =ref
     """
 
     // TODO

--- a/test/try.civet
+++ b/test/try.civet
@@ -192,14 +192,14 @@ describe "try", ->
       thing = try foo() catch(e: any) panic() finally phew()
       ---
       thing = (()=>{try { return foo() } catch(e: any) { return panic() } finally { phew() }})()
-      """
+    """
 
     testCase """
       returns from implied catch
       ---
       x := try f()
       ---
-      const x = (()=>{try { return f() } catch(e) {return}})()
+      let ref;try { ref = f() } catch(e) {ref = void 0;};const x =ref
     """
 
     testCase """


### PR DESCRIPTION
This is about 50% of #202 

Most of the work was refactoring `pushRef` to be more general `assignResults` to handle pushing to a collection or assigning to a ref.

Things remaining:

- iteration statement expressions
- if statement expression
- single assignment expression rhs

Much later:

- arbitrarily nested expressions (need to unwrap and maintain refs to keep execution order the same)
- arbitrarily chained assignments (ditto)