### PR TITLE
Nonnull checks in assignment conditions

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -80,6 +80,14 @@ while {data, next} := node
   node = next
 </Playground>
 
+You can check for nonnull instead of truthy values with a `?`:
+
+<Playground>
+sum .= 0
+while number? := next()
+  sum += number
+</Playground>
+
 ## Objects
 
 ### Unbraced Literals

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6922,11 +6922,12 @@ TypeSuffix
   # TypeScript has a special error for ! without : ("Declarations with definite
   # assignment assertions must also have type annotations.") but we parse it
   # so that the user can get this more useful error message.
-  NonNullAssertion _? (Colon MaybeIndentedType)?:ct ->
+  NonNullAssertion:nonnull _? (Colon MaybeIndentedType)?:ct ->
     const [colon, t] = ct ?? []
     return {
       type: "TypeSuffix",
       ts: true,
+      nonnull,
       t,
       children: [ $1, $2, colon, t ],
     }

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -193,10 +193,10 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
     ref = makeRef()
     grandparent := condition.parent?.parent
     children :=
-      // Check that the declaration is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
+      // Wrap declaration that is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
+      // to satisfy eslint's no-cond-assign rule
       // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
-      // @ts-ignore Just because pattern might not have a type at runtime doesn't mean it's unsafe
-      if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "WhileStatement")
+      if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "IterationStatement")
         ["(", ref, initializer, ")"]
       else
         [ref, initializer]

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -204,7 +204,8 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
 
     // `x? := ...` as a condition means `x := ..., x?`
     if nullCheck
-      children.push ", ", ref, " != null"
+      children.unshift "("
+      children.push ") != null"
       suffix = undefined
 
     Object.assign condition, {

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -177,7 +177,8 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
   { decl, bindings } := condition.declaration as DeclarationStatement
   // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
   binding := bindings[0]
-  { pattern, suffix, initializer, splices, thisAssignments } := binding
+  { pattern, suffix, initializer, splices, thisAssignments } .= binding
+  nullCheck := suffix?.optional and not suffix.t and not suffix.nonnull
 
   let ref = prependStatementExpressionBlock(initializer!, parent)
 
@@ -196,10 +197,15 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
       // Wrap declaration that is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
       // to satisfy eslint's no-cond-assign rule
       // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
-      if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "IterationStatement")
+      if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "IterationStatement") and not nullCheck
         ["(", ref, initializer, ")"]
       else
         [ref, initializer]
+
+    // `x? := ...` as a condition means `x := ..., x?`
+    if nullCheck
+      children.push ", ", ref, " != null"
+      suffix = undefined
 
     Object.assign condition, {
       type: "AssignmentExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -374,6 +374,7 @@ export type TypeSuffix =
   type: "TypeSuffix"
   ts: true
   optional?: ASTNode
+  nonnull?: ASTNode
   t?: ASTNode
   children: Children
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -753,7 +753,7 @@ describe "if", ->
       if m? := s.match(re)
         s
       ---
-      let ref;if (ref= s.match(re), ref != null) {
+      let ref;if ((ref= s.match(re)) != null) {
         const m = ref;
         s
       }
@@ -766,7 +766,7 @@ describe "if", ->
         p1 + p2
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
-      let ref;if ((ref= s.match(re), ref != null) && Array.isArray(ref) && len(ref, 3)) {
+      let ref;if (((ref= s.match(re)) != null) && Array.isArray(ref) && len(ref, 3)) {
         const [p0, p1, p2] = ref;
         p1 + p2
       }

--- a/test/if.civet
+++ b/test/if.civet
@@ -748,6 +748,31 @@ describe "if", ->
     """
 
     testCase """
+      if declaration with nonnull check
+      ---
+      if m? := s.match(re)
+        s
+      ---
+      let ref;if (ref= s.match(re), ref != null) {
+        const m = ref;
+        s
+      }
+    """
+
+    testCase """
+      if declaration with complex nonnull check
+      ---
+      if [p0, p1, p2]? := s.match(re)
+        p1 + p2
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      let ref;if ((ref= s.match(re), ref != null) && Array.isArray(ref) && len(ref, 3)) {
+        const [p0, p1, p2] = ref;
+        p1 + p2
+      }
+    """
+
+    testCase """
       if declaration with comments
       ---
       if [_, s]/*left*/:=/*right*/s.match(re)

--- a/test/while.civet
+++ b/test/while.civet
@@ -138,7 +138,7 @@ describe "while", ->
       while node? := next()
         node.visit()
       ---
-      let ref;while (ref= next(), ref != null) {
+      let ref;while ((ref= next()) != null) {
         const node = ref;
         node.visit()
       }
@@ -150,7 +150,7 @@ describe "while", ->
       while {x, y}? := next()
         x++
       ---
-      let ref;while ((ref= next(), ref != null) && 'x' in ref && 'y' in ref) {
+      let ref;while (((ref= next()) != null) && 'x' in ref && 'y' in ref) {
         const {x, y} = ref;
         x++
       }

--- a/test/while.civet
+++ b/test/while.civet
@@ -133,6 +133,30 @@ describe "while", ->
     """
 
     testCase """
+      while with nonnull check
+      ---
+      while node? := next()
+        node.visit()
+      ---
+      let ref;while (ref= next(), ref != null) {
+        const node = ref;
+        node.visit()
+      }
+    """
+
+    testCase """
+      while with complex nonnull check
+      ---
+      while {x, y}? := next()
+        x++
+      ---
+      let ref;while ((ref= next(), ref != null) && 'x' in ref && 'y' in ref) {
+        const {x, y} = ref;
+        x++
+      }
+    """
+
+    testCase """
       until
       ---
       until item := next()

--- a/test/while.civet
+++ b/test/while.civet
@@ -109,6 +109,18 @@ describe "while", ->
 
   describe "condition decs", ->
     testCase """
+      simple while
+      ---
+      while item := next()
+        item++
+      ---
+      let ref;while ((ref = next())) {
+        const item = ref;
+        item++
+      }
+    """
+
+    testCase """
       while
       ---
       while {x, y} := next()


### PR DESCRIPTION
New functionality to check for nonnull instead of truthy assignment conditions:

```js
if number? := next()
↓↓↓
let ref;if (ref = next(), ref != number) {
  const number = ref
```

Note that `number?: T :=` still means `const number: T | undefined =`. This is assigning a new meaning to the special case where `?` appears but no type annotation appears.

`if [x, y]? := foo` also works, but isn't really helpful, because the array test means that truthy and nonnull are the same. Similarly for `if {x, y}? := foo`. But they do parse fine and replace a truthy check with a nonnull check.

Fixes #1131