### PR TITLE
Astro integration based on Vite plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ The modern way to write TypeScript.
 - [Civet VSCode Extension](https://marketplace.visualstudio.com/items?itemName=DanielX.civet)
 - [Discord Server](https://discord.gg/xkrW9GebBc)
 - Plugins for
-  [Vite, esbuild, Rollup, Webpack, Rspack](integration/unplugin)
-  (including metaframeworks such as Astro),
+  [Vite, esbuild, Astro, Rollup, Webpack, Rspack](integration/unplugin)
   <!--
   [esbuild](source/esbuild-plugin.civet),
   [Vite](https://github.com/edemaine/vite-plugin-civet),

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -179,7 +179,7 @@ civet --emit-declaration src/**/*.civet
 ## Building a project
 
 Use Civet's built-in [unplugin](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin) to integrate with many
-bundlers: Vite, esbuild, Rollup, Webpack, or Rspack.  For example:
+bundlers: Vite, esbuild, Astro, Rollup, Webpack, or Rspack.  For example:
 
 ```js
 import esbuild from 'esbuild'
@@ -210,9 +210,7 @@ See the [unplugin documentation](https://github.com/DanielXMoore/Civet/blob/main
 including [full working examples](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin/examples).
 
 These plugins should support metaframeworks built upon these bundlers.
-For example, the Vite unplugin supports [Astro](https://astro.build/)
-([full example](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin/examples/astro)),
-and the esbuild unplugin supports [tsup](https://github.com/egoist/tsup):
+For example, the esbuild unplugin supports [tsup](https://github.com/egoist/tsup):
 
 ```js
 // tsup.config.ts

--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -10,7 +10,7 @@ title: Integrations
 
 ## Build tools
 
-- [unplugin](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin) integrates Civet into Vite, esbuild, Rollup, Webpack, and Rspack, including `.d.ts` generation (see [basic instructions](https://civet.dev/getting-started#building-a-project))
+- [unplugin](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin) integrates Civet into Vite, esbuild, Astro, Rollup, Webpack, and Rspack, including `.d.ts` generation (see [basic instructions](https://civet.dev/getting-started#building-a-project))
   - [Simpler esbuild plugin](https://github.com/DanielXMoore/Civet/blob/main/source/esbuild-plugin.civet)
   - [Older Vite plugin](https://github.com/edemaine/vite-plugin-civet) (no longer recommended)
 - [ESM/CJS loader](https://github.com/DanielXMoore/Civet/blob/main/register.js) for `import`/`require` to support `.civet` files

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -23,6 +23,24 @@ export default defineConfig({
 });
 ```
 
+### Astro
+
+```ts
+// astro.config.ts
+import { defineConfig } from 'astro/config';
+import civet from '@danielx/civet/astro';
+
+// https://astro.build/config
+export default defineConfig({
+  // ...
+  integrations: [
+    civet({
+      // options
+    }),
+  ],
+});
+```
+
 ### Rollup
 
 ```ts

--- a/integration/unplugin/examples/astro/astro.config.mjs
+++ b/integration/unplugin/examples/astro/astro.config.mjs
@@ -1,12 +1,14 @@
 import { defineConfig } from 'astro/config';
-import civetVitePlugin from '@danielx/civet/vite';
+import civet from '@danielx/civet/astro';
 
 import solidJs from '@astrojs/solid-js';
 
 // https://astro.build/config
 export default defineConfig({
-  vite: {
-    plugins: [civetVitePlugin({})],
-  },
-  integrations: [solidJs()],
+  integrations: [
+    civet({
+      ts: 'preserve',
+    }),
+    solidJs(),
+  ],
 });

--- a/integration/unplugin/src/astro.ts
+++ b/integration/unplugin/src/astro.ts
@@ -1,0 +1,24 @@
+//import type { AstroIntegration } from 'astro';
+interface AstroIntegration {
+  name: string,
+  hooks: {
+    "astro:config:setup": (data: { updateConfig: (config: unknown) => void }) => void
+  }
+}
+
+import civetUnplugin, { type PluginOptions } from '.'
+
+export default function(opts: PluginOptions = {}): AstroIntegration {
+  return {
+    name: "@danielx/civet",
+    hooks: {
+      "astro:config:setup": ({ updateConfig }) => {
+        updateConfig({
+          vite: {
+            plugins: [civetUnplugin.vite(opts)],
+          }
+        });
+      },
+    },
+  };
+}

--- a/integration/unplugin/tsup.config.ts
+++ b/integration/unplugin/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     vite: 'src/vite.ts',
     rollup: 'src/rollup.ts',
     esbuild: 'src/esbuild.ts',
+    astro: 'src/astro.ts',
   },
   esbuildOptions(opts) {
     opts.chunkNames = 'unplugin-shared';

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
       "require": "./dist/esbuild.js",
       "import": "./dist/esbuild.mjs"
     },
+    "./astro": {
+      "require": "./dist/astro.js",
+      "import": "./dist/astro.mjs"
+    },
     "./ts-diagnostic": {
       "require": "./dist/ts-diagnostic.js",
       "import": "./dist/ts-diagnostic.mjs"


### PR DESCRIPTION
Today I was working on an Astro project with Civet integration via our Vite plugin and old instructions (which generally work great!), and I got confused about Astro's notion of **integration** vs. **Vite plugin**. Specifically, I was trying to add Astro's Solid *integration*, but I accidentally added it to the *Vite plugin* array where I had already added Civet. I think adding a manual Vite plugin isn't very "Astro-ey", so I added a simple Astro integration for Civet. This may also unlock deeper features we can add to Astro specifically in the future. (I dream of `.astro` files one day allowing for Civet code.)