### PR TITLE
Partial application placeholders

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -32,7 +32,9 @@ import {
   isWhitespaceOrEmpty,
   lastAccessInCallExpression,
   literalValue,
+  makeAmpersandBlockRHSBody,
   makeAmpersandFunction,
+  makeAmpersandFunctionExpression,
   makeEmptyBlock,
   makeExpressionStatement,
   makeGetterMethod,
@@ -2061,57 +2063,8 @@ AmpersandFunctionExpression
   UnaryOp*:prefix ( Ampersand / ( !NumericLiteral &( QuestionMark? Dot !Dot ) ) ) AmpersandBlockRHS?:rhs ->
     if (!prefix.length && !rhs) return $skip
 
-    let body, ref, typeSuffix
+    return makeAmpersandFunctionExpression(prefix, rhs)
 
-    // Only unary ops
-    if (!rhs) {
-      body = ref = makeRef("$")
-    } else {
-      ({ref, typeSuffix} = rhs)
-      if (!ref) {
-        throw new Error("Could not find ref in ampersand shorthand block")
-      }
-      body = rhs
-    }
-    if (prefix.length) {
-      body = {
-        type: "UnaryExpression",
-        children: [ processUnaryExpression(prefix, body, undefined) ]
-      }
-    }
-
-    const parameters = {
-      type: "Parameters",
-      children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref],
-      names: [],
-    }
-    const expressions = [body]
-    const block = {
-      bare: true,
-      expressions,
-      children: [expressions],
-    }
-
-    const children = [ parameters, " => ", block ]
-    const async = hasAwait(body)
-    if (async) {
-      children.unshift("async ")
-    }
-
-    return {
-      type: "ArrowFunction",
-      signature: {
-        modifier: {
-          async,
-        },
-      },
-      children,
-      ref,
-      body,
-      ampersandBlock: true,
-      block,
-      parameters,
-    }
 
 # NOTE: Dynamic infix operators
 OperatorDeclaration
@@ -2201,51 +2154,8 @@ AmpersandTypeSuffix
 AmpersandBlockRHSBody
   AmpersandTypeSuffix?:typeSuffix (!_ CallExpressionRest+ )?:callExpRest UnaryPostfix?:unaryPostfix ( WAssignmentOp ( NotDedented UpdateExpression WAssignmentOp )* NonPipelineExtendedExpression )?:assign ( ![&] BinaryOpRHS+ )?:binopRHS ->
     if (!typeSuffix && !callExpRest && !binopRHS && !unaryPostfix) return $skip
-    const ref = makeRef("$")
 
-    let exp = {
-      type: "AmpersandRef",
-      children: [ref],
-      names: [],
-      ref,
-    }
-
-    if (callExpRest) {
-      exp.children.push(...callExpRest[1])
-    }
-
-    if (unaryPostfix) {
-      exp = processUnaryExpression([], exp, unaryPostfix)
-    }
-
-    if (assign) {
-      // Based on ActualAssignment
-      const [op1, more, rhs] = assign
-      const lhs = [
-        [undefined, exp, ...op1],
-        ...more.map((x) => [x[0], x[1], ...x[2]]),
-      ]
-      exp = {
-        type: "AssignmentExpression",
-        children: [lhs, rhs],
-        names: null,
-        lhs,
-        assigned: exp,
-        exp: rhs,
-      }
-    }
-
-    if (binopRHS) {
-      exp = {
-        children: processBinaryOpExpression([exp, binopRHS[1]]),
-      }
-    }
-
-    // Put at top level for AmpersandFunctionExpression to process
-    exp.ref = ref
-    exp.typeSuffix = typeSuffix
-
-    return exp
+    return makeAmpersandBlockRHSBody(typeSuffix, callExpRest, unaryPostfix, assign, binopRHS)
 
 ThinArrowFunction
   ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:suffix _? Arrow:arrow NoCommaBracedOrEmptyBlock:block ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3146,6 +3146,13 @@ ComputedPropertyName
       children: [ $1, expression, $4 ],
       implicit: true,
     }
+  InsertOpenBracket:open PartialPlaceholder:expression InsertCloseBracket:close ->
+    return {
+      type: "ComputedPropertyName",
+      expression,
+      children: [ open, expression, close ],
+      implicit: true,
+    }
 
 Decorator
   # Might want to disallow import, super, and return CallExpressions

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -713,6 +713,7 @@ PrimaryExpression
   ClassExpression
   RegularExpressionLiteral
   ParenthesizedExpression
+  PartialPlaceholder
   # https://facebook.github.io/jsx/#sec-jsx-PrimaryExpression
   # NOTE: Modified to parse multiple JSXElement/JSXFragments as one fragment
   JSXImplicitFragment
@@ -744,6 +745,13 @@ ParenthesizedExpression
       type: "ParenthesizedExpression",
       children: [ open, exp, ws, close ],
       expression: exp,
+    }
+
+PartialPlaceholder
+  Dot:dot !/(?:\p{ID_Continue}|[\u200C\u200D$.])/ ->
+    return {
+      type: "PartialPlaceholder",
+      children: [ dot ],
     }
 
 # https://262.ecma-international.org/#prod-ClassDeclaration

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -47,7 +47,9 @@ import {
   isFunction
   isWhitespaceOrEmpty
   literalValue
+  makeAmpersandBlockRHSBody
   makeAmpersandFunction
+  makeAmpersandFunctionExpression
   makeLeftHandSideExpression
   makeNode
   makeRef
@@ -1336,7 +1338,9 @@ export {
   isWhitespaceOrEmpty
   lastAccessInCallExpression
   literalValue
+  makeAmpersandBlockRHSBody
   makeAmpersandFunction
+  makeAmpersandFunctionExpression
   makeEmptyBlock
   makeExpressionStatement
   makeGetterMethod

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -28,6 +28,7 @@ import type {
 } from ./types.civet
 
 import {
+  findAncestor
   gatherRecursive
   gatherRecursiveAll
   gatherRecursiveWithinFunction
@@ -1057,6 +1058,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
 
   const { expressions: statements } = root
 
+  processPartialPlaceholders(statements)
   processNegativeIndexAccess(statements)
   processTypes(statements)
   processDeclarationConditions(statements, m.getRef)
@@ -1124,6 +1126,44 @@ function populateRefs(statements: ASTNode): void {
     })
   }
 }
+
+function processPartialPlaceholders(statements: StatementTuple[]): void
+  partialMap := new Map()
+
+  gatherRecursiveAll statements, .type is "PartialPlaceholder"
+  .forEach (exp) =>
+    { ancestor } .= findAncestor exp, (n) =>
+      switch n.type
+        case "Call"
+        case "ObjectExpression"
+        case "ArrayExpression"
+          return true
+      return false
+
+    if ancestor
+      if ancestor.type is "Call"
+        ancestor = ancestor.parent
+
+      if partialMap.has ancestor
+        partialMap.get(ancestor).push exp
+      else
+        partialMap.set ancestor, [exp]
+
+  for [ancestor, placeholders] of partialMap
+    ref .= makeRef("$")
+
+    placeholders.forEach (exp) =>
+      replaceNode exp, ref
+
+    rhs := {
+      ref,
+      children: [ancestor]
+    }
+
+    fnExp := makeAmpersandFunctionExpression [], rhs
+    replaceNode ancestor, fnExp
+
+  return
 
 function reorderBindingRestProperty(props) {
   const names = props.flatMap((p) => p.names)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -22,6 +22,7 @@ import type {
   MemberExpression
   MethodDefinition
   ParseRule
+  PartialPlaceholder
   StatementExpression
   StatementTuple
   WSNode
@@ -1128,32 +1129,35 @@ function populateRefs(statements: ASTNode): void {
 }
 
 function processPartialPlaceholders(statements: StatementTuple[]): void
-  partialMap := new Map()
+  partialMap := new Map<ASTNodeBase, PartialPlaceholder[]>()
 
   gatherRecursiveAll statements, .type is "PartialPlaceholder"
-  .forEach (exp) =>
-    { ancestor } .= findAncestor exp, (n) =>
-      switch n.type
-        case "Call"
-        case "ObjectExpression"
-        case "ArrayExpression"
-          return true
-      return false
+  .forEach (_exp) =>
+    exp := _exp as! PartialPlaceholder
+    { ancestor } .= findAncestor exp, ?.type is "Call"
+
+    ancestor = ancestor?.parent
+
+    while ancestor?.parent?.type is "UnaryExpression"
+      ancestor = ancestor.parent
 
     if ancestor
-      if ancestor.type is "Call"
-        ancestor = ancestor.parent
-
       if partialMap.has ancestor
-        partialMap.get(ancestor).push exp
+        partialMap.get(ancestor)!.push exp
       else
         partialMap.set ancestor, [exp]
+    else
+      replaceNode exp, {
+        type: "Error"
+        message: "Partial placeholder outside of call expression"
+        exp.parent
+      }
 
   for [ancestor, placeholders] of partialMap
-    ref .= makeRef("$")
+    ref .= makeRef "$"
 
     placeholders.forEach (exp) =>
-      replaceNode exp, ref
+      replaceNode exp.children.-1, ref
 
     rhs := {
       ref,

--- a/source/parser/traversal.civet
+++ b/source/parser/traversal.civet
@@ -95,17 +95,16 @@ function gatherRecursive<T extends ASTNode, U extends T, V extends T>(node: T, p
 
   return gatherRecursive(node.children, predicate, skipPredicate)
 
-function gatherRecursiveAll<T extends ASTNode, U extends T>(node: T, predicate: Predicate<T, U>): U[]
+function gatherRecursiveAll<T extends ASTNode, U=NonNullable<T extends (infer U)[] ? U : T>>(node: T, predicate: Predicate<U, U>): U[]
   if (node == null) return []
 
-  if (Array.isArray(node)) {
-    return node.flatMap((n) => gatherRecursiveAll(n, predicate))
-  }
+  if Array.isArray node
+    return node.flatMap (n) => gatherRecursiveAll n, predicate
 
-  const nodes = gatherRecursiveAll(node.children, predicate)
-  if (predicate(node)) {
-    nodes.push(node)
-  }
+  nodes := gatherRecursiveAll node.children, predicate
+
+  if predicate node
+    nodes.push node
 
   return nodes
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -38,19 +38,21 @@ export type ExpressionNode =
   | ParenthesizedExpression
   | StatementExpression
   | TypeNode
+  | UnaryExpression
 
 /**
 * Other nodes that aren't statements or expressions.
 */
 export type OtherNode =
   | ASTError
-  | ASTRef
   | ASTLeaf
+  | ASTRef
   | AccessStart
   | Call
-  | Index
-  | PropertyAccess
   | CommentNode
+  | Index
+  | PartialPlaceholder
+  | PropertyAccess
 
 export type ASTNodeBase = ASTNode &
   parent: ASTNodeBase?
@@ -124,6 +126,11 @@ export type Existence
   expression: ASTNode
   children: Children
   parent: ASTNodeBase?
+
+export type UnaryExpression
+  type: "UnaryExpression"
+  children: Children
+  parent: ASTNodeBase
 
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 
@@ -327,6 +334,11 @@ export type BindingPattern = ObjectBindingPattern | ArrayBindingPattern | PinPat
 export type RegularExpressionLiteral = ASTLeaf & type: "RegularExpressionLiteral"
 
 export type ArrayBindingPattern = ASTNodeBase
+
+export type PartialPlaceholder =
+  type: "PartialPlaceholder"
+  children: Children
+  parent: ASTNodeBase?
 
 export type PinPattern = ASTNodeBase
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -582,6 +582,8 @@ function wrapWithReturn(expression?: ASTNode): ASTNode
   return makeNode {
     type: "ReturnStatement",
     children,
+    expression,
+    parent: expression?.parent,
   }
 
 export {

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -14,6 +14,14 @@ import {
   gatherRecursiveWithinFunction
 } from ./traversal.civet
 
+import {
+  processBinaryOpExpression
+} from ./op.civet
+
+import {
+  processUnaryExpression
+} from ./unary.civet
+
 assert := {
   equal(a: unknown, b: unknown, msg: string): void
     /* c8 ignore next */
@@ -263,6 +271,109 @@ function makeAmpersandFunction(bodyAfterRef = []): ASTNode
   }
 
 /**
+* A more complete version of makeAmpersandFunction that handles unary prefix
+*/
+function makeAmpersandFunctionExpression(prefix: UnaryOp[], rhs: AmpersandBlockBody): ASTNode
+  let ref, body, typeSuffix
+
+  // Only unary ops
+  if (!rhs) {
+    body = ref = makeRef("$")
+  } else {
+    ({ref, typeSuffix} = rhs)
+    if (!ref) {
+      throw new Error("Could not find ref in ampersand shorthand block")
+    }
+    body = rhs
+  }
+  if (prefix.length) {
+    body = {
+      type: "UnaryExpression",
+      children: [ processUnaryExpression(prefix, body, undefined) ]
+    }
+  }
+
+  parameters := {
+    type: "Parameters",
+    children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref],
+    names: [],
+  }
+  expressions := [body]
+  block := {
+    bare: true,
+    expressions,
+    children: [expressions],
+  }
+
+  children := [ parameters, " => ", block ]
+  async := hasAwait(body)
+  if (async) {
+    children.unshift("async ")
+  }
+
+  return {
+    type: "ArrowFunction",
+    signature: {
+      modifier: {
+        async,
+      },
+    },
+    children,
+    ref,
+    body,
+    ampersandBlock: true,
+    block,
+    parameters,
+  }
+
+function makeAmpersandBlockRHSBody(typeSuffix, callExpRest?, unaryPostfix?, assign?, binopRHS?): ASTNode
+  ref := makeRef("$")
+
+  exp .= {
+    type: "AmpersandRef",
+    children: [ref],
+    names: [],
+    ref,
+  }
+
+  if (callExpRest) {
+    exp.children.push(...callExpRest[1])
+  }
+
+  if (unaryPostfix) {
+    exp = processUnaryExpression([], exp, unaryPostfix)
+  }
+
+  if (assign) {
+    // Based on ActualAssignment
+    const [op1, more, rhs] = assign
+    const lhs = [
+      [undefined, exp, ...op1],
+      ...more.map((x) => [x[0], x[1], ...x[2]]),
+    ]
+    exp = {
+      type: "AssignmentExpression",
+      children: [lhs, rhs],
+      names: null,
+      lhs,
+      assigned: exp,
+      exp: rhs,
+    }
+  }
+
+  if (binopRHS) {
+    exp = {
+      children: processBinaryOpExpression([exp, binopRHS[1]]),
+    }
+  }
+
+  // Put at top level for AmpersandFunctionExpression to process
+  exp.ref = ref
+  exp.typeSuffix = typeSuffix
+
+  return exp
+
+/**
  * Convert general ExtendedExpression into LeftHandSideExpression.
  * More generally wrap in parentheses if necessary.
  * (Consider renaming and making parentheses depend on context.)
@@ -490,7 +601,9 @@ export {
   isFunction
   isWhitespaceOrEmpty
   literalValue
+  makeAmpersandBlockRHSBody
   makeAmpersandFunction
+  makeAmpersandFunctionExpression
   makeLeftHandSideExpression
   makeNode
   makeRef

--- a/test/partial-placeholder.civet
+++ b/test/partial-placeholder.civet
@@ -24,3 +24,82 @@ describe "partial placeholder", ->
     ---
     $ => f($, $)
   """
+
+  testCase """
+    null chained call
+    ---
+    f()?.g?.().h ., x
+    ---
+    $ => f()?.g?.().h($, x)
+  """
+
+  testCase """
+    object value
+    ---
+    f a: .
+    ---
+    $ => f({a: $})
+  """
+
+  testCase """
+    object key
+    ---
+    f .: a
+    f {.: a}
+    ---
+    $ => f({[$]: a});
+    $1 => f({[$1]: a})
+  """
+
+  testCase """
+    complex nested object and array
+    ---
+    f a: [ x, b: . ]
+    ---
+    $ => f({a: [ x, {b: $} ]})
+  """
+
+  testCase """
+    nested call
+    ---
+    f .(a, b)
+    f . a, b
+    ---
+    $ => f($(a, b));
+    $1 => f($1(a, b))
+  """
+
+  testCase """
+    double nested call with
+    ---
+    f .(a, .)
+    ---
+    $ => f($1 => $(a, $1))
+  """
+
+  testCase """
+    array
+    ---
+    f [ . ]
+    ---
+    $ => f([ $ ])
+  """
+
+  testCase """
+    leading unary op
+    ---
+    x.filter !Array.isArray .
+    ---
+    x.filter($ => !Array.isArray($))
+  """
+
+  describe "pipeline", ->
+    testCase """
+      unwrap pipelines
+      ---
+      last |> f a, b, .
+      array |> [x].concat .
+      ---
+      f(a, b, last);
+      [x].concat(array)
+    """

--- a/test/partial-placeholder.civet
+++ b/test/partial-placeholder.civet
@@ -1,0 +1,26 @@
+{testCase} from ./helper.civet
+
+describe "partial placeholder", ->
+  testCase """
+    first arg
+    ---
+    f ., a
+    ---
+    $ => f($, a)
+  """
+
+  testCase """
+    second arg
+    ---
+    f a, .
+    ---
+    $ => f(a, $)
+  """
+
+  testCase """
+    both args
+    ---
+    f ., .
+    ---
+    $ => f($, $)
+  """

--- a/test/partial-placeholder.civet
+++ b/test/partial-placeholder.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{ testCase, throws } from ./helper.civet
 
 describe "partial placeholder", ->
   testCase """
@@ -92,6 +92,43 @@ describe "partial placeholder", ->
     ---
     x.filter($ => !Array.isArray($))
   """
+
+  describe "must be inside call exp", ->
+    throws """
+      as call
+      ---
+      . a
+    """
+
+    throws """
+      object
+      ---
+      a: .
+    """
+
+    throws """
+      object key
+      ---
+      .: a
+    """
+
+    throws """
+      array
+      ---
+      [ . ]
+    """
+
+    throws """
+      unary op
+      ---
+      !.
+    """
+
+    throws """
+      binary op
+      ---
+      . + 1
+    """
 
   describe "pipeline", ->
     testCase """


### PR DESCRIPTION
`.` placeholder for partial function application.

Works for the common cases but `...` is a bit strange so I'll save that for a future iteration.