### PR TITLE
Fix ASI bug caused by unstructured blockPrefix

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1256,6 +1256,12 @@ for let item of list
   console.log item
 </Playground>
 
+<Playground>
+for var item of list
+  console.log item
+console.log "Last item:", item
+</Playground>
+
 You can also keep track of the current index of the iteration
 by specifying a comma and a second variable (also defaulting to `const`):
 

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -61,7 +61,7 @@ function forRange(
       // TODO: missing indentation
       value := "StringLiteral" is start.subtype ? ["String.fromCharCode(", counterRef, ")"] : counterRef
       blockPrefix = [
-        ["", forDeclaration, " = ", value, ";"]
+        ["", [forDeclaration, " = ", value], ";"]
       ]
   else if forDeclaration // Coffee-style for loop
     varAssign = varLetAssign = [forDeclaration, " = "]

--- a/test/for.civet
+++ b/test/for.civet
@@ -135,6 +135,18 @@ describe "for", ->
   """
 
   testCase """
+    range with parenthetical inside
+    ---
+    for i of [1..10]
+      (i)
+    ---
+    for (let i1 = 1; i1 <= 10; ++i1) {
+      const i = i1;
+      (i)
+    }
+  """
+
+  testCase """
     range without declaration
     ---
     for [1..10]


### PR DESCRIPTION
Input:
```coffee
for i of [1..10]
  (i)
```
Previous output:
```js
for (let i1 = 1; i1 <= 10; ++i1) {
  const i; = i1;
  (i)
}
```
Output with this PR:
```js
for (let i1 = 1; i1 <= 10; ++i1) {
  const i = i1;
  (i)
}
```