### PR TITLE
Hoist declarations out of async wrapper and other cleanup

### DIFF
--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -35,10 +35,11 @@ onmessage = async (e) => {
 
   let jsCode = '';
   if (jsOutput) {
-    // Wrap in IIFE if there's a top-level await
+    // Wrap in IIFE if there's a top-level await or import
     // Use Civet's async do, so Civet does implicit return of last value
     try {
-      const topLevelAwait = Civet.lib.hasAwait(ast)
+      const topLevelAwait = Civet.lib.hasAwait(ast) ||
+        Civet.lib.hasImportDeclaration(ast)
       if (topLevelAwait) {
         const [prologue, rest] = Civet.parse(code,
           {startRule: 'ProloguePrefix'})

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -282,10 +282,7 @@ export function repl(options: Options)
         // Wrap in IIFE if there's a top-level await
         // Use Civet's async do, so Civet does implicit return of last value
         // (copied from playground.worker.js)
-        topLevelAwait := lib.gatherRecursive(ast,
-          .type is 'Await',
-          lib.isFunction
-        ).length > 0
+        topLevelAwait := lib.hasAwait ast
         if topLevelAwait
           [prologue, rest] := parse input, startRule: 'ProloguePrefix'
           prefix := input.slice 0, -rest.length
@@ -297,6 +294,14 @@ export function repl(options: Options)
             rest.replace(/^/gm, ' ') +
             (coffee ? ')' : ''),
             {...options, filename, ast: true}
+          // Hoist top-level declarations outside the IIFE wrapper
+          lib.gatherRecursive ast, .type is 'BlockStatement'
+          .forEach (topBlock) =>
+            lib.gatherRecursiveWithinFunction topBlock, .type is 'Declaration'
+            .forEach (decl) =>
+              type := decl.children.shift() // const/let/var
+              ast = [ast] unless Array.isArray ast
+              ast.unshift `var ${decl.names.join ','};`
 
         errors: unknown[] := []
         try
@@ -322,11 +327,13 @@ export function repl(options: Options)
         if topLevelAwait
           // If there was a top-level await, the result is a promise
           // that we need to await before returning it.
+          let threw = false
           try
             result = await result
           catch error
+            threw = true
             callback error as Error, undefined
-          callback null, result
+          callback null, result unless threw
         else
           callback null, result
       else  // still reading

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -279,10 +279,10 @@ export function repl(options: Options)
 
         ast .= compile input, {...options, filename, ast: true}
 
-        // Wrap in IIFE if there's a top-level await
+        // Wrap in IIFE if there's a top-level await or import
         // Use Civet's async do, so Civet does implicit return of last value
         // (copied from playground.worker.js)
-        topLevelAwait := lib.hasAwait ast
+        topLevelAwait := lib.hasAwait(ast) or lib.hasImportDeclaration(ast)
         if topLevelAwait
           [prologue, rest] := parse input, startRule: 'ProloguePrefix'
           prefix := input.slice 0, -rest.length

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -9,7 +9,7 @@ type Options =
   js?: boolean
   errors?: unknown[]
 
-gen := (node: any, options: Options): string ->
+function gen(node: any, options: Options): string
   if node is null or node is undefined
     return ""
 
@@ -60,7 +60,7 @@ export default gen
 // Remove empty arrays, empty string, null, undefined from node tree
 // Useful for debugging so I don't need to step though tons of empty nodes
 // Also remove parent pointers so we can JSON.stringify the tree
-export prune := (node: any): any ->
+export function prune(node: any): any
   if node is null or node is undefined
     return
 

--- a/source/main.civet
+++ b/source/main.civet
@@ -60,7 +60,7 @@ export type CompilerOptions
   filename?: string
   sourceMap?: boolean
   inlineMap?: boolean
-  ast?: boolean
+  ast?: boolean | "raw"
   js?: boolean
   noCache?: boolean
   hits?: string
@@ -98,10 +98,11 @@ export compile := (src: string, options?: CompilerOptions) ->
   try
     //@ts-ignore
     parse.config = options.parseOptions or {}
-    ast = prune parse(src, {
+    ast = parse(src, {
       filename
       events
     })
+    ast = prune ast unless options.ast is "raw"
   finally
     if hits or trace
       import('fs').then ({ writeFileSync }) ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2441,11 +2441,12 @@ NonSingleBracedBlock
   ImplicitNestedBlock
 
   # Immediate nested object literal
-  InsertOpenBrace NestedImplicitObjectLiteral:s InsertCloseBrace ->
+  InsertOpenBrace:o NestedImplicitObjectLiteral:s InsertCloseBrace:c ->
+    const expressions = [s]
     return {
       type: "BlockStatement",
-      expressions: [s],
-      children: $0,
+      expressions,
+      children: [o, expressions, c],
     }
 
 DeclarationOrStatement

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -41,26 +41,29 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
       children: block.children is block.expressions ? expressions :
         block.children.map((c) => c is block.expressions ? expressions : c),
     }
-    // Add braces if block lacked them
-    if block.bare
-      // Now copied, so mutation is OK
-      block.children = [[" {"], ...block.children, "}"]
-      block.bare = false
+    braceBlock block
 
     updateParentPointers block
 
   return block
 
+// Add braces if block lacks them
 function braceBlock(block: BlockStatement)
   if block.bare
+    if block.children is block.expressions
+      block.children = [block.expressions]
     block.children.unshift(" {")
     block.children.push("}")
     block.bare = false
 
 function duplicateBlock(block: BlockStatement): BlockStatement
   expressions := [...block.expressions]
-  children := [...block.children]
-  children.splice(children.indexOf(block.expressions), 1, expressions)
+  let children
+  if block.children is block.expressions
+    children = expressions
+  else
+    children = [...block.children]
+    children.splice(children.indexOf(block.expressions), 1, expressions)
   return {
     ...block,
     expressions,

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -528,9 +528,8 @@ function expressionizeIteration(exp: IterationExpression): void
     throw new Error("Could not find iteration statement in iteration expression")
 
   if subtype is "DoStatement"
-    // Just wrap with IIFE
-    insertReturn(block)
-    children.splice(i, 1, ...wrapIIFE(["", statement, undefined], async))
+    // Just wrap with IIFE; insertReturn will apply to the resulting function
+    children.splice(i, 1, ...wrapIIFE([["", statement, undefined]], async))
     updateParentPointers exp
     return
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -30,6 +30,7 @@ import type {
 import {
   gatherRecursive
   gatherRecursiveAll
+  gatherRecursiveWithinFunction
 } from ./traversal.civet
 
 import {
@@ -1320,6 +1321,8 @@ export {
   forRange
   gatherBindingCode
   gatherRecursive
+  gatherRecursiveAll
+  gatherRecursiveWithinFunction
   getIndentLevel
   getPrecedence
   getTrimmingSpace

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -39,6 +39,7 @@ import {
   deepCopy
   getTrimmingSpace
   hasAwait
+  hasImportDeclaration
   hasYield
   insertTrimmingSpace
   isComma
@@ -1327,6 +1328,7 @@ export {
   getPrecedence
   getTrimmingSpace
   hasAwait
+  hasImportDeclaration
   hasYield
   insertTrimmingSpace
   isEmptyBareBlock

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -410,10 +410,11 @@ function parenthesizeType(type: ASTNodeBase)
  * uses await, or just adding async if specified.
  * Returns an Array suitable for `children`.
  */
-function wrapIIFE(expressions: StatementTuple[], async?: string): ASTNode[]
+function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean): ASTNode[]
   let prefix
 
-  if async
+  let async
+  if asyncFlag
     async = "async "
   else if hasAwait expressions
     async = "async "

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -212,12 +212,16 @@ function startsWith(target: ASTNodeBase, value: RegExp)
 
 /**
  * Does this expression have an `await` in it and thus needs to be `async`?
+ * Skips over nested functions, which have their own async behavior.
  */
 function hasAwait(exp)
   gatherRecursiveWithinFunction(exp, ({ type }) => type is "Await").length > 0
 
 function hasYield(exp)
   gatherRecursiveWithinFunction(exp, ({ type }) => type is "Yield").length > 0
+
+function hasImportDeclaration(exp)
+  gatherRecursiveWithinFunction(exp, ({ type }) => type is "ImportDeclaration").length > 0
 
 function deepCopy(node: ASTNode): ASTNode {
   if (node == null) return node
@@ -477,6 +481,7 @@ export {
   deepCopy
   getTrimmingSpace
   hasAwait
+  hasImportDeclaration
   hasYield
   insertTrimmingSpace
   isComma

--- a/test/do.civet
+++ b/test/do.civet
@@ -173,6 +173,14 @@ describe "do", ->
   """
 
   testCase """
+    async do one-line declaration
+    ---
+    async do len := (await getList()).length
+    ---
+    (async ()=>{{ const len = (await getList()).length;return len }})()
+  """
+
+  testCase """
     async do
     ---
     async do

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -32,8 +32,13 @@ declare module "@danielx/civet" {
   }>
   export type CompileOptions = {
     filename?: string
-    js?: boolean
     sourceMap?: boolean
+    inlineMap?: boolean
+    ast?: boolean | "raw"
+    js?: boolean
+    noCache?: boolean
+    hits?: string
+    trace?: string
     parseOptions?: ParseOptions
   }
 


### PR DESCRIPTION
Previously, top-level `await` in the CLI or Playground caused code to get wrapped in a wrapper that hid all declared variables. This PR hoists those declarations into top-level `var`s so that they can get accessed in future operations. (It does lose the `const`/`let`ness of the variables, but this seems a far better loss, and `const` is mostly annoying in a REPL environment.)

As a bonus, top-level `import` declarations also get wrapped to use the new dynamic import declarations, so they appear to just work as usual. You can now `fs from fs` in the CLI and then access `fs.readFileSync` in the next operation. Take that, Node REPL! (`import fs from 'fs'` fails in Node, with an error message to suggest instead writing `const { default: fs } = await import("fs");`)

Along the way, I did some cleanup that ended up not being relevant, but seems worth including:
* Blocks are more consistent about keeping `expressions` in the `children`
* Removed `insertReturn` that sometimes caused a double `return` at the end of an `async do` block, once `do` blocks made a correct call to `wrapIIFE`.
* Added `ast: "raw"` option to return raw AST. Took me a long time to understand why length-1 arrays were getting unarrayed until I remembered that the returned AST was pruned. I didn't end up using an unpruned AST, but it could be useful for dealing with `expressions` for example.
* Added more compiler options to `types.d.ts`