### PR TITLE
Preserve Vite's default extensions

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -20,6 +20,7 @@ cp source/babel-plugin.mjs dist/babel-plugin.mjs
 cp types/types.d.ts dist/types.d.ts
 
 # unplugin
+node -e 'import("./node_modules/vite/dist/node/constants.js").then((c)=>console.log(`export const DEFAULT_EXTENSIONS = ${JSON.stringify(c.DEFAULT_EXTENSIONS)}`))' >./integration/unplugin/src/constants.ts
 yarn --cwd ./integration/unplugin build
 cp ./integration/unplugin/dist/* ./dist
 

--- a/integration/unplugin/src/constants.ts
+++ b/integration/unplugin/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_EXTENSIONS = [".mjs",".js",".mts",".ts",".jsx",".tsx",".json"]

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -14,6 +14,7 @@ import * as tsvfs from '@typescript/vfs';
 import type { UserConfig } from 'vite';
 import type { BuildOptions } from 'esbuild';
 import os from 'os';
+import { DEFAULT_EXTENSIONS } from './constants.js';
 
 // Copied from typescript to avoid importing the whole package
 enum DiagnosticCategory {
@@ -458,11 +459,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
 
         if (implicitExtension) {
           config.resolve ??= {};
-          config.resolve.extensions ??= [
-            // Vite's DEFAULT_EXTENSIONs from
-            // https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L29
-            '.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json',
-          ];
+          config.resolve.extensions ??= DEFAULT_EXTENSIONS;
           config.resolve.extensions.push('.civet');
         }
       },

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -458,7 +458,11 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
 
         if (implicitExtension) {
           config.resolve ??= {};
-          config.resolve.extensions ??= [];
+          config.resolve.extensions ??= [
+            // Vite's DEFAULT_EXTENSIONs from
+            // https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L29
+            '.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json',
+          ];
           config.resolve.extensions.push('.civet');
         }
       },


### PR DESCRIPTION
It turns out the default behavior of our Vite unplugin disables all of Vite's default resolve extensions, including e.g. `.jsx` which was breaking a project I have that uses external JSX libraries (written in Solid, so distributes `.jsx` files).