### PR TITLE
Optional dot before #

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -315,23 +315,22 @@ console.log ```
 
 ## Length Shorthand
 
-The property access `.#` in is short for `.length`:
+The property access `.#` or just `#` is short for `.length`:
 
 <Playground>
 array.#
+array#
 "a string also".#
 </Playground>
 
 On its own, `#` is shorthand for `this.length`:
 
 <Playground>
-function push(item)
-  @[#] = item
-</Playground>
-
-<Playground>
-function wrap(index)
-  @[index %% #]
+class List
+  push(item)
+    @[#] = item
+  wrap(index)
+    @[index %% #]
 </Playground>
 
 `# in` checks for the `"length"` property:
@@ -1512,6 +1511,8 @@ message := console@log "[MSG] "
 
 [Private class fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
 do not need an explicit `this.` or `@` prefix.
+When accessing a private field of another object,
+you can rewrite `#` in place of `.#`.
 
 <Playground>
 class Counter
@@ -1519,7 +1520,7 @@ class Counter
   increment(): void
     #count++
   add(other: Counter): void
-    #count += other.#count if #count in other
+    #count += other#count if #count in other
   set(#count)
 </Playground>
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -983,6 +983,7 @@ FieldDefinition
 
 ThisLiteral
   This
+  HashThis
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
   AtThis:at $( Hash? IdentifierName ):id ->
@@ -996,7 +997,6 @@ ThisLiteral
       thisShorthand: true,
     }
   AtThis
-  HashThis
 
 # Adds a #id -> this.#id shorthand as a "HashThis" literal in most cases
 # with the exception of keeping `#a in b` as is for branded in checks.
@@ -1004,12 +1004,12 @@ ThisLiteral
 # This is slightly different from how https://262.ecma-international.org/#sec-relational-operators handles relational operators
 # grammatically but should be equivalent in practice
 HashThis
-  LengthShorthand:id ( &( _+ ( ( Not __ In ) / In ) ) "" )?:beforeIn ->
-    if (beforeIn != null) return [ '"', id.name, '"' ]
+  AtThis?:at LengthShorthand:id ( &( _ ( Not __ )? ActualIn ) "" )?:beforeIn ->
+    if (beforeIn != null && at == null) return [ '"', id.name, '"' ]
 
     return {
       type: "MemberExpression",
-      children: ["this", {
+      children: [at ?? "this", {
         type: "PropertyAccess",
         name: id.name,
         children: [".", id],
@@ -1017,7 +1017,7 @@ HashThis
       thisShorthand: true,
     }
 
-  PrivateIdentifier:id &( _+ ( ( Not __ In ) / In ) ) ->
+  PrivateIdentifier:id &( _ ( Not __ )? ActualIn ) ->
     return id
 
   PrivateIdentifier:id ->
@@ -3715,6 +3715,10 @@ BinaryOpSymbol
   "^"
   "|"
 
+ActualIn
+  CoffeeOfEnabled Of -> $2
+  !CoffeeOfEnabled In -> $2
+
 CoffeeOfOp
   Of -> "in"
   In ->
@@ -5746,10 +5750,6 @@ LetOrConst
 
 Const
   "const" NonIdContinue ->
-    return { $loc, token: $1 }
-
-In
-  "in" NonIdContinue ->
     return { $loc, token: $1 }
 
 Is

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1163,7 +1163,7 @@ MemberBase
 
 MemberExpressionRest
   # perf: assertion to exit early
-  /(?=[\/\[{?.!@'’:])/ InlineComment*:comments MemberExpressionRestBody:body ->
+  /(?=[\/\[{?.!@#'’:])/ InlineComment*:comments MemberExpressionRestBody:body ->
     if (Array.isArray(body)) return [...comments, ...body]
     return {
       ...body,
@@ -1279,11 +1279,17 @@ SliceParameters
 
 AccessStart
   PropertyAccessModifier?:modifier Dot:dot !Dot ->
-    let children = modifier ? [modifier, dot] : [dot]
-
     return {
       type: "AccessStart",
-      children,
+      children: modifier ? [modifier, dot] : [dot],
+      optional: modifier?.token === "?",
+    }
+
+ImplicitAccessStart
+  PropertyAccessModifier?:modifier InsertDot:dot !Dot ->
+    return {
+      type: "AccessStart",
+      children: modifier ? [modifier, dot] : [dot],
       optional: modifier?.token === "?",
     }
 
@@ -1325,13 +1331,19 @@ PropertyAccess
     }
 
   AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
-    const children = [dot, ...comments, ...id.children]
-
     return {
       type: "PropertyAccess",
       name: id.name,
       dot,
-      children,
+      children: [ dot, ...comments, ...id.children ],
+    }
+
+  ImplicitAccessStart:dot ( PrivateIdentifier / LengthShorthand ):id ->
+    return {
+      type: "PropertyAccess",
+      name: id.name,
+      dot,
+      children: [ dot, ...id.children ],
     }
 
   # NOTE: Added CoffeeScript :: prototype shorthand only when enabled

--- a/test/class.civet
+++ b/test/class.civet
@@ -79,6 +79,23 @@ describe "class", ->
   """
 
   testCase """
+    private field this shorthand with coffeeOf
+    ---
+    'civet coffeeOf'
+    class X
+      #count = 0
+      isX(other)
+        #count of other
+    ---
+    class X {
+      #count = 0
+      isX(other) {
+        return #count in other
+      }
+    }
+  """
+
+  testCase """
     function field
     ---
     class X

--- a/test/class.civet
+++ b/test/class.civet
@@ -96,6 +96,22 @@ describe "class", ->
   """
 
   testCase """
+    private field this shorthand without dot
+    ---
+    class X
+      #count = 0
+      isPositive(other)
+        other#count
+    ---
+    class X {
+      #count = 0
+      isPositive(other) {
+        return other.#count
+      }
+    }
+  """
+
+  testCase """
     function field
     ---
     class X

--- a/test/length-shorthand.civet
+++ b/test/length-shorthand.civet
@@ -52,9 +52,33 @@ describe "length shorthand", ->
   """
 
   testCase """
+    property access without dot
+    ---
+    array#
+    ---
+    array.length
+  """
+
+  testCase """
+    optional property access without dot
+    ---
+    array?#
+    ---
+    array?.length
+  """
+
+  testCase """
     property access chain
     ---
     array.#.toString()
+    ---
+    array.length.toString()
+  """
+
+  testCase """
+    property access chain without dot
+    ---
+    array#.toString()
     ---
     array.length.toString()
   """

--- a/test/length-shorthand.civet
+++ b/test/length-shorthand.civet
@@ -11,9 +11,34 @@ describe "length shorthand", ->
   """
 
   testCase """
+    @#
+    ---
+    @#
+    ---
+    this.length
+  """
+
+  testCase """
+    @# in x
+    ---
+    @# in x
+    ---
+    this.length in x
+  """
+
+  testCase """
     # in x
     ---
     # in x
+    ---
+    "length" in x
+  """
+
+  testCase """
+    # of x
+    ---
+    'civet coffeeOf'
+    # of x
     ---
     "length" in x
   """


### PR DESCRIPTION
Fixes #1125, and part of #909 
* `@#` → `this.length`
* `array#` → `array.length`
* `object#field` → `object.#field`
