### PR TITLE
Statement expressions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -14,7 +14,6 @@ import {
   dedentBlockString,
   dedentBlockSubstitutions,
   deepCopy,
-  expressionizeIfClause,
   expressionizeTypeIf,
   forRange,
   gatherBindingCode,
@@ -170,8 +169,6 @@ ExpressionizedStatement
   /(?=async|debugger|if|unless|do|for|loop|until|while|switch|throw|try)/ _ExpressionizedStatement -> $2
 
 _ExpressionizedStatement
-  IfExpression
-  UnlessExpression
   IterationExpression
   StatementExpression:s ->
     const statement = ["", s]
@@ -183,6 +180,7 @@ _ExpressionizedStatement
 
 StatementExpression
   DebuggerStatement
+  IfStatement
   SwitchStatement
   ThrowStatement
   TryStatement
@@ -3904,101 +3902,6 @@ UnlessClause
       children: [kind, condition],
       condition,
     }
-
-# NOTE: Added IfExpression from CoffeeScript
-IfExpression
-  IfClause:clause ExpressionBlock:b ElseExpressionClause?:e ->
-    return expressionizeIfClause(clause, b, e)
-
-UnlessExpression
-  UnlessClause:clause ExpressionBlock:b ElseExpressionClause?:e ->
-    return expressionizeIfClause(clause, b, e)
-
-ElseExpressionClause
-  ( ( Nested Else ) / ( _? Else ) ) ElseExpressionBlock ->
-    return [...$1, $2]
-
-# Block of expressions that can't include pure statements
-ExpressionBlock
-  InsertOpenParen NestedBlockExpressions:exps InsertNewline InsertIndent InsertCloseParen ->
-    // Each element of exps is a list of same-line expressions. Flatten.
-    exps = exps.flat()
-
-    // If there is only one expression and it doesn't require parens, then return it as is, preserving whitespace
-    if (exps.length === 1) {
-      let [ws, exp] = exps[0]
-      switch (exp.type) {
-        case "Identifier":
-        case "Literal":
-          return [ws, exp]
-      }
-    }
-
-    // Remove final trailing expression delimiter
-    exps = exps.map((e, i) => {
-      if (i === exps.length - 1) {
-        return e.slice(0, -1)
-      }
-      return e
-    })
-
-    return {
-      type: "BlockExpressions",
-      expressions: exps,
-      children: [$1, exps, $3, $4, $5],
-    }
-  Then ExtendedExpression
-
-ElseExpressionBlock
-  InsertOpenParen NestedBlockExpressions:exps InsertNewline InsertIndent InsertCloseParen ->
-    // Each element of exps is a list of same-line expressions. Flatten.
-    exps = exps.flat()
-
-    // If there is only one expression and it doesn't require parens, then return it as is, preserving whitespace
-    if (exps.length === 1) {
-      let [ws, exp] = exps[0]
-      switch (exp.type) {
-        case "Identifier":
-        case "Literal":
-          return [ws, exp]
-      }
-    }
-
-    // Remove final trailing expression delimiter
-    exps = exps.map((e, i) => {
-      if (i === exps.length - 1) {
-        return e.slice(0, -1)
-      }
-      return e
-    })
-
-    return {
-      type: "BlockExpressions",
-      expressions: exps,
-      children: [$1, exps, $3, $4, $5],
-    }
-  !EOS ExpressionWithObjectApplicationForbidden -> $2
-
-NestedBlockExpressions
-  PushIndent NestedBlockExpression*:exps PopIndent ->
-    if (!exps.length) return $skip
-    return exps
-
-NestedBlockExpression
-  Nested:nested BlockExpressionPart+:expressions ->
-    return [
-      [nested, ...expressions[0]],
-      ...expressions.slice(1).map(s => ["", ...s]),
-    ]
-
-BlockExpressionPart
-  # NOTE: !EOS forces semicolon after all but last statement, forbids leading __
-  # NOTE: _? allows for leading inline comments
-  !EOS _?:ws PostfixedExpression:exp ExpressionDelimiter:delimiter ->
-    if (ws) {
-      exp = {...exp, children: [ ws, ...exp.children ]}
-    }
-    return [exp, delimiter]
 
 # https://262.ecma-international.org/#prod-IterationStatement
 IterationStatement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -166,11 +166,7 @@ ExpressionizedStatementWithTrailingCallExpressions
 
 ExpressionizedStatement
   # perf: assertion to exit early
-  /(?=async|debugger|if|unless|do|for|loop|until|while|switch|throw|try)/ _ExpressionizedStatement -> $2
-
-_ExpressionizedStatement
-  IterationExpression
-  StatementExpression:s ->
+  /(?=async|debugger|if|unless|do|for|loop|until|while|switch|throw|try)/ StatementExpression:s ->
     const statement = ["", s]
     return {
       type: "StatementExpression",
@@ -181,6 +177,8 @@ _ExpressionizedStatement
 StatementExpression
   DebuggerStatement
   IfStatement
+  # TODO: async do/for/while/until
+  IterationStatement
   SwitchStatement
   ThrowStatement
   TryStatement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -47,6 +47,7 @@ import {
   quoteString,
   reorderBindingRestProperty,
   replaceNodes,
+  skipImplicitArguments,
   typeOfJSX,
 } from "./parser/lib.civet"
 
@@ -166,8 +167,7 @@ ExpressionizedStatementWithTrailingCallExpressions
 
 ExpressionizedStatement
   # perf: assertion to exit early
-  /(?=async|debugger|if|unless|do|for|loop|until|while|switch|throw|try)/ StatementExpression:s ->
-    const statement = ["", s]
+  /(?=async|debugger|if|unless|do|for|loop|until|while|switch|throw|try)/ StatementExpression:statement ->
     return {
       type: "StatementExpression",
       statement,
@@ -177,8 +177,7 @@ ExpressionizedStatement
 StatementExpression
   DebuggerStatement
   IfStatement
-  # TODO: async do/for/while/until
-  IterationStatement
+  IterationExpression
   SwitchStatement
   ThrowStatement
   TryStatement
@@ -208,15 +207,8 @@ Arguments
 ImplicitArguments
   ApplicationStart InsertOpenParen:open _?:ws NonPipelineArgumentList:args InsertCloseParen:close ->
     // Don't treat as call if this is a postfix for/while/until/if/unless
-    if (args.length === 1) {
-      let arg0 = args[0]
-      if (Array.isArray(arg0)) arg0 = arg0[1] // skip whitespace
-      if (arg0.type === "IterationExpression" &&
-          arg0.subtype !== "DoStatement" && !arg0.async &&
-          isEmptyBareBlock(arg0.block)) {
-        return $skip
-      }
-    }
+    if (skipImplicitArguments(args)) return $skip
+
     return {
       type: "Call",
       args,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -707,6 +707,8 @@ ParenthesizedExpression
     if (!$3) return $skip
     const [exp, ws, close] = $3
     switch (exp.type) {
+      case "StatementExpression":
+        if (exp.statement.type !== "IterationExpression") break
       case "IterationExpression":
         // Avoid extra parenthetical wrapping in `(for x in y ...)`
         // TODO: losing comments in `ws`

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -78,6 +78,21 @@ function makeEmptyBlock(): BlockStatement
   }
 
 /**
+Like an empty block but can only be used inside another
+real block and won't be wrapped with braces.
+*/
+function makeBlockFragment(): BlockStatement
+  expressions: StatementTuple[] := []
+  return {
+    type: "BlockStatement",
+    children: expressions,
+    parent: undefined,
+    expressions,
+    bare: false,
+    root: false
+  }
+
+/**
  * Replace `child` with `replacement` inside the `block`.
  * Assumes a `StatementTuple[]` for `block.expressions`
  */
@@ -212,6 +227,7 @@ export {
   duplicateBlock
   getIndent
   hoistRefDecs
+  makeBlockFragment
   makeEmptyBlock
   processBlocks
   replaceBlockExpression

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -316,6 +316,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
         s.parent = block
 
 export {
+  prependStatementExpressionBlock
   processAssignmentDeclaration
   processDeclarationConditions
   processDeclarations

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -1,4 +1,4 @@
-import {
+import type {
   ASTLeaf
   ASTNode
   ASTRef

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -1,10 +1,15 @@
 import {
   ASTLeaf
   ASTNode
+  ASTRef
   Binding
   Children
+  DeclarationStatement
+  IfStatement
   Initializer
+  IterationStatement
   StatementTuple
+  SwitchStatement
   TypeSuffix
   WSNode
 } from ./types.civet
@@ -93,7 +98,7 @@ function processDeclarations(statements: StatementTuple[]): void
       if initializer
         prependStatementExpressionBlock initializer, statement
 
-function prependStatementExpressionBlock(initializer: Initializer, statement: {children: Children}): void
+function prependStatementExpressionBlock(initializer: Initializer, statement: {children: Children}): ASTRef?
   exp .= initializer[2]
 
   // Handle nested statement expression
@@ -107,6 +112,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
   pre: ASTNode[] := []
   statementExp := exp.statement
   blockStatement: StatementTuple := ["", statementExp]
+  let ref: ASTRef
 
   if statementExp.type is "IterationExpression"
     // Async iterations remain inline wrapped with IIFE
@@ -116,9 +122,9 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
     blockStatement[1] = statement
 
     wrapIterationReturningResults statement, children: blockStatement, ->
-    initializer[2] = statement.resultsRef
+    ref = initializer[2] = statement.resultsRef
   else
-    ref := initializer[2] = makeRef()
+    ref = initializer[2] = makeRef()
 
     assignResults blockStatement, (resultNode) =>
       //@ts-ignore
@@ -137,38 +143,50 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
   // insert statement before the declaration
   //@ts-ignore
   statement.children.unshift(pre, blockStatement, ";")
-
   updateParentPointers blockStatement, statement
 
-function processDeclarationCondition(condition, rootCondition, parent): void
+  return ref
+
+function processDeclarationCondition(condition, rootCondition, parent: { children: Children }): void
   return unless condition.type is "DeclarationCondition"
-  ref := makeRef()
 
   { decl, bindings } := condition.declaration as DeclarationStatement
   // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
   binding := bindings[0]
   { pattern, suffix, initializer, splices, thisAssignments } := binding
 
-  grandparent := condition.parent?.parent
-  children :=
-    // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
-    // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
-    // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
-    if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
-      ["(", ref, initializer, ")"]
-    else
-      [ref, initializer]
+  let ref = prependStatementExpressionBlock(initializer!, parent)
 
-  Object.assign condition, {
-    type: "AssignmentExpression"
-    children
-    hoistDec:
-      type: "Declaration"
-      children: ["let ", ref, suffix]
-      names: []
-    pattern
-    ref
-  }
+  if ref
+    Object.assign condition, {
+      type: "AssignmentExpression"
+      children: [ref]
+      pattern
+      ref
+      statementDeclaration: true
+    }
+  else
+    ref = makeRef()
+    grandparent := condition.parent?.parent
+    children :=
+      // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
+      // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
+      // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
+      if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
+        ["(", ref, initializer, ")"]
+      else
+        [ref, initializer]
+
+    Object.assign condition, {
+      type: "AssignmentExpression"
+      children
+      hoistDec:
+        type: "Declaration"
+        children: ["let ", ref, suffix]
+        names: []
+      pattern
+      ref
+    }
 
   // condition wasn't previously a child, so now needs parent pointers
   addParentPointers condition, parent
@@ -218,12 +236,17 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
     when "IfStatement"
       { else: e} := s
       block := blockWithPrefix(condition.expression.blockPrefix, s.then)
-      s.then = block
 
       if block.bare and e and not block.semicolon
         block.children.push block.semicolon = ";"
 
-      s.children.splice(2, 1, block)
+      // Replace then block with prefixed block
+      s.children = s.children.map (c) =>
+        if c is s.then
+          block
+        else
+          c
+      s.then = block
 
       // Update parent pointers since declaration conditions have expanded
       updateParentPointers(block, s)
@@ -237,27 +260,45 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
       updateParentPointers(newBlock, s)
 
     when "SwitchStatement"
-      { blockPrefix, ref } := condition.expression
+      { blockPrefix, ref, statementDeclaration } := condition.expression as! { blockPrefix: StatementTuple[], ref: ASTRef, statementDeclaration: boolean}
       return unless blockPrefix
 
-      s.condition =
+      newCondition :=
         type: "ParenthesizedExpression"
         children: ["(", ref, ")"]
         expression: ref
         parent: s
-      s.children[1] = s.condition
+
+      // @ts-ignore
+      s.children = s.children.map (c) ->
+        if c is s.condition
+          newCondition
+        else
+          c
+
+      // @ts-ignore
+      s.condition = newCondition
       updateParentPointers s
 
-      // wraps the entire switch statement
-      block := blockWithPrefix [["", [{
-        type: "Declaration",
-        children: ["let ", ...condition.expression.children],
-      }], ";"], ...blockPrefix], makeEmptyBlock()
-      updateParentPointers block, s.parent
+      if statementDeclaration
+        // Hacky way to make sure the declaration is after the hoisted statement declaration
+        // TODO better unify this with hoistDec mechanics
+        block := makeEmptyBlock()
+        replaceBlockExpression(s.parent as BlockStatement, s, block)
+        block.expressions.push ["", s]
+        s.children.splice s.children.findIndex(.token is "switch"), 0, blockPrefix
+        s.parent = block
+      else
+        // wraps the entire switch statement
+        block := blockWithPrefix [["", [{
+          type: "Declaration",
+          children: ["let ", ...condition.expression.children],
+        }], ";"], ...blockPrefix], makeEmptyBlock()
+        updateParentPointers block, s.parent
 
-      replaceBlockExpression(s.parent as BlockStatement, s, block)
-      block.expressions.push ["", s]
-      s.parent = block
+        replaceBlockExpression(s.parent as BlockStatement, s, block)
+        block.expressions.push ["", s]
+        s.parent = block
 
 export {
   processAssignmentDeclaration

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -10,10 +10,21 @@ import {
 } from ./types.civet
 
 import {
+  blockWithPrefix
+  makeEmptyBlock
+  replaceBlockExpression
+} from ./block.civet
+
+import {
   gatherRecursiveAll
 } from ./traversal.civet
 
 import {
+  getPatternConditions
+} from ./pattern-matching.civet
+
+import {
+  addParentPointers
   convertOptionalType
   makeNode
   makeRef
@@ -80,9 +91,9 @@ function processDeclarations(statements: StatementTuple[]): void
 
       { initializer } := binding
       if initializer
-        prependBlockStatement initializer, statement
+        prependStatementExpressionBlock initializer, statement
 
-function prependBlockStatement(initializer: Initializer, statement: {children: Children}): void
+function prependStatementExpressionBlock(initializer: Initializer, statement: {children: Children}): void
   exp .= initializer[2]
 
   // Handle nested statement expression
@@ -91,44 +102,165 @@ function prependBlockStatement(initializer: Initializer, statement: {children: C
     ws = exp[0]
     exp = exp[1]!
 
-  if exp.type is "StatementExpression"
-    pre: ASTNode[] := []
-    statementExp := exp.statement
-    blockStatement: StatementTuple := ["", statementExp]
+  return unless exp.type is "StatementExpression"
 
-    if statementExp.type is "IterationExpression"
-      // Async iterations remain inline wrapped with IIFE
-      return if statementExp.async
+  pre: ASTNode[] := []
+  statementExp := exp.statement
+  blockStatement: StatementTuple := ["", statementExp]
 
-      statement := statementExp.statement
-      blockStatement[1] = statement
+  if statementExp.type is "IterationExpression"
+    // Async iterations remain inline wrapped with IIFE
+    return if statementExp.async
 
-      wrapIterationReturningResults statement, children: blockStatement, ->
-      initializer[2] = statement.resultsRef
-    else
-      ref := initializer[2] = makeRef()
+    statement := statementExp.statement
+    blockStatement[1] = statement
 
-      assignResults blockStatement, (resultNode) =>
-        //@ts-ignore
-        makeNode
-          type: "AssignmentExpression",
-          children: [ref, " = ", resultNode]
+    wrapIterationReturningResults statement, children: blockStatement, ->
+    initializer[2] = statement.resultsRef
+  else
+    ref := initializer[2] = makeRef()
 
-      refDec :=
-        type: "Declaration",
-        children: ["let ", ref, ";"],
-
-      pre.unshift refDec
+    assignResults blockStatement, (resultNode) =>
       //@ts-ignore
-      pre.push ws if ws
+      makeNode
+        type: "AssignmentExpression",
+        children: [ref, " = ", resultNode]
 
-    // insert statement before the declaration
+    refDec :=
+      type: "Declaration",
+      children: ["let ", ref, ";"],
+
+    pre.unshift refDec
     //@ts-ignore
-    statement.children.unshift(pre, blockStatement, ";")
+    pre.push ws if ws
 
-    updateParentPointers blockStatement, statement
+  // insert statement before the declaration
+  //@ts-ignore
+  statement.children.unshift(pre, blockStatement, ";")
+
+  updateParentPointers blockStatement, statement
+
+function processDeclarationCondition(condition, rootCondition, parent): void
+  return unless condition.type is "DeclarationCondition"
+  ref := makeRef()
+
+  { decl, bindings } := condition.declaration as DeclarationStatement
+  // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
+  binding := bindings[0]
+  { pattern, suffix, initializer, splices, thisAssignments } := binding
+
+  grandparent := condition.parent?.parent
+  children :=
+    // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
+    // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
+    // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
+    if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
+      ["(", ref, initializer, ")"]
+    else
+      [ref, initializer]
+
+  Object.assign condition, {
+    type: "AssignmentExpression"
+    children
+    hoistDec:
+      type: "Declaration"
+      children: ["let ", ref, suffix]
+      names: []
+    pattern
+    ref
+  }
+
+  // condition wasn't previously a child, so now needs parent pointers
+  addParentPointers condition, parent
+
+  Object.assign rootCondition,
+    blockPrefix: [
+      ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
+      ...thisAssignments
+    ]
+
+function processDeclarationConditions(node: ASTNode): void
+  gatherRecursiveAll node, (n) =>
+    n.type is "IfStatement" or n.type is "IterationStatement" or n.type is "SwitchStatement"
+  .forEach processDeclarationConditionStatement
+
+/**
+ * Processes adding additional conditions when declarations are used as a condition in IfStatements, WhileStatements, and SwitchStatements.
+ * Also does additional processing for IfStatements that used to be in the parser (inserting semi-colon on bare-block consequent with else).
+ */
+function processDeclarationConditionStatement(s: IfStatement | IterationStatement | SwitchStatement): void
+  { condition } := s
+  return unless condition?.expression
+  { expression } .= condition
+  // Support for negated conditions built by unless/until
+  switch expression
+    {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]}
+      expression = expression2
+  processDeclarationCondition expression, condition.expression, s
+
+  { ref, pattern } := expression
+
+  if pattern
+    conditions .= []
+    getPatternConditions(pattern, ref, conditions)
+
+    conditions = conditions.filter (c) =>
+      !(c.length is 3 and c[0] is "typeof " and c[1] is ref and c[2] is " === 'object'") and
+      !(c.length is 2 and c[0] is ref and c[1] is " != null")
+
+    if conditions.length
+      condition.children.unshift "("
+      conditions.forEach (c) ->
+        condition.children.push " && ", c
+      condition.children.push ")"
+
+  switch s.type
+    when "IfStatement"
+      { else: e} := s
+      block := blockWithPrefix(condition.expression.blockPrefix, s.then)
+      s.then = block
+
+      if block.bare and e and not block.semicolon
+        block.children.push block.semicolon = ";"
+
+      s.children.splice(2, 1, block)
+
+      // Update parent pointers since declaration conditions have expanded
+      updateParentPointers(block, s)
+
+    when "IterationStatement"
+      { children, block } := s
+      newBlock := blockWithPrefix(condition.expression.blockPrefix, block)
+      s.children = children.map (c) => c?.type is "BlockStatement" ? newBlock : c
+
+      // Update parent pointers since declaration conditions have expanded
+      updateParentPointers(newBlock, s)
+
+    when "SwitchStatement"
+      { blockPrefix, ref } := condition.expression
+      return unless blockPrefix
+
+      s.condition =
+        type: "ParenthesizedExpression"
+        children: ["(", ref, ")"]
+        expression: ref
+        parent: s
+      s.children[1] = s.condition
+      updateParentPointers s
+
+      // wraps the entire switch statement
+      block := blockWithPrefix [["", [{
+        type: "Declaration",
+        children: ["let ", ...condition.expression.children],
+      }], ";"], ...blockPrefix], makeEmptyBlock()
+      updateParentPointers block, s.parent
+
+      replaceBlockExpression(s.parent as BlockStatement, s, block)
+      block.expressions.push ["", s]
+      s.parent = block
 
 export {
   processAssignmentDeclaration
+  processDeclarationConditions
   processDeclarations
 }

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -1,0 +1,134 @@
+import {
+  ASTLeaf
+  ASTNode
+  Binding
+  Children
+  Initializer
+  StatementTuple
+  TypeSuffix
+  WSNode
+} from ./types.civet
+
+import {
+  gatherRecursiveAll
+} from ./traversal.civet
+
+import {
+  convertOptionalType
+  makeNode
+  makeRef
+  updateParentPointers
+} from ./util.civet
+
+import {
+  assignResults
+  wrapIterationReturningResults
+} from ./function.civet
+
+import {
+  gatherBindingCode
+} from ./binding.civet
+
+function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix, ws: WSNode, assign: ASTLeaf, e: ASTNode)
+  // Adjust position to space before assignment to make TypeScript remapping happier
+  decl = {
+    ...decl,
+    $loc:
+      pos: assign.$loc.pos - 1
+      length: assign.$loc.length + 1
+  }
+
+  [splices, assignments] .= gatherBindingCode pattern
+
+  splices = splices.map (s) => [", ", s]
+  thisAssignments := assignments.map (a) => ["", a, ";"] as const
+
+  initializer := [ws, assign, e]
+  binding := makeNode {
+    type: "Binding",
+    pattern,
+    initializer,
+    splices,
+    suffix,
+    thisAssignments,
+    children: [pattern, suffix, initializer]
+  }
+
+  children := [decl, binding]
+
+  makeNode {
+    type: "Declaration",
+    pattern.names,
+    decl,
+    bindings: [binding],
+    splices,
+    thisAssignments,
+    children,
+  }
+
+function processDeclarations(statements: StatementTuple[]): void
+  // @ts-ignore
+  gatherRecursiveAll statements, .type is "Declaration"
+  // @ts-ignore
+  .forEach (statement: DeclarationStatement) =>
+    { bindings } := statement as DeclarationStatement
+    bindings?.forEach (binding) =>
+      suffix := binding.suffix
+      if suffix and suffix.optional and suffix.t
+        // Convert `let x?: T` to `let x: undefined | T`
+        convertOptionalType suffix
+
+      { initializer } := binding
+      if initializer
+        prependBlockStatement initializer, statement
+
+function prependBlockStatement(initializer: Initializer, statement: {children: Children}): void
+  exp .= initializer[2]
+
+  // Handle nested statement expression
+  let ws
+  if Array.isArray(exp)
+    ws = exp[0]
+    exp = exp[1]!
+
+  if exp.type is "StatementExpression"
+    pre: ASTNode[] := []
+    statementExp := exp.statement
+    blockStatement: StatementTuple := ["", statementExp]
+
+    if statementExp.type is "IterationExpression"
+      // Async iterations remain inline wrapped with IIFE
+      return if statementExp.async
+
+      statement := statementExp.statement
+      blockStatement[1] = statement
+
+      wrapIterationReturningResults statement, children: blockStatement, ->
+      initializer[2] = statement.resultsRef
+    else
+      ref := initializer[2] = makeRef()
+
+      assignResults blockStatement, (resultNode) =>
+        //@ts-ignore
+        makeNode
+          type: "AssignmentExpression",
+          children: [ref, " = ", resultNode]
+
+      refDec :=
+        type: "Declaration",
+        children: ["let ", ref, ";"],
+
+      pre.unshift refDec
+      //@ts-ignore
+      pre.push ws if ws
+
+    // insert statement before the declaration
+    //@ts-ignore
+    statement.children.unshift(pre, blockStatement, ";")
+
+    updateParentPointers blockStatement, statement
+
+export {
+  processAssignmentDeclaration
+  processDeclarations
+}

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -121,8 +121,23 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
     statement := statementExp.statement
     blockStatement[1] = statement
 
-    wrapIterationReturningResults statement, children: blockStatement, ->
-    ref = initializer[2] = statement.resultsRef
+    if statement.type is "DoStatement"
+      ref = initializer[2] = makeRef()
+      assignResults blockStatement, (resultNode) =>
+        //@ts-ignore
+        makeNode
+          type: "AssignmentExpression",
+          children: [ref, " = ", resultNode]
+
+      refDec :=
+        type: "Declaration",
+        children: ["let ", ref, ";"],
+
+      // @ts-ignore
+      pre.unshift refDec
+    else
+      wrapIterationReturningResults statement, children: blockStatement, ->
+      ref = initializer[2] = statement.resultsRef
   else
     ref = initializer[2] = makeRef()
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -551,7 +551,7 @@ function expressionizeIteration(exp: IterationExpression): void
   updateParentPointers exp
 
 /**
-Utility function to check if an implict function application should be skipped
+Utility function to check if an implicit function application should be skipped
 based on the shape of the arguments.
 
 Don't treat as call if this is a postfix for/while/until/if/unless

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,11 +1,15 @@
 import type {
   ASTNode
   ASTNodeBase
+  DoStatement
+  ForStatement
   FunctionNode
+  IterationExpression
+  IterationStatement
   LabeledStatement
   StatementTuple
-  TypeNode
   TypeIdentifierNode
+  TypeNode
 } from ./types.civet
 
 import {
@@ -27,6 +31,7 @@ import {
 } from ./traversal.civet
 
 import {
+  assert
   convertOptionalType
   isEmptyBareBlock
   isFunction
@@ -406,7 +411,11 @@ function insertSwitchReturns(exp): void
   exp.caseBlock.clauses.forEach (clause) =>
     insertReturn clause
 
-function wrapIterationReturningResults(statement, outer, collect?: (node: ASTNode) => ASTNode): void
+function wrapIterationReturningResults(
+  statement: ForStatement | IterationStatement | DoStatement,
+  outer: { children: StatementTuple[] },
+  collect?: (node: ASTNode) => ASTNode
+): void
   if statement.type is "DoStatement"
     if collect
       assignResults(statement.block, collect)
@@ -414,20 +423,23 @@ function wrapIterationReturningResults(statement, outer, collect?: (node: ASTNod
       insertReturn(statement.block, outer)
     return
 
-  const resultsRef = makeRef("results")
+  assert.equal statement.resultsRef, undefined,
+    "wrapIterationReturningResults should not be called twice on the same statement"
 
-  const declaration = {
-    type: "Declaration",
-    children: ["const ", resultsRef, "=[];"],
-  }
+  resultsRef := statement.resultsRef = makeRef "results"
+
+  declaration :=
+    type: "Declaration"
+    children: ["const ", resultsRef, "=[]"]
+
+  outer.children.unshift(["", declaration, ";"])
 
   assignResults statement.block, (node) =>
-    // TODO: real node
+    // TODO: real ast node
     [ resultsRef, ".push(", node, ")" ]
 
-  outer.children.unshift(declaration)
   if collect
-    statement.children.push ";", collect(resultsRef), ";"
+    statement.children.push collect(resultsRef)
   else
     statement.children.push(";return ", resultsRef, ";")
 
@@ -505,9 +517,9 @@ function processFunctions(statements, config): void
     processParams(f)
     processReturn(f, config.implicitReturns)
 
-function expressionizeIteration(exp): void
-  const { async, subtype, block, children, statement } = exp
-  const i = children.indexOf(statement)
+function expressionizeIteration(exp: IterationExpression): void
+  { async, subtype, block, children, statement } := exp
+  i := children.indexOf statement
   if i < 0
     throw new Error("Could not find iteration statement in iteration expression")
 
@@ -518,7 +530,8 @@ function expressionizeIteration(exp): void
     updateParentPointers exp
     return
 
-  const resultsRef = makeRef("results")
+  exp.resultsRef ??= makeRef "results"
+  { resultsRef } := exp
 
   // insert `results.push` to gather results array
   assignResults block, (node) =>
@@ -565,4 +578,5 @@ export {
   expressionizeIteration
   processFunctions
   skipImplicitArguments
+  wrapIterationReturningResults
 }

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -3,6 +3,7 @@ import type {
   ASTNodeBase
   FunctionNode
   LabeledStatement
+  StatementTuple
   TypeNode
   TypeIdentifierNode
 } from ./types.civet
@@ -27,12 +28,13 @@ import {
 
 import {
   convertOptionalType
+  isEmptyBareBlock
   isFunction
-  makeRef
   isWhitespaceOrEmpty
+  makeRef
   updateParentPointers
-  wrapWithReturn
   wrapIIFE
+  wrapWithReturn
 } from ./util.civet
 
 function isVoidType(t?: TypeNode): boolean
@@ -535,8 +537,32 @@ function expressionizeIteration(exp): void
   )
   updateParentPointers exp
 
+/**
+Utility function to check if an implict function application should be skipped
+based on the shape of the arguments.
+
+Don't treat as call if this is a postfix for/while/until/if/unless
+*/
+function skipImplicitArguments(args: unknown[])
+  if args.length is 1
+    arg0 .= args[0]
+    if Array.isArray arg0
+      arg0 = arg0[1] // skip whitespace
+
+    if arg0.type is "StatementExpression"
+      arg0 = arg0.statement
+
+    return (and)
+      arg0.type is "IterationExpression"
+      arg0.subtype !== "DoStatement"
+      !arg0.async
+      isEmptyBareBlock arg0.block
+
+  return false
+
 export {
+  assignResults
   expressionizeIteration
   processFunctions
-  assignResults
+  skipImplicitArguments
 }

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -14,7 +14,9 @@ import type {
   BlockStatement
   DeclarationStatement
   MethodDefinition
+  ParenthesizedExpression
   ParseRule
+  StatementExpression
   StatementTuple
   TypeSuffix
   WSNode
@@ -129,17 +131,27 @@ function negateCondition(condition)
     ]
   { ...condition, expression, children }
 
-function expressionizeIfClause(clause, b, e)
-  { condition } := clause  // remove 'if'
+function expressionizeBlock(blockOrExpression: ASTNode)
+  if { expressions } := blockOrExpression
+    l := expressions.length
+    expressions.map ([ws, s, _delim], i) ->
+      if i is l - 1
+        [ws, s]
+      else
+        [ws, s, ","]
+  else
+    blockOrExpression
+
+function expressionizeIfClause(condition: ParenthesizedExpression, b: ASTNode, e?: [WSNode , ASTLeaf, ASTNode, WSNode])
   [ ...condRest, closeParen ] := condition.children  // separate ')'
   children := [
     ...condRest
     "?"
-    b
+    expressionizeBlock b
   ]
   if e
     // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
-    children.push e[0], ":", ...e[2..]
+    children.push e[0], ":", expressionizeBlock(e[2]), ...e[3..]
   else
     children.push ":void 0"
   children.push closeParen
@@ -771,8 +783,8 @@ function processAssignments(statements): void {
     })
 }
 
-function attachPostfixStatementAsExpression(exp, post): void {
-  switch (post[1].type) {
+function attachPostfixStatementAsExpression(exp, post)
+  switch post[1].type
     case "ForStatement":
     case "IterationStatement":
     case "DoStatement": {
@@ -785,11 +797,9 @@ function attachPostfixStatementAsExpression(exp, post): void {
       }
     }
     case "IfStatement":
-      return expressionizeIfClause(post[1], exp)
+      return expressionizeIfClause post[1].condition, exp
     default:
       throw new Error("Unknown postfix statement")
-  }
-}
 
 function processTypes(node: ASTNode)
   // T? -> T | undefined; T?? -> T | undefined | null
@@ -828,9 +838,22 @@ Wrap any remaining statement expressions in IIFE.
 */
 function processStatementExpressions(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, .type is "StatementExpression")
-    .forEach (exp) =>
-      exp.children = wrapIIFE(exp.children)
+    .forEach (_exp) =>
+      exp := _exp as! StatementExpression
+      { statement: [, statement] } := exp
+      let ws
+      unless exp.children[0] is exp.statement
+        ws = exp.children[0]
 
+      if statement.type is "IfStatement"
+        debugger
+        // TODO: detect non-expressionable ifs and wrap in iife
+        exp.statement = expressionizeIfClause(statement.condition, statement.then, statement.else)
+        exp.children = [exp.statement]
+      else
+        exp.children = wrapIIFE(exp.children)
+
+      exp.children.unshift(ws) if ws
 
 function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule): void {
   // invariants
@@ -1078,7 +1101,6 @@ export {
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
-  expressionizeIfClause
   expressionizeTypeIf
   forRange
   gatherBindingCode

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -133,6 +133,11 @@ function negateCondition(condition)
     ]
   { ...condition, expression, children }
 
+/**
+Somewhat incomplete detection of expressions used to
+determine when we have to wrap if blocks in IIFE instead of
+converting to ternary expressions.
+*/
 function isExpression(node: ASTNode): boolean
   if Array.isArray(node)
     return node.every(isExpression)
@@ -141,9 +146,10 @@ function isExpression(node: ASTNode): boolean
     // TODO: may not quite be correct
     return true
 
-  switch node.type
+  switch node?.type
     case "BlockStatement"
     case "DebuggerStatement"
+    case "Declaration"
     case "IfStatement"
     case "IterationStatement"
     case "ReturnStatement"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -29,6 +29,7 @@ import {
 
 import {
   addParentPointers
+  assert
   convertOptionalType
   deepCopy
   getTrimmingSpace
@@ -65,6 +66,7 @@ import {
   processFunctions
   expressionizeIteration
   skipImplicitArguments
+  wrapIterationReturningResults
 } from ./function.civet
 import { processDeclarationConditions, processPatternMatching } from ./pattern-matching.civet
 import {
@@ -110,12 +112,6 @@ function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   if post.type is "IfStatement"
     post.then = block
   return post
-
-assert := {
-  equal(a, b, msg): void
-    /* c8 ignore next */
-    throw new Error(`Assertion failed [${msg}]: ${a} !== ${b}`) if a !== b
-}
 
 // Negate expression inside condition
 function negateCondition(condition)
@@ -610,35 +606,35 @@ function processDeclarations(statements: StatementTuple[]): void
           exp = exp[1]!
 
         if exp.type is "StatementExpression"
+          pre: ASTNode[] := []
           statementExp := exp.statement
+          blockStatement: StatementTuple := ["", statementExp]
 
           if statementExp.type is "IterationExpression"
             // Async iterations remain inline wrapped with IIFE
             return if statementExp.async
 
-            // Prevent extracted iteration statement from being wrapped in IIFE
-            statementExp.type = "IterationStatement"
+            statement := statementExp.statement
+            blockStatement[1] = statement
 
-          ref := makeRef()
+            wrapIterationReturningResults statement, children: blockStatement, ->
+            initializer[2] = statement.resultsRef
+          else
+            ref := initializer[2] = makeRef()
 
-          // Detach statement and assign results to ref
-          blockStatement := ["", statementExp]
-          debugger
-          assignResults blockStatement, (resultNode) =>
-            makeNode
-              //@ts-ignore
-              type: "AssignmentExpression",
-              children: [ref, " = ", resultNode]
+            assignResults blockStatement, (resultNode) =>
+              makeNode
+                //@ts-ignore
+                type: "AssignmentExpression",
+                children: [ref, " = ", resultNode]
 
-          initializer[2] = ref
+            refDec :=
+              type: "Declaration",
+              children: ["let ", ref, ";"],
 
-          refDec :=
-            type: "Declaration",
-            children: ["let ", ref, ";"],
-
-          pre := [refDec]
-          //@ts-ignore
-          pre.push ws if ws
+            pre.unshift refDec
+            //@ts-ignore
+            pre.push ws if ws
 
           // insert statement before the declaration
           //@ts-ignore

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -7,22 +7,17 @@
  */
 
 import type {
-  ASTLeaf
   ASTNode
   ASTNodeBase
-  Binding
   BlockStatement
-  DeclarationStatement
   DoStatement
   ForStatement
   IfStatement
   IterationStatement
   MethodDefinition
-  ParenthesizedExpression
   ParseRule
   StatementExpression
   StatementTuple
-  TypeSuffix
   WSNode
 } from ./types.civet
 
@@ -34,7 +29,6 @@ import {
 import {
   addParentPointers
   assert
-  convertOptionalType
   deepCopy
   getTrimmingSpace
   hasAwait
@@ -50,7 +44,6 @@ import {
   makeRef
   maybeRef
   parenthesizeType
-  updateParentPointers
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
@@ -63,14 +56,17 @@ import {
   processBlocks
 } from ./block.civet
 
+import {
+  processAssignmentDeclaration
+  processDeclarations
+} from ./declaration.civet
+
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf } from ./for.civet
 import {
-  assignResults
   processFunctions
   expressionizeIteration
   skipImplicitArguments
-  wrapIterationReturningResults
 } from ./function.civet
 import { processDeclarationConditions, processPatternMatching } from ./pattern-matching.civet
 import {
@@ -590,102 +586,6 @@ function makeGetterMethod(name, ws, value, returnType, block?: BlockStatement, k
     block,
     parameters,
   }
-
-function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix, ws: WSNode, assign: ASTLeaf, e: ASTNode)
-  // Adjust position to space before assignment to make TypeScript remapping happier
-  decl = {
-    ...decl,
-    $loc:
-      pos: assign.$loc.pos - 1
-      length: assign.$loc.length + 1
-  }
-
-  [splices, assignments] .= gatherBindingCode pattern
-
-  splices = splices.map (s) => [", ", s]
-  thisAssignments := assignments.map (a) => ["", a, ";"] as const
-
-  initializer := [ws, assign, e]
-  binding := makeNode {
-    type: "Binding",
-    pattern,
-    initializer,
-    splices,
-    suffix,
-    thisAssignments,
-    children: [pattern, suffix, initializer]
-  }
-
-  children := [decl, binding]
-
-  makeNode {
-    type: "Declaration",
-    pattern.names,
-    decl,
-    bindings: [binding],
-    splices,
-    thisAssignments,
-    children,
-  }
-
-function processDeclarations(statements: StatementTuple[]): void
-  // @ts-ignore
-  gatherRecursiveAll statements, .type is "Declaration"
-  // @ts-ignore
-  .forEach (statement: DeclarationStatement) =>
-    { bindings } := statement as DeclarationStatement
-    bindings?.forEach (binding) =>
-      suffix := binding.suffix
-      if suffix and suffix.optional and suffix.t
-        // Convert `let x?: T` to `let x: undefined | T`
-        convertOptionalType suffix
-
-      { initializer } := binding
-      if initializer
-        exp .= initializer[2]
-
-        // Handle nested statement expression
-        let ws
-        if Array.isArray(exp)
-          ws = exp[0]
-          exp = exp[1]!
-
-        if exp.type is "StatementExpression"
-          pre: ASTNode[] := []
-          statementExp := exp.statement
-          blockStatement: StatementTuple := ["", statementExp]
-
-          if statementExp.type is "IterationExpression"
-            // Async iterations remain inline wrapped with IIFE
-            return if statementExp.async
-
-            statement := statementExp.statement
-            blockStatement[1] = statement
-
-            wrapIterationReturningResults statement, children: blockStatement, ->
-            initializer[2] = statement.resultsRef
-          else
-            ref := initializer[2] = makeRef()
-
-            assignResults blockStatement, (resultNode) =>
-              makeNode
-                //@ts-ignore
-                type: "AssignmentExpression",
-                children: [ref, " = ", resultNode]
-
-            refDec :=
-              type: "Declaration",
-              children: ["let ", ref, ";"],
-
-            pre.unshift refDec
-            //@ts-ignore
-            pre.push ws if ws
-
-          // insert statement before the declaration
-          //@ts-ignore
-          statement.children.unshift(pre, blockStatement, ";")
-
-          updateParentPointers blockStatement, statement
 
 function processBindingPatternLHS(lhs, tail): void
   // Expand AtBindings first before gathering splices

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -13,6 +13,10 @@ import type {
   Binding
   BlockStatement
   DeclarationStatement
+  DoStatement
+  ForStatement
+  IfStatement
+  IterationStatement
   MethodDefinition
   ParenthesizedExpression
   ParseRule
@@ -128,27 +132,68 @@ function negateCondition(condition)
     ]
   { ...condition, expression, children }
 
+function isExpression(node: ASTNode): boolean
+  if Array.isArray(node)
+    return node.every(isExpression)
+
+  if typeof node is "string"
+    // TODO: may not quite be correct
+    return true
+
+  switch node.type
+    case "BlockStatement"
+    case "DebuggerStatement"
+    case "IfStatement"
+    case "IterationStatement"
+    case "ReturnStatement"
+    case "SwitchStatement"
+    case "ThrowStatement"
+    case "TryStatement"
+      return false
+
+  return true
+
 function expressionizeBlock(blockOrExpression: ASTNode)
   if { expressions } := blockOrExpression
     l := expressions.length
-    expressions.map ([ws, s, _delim], i) ->
+    results := []
+
+    for [ws, s, _delim], i of expressions
+      if (!isExpression(s)) return
+      wrapped := makeLeftHandSideExpression s
       if i is l - 1
-        [ws, s]
+        results.push [ws, wrapped]
       else
-        [ws, s, ","]
+        results.push [ws, wrapped, ","]
+
+    if results.length > 1
+      return makeLeftHandSideExpression results
+
+    return results
   else
     blockOrExpression
 
-function expressionizeIfClause(condition: ParenthesizedExpression, b: ASTNode, e?: [WSNode , ASTLeaf, ASTNode, WSNode])
+function expressionizeIfStatement(statement: IfStatement)
+  { condition, then: b, else: e } := statement
   [ ...condRest, closeParen ] := condition.children  // separate ')'
+
+  expressionizedBlock := expressionizeBlock b
+
+  unless expressionizedBlock
+    return wrapIIFE([["", statement]])
+
   children := [
     ...condRest
     "?"
-    expressionizeBlock b
+    expressionizedBlock
   ]
   if e
+    e2 := expressionizeBlock(e[2])
+    unless e2
+      return wrapIIFE([["", statement]])
+
     // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
-    children.push e[0], ":", expressionizeBlock(e[2]), ...e[3..]
+    children.push e[0], ":", e2, ...e[3..]
   else
     children.push ":void 0"
   children.push closeParen
@@ -790,12 +835,14 @@ function processAssignments(statements): void {
     })
 }
 
-function attachPostfixStatementAsExpression(exp, post)
-  switch post[1].type
+function attachPostfixStatementAsExpression(exp, post: [WSNode, IfStatement | IterationStatement | DoStatement | ForStatement])
+  postfixStatement := post[1]
+
+  switch postfixStatement.type
     case "ForStatement":
     case "IterationStatement":
     case "DoStatement": {
-      const statement = addPostfixStatement(exp, ...post)
+      statement := addPostfixStatement(exp, ...post)
       return {
         type: "IterationExpression",
         children: [statement],
@@ -804,7 +851,7 @@ function attachPostfixStatementAsExpression(exp, post)
       }
     }
     case "IfStatement":
-      return expressionizeIfClause post[1].condition, exp
+      return expressionizeIfStatement { ...postfixStatement, then: exp }
     default:
       throw new Error("Unknown postfix statement")
 
@@ -855,8 +902,11 @@ function processStatementExpressions(statements: StatementTuple[]): void
       switch statement.type
         when "IfStatement"
           // TODO: detect non-expressionable ifs and wrap in iife
-          exp.statement = expressionizeIfClause(statement.condition, statement.then, statement.else)
-          exp.children = [exp.statement]
+          if expression := expressionizeIfStatement(statement)
+            exp.statement = expression
+            exp.children = [exp.statement]
+          else
+            exp.children = wrapIIFE([["", statement]])
         when "IterationExpression"
           // Do nothing, handled separately currently
         else

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -612,11 +612,11 @@ function processDeclarations(statements: StatementTuple[]): void
         if exp.type is "StatementExpression"
           statementExp := exp.statement
 
-          // Prevent extracted statement from being wrapped in IIFE
           if statementExp.type is "IterationExpression"
             // Async iterations remain inline wrapped with IIFE
             return if statementExp.async
 
+            // Prevent extracted iteration statement from being wrapped in IIFE
             statementExp.type = "IterationStatement"
 
           ref := makeRef()

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -58,6 +58,7 @@ import {
 
 import {
   processAssignmentDeclaration
+  processDeclarationConditions
   processDeclarations
 } from ./declaration.civet
 
@@ -68,7 +69,7 @@ import {
   expressionizeIteration
   skipImplicitArguments
 } from ./function.civet
-import { processDeclarationConditions, processPatternMatching } from ./pattern-matching.civet
+import { processPatternMatching } from ./pattern-matching.civet
 import {
   adjustAtBindings
   adjustBindingElements

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -61,9 +61,10 @@ import {
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf } from ./for.civet
 import {
-  assignResults,
-  processFunctions,
+  assignResults
+  processFunctions
   expressionizeIteration
+  skipImplicitArguments
 } from ./function.civet
 import { processDeclarationConditions, processPatternMatching } from ./pattern-matching.civet
 import {
@@ -609,11 +610,21 @@ function processDeclarations(statements: StatementTuple[]): void
           exp = exp[1]!
 
         if exp.type is "StatementExpression"
-          ref := makeRef()
           statementExp := exp.statement
 
+          // Prevent extracted statement from being wrapped in IIFE
+          if statementExp.type is "IterationExpression"
+            // Async iterations remain inline wrapped with IIFE
+            return if statementExp.async
+
+            statementExp.type = "IterationStatement"
+
+          ref := makeRef()
+
           // Detach statement and assign results to ref
-          assignResults statementExp, (resultNode) =>
+          blockStatement := ["", statementExp]
+          debugger
+          assignResults blockStatement, (resultNode) =>
             makeNode
               //@ts-ignore
               type: "AssignmentExpression",
@@ -631,9 +642,9 @@ function processDeclarations(statements: StatementTuple[]): void
 
           // insert statement before the declaration
           //@ts-ignore
-          statement.children.unshift(pre, statementExp, ";")
+          statement.children.unshift(pre, blockStatement, ";")
 
-          updateParentPointers statementExp, statement
+          updateParentPointers blockStatement, statement
 
 function processBindingPatternLHS(lhs, tail): void
   // Expand AtBindings first before gathering splices
@@ -840,18 +851,20 @@ function processStatementExpressions(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, .type is "StatementExpression")
     .forEach (_exp) =>
       exp := _exp as! StatementExpression
-      { statement: [, statement] } := exp
+      { statement } := exp
       let ws
       unless exp.children[0] is exp.statement
         ws = exp.children[0]
 
-      if statement.type is "IfStatement"
-        debugger
-        // TODO: detect non-expressionable ifs and wrap in iife
-        exp.statement = expressionizeIfClause(statement.condition, statement.then, statement.else)
-        exp.children = [exp.statement]
-      else
-        exp.children = wrapIIFE(exp.children)
+      switch statement.type
+        when "IfStatement"
+          // TODO: detect non-expressionable ifs and wrap in iife
+          exp.statement = expressionizeIfClause(statement.condition, statement.then, statement.else)
+          exp.children = [exp.statement]
+        when "IterationExpression"
+          // Do nothing, handled separately currently
+        else
+          exp.children = wrapIIFE([["", statement]])
 
       exp.children.unshift(ws) if ws
 
@@ -1135,6 +1148,7 @@ export {
   quoteString
   reorderBindingRestProperty
   replaceNodes
+  skipImplicitArguments
   typeOfJSX
   wrapIIFE
 }

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -7,10 +7,12 @@
  */
 
 import type {
+  AssignmentExpression
   ASTNode
   ASTNodeBase
   BlockStatement
   DoStatement
+  ExpressionNode
   ForStatement
   IfStatement
   IterationStatement
@@ -52,11 +54,13 @@ import {
   blockWithPrefix
   duplicateBlock
   hoistRefDecs
+  makeBlockFragment
   makeEmptyBlock
   processBlocks
 } from ./block.civet
 
 import {
+  prependStatementExpressionBlock
   processAssignmentDeclaration
   processDeclarationConditions
   processDeclarations
@@ -642,9 +646,19 @@ function processAssignments(statements): void {
       // TODO: need to make this a parenthesized expression when when we add parens
     })
 
-  gatherRecursiveAll(statements, (n) => n.type is "AssignmentExpression" and n.names is null)
-    .forEach((exp) => {
+  replaceNodesRecursive statements, (n) => n.type is "AssignmentExpression" and n.names is null, (exp: AssignmentExpression): AssignmentExpression | BlockStatement | ExpressionNode => {
       let { lhs: $1, exp: $2 } = exp, tail = [], i = 0, len = $1.length
+
+      let block?: BlockStatement
+      // Extract StatementExpression as block
+      if exp.parent.type is "BlockStatement" and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
+        block = makeBlockFragment()
+        if ref := prependStatementExpressionBlock([null,null,$2], block)
+          exp.children = exp.children.map (c: ASTNode) -> if c is $2 then ref else c
+          // @ts-ignore
+          $2 = ref
+        else
+          block = undefined
 
       // identifier=, xor=, ++=
       if $1.some((left) => left[left.length - 1].special)
@@ -657,7 +671,7 @@ function processAssignments(statements): void {
         exp.children.splice index, 1,
           exp.exp = $2 = [call, "(", lhs, ", ", $2, ")"]
         if omitLhs
-          replaceNode exp, $2
+          return $2
 
       // Force parens around destructuring object assignments
       // Walk from left to right the minimal number of parens are added and enclose all destructured assignments
@@ -717,7 +731,7 @@ function processAssignments(statements): void {
 
               exp.children = [$1]
               exp.names = []
-              return
+              return exp
             }
           } else if (lhs.type is "ObjectBindingPattern" or lhs.type is "ArrayBindingPattern") {
             processBindingPatternLHS(lhs, tail)
@@ -733,7 +747,15 @@ function processAssignments(statements): void {
       const index = exp.children.indexOf($2)
       if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
       exp.children.splice(index + 1, 0, ...tail)
-    })
+
+      if block
+        block.parent = exp.parent
+        block.expressions.push(["", exp])
+        exp.parent = block
+        return block
+
+      return exp
+    }
 }
 
 function attachPostfixStatementAsExpression(exp, post: [WSNode, IfStatement | IterationStatement | DoStatement | ForStatement])
@@ -967,18 +989,44 @@ function reorderBindingRestProperty(props) {
  */
 function replaceNodes(root, predicate, replacer)
   return root unless root?
+
   array := Array.isArray(root) ? root : root.children
+
   unless array
     if predicate root
       return replacer root, root
     else
       return root
+
   for each node, i of array
     return unless node?
     if predicate node
       array[i] = replacer node, root
     else
       replaceNodes node, predicate, replacer
+
+  return root
+
+function replaceNodesRecursive(root, predicate, replacer)
+  return root unless root?
+
+  array := Array.isArray(root) ? root : root.children
+
+  unless array
+    if predicate root
+      return replacer root, root
+    else
+      return root
+
+  for each node, i of array
+    continue unless node?
+    if predicate node
+      ret := replacer node, root
+      replaceNodesRecursive ret, predicate, replacer
+      array[i] = ret
+    else
+      replaceNodesRecursive node, predicate, replacer
+
   return root
 
 function typeOfJSX(node, config, getRef) {

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -1,10 +1,6 @@
 import type {
   ASTNode
   ASTRef
-  BlockStatement
-  DeclarationStatement
-  IfStatement
-  IterationStatement
   ParenthesizedExpression
   ParseRule
   SwitchStatement
@@ -19,14 +15,10 @@ import {
   isExit
   makeRef
   maybeRef
-  updateParentPointers
 } from ./util.civet
 
 import {
-  blockWithPrefix
   braceBlock
-  makeEmptyBlock
-  replaceBlockExpression
 } from ./block.civet
 
 import {
@@ -435,125 +427,6 @@ function aggregateDuplicateBindings(bindings, ReservedWord: ParseRule) {
   return declarations
 }
 
-function processDeclarationCondition(condition, rootCondition, parent): void
-  return unless condition.type is "DeclarationCondition"
-  ref := makeRef()
-
-  { decl, bindings } := condition.declaration as DeclarationStatement
-  // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
-  binding := bindings[0]
-  { pattern, suffix, initializer, splices, thisAssignments } := binding
-
-  grandparent := condition.parent?.parent
-  children :=
-    // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
-    // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
-    // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
-    if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
-      ["(", ref, initializer, ")"]
-    else
-      [ref, initializer]
-
-  Object.assign condition, {
-    type: "AssignmentExpression"
-    children
-    hoistDec:
-      type: "Declaration"
-      children: ["let ", ref, suffix]
-      names: []
-    pattern
-    ref
-  }
-
-  // condition wasn't previously a child, so now needs parent pointers
-  addParentPointers condition, parent
-
-  Object.assign rootCondition,
-    blockPrefix: [
-      ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
-      ...thisAssignments
-    ]
-
-function processDeclarationConditions(node: ASTNode): void
-  gatherRecursiveAll node, (n) =>
-    n.type is "IfStatement" or n.type is "IterationStatement" or n.type is "SwitchStatement"
-  .forEach processDeclarationConditionStatement
-
-/**
- * Processes adding additional conditions when declarations are used as a condition in IfStatements, WhileStatements, and SwitchStatements.
- * Also does additional processing for IfStatements that used to be in the parser (inserting semi-colon on bare-block consequent with else).
- */
-function processDeclarationConditionStatement(s: IfStatement | IterationStatement | SwitchStatement): void
-  { condition } := s
-  return unless condition?.expression
-  { expression } .= condition
-  // Support for negated conditions built by unless/until
-  switch expression
-    {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]}
-      expression = expression2
-  processDeclarationCondition expression, condition.expression, s
-
-  { ref, pattern } := expression
-
-  if pattern
-    conditions .= []
-    getPatternConditions(pattern, ref, conditions)
-
-    conditions = conditions.filter (c) =>
-      !(c.length is 3 and c[0] is "typeof " and c[1] is ref and c[2] is " === 'object'") and
-      !(c.length is 2 and c[0] is ref and c[1] is " != null")
-
-    if conditions.length
-      condition.children.unshift "("
-      conditions.forEach (c) ->
-        condition.children.push " && ", c
-      condition.children.push ")"
-
-  switch s.type
-    when "IfStatement"
-      { else: e} := s
-      block := blockWithPrefix(condition.expression.blockPrefix, s.then)
-      s.then = block
-
-      if block.bare and e and not block.semicolon
-        block.children.push block.semicolon = ";"
-
-      s.children.splice(2, 1, block)
-
-      // Update parent pointers since declaration conditions have expanded
-      updateParentPointers(block, s)
-
-    when "IterationStatement"
-      { children, block } := s
-      newBlock := blockWithPrefix(condition.expression.blockPrefix, block)
-      s.children = children.map (c) => c?.type is "BlockStatement" ? newBlock : c
-
-      // Update parent pointers since declaration conditions have expanded
-      updateParentPointers(newBlock, s)
-
-    when "SwitchStatement"
-      { blockPrefix, ref } := condition.expression
-      return unless blockPrefix
-
-      s.condition =
-        type: "ParenthesizedExpression"
-        children: ["(", ref, ")"]
-        expression: ref
-        parent: s
-      s.children[1] = s.condition
-      updateParentPointers s
-
-      // wraps the entire switch statement
-      block := blockWithPrefix [["", [{
-        type: "Declaration",
-        children: ["let ", ...condition.expression.children],
-      }], ";"], ...blockPrefix], makeEmptyBlock()
-      updateParentPointers block, s.parent
-
-      replaceBlockExpression(s.parent as BlockStatement, s, block)
-      block.expressions.push ["", s]
-      s.parent = block
-
 /**
  * Adjust the alias of a binding property, adding an alias if one doesn't exist or
  * replacing an existing alias. This mutates the property in place.
@@ -576,6 +449,6 @@ function aliasBinding(p, ref: ASTRef): void
     p.children.splice index + 1, 0, ": ", ref
 
 export {
-  processDeclarationConditions
+  getPatternConditions
   processPatternMatching
 }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -78,10 +78,13 @@ export type BinaryOp = (string &
 export type AssignmentExpression
   type: "AssignmentExpression"
   children: Children
+  parent: ASTNodeBase
   names: null
-  lhs: ???
+  lhs: AssignmentExpressionLHS
   assigned: ???
   exp: ExpressionNode
+
+export type AssignmentExpressionLHS = [undefined, ASTNode, [WSNode, [string, WSNode]]][]
 
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -10,6 +10,7 @@ export type ASTNode =
 
 export type StatementNode =
   | BlockStatement
+  | DebuggerStatement
   | DeclarationStatement
   | DoStatement
   | ExpressionNode
@@ -17,7 +18,10 @@ export type StatementNode =
   | IfStatement
   | IterationStatement
   | LabeledStatement
+  | ReturnStatement
   | SwitchStatement
+  | ThrowStatement
+  | TryStatement
 
 export type ExpressionNode =
   | AssignmentExpression
@@ -32,9 +36,10 @@ export type ExpressionNode =
   | TypeNode
 
 export type ASTNodeBase = ASTNode &
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   children: Children
 
+export type Parent = { children: Children }
 export type Children = ASTNode[] & (type?: undefined) & (token?: undefined)
 export type ASTString = string & (type?: undefined) & (token?: undefined)
 
@@ -66,7 +71,7 @@ export type BinaryOp = (string &
   special?: true
   // The following are allowed only when special is true:
   prec?: string | number | undefined
-  assoc?: string | undefined
+  assoc?: string?
   call?: ASTNode
   method?: ASTNode
   relational?: boolean
@@ -107,7 +112,7 @@ export type IfStatement
   children: Children
   condition: Condition
   then: BlockStatement
-  else: [ ASTNode, ElseToken, BlockStatement ] | undefined
+  else: [ ASTNode, ElseToken, BlockStatement ]?
 
 export type IterationExpression
   type: "IterationExpression"
@@ -117,33 +122,33 @@ export type IterationExpression
   block: BlockStatement,
   statement: IterationStatement | DoStatement | ForStatement
   async: boolean
-  resultsRef: ASTRef | undefined
+  resultsRef: ASTRef?
 
 export type IterationStatement
   type: "IterationStatement"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   condition: Condition
   block: BlockStatement
 
 export type DoStatement
   type: "DoStatement"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   block: BlockStatement
 
 export type ForStatement
   type: "ForStatement"
   children: Children
-  parent: ASTNodeBase | undefined
-  declaration: DeclarationStatement | undefined
+  parent: ASTNodeBase?
+  declaration: DeclarationStatement?
   block: BlockStatement
   hoistDec: unknown
 
 export type SwitchStatement
   type: "SwitchStatement"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   condition: Condition
   caseBlock: CaseBlock
 
@@ -182,14 +187,14 @@ export type BlockStatement =
   expressions: StatementTuple[]
   bare: boolean
   root: boolean
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type DeclarationStatement =
   type: "Declaration"
   children: Children
   names: string[]
   bindings: Binding[]
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   decl: "let" | "const" | "var"
   splices: unknown
   thisAssignments: ThisAssignments
@@ -199,7 +204,7 @@ export type Binding =
   children: Children
   names: string[]
   pattern: BindingIdentifier | BindingPattern
-  suffix: TypeSuffix | undefined
+  suffix: TypeSuffix?
   initializer: Initializer?
   splices: unknown[]
   thisAssignments: unknown[]
@@ -211,7 +216,7 @@ export type Identifier =
   name: string
   names: string[]
   children: [ ASTLeaf ]
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type ReturnValue =
   type: "ReturnValue"
@@ -228,20 +233,26 @@ export type StatementExpression =
     | ThrowStatement
     | TryStatement
 
+export type ReturnStatement
+  type: "ReturnStatement"
+  expression: ASTNode
+  children: Children
+  parent: ASTNodeBase?
+
 export type ThrowStatement
   type: "ThrowStatement"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type DebuggerStatement
   type: "DebuggerStatement"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type TryStatement
   type: "TryStatement"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   blocks: BlockStatement[]
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
@@ -271,7 +282,7 @@ export type FunctionExpression =
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type MethodDefinition =
   type: "MethodDefinition"
@@ -280,7 +291,7 @@ export type MethodDefinition =
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type ArrowFunction =
   type: "ArrowFunction"
@@ -289,7 +300,7 @@ export type ArrowFunction =
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type FunctionSignature =
   type: "MethodSignature" | "FunctionSignature"
@@ -297,9 +308,9 @@ export type FunctionSignature =
   name: string
   optional: unknown
   modifier: MethodModifier
-  returnType: ReturnTypeAnnotation | undefined
+  returnType: ReturnTypeAnnotation?
   parameters: ParametersNode
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
 
 export type TypeSuffix =
   type: "TypeSuffix"
@@ -326,8 +337,8 @@ export type ParametersNode =
   type: "Parameters"
   children: ASTNode[]
   names: string[]
-  parent: ASTNode | undefined
-  tp: TypeParameters | undefined
+  parent: ASTNode?
+  tp: TypeParameters?
 
 export type TypeParameters = unknown
 
@@ -343,7 +354,7 @@ export type LiteralContentNode = ASTLeaf & {
   type?: "NumericLiteral" | "StringLiteral"
 }
 
-export type TabConfig = number | undefined
+export type TabConfig = number?
 
 export type ParseRule = (context: {fail: () => void}, state: {pos: number, input: string}) => ???
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -20,6 +20,7 @@ export type StatementNode =
   | SwitchStatement
 
 export type ExpressionNode =
+  | AssignmentExpression
   | BinaryOp
   | FunctionNode
   | Identifier
@@ -74,6 +75,14 @@ export type BinaryOp = (string &
   asConst?: boolean
 )
 
+export type AssignmentExpression
+  type: "AssignmentExpression"
+  children: Children
+  names: null
+  lhs: ???
+  assigned: ???
+  exp: ExpressionNode
+
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 
 export type StatementDelimiter = ASTNode
@@ -111,6 +120,7 @@ export type IterationStatement
   type: "IterationStatement"
   children: Children
   parent: ASTNodeBase | undefined
+  condition: Condition
   block: BlockStatement
 
 export type DoStatement
@@ -187,9 +197,11 @@ export type Binding =
   names: string[]
   pattern: BindingIdentifier | BindingPattern
   suffix: TypeSuffix | undefined
-  initializer: [unknown, unknown, NonNullable<ASTNode>] | undefined
+  initializer: Initializer?
   splices: unknown[]
   thisAssignments: unknown[]
+
+export type Initializer = [unknown, unknown, NonNullable<ASTNode>]
 
 export type Identifier =
   type: "Identifier"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -112,7 +112,7 @@ export type IfStatement
 export type IterationExpression
   type: "IterationExpression"
   children: Children
-  parent: ASTNodeBase | undefined
+  parent: ASTNodeBase?
   subtype: IterationExpression["statement"]["type"]
   block: BlockStatement,
   statement: IterationStatement | DoStatement | ForStatement

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -95,7 +95,7 @@ export type Condition = ParenthesizedExpression
 export type ParenthesizedExpression
   type: "ParenthesizedExpression"
   children: Children
-  parent: ASTNodeBase
+  parent: ASTNodeBase?
   expression: ASTNode
   implicit?: boolean
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -8,8 +8,27 @@ export type ASTNode =
   | CommentNode
   | undefined
 
-export type StatementNode = IfStatement | IterationStatement | SwitchStatement | LabeledStatement | BlockStatement | DeclarationStatement | ExpressionNode
-export type ExpressionNode = StatementExpression | ParenthesizedExpression | BinaryOp | Identifier | Literal | MethodDefinition | FunctionNode | TypeNode
+export type StatementNode =
+  | BlockStatement
+  | DeclarationStatement
+  | DoStatement
+  | ExpressionNode
+  | ForStatement
+  | IfStatement
+  | IterationStatement
+  | LabeledStatement
+  | SwitchStatement
+
+export type ExpressionNode =
+  | BinaryOp
+  | FunctionNode
+  | Identifier
+  | IterationExpression
+  | Literal
+  | MethodDefinition
+  | ParenthesizedExpression
+  | StatementExpression
+  | TypeNode
 
 export type ASTNodeBase = ASTNode &
   parent: ASTNodeBase | undefined
@@ -78,11 +97,35 @@ export type IfStatement
   then: BlockStatement
   else: [ ASTNode, ElseToken, BlockStatement ] | undefined
 
+export type IterationExpression
+  type: "IterationExpression"
+  children: Children
+  parent: ASTNodeBase | undefined
+  subtype: IterationExpression["statement"]["type"]
+  block: BlockStatement,
+  statement: IterationStatement | DoStatement | ForStatement
+  async: boolean
+  resultsRef: ASTRef | undefined
+
 export type IterationStatement
   type: "IterationStatement"
   children: Children
   parent: ASTNodeBase | undefined
   block: BlockStatement
+
+export type DoStatement
+  type: "DoStatement"
+  children: Children
+  parent: ASTNodeBase | undefined
+  block: BlockStatement
+
+export type ForStatement
+  type: "ForStatement"
+  children: Children
+  parent: ASTNodeBase | undefined
+  declaration: DeclarationStatement | undefined
+  block: BlockStatement
+  hoistDec: unknown
 
 export type SwitchStatement
   type: "SwitchStatement"
@@ -162,7 +205,29 @@ export type ReturnValue =
 export type StatementExpression =
   type: "StatementExpression"
   children: Children
-  statement: ASTNode & type: any
+  statement:
+    | DebuggerStatement
+    | IterationExpression
+    | IfStatement
+    | SwitchStatement
+    | ThrowStatement
+    | TryStatement
+
+export type ThrowStatement
+  type: "ThrowStatement"
+  children: Children
+  parent: ASTNodeBase | undefined
+
+export type DebuggerStatement
+  type: "DebuggerStatement"
+  children: Children
+  parent: ASTNodeBase | undefined
+
+export type TryStatement
+  type: "TryStatement"
+  children: Children
+  parent: ASTNodeBase | undefined
+  blocks: BlockStatement[]
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -3,6 +3,7 @@ import type {
   ASTLeaf
   ASTNode
   ASTNodeBase
+  Children
   Literal
   TypeSuffix
   ReturnTypeAnnotation
@@ -290,7 +291,7 @@ function makeLeftHandSideExpression(expression)
  * recursing into arrays but not objects.  More efficient version of
  * `addParentPointers` when just injecting one new node.
  */
-function updateParentPointers(node: ASTNode, parent?: ASTNodeBase, depth = 1): void
+function updateParentPointers(node: ASTNode, parent?: { children: Children }, depth = 1): void
   if (not node?) return
   if (typeof node !== "object") return
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -13,6 +13,12 @@ import {
   gatherRecursiveWithinFunction
 } from ./traversal.civet
 
+assert := {
+  equal(a: unknown, b: unknown, msg: string): void
+    /* c8 ignore next */
+    throw new Error(`Assertion failed [${msg}]: ${a} !== ${b}`) if a !== b
+}
+
 /**
  * Adds parent pointers to all nodes in the AST. Elements within
  * arrays of nodes receive the closest non-array object parent.
@@ -461,6 +467,7 @@ function wrapWithReturn(expression?: ASTNode): ASTNode
 
 export {
   addParentPointers
+  assert
   clone
   convertOptionalType
   deepCopy

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -265,14 +265,16 @@ function makeAmpersandFunction(bodyAfterRef = []): ASTNode
 function makeLeftHandSideExpression(expression)
   return expression if expression.parenthesized
   switch (expression.type)
-    case "Ref":
     case "AmpersandRef":
-    case "Identifier":
-    case "Literal":
     case "CallExpression":
+    case "Identifier":
+    case "JSXElement":
+    case "JSXFragment":
+    case "Literal":
     case "MemberExpression":
     case "NewExpression":
     case "ParenthesizedExpression":
+    case "Ref":
     case "StatementExpression": // wrapIIFE
       return expression
 
@@ -407,7 +409,6 @@ function parenthesizeType(type: ASTNodeBase)
  * Returns an Array suitable for `children`.
  */
 function wrapIIFE(expressions: StatementTuple[], async?: string): ASTNode[]
-  debugger
   let prefix
 
   if async

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -263,12 +263,10 @@ function makeLeftHandSideExpression(expression)
     case "AmpersandRef":
     case "Identifier":
     case "Literal":
-    case "IterationExpression": // already a CallExpression
     case "CallExpression":
     case "MemberExpression":
     case "NewExpression":
     case "ParenthesizedExpression":
-    case "IfExpression": // already wrapped in parens
     case "StatementExpression": // wrapIIFE
       return expression
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -3,8 +3,8 @@ import type {
   ASTLeaf
   ASTNode
   ASTNodeBase
-  Children
   Literal
+  Parent
   TypeSuffix
   ReturnTypeAnnotation
   StatementTuple
@@ -284,6 +284,7 @@ function makeLeftHandSideExpression(expression)
     children: ["(", expression, ")"]
     expression
     implicit: true
+    parent: undefined
   }
 
 /**
@@ -291,7 +292,7 @@ function makeLeftHandSideExpression(expression)
  * recursing into arrays but not objects.  More efficient version of
  * `addParentPointers` when just injecting one new node.
  */
-function updateParentPointers(node: ASTNode, parent?: { children: Children }, depth = 1): void
+function updateParentPointers(node: ASTNode, parent?: Parent, depth = 1): void
   if (not node?) return
   if (typeof node !== "object") return
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -401,6 +401,7 @@ function parenthesizeType(type: ASTNodeBase)
  * Returns an Array suitable for `children`.
  */
 function wrapIIFE(expressions: StatementTuple[], async?: string): ASTNode[]
+  debugger
   let prefix
 
   if async

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -511,12 +511,12 @@ describe "binary operations", ->
         throw new Error
     ---
     const name = optionalName ??
-      (loaded?(
-        file.name
-      )
-      :(
-        (()=>{throw new Error})()
-      ))
+      (()=>{if (loaded) {
+        return file.name
+      }
+      else {
+        throw new Error
+      }})()
   """
 
   testCase """

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -109,20 +109,21 @@ describe "example code", ->
           else
             ' '
     ---
-    var val, indentRegex;
+    var val;
     val =
-      (!this.fromSourceString?
-        val
-      : (heredoc?(
-        (this.indent?indentRegex = RegExp(`\\\\n${this.indent}`, "g"):void 0),
+      (()=>{var indentRegex;if(!this.fromSourceString) {
+        return val
+      }
+      else if (heredoc) {
+        if (this.indent) { indentRegex = RegExp(`\\\\n${this.indent}`, "g") }
 
-        (indentRegex?val = val.replace(indentRegex, '\\n'):void 0),
-        (this.initialChunk?val = val.replace(LEADING_BLANK_LINE,  ''):void 0),
-        (this.finalChunk?val = val.replace(TRAILING_BLANK_LINE, ''):void 0),
-        val
-      )
-      :(
-        val.replace(SIMPLE_STRING_OMIT, (match, offset) => {
+        if (indentRegex) { val = val.replace(indentRegex, '\\n') }
+        if (this.initialChunk) { val = val.replace(LEADING_BLANK_LINE,  '') }
+        if (this.finalChunk) { val = val.replace(TRAILING_BLANK_LINE, '') }
+        return val
+      }
+      else {
+        return val.replace(SIMPLE_STRING_OMIT, (match, offset) => {
           if ((this.initialChunk && offset === 0) ||
               (this.finalChunk && offset + match.length === val.length)) {
             return ''
@@ -131,7 +132,7 @@ describe "example code", ->
             return ' '
           }
         })
-      )))
+      }})()
   """
 
   testCase """

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -44,13 +44,15 @@ describe "example code", ->
         'IDENTIFIER'
     ---
     var tag;var indexOf: <T>(this: T[], searchElement: T) => number = [].indexOf as any;
-    tag =
-      (colon || (prev != null) &&
+    let ref;
+      if (colon || (prev != null) &&
          (indexOf.call(['.', '?.', '::', '?::'], prev[0]) >= 0 ||
-         !prev.spaced && prev[0] === '@')?
-        'PROPERTY'
-      :
-        'IDENTIFIER')
+         !prev.spaced && prev[0] === '@')) {
+        ref = 'PROPERTY'
+      }
+      else {
+        ref = 'IDENTIFIER'
+      };tag =ref
   """
 
   testCase """
@@ -109,10 +111,10 @@ describe "example code", ->
           else
             ' '
     ---
-    var val;
-    val =
-      (()=>{var indentRegex;if(!this.fromSourceString) {
-        return val
+    var val, indentRegex;
+    let ref;
+      if(!this.fromSourceString) {
+        ref = val
       }
       else if (heredoc) {
         if (this.indent) { indentRegex = RegExp(`\\\\n${this.indent}`, "g") }
@@ -120,10 +122,10 @@ describe "example code", ->
         if (indentRegex) { val = val.replace(indentRegex, '\\n') }
         if (this.initialChunk) { val = val.replace(LEADING_BLANK_LINE,  '') }
         if (this.finalChunk) { val = val.replace(TRAILING_BLANK_LINE, '') }
-        return val
+        ref = val
       }
       else {
-        return val.replace(SIMPLE_STRING_OMIT, (match, offset) => {
+        ref = val.replace(SIMPLE_STRING_OMIT, (match, offset) => {
           if ((this.initialChunk && offset === 0) ||
               (this.finalChunk && offset + match.length === val.length)) {
             return ''
@@ -132,7 +134,7 @@ describe "example code", ->
             return ' '
           }
         })
-      }})()
+      };val =ref
   """
 
   testCase """

--- a/test/do.civet
+++ b/test/do.civet
@@ -215,3 +215,17 @@ describe "do", ->
       return await result.json()
     }})()
   """
+
+  testCase """
+    yield
+    ---
+    f := (x) ->
+      y := do
+        yield x
+    ---
+    const f = function*(x) {
+      let ref;{
+        ref = yield x
+      };const y =ref;return y
+    }
+  """

--- a/test/do.civet
+++ b/test/do.civet
@@ -219,13 +219,13 @@ describe "do", ->
   testCase """
     yield
     ---
-    f := (x) ->
-      y := do
+    f = (x) ->
+      y = do
         yield x
     ---
-    const f = function*(x) {
+    f = function*(x) {
       let ref;{
         ref = yield x
-      };const y =ref;return y
+      };return y = ref
     }
   """

--- a/test/do.civet
+++ b/test/do.civet
@@ -89,10 +89,10 @@ describe "do", ->
       y * y
     ---
     const x = 1
-    const z = (()=>{{
+    let ref;{
       const y = x * x
-      return y * y
-    }})()
+      ref = y * y
+    };const z =ref
   """
 
   testCase """

--- a/test/do.civet
+++ b/test/do.civet
@@ -140,13 +140,12 @@ describe "do", ->
           y := x * x
           y * y
     ---
-    const list =
-      (()=>{const results=[];for (const x of items) {
+    const results=[];for (const x of items) {
         {
           const y = x * x
           results.push(y * y)
         }
-      }return results})()
+      };const list =results
   """
 
   testCase """

--- a/test/do.civet
+++ b/test/do.civet
@@ -106,7 +106,7 @@ describe "do", ->
     ---
     function f(x) {
       x = x * x
-      return (()=>{{
+      return  (()=>{{
         const y = x * x
         return y * y
       }})()
@@ -157,7 +157,7 @@ describe "do", ->
         y * y
     ---
     async function f(x) {
-      return (await (async ()=>{{
+      return  (await (async ()=>{{
         const y = await x
         return y * y
       }})())
@@ -210,7 +210,7 @@ describe "do", ->
       result := await fetch url
       await result.json()
     ---
-    const promise = (async ()=>{{
+    const promise =  (async ()=>{{
       const result = await fetch(url)
       return await result.json()
     }})()

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -438,20 +438,20 @@ describe "examples (from real life)", ->
       when '&&', '||'          then id
       else  tag
     ---
-    tag = (()=>{switch(id) {
-      case '!': { return 'UNARY'
+    let ref;switch(id) {
+      case '!': { ref = 'UNARY';break;
       }
-      case '==':case '!=': { return 'COMPARE'
+      case '==':case '!=': { ref = 'COMPARE';break;
       }
-      case 'true':case 'false': { return 'BOOL'
+      case 'true':case 'false': { ref = 'BOOL';break;
       }
-      case 'break':case 'continue':case \n\
-           'debugger': { return 'STATEMENT'
+      case 'break':case 'continue':case\u0020
+           'debugger': { ref = 'STATEMENT';break;
       }
-      case '&&':case '||': { return id
+      case '&&':case '||': { ref = id;break;
       }
-      default: {  return tag }
-    }})()
+      default: {  ref = tag }
+    };tag = ref
   """
 
   describe.skip "", ->

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -298,7 +298,7 @@ describe "examples (from real life)", ->
     ---
     date := if x==1 then "a" else "b"
     ---
-    const date = (x==1? "a" : "b")
+    let ref;if (x==1) ref = "a"; else ref = "b";const date =ref
   """
 
   testCase """
@@ -670,7 +670,7 @@ describe "examples (from real life)", ->
     ---
     function foo(a) {
       if (bar[a] === 'three') return 3
-      if (a < 0) return(()=>{ let m;if(m = bar[-a],m === 'three') { return 3}})()
+      if (a < 0) return (()=>{let m;if(m = bar[-a],m === 'three') { return 3}})()
       let ret = 9
       ret *= a
       return ret

--- a/test/for.civet
+++ b/test/for.civet
@@ -520,9 +520,9 @@ describe "for", ->
       x = for (let i = 0; i < 10; i++)
         i
       ---
-      x = (()=>{const results=[];for (let i = 0; i < 10; i++) {
+      const results=[];for (let i = 0; i < 10; i++) {
         results.push(i)
-      }return results})()
+      };x = results
     """
 
     testCase """
@@ -530,7 +530,7 @@ describe "for", ->
       ---
       x = for (let i = 0; i < 10; i++) i
       ---
-      x = (()=>{const results=[];for (let i = 0; i < 10; i++) { results.push(i)}return results})()
+      const results=[];for (let i = 0; i < 10; i++) results.push(i);x = results
     """
 
     testCase """
@@ -550,9 +550,9 @@ describe "for", ->
       x = for (let i = 0; i < 10; i++)
         results.push(i)
       ---
-      x = (()=>{const results1=[];for (let i = 0; i < 10; i++) {
+      const results1=[];for (let i = 0; i < 10; i++) {
         results1.push(results.push(i))
-      }return results1})()
+      };x = results1
     """
 
     testCase """
@@ -577,7 +577,7 @@ describe "for", ->
           when 1 then 2
           else 3; 4
       ---
-      x = (()=>{const results=[];for (let i = 0; i < 10; i++) {
+      const results=[];for (let i = 0; i < 10; i++) {
         switch(i) {
           case 0: { results.push(1);break;
           }
@@ -585,7 +585,7 @@ describe "for", ->
           }
           default: { 3; results.push(4) }
         }
-      }return results})()
+      };x = results
     """
 
     testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -539,9 +539,9 @@ describe "for", ->
       x := for i .= 0; i < x; i += 1
         i
       ---
-      const x = (()=>{const results=[]; for (let i = 0; i < x; i += 1) {
+      const results=[];for (let i = 0; i < x; i += 1) {
         results.push(i)
-      }return results})()
+      };const x =results
     """
 
     testCase """
@@ -562,11 +562,10 @@ describe "for", ->
         for i of [0..7]
           if true then 'yes' else 'no'
       ---
-      const check =
-        (()=>{const results=[];for (let i1 = 0; i1 <= 7; ++i1) {
+      const results=[];for (let i1 = 0; i1 <= 7; ++i1) {
           const i = i1;
           if (true) results.push('yes'); else results.push('no')
-        }return results})()
+        };const check =results
     """
 
     testCase """
@@ -641,11 +640,10 @@ describe "for", ->
         for item, index of array
           `${index}. ${item}`
       ---
-      const strings =
-        (()=>{const results=[];let i = 0;for (const item of array) {
+      let i = 0;const results=[];for (const item of array) {
           const index = i++;
           results.push(`${index}. ${item}`)
-        }return results})()
+        };const strings =results
     """
 
     testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -1215,7 +1215,7 @@ describe "function", ->
         const results=[];for (i = 0; i < x.length; i++) {
           const results1=[];for (const v of x[i]) {
             results1.push(v + 1)
-          };results.push(results1);
+          }results.push(results1)
         };return results;
       })
     """
@@ -1229,7 +1229,7 @@ describe "function", ->
       ---
       (function(x) {
         const results=[];for (i = 0; i < x.length; i++) {
-          const results1=[];for (const v of x[i]) { results1.push(v + 1) };results.push(results1);
+          const results1=[];for (const v of x[i]) { results1.push(v + 1) }results.push(results1)
         };return results;
       })
     """
@@ -1248,7 +1248,7 @@ describe "function", ->
           const results1=[];inner: for (const v of x[i]) {
             if (!(v != null)) { break outer }
             results1.push(v + 1)
-          };results.push(results1);
+          }results.push(results1)
         };return results;
       })
     """

--- a/test/if.civet
+++ b/test/if.civet
@@ -844,7 +844,7 @@ describe "if", ->
       if a := try b
         log a
       ---
-      let ref;if ((ref =(()=>{ try { return b } catch(e) {return}})())) {
+      let ref;try { ref = b } catch(e) {ref = void 0;};if (ref) {
         const a = ref;
         log(a)
       }

--- a/test/if.civet
+++ b/test/if.civet
@@ -862,8 +862,7 @@ describe "if", ->
       }
     """
 
-    // TODO
-    testCase.skip """
+    testCase """
       declaration in expression
       ---
       x = if {y} := f()
@@ -871,10 +870,29 @@ describe "if", ->
       else
         b
       ---
-      let ref, y;x = ((ref = f()))?
-        ({y} = ref,a)
-      :
-        b
+      let ref;let ref1;if ((ref1 = f()) && 'y' in ref1) {
+        const {y} = ref1;
+        ref = a
+      }
+      else {
+        ref = b
+      };x = ref
+    """
+
+    testCase """
+      declaration in nested expression
+      ---
+      z = 5 + if x
+        y := 5
+      else
+        z
+      ---
+      z = 5 + (()=>{if (x) {
+        const y = 5;return y
+      }
+      else {
+        return z
+      }})()
     """
 
     // TODO

--- a/test/if.civet
+++ b/test/if.civet
@@ -498,14 +498,17 @@ describe "if", ->
       else
         "c"
       ---
-      x = (y?(
-        (z?
-          "a"
-        :
-          "b")
-      )
-      :
-        "c")
+      x = (()=>{if (y) {
+        if (z) {
+          return "a"
+        }
+        else {
+          return "b"
+        }
+      }
+      else {
+        return "c"
+      }})()
     """
 
     testCase """
@@ -517,13 +520,12 @@ describe "if", ->
         c; d
       ---
       x = (y?(
-        a, b
-      )
+        a,b)
       :(
-        c, d
-      ))
+        c,d))
     """
 
+    // TODO: keep middle comments
     testCase """
       if expression with multiple semicolon-separated commented statements
       ---
@@ -533,11 +535,9 @@ describe "if", ->
         /*c*/ c; /*d*/ d
       ---
       x = (y?(
-        /*a*/ a, /*b*/ b
-      )
+        /*a*/ a,b)
       :(
-        /*c*/ c, /*d*/ d
-      ))
+        /*c*/ c,d))
     """
 
     testCase """
@@ -548,11 +548,12 @@ describe "if", ->
       else
         "b"
       ---
-      x = (y?(
-        (()=>{throw new Error})()
-      )
-      :
-        "b")
+      x = (()=>{if (y) {
+        throw new Error
+      }
+      else {
+        return "b"
+      }})()
     """
 
     testCase """
@@ -563,11 +564,12 @@ describe "if", ->
       else
         "b"
       ---
-      x = (y?(
-        (()=>{debugger})()
-      )
-      :
-        "b")
+      x = (()=>{if (y) {
+        debugger
+      }
+      else {
+        return "b"
+      }})()
     """
 
     testCase """
@@ -614,9 +616,8 @@ describe "if", ->
       x = if y
         {}
       ---
-      x = (y?(
-        {}
-      ):void 0)
+      x = (y?
+        ({}):void 0)
     """
 
     testCase """
@@ -625,9 +626,8 @@ describe "if", ->
       x = if (y)
         {}
       ---
-      x = (y?(
-        {}
-      ):void 0)
+      x = (y?
+        ({}):void 0)
     """
 
     testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -443,10 +443,12 @@ describe "if", ->
       else
         "b"
       ---
-      x = (y?
-        "a"
-      :
-        "b")
+      let ref;if (y) {
+        ref = "a"
+      }
+      else {
+        ref = "b"
+      };x = ref
     """
 
     testCase """
@@ -458,11 +460,12 @@ describe "if", ->
       else
         "b"
       ---
-      x =
-      (y?
-        "a"
-      :
-        "b")
+      let ref;if (y) {
+        ref = "a"
+      }
+      else {
+        ref = "b"
+      };x =ref
     """
 
     testCase """
@@ -472,9 +475,10 @@ describe "if", ->
         "a"
       else "b"
       ---
-      x = (y?
-        "a"
-      : "b")
+      let ref;if (y) {
+        ref = "a"
+      }
+      else ref = "b";x = ref
     """
 
     testCase """
@@ -483,8 +487,9 @@ describe "if", ->
       x = if (y)
         "a"
       ---
-      x = (y?
-        "a":void 0)
+      let ref;if (y) {
+        ref = "a"
+      } else {ref = undefined};x = ref
     """
 
     testCase """
@@ -498,17 +503,17 @@ describe "if", ->
       else
         "c"
       ---
-      x = (()=>{if (y) {
+      let ref;if (y) {
         if (z) {
-          return "a"
+          ref = "a"
         }
         else {
-          return "b"
+          ref = "b"
         }
       }
       else {
-        return "c"
-      }})()
+        ref = "c"
+      };x = ref
     """
 
     testCase """
@@ -519,13 +524,14 @@ describe "if", ->
       else
         c; d
       ---
-      x = (y?(
-        a,b)
-      :(
-        c,d))
+      let ref;if (y) {
+        a; ref = b
+      }
+      else {
+        c; ref = d
+      };x = ref
     """
 
-    // TODO: keep middle comments
     testCase """
       if expression with multiple semicolon-separated commented statements
       ---
@@ -534,10 +540,12 @@ describe "if", ->
       else
         /*c*/ c; /*d*/ d
       ---
-      x = (y?(
-        /*a*/ a,b)
-      :(
-        /*c*/ c,d))
+      let ref;if (y) {
+        /*a*/ a; /*b*/ ref = b
+      }
+      else {
+        /*c*/ c; /*d*/ ref = d
+      };x = ref
     """
 
     testCase """
@@ -548,12 +556,12 @@ describe "if", ->
       else
         "b"
       ---
-      x = (()=>{if (y) {
+      let ref;if (y) {
         throw new Error
       }
       else {
-        return "b"
-      }})()
+        ref = "b"
+      };x = ref
     """
 
     testCase """
@@ -564,12 +572,12 @@ describe "if", ->
       else
         "b"
       ---
-      x = (()=>{if (y) {
+      let ref;if (y) {
         debugger
       }
       else {
-        return "b"
-      }})()
+        ref = "b"
+      };x = ref
     """
 
     testCase """
@@ -580,10 +588,12 @@ describe "if", ->
       else
         "b"
       ---
-      x = (!y?
-        "a"
-      :
-        "b")
+      let ref;if(!y) {
+        ref = "a"
+      }
+      else {
+        ref = "b"
+      };x = ref
     """
 
     testCase """
@@ -616,8 +626,9 @@ describe "if", ->
       x = if y
         {}
       ---
-      x = (y?
-        ({}):void 0)
+      let ref;if (y) {
+        ref = ({})
+      } else {ref = undefined};x = ref
     """
 
     testCase """
@@ -626,8 +637,9 @@ describe "if", ->
       x = if (y)
         {}
       ---
-      x = (y?
-        ({}):void 0)
+      let ref;if (y) {
+        ref = ({})
+      } else {ref = undefined};x = ref
     """
 
     testCase """

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -577,12 +577,10 @@ describe "Unbraced function children in JSX", ->
     ---
     <>
       {
-        (loggedIn?(
+        (loggedIn?
           <LogoutButton />
-        )
-        :(
-          <LoginButton />
-        ))
+        :
+          <LoginButton />)
       }
     </>
   """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1095,7 +1095,7 @@ describe "switch", ->
           else
             4
       ---
-      const y = (()=>{const results=[]; for (const x in [1, 2, 3]) {
+      const results=[];for (const x in [1, 2, 3]) {
         if(x === 1) {
             results.push(2)}
       else if(x === 2) {
@@ -1103,7 +1103,7 @@ describe "switch", ->
       else  {
             results.push(4)
           }
-      }return results})()
+      };const y =results
     """
 
     testCase """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1292,3 +1292,17 @@ describe "switch", ->
       else if(ref instanceof UsefulType) {
           utilize(u)}}
     """
+
+    testCase """
+      conditional declaration with StatementExpression
+      ---
+      switch x := try foo()
+        when 1
+          true
+      ---
+      {let ref;try { ref = foo() } catch(e) {ref = void 0;};const  x = ref;switch(ref) {
+        case 1: {
+          true;break;
+        }
+      }}
+    """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -392,11 +392,11 @@ describe "switch", ->
         when 1
           2
       ---
-      x = (()=>{switch(y) {
+      let ref;switch(y) {
         case 1: {
-          return 2
+          ref = 2;break;
         }
-      }})()
+      };x = ref
     """
 
   describe "expressionless", ->

--- a/test/try.civet
+++ b/test/try.civet
@@ -226,9 +226,9 @@ describe "try", ->
       y := for x of xs
         try foo()
       ---
-      const y = (()=>{const results=[]; for (const x of xs) {
+      const results=[];for (const x of xs) {
         try { results.push(foo()) } catch(e) {results.push(void 0);}
-      }return results})()
+      };const y =results
     """
 
     testCase """

--- a/test/try.civet
+++ b/test/try.civet
@@ -183,7 +183,7 @@ describe "try", ->
       ---
       thing = try foo()
       ---
-      thing = (()=>{try { return foo() } catch(e) {return}})()
+      let ref;try { ref = foo() } catch(e) {ref = void 0;};thing = ref
     """
 
     testCase """
@@ -191,7 +191,7 @@ describe "try", ->
       ---
       thing = try foo() catch(e: any) panic() finally phew()
       ---
-      thing = (()=>{try { return foo() } catch(e: any) { return panic() } finally { phew() }})()
+      let ref;try { ref = foo() } catch(e: any) { ref = panic() } finally { phew() };thing = ref
     """
 
     testCase """
@@ -236,5 +236,5 @@ describe "try", ->
       ---
       thing = try await foo()
       ---
-      thing = (await (async ()=>{try { return await foo() } catch(e) {return}})())
+      let ref;try { ref = await foo() } catch(e) {ref = void 0;};thing = ref
     """

--- a/test/while.civet
+++ b/test/while.civet
@@ -97,14 +97,14 @@ describe "while", ->
         else
           b;
       ---
-      x = (()=>{const results=[];while (y) {
+      const results=[];while (y) {
         if (y(1)) {
           results.push(a)
         }
         else {
           b;
         }
-      }return results})()
+      };x = results
     """
 
   describe "condition decs", ->


### PR DESCRIPTION
This is probably good enough to merge in.

- Removed IfExpression as separate part of grammar
  - Now get hoisted as StatementExpressions or wrapped in IIFEs similar to IterationExpression
- Made DeclarationConditions work with StatementExpressions
- Added more types
- Moved skipImplicitArguments check from parser to .civet file
- Moved declaration logic to parser/declaration.civet
- Handle simple assignments expressions

To add later:

- Extend wrap IIFE to handle return from outer function, yield.

Related: #380, #202