### PR TITLE
Fix #1043 - Add missing unary numeric and undefined pin patterns in switch

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1630,6 +1630,20 @@ PinPattern
       children: [expression],
       expression,
     }
+  # Handle unary numeric in switch patterns
+  ([+-] NumericLiteral):expression ->
+    return {
+      type: "PinPattern",
+      children: [expression],
+      expression,
+    }
+  # Handle undefined in switch patterns
+  Undefined:expression ->
+    return {
+      type: "PinPattern",
+      children: [expression],
+      expression,
+    }
 
 # https://262.ecma-international.org/#prod-BindingPattern
 BindingPattern
@@ -5930,6 +5944,10 @@ Try
 
 Typeof
   "typeof" NonIdContinue ->
+    return { $loc, token: $1 }
+
+Undefined
+  "undefined" NonIdContinue ->
     return { $loc, token: $1 }
 
 Unless

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -550,6 +550,25 @@ describe "switch", ->
     """
 
     testCase """
+      unary numbers and undefined
+      ---
+      switch x
+        -1
+          "negative"
+        +1
+          "positive"
+        undefined
+          "undefined"
+      ---
+      if(x === -1) {
+          "negative"}
+      else if(x === +1) {
+          "positive"}
+      else if(x === undefined) {
+          "undefined"}
+    """
+
+    testCase """
       multiple non-binding cases
       ---
       switch x


### PR DESCRIPTION
There may be a better way to handle the unification of unary numeric literals but this seems good for now.