### PR TITLE
Prevent `...` as array element in right-hand side

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2817,15 +2817,14 @@ ArrayElementExpression
   JSXTag
   ImplicitObjectLiteral &ArrayElementDelimiter -> $1
   # NOTE: Allow for postfix splat like CoffeeScript
-  # NOTE: Allow empty exp spread for destructuring
-  ExtendedExpression?:exp __:ws DotDotDot:dots &ArrayElementDelimiter ->
+  ExtendedExpression:exp _?:ws DotDotDot:dots &ArrayElementDelimiter ->
     if (!exp) {
       exp = { ...makeRef(), names: [] }
     }
 
     return {
       type: "SpreadElement",
-      children: [...ws, dots, exp],
+      children: [ws, dots, exp],
       names: exp.names,
     }
 

--- a/test/array.civet
+++ b/test/array.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "array", ->
   testCase """
@@ -197,6 +197,12 @@ describe "array", ->
     y = [x...]
     ---
     y = [...x]
+  """
+
+  throws """
+    empty spread
+    ---
+    y = [...]
   """
 
   testCase """


### PR DESCRIPTION
Fixes #1132

The comment says `NOTE: Allow empty exp spread for destructuring` but I think this was before there was pattern matching, and a separate set of rules for left-hand sides where `...` is still allowed. For example, `function f([a, ..., b])` is still allowed, as is `[a, ..., b] = c`. The latter has a bug, which I'll raise separately (#1139).

Let me know if you see a way that this could be relevant. It's at least not breaking any tests.