### PR TITLE
Late arrow functions like late assignments

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -396,12 +396,8 @@ SingleLineBinaryOpRHS
     return [ws1 || [], op, ws2, rhs]
 
 RHS
-  ParenthesizedAssignment
   UnaryExpression
   ExpressionizedStatementWithTrailingCallExpressions
-
-ParenthesizedAssignment
-  InsertOpenParen ActualAssignment InsertCloseParen
 
 # https://262.ecma-international.org/#prod-UnaryExpression
 UnaryExpression
@@ -435,6 +431,11 @@ UnaryWithoutParenthesizedAssignmentBody
   UpdateExpression
   ExpressionizedStatementWithTrailingCallExpressions
   NestedNonAssignmentExtendedExpression
+
+# NOTE: Parts of AssignmentExpression (specifically AssignmentExpressionTail)
+# that make sense as a UnaryBody, e.g. as the RHS of a binary op like `??`
+ParenthesizedAssignment
+  InsertOpenParen ( ActualAssignment / ArrowFunction ) InsertCloseParen
 
 UnaryPostfix
   QuestionMark

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -544,6 +544,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    arrow function fallbacks
+    ---
+    callback ?? (x) => console.log 'finished:', x
+    ---
+    callback ?? ((x) => console.log('finished:', x))
+  """
+
+  testCase """
     instanceof
     ---
     a instanceof b

--- a/test/unary-expression.civet
+++ b/test/unary-expression.civet
@@ -86,6 +86,14 @@ describe "unary expression", ->
   """
 
   testCase """
+    late arrow function
+    ---
+    typeof (x) => x
+    ---
+    typeof ((x) => x)
+  """
+
+  testCase """
     expressionized statement
     ---
     !debugger


### PR DESCRIPTION
Fixes #1127 as described in comment there.

`Assignment` and `ArrowFunction` are both part of `AssignmentExpressionTail` so I kept the "assignment" naming scheme.

I also noticed that both `RHS` and `UnaryBody` both derive to `ParenthesizedAssignment`, but this seems to be redundant, unless we wanted unary operators to be pulled into the assignment, but that's not currently possible (e.g. `+x = 5` → `+(x = 5)` even now). So I removed the `RHS` derivation.