### PR TITLE
Fix #54 - Optional chain in assignment lhs

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1103,17 +1103,23 @@ CallExpressionRest
     }
     return literal
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
-  OptionalShorthand? ArgumentsWithTrailingMemberExpressions ->
-    if (!$1) return $2
-    return [ $1, ...$2 ]
+  OptionalShorthand?:optional ArgumentsWithTrailingMemberExpressions:argsWithTrailing ->
+    if (!optional) return argsWithTrailing
+
+    const call = argsWithTrailing[0];
+    return [ {
+      ...call,
+      children: [optional, ...call.children],
+      optional,
+    }, ...argsWithTrailing.slice(1) ]
 
 # NOTE: Added shorthand x?(3) -> x?.(3)
 OptionalShorthand
   # perf: assertion to exit early
-  /(?=[\/?])/ InlineComment* QuestionMark OptionalDot ->
+  /(?=[\/?])/ InlineComment*:comments QuestionMark:q OptionalDot:d ->
     return {
       type: "Optional",
-      children: $0,
+      children: [...comments, q, d],
     }
 
 OptionalDot
@@ -1262,9 +1268,14 @@ SliceParameters
     }
 
 AccessStart
-  PropertyAccessModifier? Dot !Dot ->
-    if ($1) return [$1, $2]
-    return $2
+  PropertyAccessModifier?:modifier Dot:dot !Dot ->
+    let children = modifier ? [modifier, dot] : [dot]
+
+    return {
+      type: "AccessStart",
+      children,
+      optional: modifier?.token === "?",
+    }
 
 PropertyAccessModifier
   QuestionMark
@@ -1303,28 +1314,33 @@ PropertyAccess
       len,
     }
 
-  AccessStart:access InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
-    const children = [access, ...comments, ...id.children]
+  AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
+    const children = [dot, ...comments, ...id.children]
 
     return {
       type: "PropertyAccess",
       name: id.name,
+      dot,
       children,
     }
 
   # NOTE: Added CoffeeScript :: prototype shorthand only when enabled
   CoffeePrototypeEnabled DoubleColon:p IdentifierName?:id ->
     if (id) {
+      const dot = {token: ".prototype.", $loc: p.$loc}
       return {
         type: "PropertyAccess",
         name: id.name,
-        children: [ {token: ".prototype.", $loc: p.$loc}, id ],
+        dot,
+        children: [ dot, id ],
       }
     } else {
+      const dot = {token: ".prototype", $loc: p.$loc}
       return {
         type: "PropertyAccess",
         name: "prototype",
-        children: [ {token: ".prototype", $loc: p.$loc} ],
+        dot,
+        children: [ dot ],
       }
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1174,7 +1174,11 @@ MemberExpressionRestBody
         // Remove '.' from optional since it is present in '.slice'
         return [...dot.children.slice(0, -1), ...comments, content]
       }
-      return [dot, ...comments, content]
+      return {
+        ...content,
+        children: [dot, ...comments, ...content.children],
+        optional: dot,
+      }
     }
     return [...comments, content]
   # NOTE: Combined Optional and Property access

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -856,7 +856,7 @@ function unchainOptionalMemberExpression(exp: MemberExpression | CallExpression,
           hasOptional = true
           child.dot.children.shift()
           child.dot.optional = false
-      when "Call"
+      when "Call", "Index"
         if child.optional
           hasOptional = true
           child.children.shift()

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -45,6 +45,7 @@ import {
   makeNode
   makeRef
   maybeRef
+  needsRef
   parenthesizeType
   wrapIIFE
   wrapWithReturn
@@ -668,7 +669,9 @@ function processAssignments(statements): void {
       // TODO: need to make this a parenthesized expression when when we add parens
     })
 
-  replaceNodesRecursive statements, (n) => n.type is "AssignmentExpression" and n.names is null, (exp: AssignmentExpression): AssignmentExpression | BlockStatement | ExpressionNode => {
+  replaceNodesRecursive statements,
+    (n) => n.type is "AssignmentExpression" and n.names is null,
+    (exp: AssignmentExpression): AssignmentExpression | BlockStatement | ExpressionNode => {
       let { lhs: $1, exp: $2 } = exp, tail = [], i = 0, len = $1.length
 
       let block?: BlockStatement
@@ -714,11 +717,9 @@ function processAssignments(statements): void {
         }
       }
 
-      // TODO: Handle optional assignment refs
-
       // Walk from right to left to handle splices
       i = len - 1
-      while (i >= 0) {
+      while i >= 0
         const lastAssignment = $1[i]
 
         if (lastAssignment[3].token is "=") {
@@ -762,7 +763,59 @@ function processAssignments(statements): void {
           // This might not be correct in all situations, esp BindingPatterns nested inside ObjectExpressions
         }
         i--
-      }
+
+      // Handle optional chain ?. in lhs of assignments
+      i = len - 1
+      while i >= 0
+        assignment := $1[i--]
+        [ws1, lhs, ws2, op] := assignment
+
+        if lhs.type is "MemberExpression"
+          j .= 0
+          { children } := lhs
+          outerRef := makeRef()
+          usesRef .= false
+          hasOptional .= false
+          head := []
+          tail := []
+          let base
+
+          // NOTE: not caching length because the array mutates inside
+          while j < children.length
+            child := children[j]
+            if child.type is "PropertyAccess"
+              if child.children[0]?.[0]?.token is "?"
+                hasOptional = true
+                child.children[0].shift()
+
+                let ref
+                if j > 1 or needsRef children[0]
+                  ref = outerRef
+                  usesRef = true
+                  base = makeLeftHandSideExpression
+                    type: "AssignmentExpression"
+                    children: [ref, " = ", children.splice(0, j)]
+
+                  base.parent = child
+                  children.unshift ref
+
+                  j = 0
+                else
+                  base = children[0]
+
+                tail.push " : void 0"
+                head.push base, " != null ? "
+
+            j++
+
+          if hasOptional
+            if usesRef
+              exp.hoistDec =
+                type: "Declaration"
+                children: ["let ", outerRef]
+                names: []
+
+            exp.children.splice(0, Infinity, ...head, ws1, ...children, ws2, op, $2, ...tail)
 
       // Gather all identifier names from the lhs array
       exp.names = $1.flatMap(([, l]) => l.names or [])

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -627,7 +627,7 @@ function processAssignments(statements): void {
   // Move assignments/updates within LHS of assignments/updates
   // to run earlier via comma operator
   gatherRecursiveAll(statements, (n) => n.type is "AssignmentExpression" or n.type is "UpdateExpression")
-    .forEach((exp) => {
+    .forEach (exp) =>
       function extractAssignment(lhs) {
         let expr = lhs
         while expr.type is "ParenthesizedExpression"
@@ -668,7 +668,26 @@ function processAssignments(statements): void {
       if (pre.length) exp.children.unshift(...pre)
       if (post.length) exp.children.push(...post)
       // TODO: need to make this a parenthesized expression when when we add parens
-    })
+
+      if exp.type is "UpdateExpression"
+        { assigned } := exp
+        ref := makeRef()
+        newMemberExp := unchainOptionalMemberExpression assigned, ref, (children) =>
+          exp.children.map (c) =>
+            if c is assigned
+              children
+            else
+              c
+
+        if newMemberExp !== assigned
+          if newMemberExp.usesRef
+            exp.hoistDec = {
+              type: "Declaration"
+              children: ["let ", ref]
+              names: []
+            }
+          exp.children = [newMemberExp]
+          newMemberExp.parent = exp
 
   replaceNodesRecursive statements,
     (n) => n.type is "AssignmentExpression" and n.names is null,

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -10,6 +10,7 @@ import type {
   AssignmentExpression
   ASTNode
   ASTNodeBase
+  ASTRef
   BlockStatement
   DoStatement
   ExpressionNode
@@ -766,56 +767,32 @@ function processAssignments(statements): void {
 
       // Handle optional chain ?. in lhs of assignments
       i = len - 1
+      optionalChainRef := makeRef()
       while i >= 0
-        assignment := $1[i--]
+        assignment := $1[i]
         [ws1, lhs, ws2, op] := assignment
 
         if lhs.type is "MemberExpression"
-          j .= 0
-          { children } := lhs
-          outerRef := makeRef()
-          usesRef .= false
-          hasOptional .= false
-          head := []
-          tail := []
-          let base
+          newMemberExp := unchainOptionalMemberExpression lhs, optionalChainRef, (children) =>
+            // NOTE: This only executes when lhs contains chains
+            // this mutates the assignments array to account for the parts moved into the conditionals
+            assigns := $1.splice(i + 1, len - 1 - i)
+            $1.pop()
+            [ws1, ...children, ws2, op, ...assigns, $2]
 
-          // NOTE: not caching length because the array mutates inside
-          while j < children.length
-            child := children[j]
-            if child.type is "PropertyAccess"
-              if child.children[0]?.[0]?.token is "?"
-                hasOptional = true
-                child.children[0].shift()
-
-                let ref
-                if j > 1 or needsRef children[0]
-                  ref = outerRef
-                  usesRef = true
-                  base = makeLeftHandSideExpression
-                    type: "AssignmentExpression"
-                    children: [ref, " = ", children.splice(0, j)]
-
-                  base.parent = child
-                  children.unshift ref
-
-                  j = 0
-                else
-                  base = children[0]
-
-                tail.push " : void 0"
-                head.push base, " != null ? "
-
-            j++
-
-          if hasOptional
-            if usesRef
-              exp.hoistDec =
+          if newMemberExp !== lhs
+            if newMemberExp.usesRef
+              exp.hoistDec = {
                 type: "Declaration"
-                children: ["let ", outerRef]
+                children: ["let ", optionalChainRef]
                 names: []
+              }
 
-            exp.children.splice(0, Infinity, ...head, ws1, ...children, ws2, op, $2, ...tail)
+            replaceNode $2, newMemberExp
+            newMemberExp.parent = exp
+            $2 = newMemberExp
+
+        i--
 
       // Gather all identifier names from the lhs array
       exp.names = $1.flatMap(([, l]) => l.names or [])
@@ -832,6 +809,50 @@ function processAssignments(statements): void {
       return exp
     }
 }
+
+function unchainOptionalMemberExpression(exp: MemberExpression, ref: ASTRef, innerExp: (exp) => ASTNode)
+  j .= 0
+  { children } := exp
+  usesRef .= false
+  hasOptional .= false
+  head := []
+  tail := []
+  let base
+
+  // NOTE: not caching length because the array mutates inside
+  while j < children.length
+    child := children[j]
+    if child.type is "PropertyAccess"
+      if child.children[0]?.[0]?.token is "?"
+        hasOptional = true
+        child.children[0].shift()
+
+        if j > 1 or needsRef children[0]
+          usesRef = true
+          base = makeLeftHandSideExpression
+            type: "AssignmentExpression"
+            children: [ref, " = ", children.splice(0, j)]
+
+          base.parent = child
+          children.unshift ref
+
+          j = 0
+        else
+          base = children[0]
+
+        tail.push " : void 0"
+        head.push base, " != null ? "
+
+    j++
+
+  if hasOptional
+    {
+      ...exp
+      children: [...head, innerExp(children), ...tail]
+      usesRef
+    }
+  else // Unchanged
+    exp
 
 function attachPostfixStatementAsExpression(exp, post: [WSNode, IfStatement | IterationStatement | DoStatement | ForStatement])
   postfixStatement := post[1]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -7,16 +7,19 @@
  */
 
 import type {
-  AssignmentExpression
+  AccessStart
   ASTNode
   ASTNodeBase
   ASTRef
+  AssignmentExpression
   BlockStatement
+  CallExpression
   DoStatement
   ExpressionNode
   ForStatement
   IfStatement
   IterationStatement
+  MemberExpression
   MethodDefinition
   ParseRule
   StatementExpression
@@ -124,14 +127,17 @@ function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
  * Adjusts the index access to use brackets instead of dot
  * while accounting for optional chaining.
  */
-function adjustIndexAccess(dot: ASTNode | ASTNode[]): ASTNode
-  if gatherRecursive(dot, (node) => node.token is "?").length
+function adjustIndexAccess(dot: AccessStart): AccessStart
+  if dot.optional
     // ?. turns into ?.[
-    dot = [ ...dot, "[" ]
+    return {
+      ...dot,
+      children: [...dot.children, "["]
+    }
   else
-    // . turns into [
-    dot = replaceNodes(deepCopy(dot), (node) => node.token is ".",
-      (node) => ({ ...node, token: "[" }))
+    dot = replaceNodes deepCopy(dot),
+      (node) => node.token is ".",
+      (node) => ({ ...node, token: "[" })
 
   return dot
 
@@ -431,6 +437,7 @@ function processCallMemberExpression(node)
 function replaceNode(node: ASTNodeBase, newNode: ASTNode): void
   unless node.parent?
     throw new Error "replaceNode failed: node has no parent"
+
   function recurse(children: ASTNode[]): boolean
     for each child, i of children
       if child is node
@@ -439,8 +446,10 @@ function replaceNode(node: ASTNodeBase, newNode: ASTNode): void
       else if Array.isArray child
         return true if recurse child
     return false
+
   unless recurse node.parent.children
     throw new Error "replaceNode failed: didn't find child node in parent"
+
   if newNode <? "object" and not Array.isArray newNode
     newNode.parent = node.parent
 
@@ -646,6 +655,7 @@ function processAssignments(statements): void {
           return expr.assigned
         }
       }
+
       const pre = [], post = []
       switch (exp.type) {
         case "AssignmentExpression":
@@ -681,13 +691,12 @@ function processAssignments(statements): void {
 
         if newMemberExp !== assigned
           if newMemberExp.usesRef
-            exp.hoistDec = {
+            newMemberExp.hoistDec = {
               type: "Declaration"
               children: ["let ", ref]
               names: []
             }
-          exp.children = [newMemberExp]
-          newMemberExp.parent = exp
+          replaceNode exp, newMemberExp
 
   replaceNodesRecursive statements,
     (n) => n.type is "AssignmentExpression" and n.names is null,
@@ -791,7 +800,7 @@ function processAssignments(statements): void {
         assignment := $1[i]
         [ws1, lhs, ws2, op] := assignment
 
-        if lhs.type is "MemberExpression"
+        if lhs.type is "MemberExpression" or lhs.type is "CallExpression"
           newMemberExp := unchainOptionalMemberExpression lhs, optionalChainRef, (children) =>
             // NOTE: This only executes when lhs contains chains
             // this mutates the assignments array to account for the parts moved into the conditionals
@@ -829,45 +838,60 @@ function processAssignments(statements): void {
     }
 }
 
-function unchainOptionalMemberExpression(exp: MemberExpression, ref: ASTRef, innerExp: (exp) => ASTNode)
+function unchainOptionalMemberExpression(exp: MemberExpression | CallExpression, ref: ASTRef, innerExp: (exp) => ASTNode)
   j .= 0
   { children } := exp
   usesRef .= false
-  hasOptional .= false
-  head := []
-  tail := []
-  let base
+  conditions := []
 
   // NOTE: not caching length because the array mutates inside
   while j < children.length
     child := children[j]
-    if child.type is "PropertyAccess"
-      if child.children[0]?.[0]?.token is "?"
-        hasOptional = true
-        child.children[0].shift()
+    type := child?.type
+    hasOptional .= false
 
-        if j > 1 or needsRef children[0]
-          usesRef = true
-          base = makeLeftHandSideExpression
-            type: "AssignmentExpression"
-            children: [ref, " = ", children.splice(0, j)]
+    switch type
+      when "PropertyAccess"
+        if child.dot?.optional
+          hasOptional = true
+          child.dot.children.shift()
+          child.dot.optional = false
+      when "Call"
+        if child.optional
+          hasOptional = true
+          child.children.shift()
+          child.optional = undefined
 
-          base.parent = child
-          children.unshift ref
+    if hasOptional
+      let base
 
-          j = 0
-        else
-          base = children[0]
+      if j > 1 or needsRef children[0]
+        usesRef = true
+        base = makeLeftHandSideExpression
+          type: "AssignmentExpression"
+          children: [ref, " = ", children.splice(0, j)]
 
-        tail.push " : void 0"
-        head.push base, " != null ? "
+        base.parent = child
+        children.unshift ref
+
+        j = 0
+      else
+        base = children[0]
+
+      conditions.push [ base, " != null" ]
 
     j++
 
-  if hasOptional
+  if l := conditions.length
+    cs := conditions.map (c, i) =>
+      if i is l - 1
+        c
+      else
+        [c, " && "]
+
     {
       ...exp
-      children: [...head, innerExp(children), ...tail]
+      children: [...cs, " ? ", innerExp(children), " : void 0"]
       usesRef
     }
   else // Unchanged

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -89,7 +89,7 @@ export type AssignmentExpression
   assigned: ???
   exp: ExpressionNode
 
-export type AssignmentExpressionLHS = [undefined, ASTNode, [WSNode, [string, WSNode]]][]
+export type AssignmentExpressionLHS = [undefined, ASTNode, [WSNode, [string, WSNode]], ASTLeaf][]
 
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1,13 +1,13 @@
 export type ASTNode =
-  | ASTError
-  | ASTRef
-  | ASTLeaf
   | ASTString
   | Children
   | StatementNode
-  | CommentNode
+  | OtherNode
   | undefined
 
+/**
+* Nodes that represent statements.
+*/
 export type StatementNode =
   | BlockStatement
   | DebuggerStatement
@@ -23,6 +23,9 @@ export type StatementNode =
   | ThrowStatement
   | TryStatement
 
+/**
+* Nodes that represent expressions.
+*/
 export type ExpressionNode =
   | AssignmentExpression
   | BinaryOp
@@ -34,6 +37,18 @@ export type ExpressionNode =
   | ParenthesizedExpression
   | StatementExpression
   | TypeNode
+
+/**
+* Other nodes that aren't statements or expressions.
+*/
+export type OtherNode =
+  | ASTError
+  | ASTRef
+  | ASTLeaf
+  | AccessStart
+  | Call
+  | PropertyAccess
+  | CommentNode
 
 export type ASTNodeBase = ASTNode &
   parent: ASTNodeBase?
@@ -47,6 +62,7 @@ export type ASTError =
   type: "Error"
   message: string
   token?: undefined
+  parent: ASTNodeBase?
 
 export type Loc =
   pos: number
@@ -90,6 +106,16 @@ export type AssignmentExpression
   exp: ExpressionNode
 
 export type AssignmentExpressionLHS = [undefined, ASTNode, [WSNode, [string, WSNode]], ASTLeaf][]
+
+export type MemberExpression
+  type: "MemberExpression"
+  children: Children
+  parent: ASTNodeBase
+
+export type CallExpression
+  type: "CallExpression"
+  children: Children
+  parent: ASTNodeBase
 
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 
@@ -171,11 +197,36 @@ export type LabeledStatement
 
 export type ElseToken = { $loc: Loc, token: "else" }
 
+export type AccessStart
+  type: "AccessStart"
+  children: Children
+  optional: boolean
+  parent: ASTNodeBase?
+
+export type PropertyAccess
+  type: "PropertyAccess"
+  children: Children
+  dot?: AccessStart
+  parent: ASTNodeBase?
+
+export type Call
+  type: "Call"
+  children: Children
+  optional?: Optional?
+  parent: ASTNodeBase?
+
+export type Optional
+  type: "Optional"
+  children: Children
+  parent: ASTNodeBase?
+
 export type ASTRef =
   type: "Ref"
   base: string
   id: string
   token?: undefined
+  /** NOTE: Currently parent may be inaccurate since multiple copies of the same ASTRef can exist in the tree. */
+  parent?: ASTNodeBase?
 
 export type AtBinding =
   type: "AtBinding"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -47,6 +47,7 @@ export type OtherNode =
   | ASTLeaf
   | AccessStart
   | Call
+  | Index
   | PropertyAccess
   | CommentNode
 
@@ -211,6 +212,12 @@ export type PropertyAccess
 
 export type Call
   type: "Call"
+  children: Children
+  optional?: Optional?
+  parent: ASTNodeBase?
+
+export type Index
+  type: "Index"
   children: Children
   optional?: Optional?
   parent: ASTNodeBase?

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -652,3 +652,19 @@ describe "assignment", ->
     ---
     let ref;x != null ? (ref = x.y) != null ? ref.z = a : void 0 : void 0
   """
+
+  testCase """
+    ?. multiple assignments
+    ---
+    x?.y = a = b
+    ---
+    x != null ? x.y = a = b : void 0
+  """
+
+  testCase """
+    ?. multiple assignments with ref
+    ---
+    x.y?.z = a.b?.c = d
+    ---
+    let ref;(ref = x.y) != null ? ref.z = (ref = a.b) != null ? ref.c = d : void 0 : void 0
+  """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -650,7 +650,7 @@ describe "assignment", ->
     ---
     x?.y?.z = a
     ---
-    let ref;x != null ? (ref = x.y) != null ? ref.z = a : void 0 : void 0
+    let ref;x != null && (ref = x.y) != null ? ref.z = a : void 0
   """
 
   testCase """
@@ -667,4 +667,20 @@ describe "assignment", ->
     x.y?.z = a.b?.c = d
     ---
     let ref;(ref = x.y) != null ? ref.z = (ref = a.b) != null ? ref.c = d : void 0 : void 0
+  """
+
+  testCase """
+    optional call expression
+    ---
+    f?().x.y?.z = 1
+    ---
+    let ref;f != null && (ref = f().x.y) != null ? ref.z = 1 : void 0
+  """
+
+  testCase.skip """
+    optional index expression
+    ---
+    x?[y] = 1
+    ---
+    x != null ? x[y] = 1 : void 0
   """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -636,3 +636,19 @@ describe "assignment", ->
     ---
     x = z.includes(y)
   """
+
+  testCase """
+    ?. on lhs
+    ---
+    x?.y = z
+    ---
+    x != null ? x.y = z : void 0
+  """
+
+  testCase """
+    ?. complex exp on lhs
+    ---
+    x?.y?.z = a
+    ---
+    let ref;x != null ? (ref = x.y) != null ? ref.z = a : void 0 : void 0
+  """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -677,10 +677,18 @@ describe "assignment", ->
     let ref;f != null && (ref = f().x.y) != null ? ref.z = 1 : void 0
   """
 
-  testCase.skip """
+  testCase """
     optional index expression
     ---
-    x?[y] = 1
+    x.z?[y] = 1
     ---
-    x != null ? x[y] = 1 : void 0
+    let ref;(ref = x.z) != null ? ref[y] = 1 : void 0
+  """
+
+  testCase """
+    optional negative index
+    ---
+    x.-1?[y] = 1
+    ---
+    let ref;(ref = x[x.length-1]) != null ? ref[y] = 1 : void 0
   """

--- a/test/update-expression.civet
+++ b/test/update-expression.civet
@@ -32,3 +32,11 @@ describe "update expression", ->
     ---
     --x
   """
+
+  testCase """
+    optional chain
+    ---
+    x?.y?.z++
+    ---
+    let ref;x != null ? (ref = x.y) != null ? ref.z++ : void 0 : void 0
+  """

--- a/test/update-expression.civet
+++ b/test/update-expression.civet
@@ -38,5 +38,5 @@ describe "update expression", ->
     ---
     x?.y?.z++
     ---
-    let ref;x != null ? (ref = x.y) != null ? ref.z++ : void 0 : void 0
+    let ref;x != null && (ref = x.y) != null ? ref.z++ : void 0
   """


### PR DESCRIPTION
Also added support for `x?.y?.z++`