### PR TITLE
Dynamic import declarations and expressions

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1823,10 +1823,37 @@ import {X: LocalX, Y: LocalY} from "./util"
 ### Dynamic Import
 
 If it's not the start of a statement,
-dynamic `import` does not require parentheses.
+dynamic `import` does not require parentheses:
 
 <Playground>
 {x} = await import url
+</Playground>
+
+### Dynamic Import Declarations
+
+If you're not at the top level, `import` declarations get transformed
+into dynamic imports:
+
+<Playground>
+function load
+  * as utils from ./utils
+  { version: nodeVer,
+    execPath as nodePath } from process
+  fs, {readFile} from fs
+  return {utils, nodeVer, nodePath, fs, readFile}
+</Playground>
+
+::: info
+Note that the `import` gets `await`ed, so the function becomes asynchronous.
+:::
+
+You can also use `import` declarations as expressions, as a shorthand for
+`await`ing and destructuring a dynamic `import`:
+
+<Playground>
+urlPath := import {
+  fileURLToPath, pathToFileURL
+} from url
 </Playground>
 
 ### Export Shorthand

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -17,6 +17,7 @@ import {
   dedentBlockSubstitutions,
   deepCopy,
   dynamizeImportDeclaration,
+  dynamizeImportDeclarationExpression,
   expressionizeTypeIf,
   forRange,
   gatherBindingCode,
@@ -1073,26 +1074,8 @@ CallExpression
       children: [$1, ...$2, ...rest.flat()],
     })
   # Import declaration as an expression
-  Import:imp _:ws1 NamedImports:named __:ws2 FromClause:from ->
-    const object = convertNamedImportsToObject(named)
-    const dot = "."
-    return processCallMemberExpression({
-      type: "CallExpression",
-      children: [
-        { type: "Await", children: "await" }, " ",
-        imp, "(",
-        insertTrimmingSpace(ws2, ""),
-        insertTrimmingSpace(from.slice(1), ""), // remove 'from'
-        ")",
-        {
-          type: "PropertyGlob",
-          dot,
-          object,
-          children: [ws1, dot, object],
-          reversed: true,
-        }
-      ]
-    })
+  Import _ NamedImports __ FromClause ->
+    return dynamizeImportDeclarationExpression($0)
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
@@ -4837,7 +4820,9 @@ NamedImports
 
 # https://262.ecma-international.org/#prod-FromClause
 FromClause
-  From __ ModuleSpecifier:module
+  From __ ModuleSpecifier:module ->
+    if (!Array.isArray(module)) return $0
+    return [ $1, $2, ...module ]
 
 # https://github.com/tc39/proposal-import-assertions
 # https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#import-assertions
@@ -4845,7 +4830,13 @@ FromClause
 # https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#import-attributes
 # NOTE: Forbid newline before `with` which could mean a function call
 ImportAssertion
-  _? ( "with" / "assert" ) NonIdContinue _? ObjectLiteral
+  _? ( "with" / "assert" ):keyword NonIdContinue _? ObjectLiteral:object ->
+    return {
+      type: "ImportAssertion",
+      keyword,
+      object,
+      children: $0,
+    }
 
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4799,11 +4799,13 @@ ImportClause
 
 # https://262.ecma-international.org/#prod-NameSpaceImport
 NameSpaceImport
-  Star ImportAsToken __ ImportedBinding:binding  ->
+  Star:star ImportAsToken __ ImportedBinding:binding  ->
     return {
       type: "Declaration",
       children: $0,
-      names: binding.names
+      names: binding.names,
+      binding,
+      star,
     }
 
 # https://262.ecma-international.org/#prod-NamedImports

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -11,6 +11,7 @@ import {
   adjustIndexAccess,
   attachPostfixStatementAsExpression,
   blockWithPrefix,
+  convertNamedImportsToObjectExpression,
   convertObjectToJSXAttributes,
   dedentBlockString,
   dedentBlockSubstitutions,
@@ -1069,6 +1070,26 @@ CallExpression
     return processCallMemberExpression({
       type: "CallExpression",
       children: [$1, ...$2, ...rest.flat()],
+    })
+  # Import declaration as an expression
+  Import:imp _:ws1 NamedImports:named __:ws2 FromClause:from ->
+    const object = convertNamedImportsToObjectExpression(named)
+    const dot = "."
+    return processCallMemberExpression({
+      type: "CallExpression",
+      children: [
+        { type: "Await", children: "await" }, " ",
+        imp, "(",
+        insertTrimmingSpace(ws2, ""),
+        insertTrimmingSpace(from.slice(1), ""), // remove 'from'
+        ")",
+        {
+          type: "PropertyGlob",
+          dot,
+          object,
+          children: [ws1, dot, object],
+        }
+      ]
     })
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
@@ -4806,12 +4827,13 @@ NamedImports
     return {
       type: "Declaration",
       children: $0,
-      names
+      names,
+      specifiers,
     }
 
 # https://262.ecma-international.org/#prod-FromClause
 FromClause
-  From __ ModuleSpecifier
+  From __ ModuleSpecifier:module
 
 # https://github.com/tc39/proposal-import-assertions
 # https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#import-assertions
@@ -4842,13 +4864,15 @@ TypeAndImportSpecifier
 
 # https://262.ecma-international.org/#prod-ImportSpecifier
 ImportSpecifier
-  __ ModuleExportName ImportAsToken __ ImportedBinding:binding ObjectPropertyDelimiter ->
+  __ ModuleExportName:source ImportAsToken __ ImportedBinding:binding ObjectPropertyDelimiter ->
     return {
+      source,
       binding,
       children: $0,
     }
   __ ImportedBinding:binding ObjectPropertyDelimiter ->
     return {
+      source: binding,
       binding,
       children: $0,
     }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -11,7 +11,7 @@ import {
   adjustIndexAccess,
   attachPostfixStatementAsExpression,
   blockWithPrefix,
-  convertNamedImportsToObjectExpression,
+  convertNamedImportsToObject,
   convertObjectToJSXAttributes,
   dedentBlockString,
   dedentBlockSubstitutions,
@@ -1073,7 +1073,7 @@ CallExpression
     })
   # Import declaration as an expression
   Import:imp _:ws1 NamedImports:named __:ws2 FromClause:from ->
-    const object = convertNamedImportsToObjectExpression(named)
+    const object = convertNamedImportsToObject(named)
     const dot = "."
     return processCallMemberExpression({
       type: "CallExpression",
@@ -1088,6 +1088,7 @@ CallExpression
           dot,
           object,
           children: [ws1, dot, object],
+          reversed: true,
         }
       ]
     })
@@ -4770,22 +4771,21 @@ ImportDeclaration
       type: "ImportDeclaration",
       children: [imp, $0.slice(1)],
     }
-  Import __ TypeKeyword __ ImportClause __ FromClause -> { type: "ImportDeclaration", ts: true, children: $0 }
-  Import __ ImportClause __ FromClause -> { type: "ImportDeclaration", children: $0 }
-  Import __ ModuleSpecifier -> { type: "ImportDeclaration", children: $0 }
+  Import __ TypeKeyword __ ImportClause:imports __ FromClause:from -> { type: "ImportDeclaration", ts: true, children: $0, imports, from }
+  Import __ ImportClause:imports __ FromClause:from -> { type: "ImportDeclaration", children: $0, imports, from }
+  Import __ ModuleSpecifier:module -> { type: "ImportDeclaration", children: $0, module }
   # NOTE: Added import shorthand
   # NOTE: Not adding $loc to source map here yet because it will point to the start of the identifier
   # the proper place may be to use the From location
-  ImpliedImport:i ( TypeKeyword __ )?:t ImportClause:c __:w FromClause:f ->
+  ImpliedImport:i ( TypeKeyword __ )?:t ImportClause:imports __:w FromClause:from ->
     // Map implied import location to `from`
     // The pos and length adjustment better match how tsc outputs to include the space before `from` with the `from` token
     i.$loc = {
-      pos: f[0].$loc.pos-1,
-      length: f[0].$loc.length+1,
+      pos: from[0].$loc.pos-1,
+      length: from[0].$loc.length+1,
     }
-    const children = [i, t, c, w, f]
-    if (!t) return children
-    return { type: "ImportDeclaration", ts: true, children }
+    const children = [i, t, imports, w, from]
+    return { type: "ImportDeclaration", ts: !!t, children, imports, from }
 
 ImpliedImport
   "" ->
@@ -4797,15 +4797,18 @@ ImportClause
     if (rest) {
       return {
         type: "Declaration",
-        children: $0,
+        children: [binding, ...rest],
         names: [...binding.names, ...rest[3].names],
+        binding,
+        specifiers: rest[3].specifiers,
       }
     }
 
     return {
       type: "Declaration",
-      children: $0,
+      children: [binding],
       names: binding.names,
+      binding,
     }
   NameSpaceImport
   NamedImports
@@ -5038,6 +5041,55 @@ ImplicitExportSpecifier
 
 # https://262.ecma-international.org/#prod-Declaration
 Declaration
+  ImportDeclaration:decl ->
+    if (decl.ts || decl.module || !decl.imports || !decl.from) return $skip
+    const { imports } = decl
+    if (!imports.binding && !imports.specifiers) return $skip
+    const pattern = imports.binding ||
+      convertNamedImportsToObject(imports, true)
+    const c = "const"
+    const initializer = [
+      " = ",
+      {type: "Await", children: ["await"]},
+      " ",
+      decl.children[0], // import
+      "(",
+      insertTrimmingSpace(decl.from.slice(1), ""),
+      ")",
+    ]
+    const bindings = [{
+      type: "Binding",
+      names: pattern.names,
+      pattern,
+      initializer,
+      children: [pattern, initializer],
+    }]
+    if (imports.binding && imports.specifiers) {
+      // import x, {y} --> const x = await import(...), {y} = x
+      const pattern2 = convertNamedImportsToObject(imports.children.at(-1), true)
+      const initializer2 = [
+        " = ",
+        pattern,
+      ]
+      bindings.push({
+        type: "Binding",
+        names: imports.specifiers.names,
+        pattern: pattern2,
+        initializer: initializer2,
+        children: [pattern2, initializer2],
+      })
+    }
+    return {
+      type: "Declaration",
+      names: imports.names,
+      bindings,
+      decl: c,
+      children: [
+        c, " ",
+        bindings.flatMap((binding, i) => i > 0 ? [", ", binding] : [binding]),
+      ]
+    }
+    return decl
   HoistableDeclaration
   ClassDeclaration
   LexicalDeclaration:d ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -16,6 +16,7 @@ import {
   dedentBlockString,
   dedentBlockSubstitutions,
   deepCopy,
+  dynamizeImportDeclaration,
   expressionizeTypeIf,
   forRange,
   gatherBindingCode,
@@ -5045,51 +5046,7 @@ Declaration
     if (decl.ts || decl.module || !decl.imports || !decl.from) return $skip
     const { imports } = decl
     if (!imports.binding && !imports.specifiers) return $skip
-    const pattern = imports.binding ||
-      convertNamedImportsToObject(imports, true)
-    const c = "const"
-    const initializer = [
-      " = ",
-      {type: "Await", children: ["await"]},
-      " ",
-      decl.children[0], // import
-      "(",
-      insertTrimmingSpace(decl.from.slice(1), ""),
-      ")",
-    ]
-    const bindings = [{
-      type: "Binding",
-      names: pattern.names,
-      pattern,
-      initializer,
-      children: [pattern, initializer],
-    }]
-    if (imports.binding && imports.specifiers) {
-      // import x, {y} --> const x = await import(...), {y} = x
-      const pattern2 = convertNamedImportsToObject(imports.children.at(-1), true)
-      const initializer2 = [
-        " = ",
-        pattern,
-      ]
-      bindings.push({
-        type: "Binding",
-        names: imports.specifiers.names,
-        pattern: pattern2,
-        initializer: initializer2,
-        children: [pattern2, initializer2],
-      })
-    }
-    return {
-      type: "Declaration",
-      names: imports.names,
-      bindings,
-      decl: c,
-      children: [
-        c, " ",
-        bindings.flatMap((binding, i) => i > 0 ? [", ", binding] : [binding]),
-      ]
-    }
-    return decl
+    return dynamizeImportDeclaration(decl)
   HoistableDeclaration
   ClassDeclaration
   LexicalDeclaration:d ->

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -46,6 +46,11 @@ import {
   gatherBindingCode
 } from ./binding.civet
 
+import {
+  convertNamedImportsToObject
+  insertTrimmingSpace
+} from ./lib.civet
+
 function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix, ws: WSNode, assign: ASTLeaf, e: ASTNode)
   // Adjust position to space before assignment to make TypeScript remapping happier
   decl = {
@@ -319,7 +324,53 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
         block.expressions.push ["", s]
         s.parent = block
 
+function dynamizeImportDeclaration(decl)
+  { imports } := decl
+  pattern := imports.binding or convertNamedImportsToObject(imports, true)
+  c := "const"
+  initializer := [
+    " = "
+    {type: "Await", children: ["await"]}
+    " "
+    decl.children[0] // import
+    "("
+    insertTrimmingSpace(decl.from.slice(1), "")
+    ")"
+  ]
+  bindings := [{
+    type: "Binding"
+    names: pattern.names
+    pattern
+    initializer
+    children: [pattern, initializer]
+  }]
+  if imports.binding and imports.specifiers
+    // import x, {y} --> const x = await import(...), {y} = x
+    pattern2 := convertNamedImportsToObject(imports.children.at(-1), true)
+    initializer2 := [
+      " = ",
+      pattern,
+    ]
+    bindings.push {
+      type: "Binding"
+      names: imports.specifiers.names
+      pattern: pattern2
+      initializer: initializer2
+      children: [pattern2, initializer2]
+    }
+  {
+    type: "Declaration"
+    names: imports.names
+    bindings
+    decl: c
+    children: [
+      c, " "
+      bindings.flatMap (binding, i) => i > 0 ? [", ", binding] : [binding]
+    ]
+  }
+
 export {
+  dynamizeImportDeclaration
   prependStatementExpressionBlock
   processAssignmentDeclaration
   processDeclarationConditions

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -336,14 +336,25 @@ function dynamizeFromClause(from)
 
 function dynamizeImportDeclaration(decl)
   { imports } := decl
-  pattern := imports.binding or convertNamedImportsToObject(imports, true)
+  { star, binding, specifiers } .= imports
+  justDefault := binding and not specifiers and not star
+  pattern := do
+    if binding
+      if specifiers
+        makeRef()
+      else
+        binding
+    else
+      convertNamedImportsToObject(imports, true)
   c := "const"
   initializer := [
     " = "
+    if justDefault then "("
     {type: "Await", children: ["await"]}
     " "
     decl.children[0] // import
     dynamizeFromClause decl.from
+    if justDefault then ").default"
   ]
   bindings := [{
     type: "Binding"
@@ -352,20 +363,31 @@ function dynamizeImportDeclaration(decl)
     initializer
     children: [pattern, initializer]
   }]
-  if imports.binding and imports.specifiers
-    // import x, {y} --> const x = await import(...), {y} = x
-    pattern2 := convertNamedImportsToObject(imports.children.at(-1), true)
+  if binding and specifiers
+    // import x, {y} --> const ref = await import(...), x = ref.default, {y} = ref
+    pattern2 := binding
     initializer2 := [
-      " = ",
-      pattern,
+      " = "
+      pattern
+      ".default"
     ]
-    bindings.push {
+    bindings.push
       type: "Binding"
-      names: imports.specifiers.names
+      names: binding.names
       pattern: pattern2
       initializer: initializer2
       children: [pattern2, initializer2]
-    }
+    pattern3 := convertNamedImportsToObject(imports.children.at(-1), true)
+    initializer3 := [
+      " = "
+      pattern
+    ]
+    bindings.push
+      type: "Binding"
+      names: specifiers.names
+      pattern: pattern3
+      initializer: initializer3
+      children: [pattern3, initializer3]
   {
     type: "Declaration"
     names: imports.names

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -49,6 +49,7 @@ import {
 import {
   convertNamedImportsToObject
   insertTrimmingSpace
+  processCallMemberExpression
 } from ./lib.civet
 
 function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix, ws: WSNode, assign: ASTLeaf, e: ASTNode)
@@ -324,6 +325,15 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
         block.expressions.push ["", s]
         s.parent = block
 
+// Convert FromClause into arguments for dynamic import
+function dynamizeFromClause(from)
+  from = from[1..]  // remove 'from'
+  from = insertTrimmingSpace from, ""
+  if from.-1?.type is "ImportAssertion"
+    assert := from.pop()
+    from.push ", {", assert.keyword, ":", assert.object, "}"
+  ["(", ...from, ")"]
+
 function dynamizeImportDeclaration(decl)
   { imports } := decl
   pattern := imports.binding or convertNamedImportsToObject(imports, true)
@@ -333,9 +343,7 @@ function dynamizeImportDeclaration(decl)
     {type: "Await", children: ["await"]}
     " "
     decl.children[0] // import
-    "("
-    insertTrimmingSpace(decl.from.slice(1), "")
-    ")"
+    dynamizeFromClause decl.from
   ]
   bindings := [{
     type: "Binding"
@@ -369,8 +377,30 @@ function dynamizeImportDeclaration(decl)
     ]
   }
 
+function dynamizeImportDeclarationExpression($0)
+  [imp, ws1, named, ws2, from] := $0
+  object := convertNamedImportsToObject(named)
+  dot := "."
+  processCallMemberExpression {
+    type: "CallExpression",
+    children: [
+      { type: "Await", children: "await" }, " ",
+      imp,
+      insertTrimmingSpace(ws2, ""),
+      dynamizeFromClause(from),
+      {
+        type: "PropertyGlob",
+        dot,
+        object,
+        children: [ws1, dot, object],
+        reversed: true,
+      }
+    ]
+  }
+
 export {
   dynamizeImportDeclaration
+  dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
   processAssignmentDeclaration
   processDeclarationConditions

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -197,12 +197,16 @@ function patternAsValue(pattern)
       const children = [...pattern.children]
       const index = children.indexOf(pattern.properties)
       if (index < 0) throw new Error("failed to find properties in ArrayBindingPattern")
-      children[index] = pattern.properties.map(patternAsValue)
+      children[index] = pattern.properties.map patternAsValue
       return { ...pattern, children }
     }
     case "Identifier":
     case "BindingProperty": {
-      const children = [pattern.name, pattern.delim]
+      const children = [
+        // { name: value } = ... declares value, not name
+        pattern.value ?? pattern.name
+        pattern.delim
+      ]
       // Check for leading whitespace
       if (isWhitespaceOrEmpty(pattern.children[0])) {
         children.unshift(pattern.children[0])

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -340,66 +340,67 @@ function processCallMemberExpression(node)
       }
       prefix = prefix.concat(glob.dot)
 
-      for (const part of glob.object.properties) {
+      for part of glob.object.properties
         if part.type is "MethodDefinition"
           throw new Error("Glob pattern cannot have method definition")
         if part.value and !["CallExpression", "MemberExpression", "Identifier"].includes(part.value.type)
           throw new Error(`Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`)
 
         suppressPrefix .= false
-        value .= part.value ?? part.name
+        name .= part.name
+        value .= part.value ?? name
         wValue := getTrimmingSpace part.value
 
         [value, suppressPrefix] = handleThisPrivateShorthands value
 
+        // Not yet needed:
+        //[name, value] = [value, name] if glob.reversed
+
         if !suppressPrefix // Don't prefix @ shorthand
           value = prefix.concat(insertTrimmingSpace(value, ""))
         if (wValue) value.unshift(wValue)
-        if (part.type is "SpreadProperty") {
-          parts.push({
-            type: part.type,
-            value,
-            dots: part.dots,
-            delim: part.delim,
-            names: part.names,
+        if part.type is "SpreadProperty"
+          parts.push {
+            type: part.type
+            value
+            dots: part.dots
+            delim: part.delim
+            names: part.names
             children: part.children.slice(0, 2) // whitespace, ...
               .concat(value, part.delim)
-          })
-        } else {
-          parts.push({
-            type: part.type is "Identifier" ? "Property" : part.type,
-            name: part.name,
-            value,
-            delim: part.delim,
-            names: part.names,
+          }
+        else
+          parts.push {
+            type: part.type is "Identifier" ? "Property" : part.type
+            name
+            value
+            delim: part.delim
+            names: part.names
             children: [
-              isWhitespaceOrEmpty(part.children[0]) and part.children[0],
-              part.name,
-              isWhitespaceOrEmpty(part.children[2]) and part.children[2],
-              part.children[3]?.token is ":" ? part.children[3] : ":",
-              value,
-              part.delim, // comma delimiter
+              isWhitespaceOrEmpty(part.children[0]) and part.children[0]
+              name
+              isWhitespaceOrEmpty(part.children[2]) and part.children[2]
+              part.children[3]?.token is ":" ? part.children[3] : ":"
+              value
+              part.delim // comma delimiter
             ]
-          })
-        }
-      }
-      let object = {
-        type: "ObjectExpression",
+          }
+      object .= {
+        type: "ObjectExpression"
         children: [
-          glob.object.children.0, // {
-          ...parts,
-          glob.object.children.-1, // whitespace and }
+          glob.object.children.0 // {
+          ...parts
+          glob.object.children.-1 // whitespace and }
         ],
-        properties: parts,
-        hoistDec,
+        properties: parts
+        hoistDec
       }
-      if (refAssignment) {
+      if refAssignment
         object = {
-          type: "ParenthesizedExpression",
-          children: ["(", ...refAssignment, object, ")"],
-          expression: object,
+          type: "ParenthesizedExpression"
+          children: ["(", ...refAssignment, object, ")"]
+          expression: object
         }
-      }
       if (i is children.length - 1) return object
       return processCallMemberExpression({  // in case there are more
         ...node,
@@ -521,6 +522,36 @@ function convertMethodToFunction(method) {
     block,
   }
 }
+
+// Convert NamedImports such as {name, old1: new1, old2 as new2}
+// into ObjectExpression such as {name, new1: old1, new2: old2}
+function convertNamedImportsToObjectExpression(node)
+  properties := node.specifiers.map (specifier) =>
+    if specifier.ts
+      { type: "Error", message: "cannot use `type` in dynamic import" }
+    else
+      { source, binding } := specifier
+      delim := specifier.children.-1
+      {
+        type: "Property"
+        name: binding
+        value: source
+        delim
+        children: [
+          binding, ":", source, delim
+        ]
+      }
+
+  {
+    type: "ObjectExpression"
+    names: node.names
+    properties
+    children: [
+      node.children.0 // {
+      properties
+      node.children.-1 // }
+    ]
+  }
 
 // Convert an ObjectExpression (with `properties`)
 // into a set of JSX attributes.
@@ -1276,6 +1307,7 @@ export {
   adjustIndexAccess
   attachPostfixStatementAsExpression
   blockWithPrefix
+  convertNamedImportsToObjectExpression
   convertObjectToJSXAttributes
   dedentBlockString
   dedentBlockSubstitutions

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -354,7 +354,7 @@ function processCallMemberExpression(node)
         [value, suppressPrefix] = handleThisPrivateShorthands value
 
         // Not yet needed:
-        //[name, value] = [value, name] if glob.reversed
+        [name, value] = [value, name] if glob.reversed
 
         if !suppressPrefix // Don't prefix @ shorthand
           value = prefix.concat(insertTrimmingSpace(value, ""))
@@ -523,9 +523,8 @@ function convertMethodToFunction(method) {
   }
 }
 
-// Convert NamedImports such as {name, old1: new1, old2 as new2}
-// into ObjectExpression such as {name, new1: old1, new2: old2}
-function convertNamedImportsToObjectExpression(node)
+// Convert NamedImports into equivalent ObjectExpression or ObjectBindingPattern
+function convertNamedImportsToObject(node, pattern?: boolean)
   properties := node.specifiers.map (specifier) =>
     if specifier.ts
       { type: "Error", message: "cannot use `type` in dynamic import" }
@@ -533,17 +532,17 @@ function convertNamedImportsToObjectExpression(node)
       { source, binding } := specifier
       delim := specifier.children.-1
       {
-        type: "Property"
-        name: binding
-        value: source
+        type: pattern ? "BindingProperty" : "Property"
+        name: source
+        value: binding unless source is binding
         delim
-        children: [
-          binding, ":", source, delim
-        ]
+        children: source is binding
+          ? [ source, delim ]
+          : [ source, ":", binding, delim ]
       }
 
   {
-    type: "ObjectExpression"
+    type: pattern ? "ObjectBindingPattern" : "ObjectExpression"
     names: node.names
     properties
     children: [
@@ -1307,7 +1306,7 @@ export {
   adjustIndexAccess
   attachPostfixStatementAsExpression
   blockWithPrefix
-  convertNamedImportsToObjectExpression
+  convertNamedImportsToObject
   convertObjectToJSXAttributes
   dedentBlockString
   dedentBlockSubstitutions

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -65,6 +65,7 @@ import {
 } from ./block.civet
 
 import {
+  dynamizeImportDeclaration
   prependStatementExpressionBlock
   processAssignmentDeclaration
   processDeclarationConditions
@@ -1311,6 +1312,7 @@ export {
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
+  dynamizeImportDeclaration
   expressionizeTypeIf
   forRange
   gatherBindingCode

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -66,6 +66,7 @@ import {
 
 import {
   dynamizeImportDeclaration
+  dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
   processAssignmentDeclaration
   processDeclarationConditions
@@ -1313,6 +1314,7 @@ export {
   dedentBlockSubstitutions
   deepCopy
   dynamizeImportDeclaration
+  dynamizeImportDeclarationExpression
   expressionizeTypeIf
   forRange
   gatherBindingCode

--- a/test/function.civet
+++ b/test/function.civet
@@ -1066,13 +1066,24 @@ describe "function", ->
     """
 
     testCase """
+      renamed declaration
+      ---
+      ->
+        {x: y} := obj
+      ---
+      (function() {
+        const {x: y} = obj;return {y}
+      })
+    """
+
+    testCase """
       complex declaration
       ---
       ->
         [ { x: other, y = init, ...r, }, z = 0, ...rest ] := list
       ---
       (function() {
-        const [ { x: other, y = init, ...r }, z = 0, ...rest ] = list;return [ { x, y, ...r }, z, ...rest ]
+        const [ { x: other, y = init, ...r }, z = 0, ...rest ] = list;return [ { other, y, ...r }, z, ...rest ]
       })
     """
 

--- a/test/import.civet
+++ b/test/import.civet
@@ -312,6 +312,17 @@ describe "import", ->
     """
 
     testCase """
+      dynamic import declaration with assertion
+      ---
+      =>
+        import foo from bar with type: 'json'
+      ---
+      async () => {
+        const foo = await import("bar", {with:{type: 'json'}});return foo
+      }
+    """
+
+    testCase """
       dynamic import declaration expression
       ---
       fs := import { readFileSync, writeFile as wf, writeFileSync: wfs } from fs
@@ -323,6 +334,14 @@ describe "import", ->
       dynamic import declaration expression with type
       ---
       fs := import { type File } from fs
+    """
+
+    testCase """
+      dynamic import declaration expression with assertion
+      ---
+      data := import { version } from package.json with type: 'json'
+      ---
+      let ref;const data = (ref = await import("package.json", {with:{type: 'json'}}),{version:ref.version})
     """
 
   for keyword of ['assert', 'with']

--- a/test/import.civet
+++ b/test/import.civet
@@ -271,10 +271,21 @@ describe "import", ->
       dynamic import declaration, full
       ---
       =>
-        import foo from bar
+        import * as foo from bar
       ---
       async () => {
         const foo = await import("bar");return foo
+      }
+    """
+
+    testCase """
+      dynamic import declaration, full
+      ---
+      =>
+        import foo from bar
+      ---
+      async () => {
+        const foo = (await import("bar")).default;return foo
       }
     """
 
@@ -285,7 +296,7 @@ describe "import", ->
         foo from bar
       ---
       async () => {
-        const foo = await import ("bar");return foo
+        const foo = (await import ("bar")).default;return foo
       }
     """
 
@@ -307,7 +318,7 @@ describe "import", ->
         foo, {a, b:c, d as e} from bar
       ---
       async () => {
-        const foo = await import ("bar"), {a,b:c,d:e} = foo;return {a,c,e}
+        const ref = await import ("bar"), foo = ref.default, {a,b:c,d:e} = ref;return {a,c,e}
       }
     """
 
@@ -318,7 +329,7 @@ describe "import", ->
         import foo from bar with type: 'json'
       ---
       async () => {
-        const foo = await import("bar", {with:{type: 'json'}});return foo
+        const foo = (await import("bar", {with:{type: 'json'}})).default;return foo
       }
     """
 

--- a/test/import.civet
+++ b/test/import.civet
@@ -238,6 +238,7 @@ describe "import", ->
       } from "typescript"
     """
 
+  describe "dynamic import", ->
     testCase """
       dynamic import
       ---
@@ -264,6 +265,50 @@ describe "import", ->
       await import("./x.js")
       const promise = import("./x.js")
       fetch = () => import("./x.js")
+    """
+
+    testCase """
+      dynamic import declaration, full
+      ---
+      =>
+        import foo from bar
+      ---
+      async () => {
+        const foo = await import("bar");return foo
+      }
+    """
+
+    testCase """
+      dynamic import declaration, implicit
+      ---
+      =>
+        foo from bar
+      ---
+      async () => {
+        const foo = await import ("bar");return foo
+      }
+    """
+
+    testCase """
+      dynamic import declaration, named
+      ---
+      =>
+        {a, b:c, d as e} from bar
+      ---
+      async () => {
+        const {a,b:c,d:e} = await import ("bar");return {a,c,e}
+      }
+    """
+
+    testCase """
+      dynamic import declaration, full and named
+      ---
+      =>
+        foo, {a, b:c, d as e} from bar
+      ---
+      async () => {
+        const foo = await import ("bar"), {a,b:c,d:e} = foo;return {a,c,e}
+      }
     """
 
     testCase """

--- a/test/import.civet
+++ b/test/import.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "import", ->
   testCase """
@@ -264,6 +264,20 @@ describe "import", ->
       await import("./x.js")
       const promise = import("./x.js")
       fetch = () => import("./x.js")
+    """
+
+    testCase """
+      dynamic import declaration expression
+      ---
+      fs := import { readFileSync, writeFile as wf, writeFileSync: wfs } from fs
+      ---
+      let ref;const fs = (ref = await import("fs"),{readFileSync:ref.readFileSync,wf:ref.writeFile,wfs:ref.writeFileSync})
+    """
+
+    throws """
+      dynamic import declaration expression with type
+      ---
+      fs := import { type File } from fs
     """
 
   for keyword of ['assert', 'with']


### PR DESCRIPTION
Fixes #727:
* `import { getX } from library` → `const { getX } = await import('library')` if not at the top level
* `import lib, {getX} from library` → `const lib = await import('library'), {getX} = lib` if not at the top level
* `stuff := import { getX, getY } from library` → `const stuff = (await import('library')).{getX, getY}`

This complements existing functionality of `stuff := import 'library'` → `stuff := import('library')`. Note that `stuff := import library` has a different meaning than above (use the variable `library` instead of the string).

~~I haven't implemented `assert`/`with` yet. I probably should...~~ Import assertions via `assert`/`with` should work now.

Also fixes a bug where `{x: y} := obj` got implicitly returned as `{x}`, but it should be `{y}` (!).