### PR TITLE
Modern NodeJS register and CLI require/import fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ The modern way to write TypeScript.
   [esbuild](source/esbuild-plugin.civet),
   [Vite](https://github.com/edemaine/vite-plugin-civet),
   -->
+  [ESM/CJS loader](source/esm.civet),
   [Babel](source/babel-plugin.mjs),
   [Gulp](integration/gulp),
-  [ESM module resolution](source/esm.civet),
-  [CJS](register.js),
   [Bun](source/bun-civet.civet)
 - Starter templates for [Solid](https://github.com/orenelbaum/solid-civet-template) and [Solid Start](https://github.com/orenelbaum/solid-start-civet-template)
 
@@ -43,8 +42,8 @@ civet -c
 civet < source.civet > output.ts
 # Execute a .civet script
 civet source.civet ...args...
-# Execute a .civet source file in node using ts-node
-node --loader ts-node/esm --loader @danielx/civet/esm source.civet
+# Execute a .civet source file in node
+node --import @danielx/civet/register source.civet
 ```
 
 ![image](https://user-images.githubusercontent.com/18894/184558519-b675a903-7490-43ba-883e-0d8addacd4b9.png)

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -79,17 +79,14 @@ Simple execution of a .civet source file (CommonJS or ESM):
 civet source.civet ...args...
 ```
 
-Directly execute a .civet CommonJS source file in Node:
+Directly execute a .civet CommonJS or ESM source file in Node:
 
 ```sh
-node -r @danielx/civet/register source.civet ...args...
+node --import @danielx/civet/register source.civet ...args...
 ```
 
-Directly execute a .civet ESM source file in Node:
-
-```sh
-node --loader @danielx/civet/esm source.civet ...args...
-```
+On Node <20.6.0, you also need to specify `--loader @danielx/civet/esm`
+for ESM `import` of .civet files.
 
 Directly execute a .civet or .ts source file that mixes .civet and .ts code,
 using [ts-node](https://typestrong.org/ts-node/):
@@ -100,7 +97,7 @@ node --loader ts-node/esm --loader @danielx/civet/esm source.civet ...args...
 
 ## Transpilation
 
-Simple compilation of one civet source file to TypeScript:
+Simple compilation of one .civet source file to TypeScript:
 
 ```sh
 npx @danielx/civet < source.civet > output.ts

--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -13,10 +13,9 @@ title: Integrations
 - [unplugin](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin) integrates Civet into Vite, esbuild, Rollup, Webpack, and Rspack, including `.d.ts` generation (see [basic instructions](https://civet.dev/getting-started#building-a-project))
   - [Simpler esbuild plugin](https://github.com/DanielXMoore/Civet/blob/main/source/esbuild-plugin.civet)
   - [Older Vite plugin](https://github.com/edemaine/vite-plugin-civet) (no longer recommended)
+- [ESM/CJS loader](https://github.com/DanielXMoore/Civet/blob/main/register.js) for `import`/`require` to support `.civet` files
 - [Babel plugin](https://github.com/DanielXMoore/Civet/blob/main/source/babel-plugin.mjs)
 - [Gulp plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/gulp)
-- [ESM loader](https://github.com/DanielXMoore/Civet/blob/main/source/esm.civet)
-- [CJS require hook](https://github.com/DanielXMoore/Civet/blob/main/register.js)
 - [Bun plugin](https://github.com/DanielXMoore/Civet/blob/main/source/bun-civet.civet)
 - [Civetman](https://github.com/zihan-ch/civetman) automatically compiles `.civet` files, making it easy to integrate with arbitrary build chains (see also [vite-plugin-civetman](https://github.com/krist7599555/vite-plugin-civetman))
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@prettier/sync": "^0.3.0",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^9.1.1",
-    "@types/node": "^20.5.1",
+    "@types/node": "^20.12.2",
     "c8": "^7.12.0",
     "esbuild": "0.20.0",
     "marked": "^4.2.4",

--- a/register.js
+++ b/register.js
@@ -1,8 +1,16 @@
 /**
-@file Civet CJS registration
+@file Civet CJS and ESM registration
 
-`require`ing this file will register the `.civet` extension with
-Node.js's `require`.
+`import`ing this file in Node 20.6.0+ will register the `.civet` extension
+for both ESM `import`s and CJS `require`s.
+
+@example
+```bash
+node --import @danielx/civet/register source.civet
+```
+
+On older Node, `require`ing this file will register the `.civet` extension
+for CJS `require`s.
 
 @example
 ```bash
@@ -10,17 +18,25 @@ node -r @danielx/civet/register source.civet
 ```
 */
 
+try {
+  const { register } = require('node:module');
+  const { pathToFileURL } = require('node:url');
+
+  register('./dist/esm.mjs', pathToFileURL(__filename));
+} catch (e) {}
+
+// CJS registration
 if (require.extensions) {
   const fs = require("fs");
   const { compile } = require("./");
 
   require.extensions[".civet"] = function (module, filename) {
     const js = compile(fs.readFileSync(filename, 'utf8'), {
+      filename,
       js: true,
       inlineMap: true,
     });
     module._compile(js, filename);
-    return;
   };
 
   try {

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,4 +1,4 @@
-{ compile, parse } from ./main.civet
+{ compile, generate, parse, lib } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
 // unplugin ends up getting installed in the same dist directory
@@ -268,23 +268,66 @@ export function repl(options: Options)
         process.exit 0
       else if input.endsWith '\n\n'  // finished input with blank line
         let output: string
+        if options.compile or options.ast
+          try
+            output = compile input, {...options, filename}
+          catch error
+            //console.error "Failed to transpile Civet:"
+            console.error error
+            return callback null, undefined
+          return callback null, output
+
+        ast .= compile input, {...options, filename, ast: true}
+
+        // Wrap in IIFE if there's a top-level await
+        // Use Civet's async do, so Civet does implicit return of last value
+        // (copied from playground.worker.js)
+        topLevelAwait := lib.gatherRecursive(ast,
+          .type is 'Await',
+          lib.isFunction
+        ).length > 0
+        if topLevelAwait
+          [prologue, rest] := parse input, startRule: 'ProloguePrefix'
+          prefix := input.slice 0, -rest.length
+          coffee := prologue.some (p) => p.type is "CivetPrologue" and
+            (p.config.coffeeCompat or p.config.coffeeDo)
+          ast = compile
+            prefix +
+            (coffee ? '(do ->\n' : 'async do\n') +
+            rest.replace(/^/gm, ' ') +
+            (coffee ? ')' : ''),
+            {...options, filename, ast: true}
+
+        errors: unknown[] := []
         try
-          output = compile input, {...options, filename}
+          output = generate ast, { errors }
         catch error
           //console.error "Failed to transpile Civet:"
           console.error error
           return callback null, undefined
-        if options.compile or options.ast
-          callback null, output
-        else
-          let result: string
+        if errors.length
+          // TODO: Better error display; copied from main.civet
+          console.error `Parse errors: ${errors.map(.message).join("\n")}`
+          return callback null, undefined
+
+        let result: string
+        try
+          result = vm.runInContext output, context, {
+            filename
+            importModuleDynamically
+          }
+        catch error
+          return callback error as Error, undefined
+
+        if topLevelAwait
+          // If there was a top-level await, the result is a promise
+          // that we need to await before returning it.
           try
-            result = vm.runInContext output, context, {
-              filename
-              importModuleDynamically
-            }
+            result = await result
           catch error
-            return callback error as Error, undefined
+            callback error as Error, undefined
+          callback null, result
+        else
           callback null, result
       else  // still reading
         callback (new nodeRepl.Recoverable new Error "Enter a blank line to execute code."), null

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -465,13 +465,14 @@ export function cli
         { fork } := await import 'child_process'
 
         { register } := await import 'module'
+        let execArgv
         if register
           // On Node 20.6.0+, module.register does the work for us;
           // we just need to `--import` ESM/CJS registration.
           execArgv = [ '--import', '@danielx/civet/register' ]
         else
           // On Node <20.6.0, we need to use `--loader` for the ESM loader.
-          execArgv .= [
+          execArgv = [
             '--loader', '@danielx/civet/esm' // ESM
             '--require', '@danielx/civet/register' // CJS
           ]

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -8,7 +8,7 @@ let unplugin:
   buildEnd: (this: {emitFile: (data: {source: string, fileName: string, type: string}) => void}) => Promise<void>
   load: (this: {addWatchFile: (filename: string) => void}, filename: string) => Promise<{code: string, map: unknown}>
 
-function version: string
+export function version: string
   require("../package.json").version
 
 if process.argv.includes "--version"
@@ -90,7 +90,7 @@ interface ParsedArgs
   scriptArgs: string[]
   options: Options
 
-function parseArgs(args: string[]): ParsedArgs
+export function parseArgs(args: string[]): ParsedArgs
   options: Options := {}
   Object.defineProperty options, 'run',
     get: (this: Options) -> not (@ast or @compile or @typecheck or @emitDeclaration)
@@ -200,7 +200,39 @@ declare global
   var quit: () => void, exit: () => void
   var v8debug: unknown
 
-function repl(options: Options)
+export function repl(options: Options)
+  vm := await import 'vm'
+  // Node 21.7.0+ supports dynamic import() in vm calls via this constant:
+  importModuleDynamically .= vm.constants?.USE_MAIN_CONTEXT_DEFAULT_LOADER
+  unless importModuleDynamically
+    // For older Node, we need to provide our own dynamic import function,
+    // which requires `--experimental-vm-modules`.  Check if we did it already:
+    if vm.SourceTextModule?
+      { pathToFileURL } := await import 'url'
+      importModuleDynamically = (specifier: string) =>
+        if /^\.\.?[/\\]/.test specifier
+          import pathToFileURL path.join process.cwd(), specifier
+        else
+          import specifier
+    else
+      // If not, run this script with `--experimental-vm-modules`.
+      execArgv := [ '--experimental-vm-modules' ]
+      { register } := await import 'module'
+      /* This doesn't work; --loader seems to force ESM mode which breaks CLI.
+      unless register
+        // On Node <20.6.0, we need to use `--loader` for the ESM loader.
+        execArgv.push '--loader', '@danielx/civet/esm'
+      */
+      if process.env.NODE_OPTIONS
+        execArgv.push process.env.NODE_OPTIONS
+      { fork } := await import 'child_process'
+      fork __filename, process.argv[2..], {
+        execArgv
+        stdio: 'inherit'
+      }
+      return
+
+  require '../register.js'
   console.log `Civet ${version()} REPL.  Enter a blank line to ${
     switch
       when options.ast then 'parse'
@@ -209,7 +241,6 @@ function repl(options: Options)
   } code.`
   global.quit = global.exit = => process.exit 0
   nodeRepl := await import 'repl'
-  vm := await import 'vm'
   r := nodeRepl.start
     prompt:
       switch
@@ -248,14 +279,17 @@ function repl(options: Options)
         else
           let result: string
           try
-            result = vm.runInContext output, context, {filename}
+            result = vm.runInContext output, context, {
+              filename
+              importModuleDynamically
+            }
           catch error
             return callback error as Error, undefined
           callback null, result
       else  // still reading
         callback (new nodeRepl.Recoverable new Error "Enter a blank line to execute code."), null
 
-function cli
+export function cli
   argv := process.argv  // process.argv gets overridden when running scripts
   {filenames, scriptArgs, options} .= parseArgs argv[2..]
 
@@ -374,7 +408,7 @@ function cli
     else if options.run
       esm := /^\s*(import|export)\b/m.test output
       if esm
-        // Run ESM code via `node --loader @danielx/civet/esm` subprocess
+        // Run ESM code via `node --import @danielx/civet/register` subprocess
         if stdin
           // If code was read on stdin via command-line argument "-", try to
           // save it in a temporary file in same directory so paths are correct.
@@ -386,7 +420,19 @@ function cli
             console.error e
             process.exit 1
         { fork } := await import 'child_process'
-        execArgv := [ '--loader', '@danielx/civet/esm' ]
+
+        { register } := await import 'module'
+        if register
+          // On Node 20.6.0+, module.register does the work for us;
+          // we just need to `--import` ESM/CJS registration.
+          execArgv = [ '--import', '@danielx/civet/register' ]
+        else
+          // On Node <20.6.0, we need to use `--loader` for the ESM loader.
+          execArgv .= [
+            '--loader', '@danielx/civet/esm' // ESM
+            '--require', '@danielx/civet/register' // CJS
+          ]
+
         debugRe := /--debug|--inspect/
         isDebug := v8debug <? "object" or debugRe.test(process.execArgv.join(' ')) or debugRe.test(process.env.NODE_OPTIONS ?? '')
         if process.env.NODE_OPTIONS

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -1,7 +1,21 @@
 /**
 @file Civet ESM loader.
 
-Currently depends on ts-node esm loader being downstream
+In Node 20.6.0+, use Civet's `register` to install this ESM loader:
+
+@example
+```bash
+node --import @danielx/civet/register source.civet
+```
+
+In older Node, use `--loader` to install this ESM loader:
+
+@example
+```bash
+node --loader @danielx/civet/esm source.civet
+```
+
+Previously depended on ts-node esm loader being downstream:
 
 @example
 ```bash
@@ -10,7 +24,6 @@ node --loader ts-node/esm --loader @danielx/civet/esm source.civet
 */
 
 { readFileSync } from fs
-{ createRequire } from module
 { pathToFileURL, fileURLToPath } from url
 
 sourceMapSupport from @cspotcode/source-map-support
@@ -104,16 +117,3 @@ export async function load(url: string, context: any, next: any)
 
   // Other URLs continue unchanged.
   return next url, context
-
-// commonjs hook
-require := createRequire import.meta.url
-require.extensions[".civet"] = (m, filename) ->
-  source := readFileSync filename, "utf8"
-  code := compile source, {
-    filename
-    inlineMap: true
-    js: true
-  }
-
-  //@ts-ignore TODO: Figure out how to load types from inculde folders in Civet LSP
-  m._compile code, filename

--- a/yarn.lock
+++ b/yarn.lock
@@ -526,10 +526,12 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
-"@types/node@^20.5.1":
-  version "20.5.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.9.tgz#a70ec9d8fa0180a314c3ede0e20ea56ff71aed9a"
-  integrity sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==
+"@types/node@^20.12.2":
+  version "20.12.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.2.tgz#9facdd11102f38b21b4ebedd9d7999663343d72e"
+  integrity sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/web-bluetooth@^0.0.17":
   version "0.0.17"
@@ -1864,6 +1866,11 @@ typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unplugin@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
* `@danielx/civet/register` now calls Node 20.6.0+'s `module.register` method to register ESM, in addition to CJS registration.
* New recommended method for ESM and CJS registration (for Node 20.6.0+):
  `node --import @danielx/civet/register`
  (avoids new warning ``ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()` ``)
* Removed duplicate CJS registration code from ESM loader; should use `@danielx/civet/register` for this
* CLI runs `@danielx/civet/register` even in REPL mode, so you can `require` or `import` Civet files interactively (one catch: I couldn't get `import` to work on Node <20.6.0)
* CLI provides `importModuleDynamically` to enable dynamic `import()`
* CLI supports top-level `await` (like Node CLI), based on previous code written for the playground