### PR TITLE
Infinite loop detection and no return

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3958,25 +3958,42 @@ IterationExpression
 LoopStatement
   LoopClause:clause Block:block ->
     return {
+      ...clause,
       type: "IterationStatement",
       children: [...clause.children, block],
       block,
     }
 
 LoopClause
-  Loop -> {
-    type: "IterationStatement",
-    children: [$1],
-  }
+  Loop:kind ->
+    const expression = {
+      type: "Literal",
+      children: ["true"],
+      raw: "true",
+    }
+    const condition = {
+      type: "ParenthesizedExpression",
+      children: [ "(", expression, ")" ],
+      expression,
+    }
+    return {
+      type: "IterationStatement",
+      subtype: kind.token,
+      children: [kind, condition],
+      condition,
+    }
 
 # https://262.ecma-international.org/#prod-DoWhileStatement
 DoWhileStatement
   # NOTE: Condition provides optional parens
-  Do NoPostfixBracedBlock:block __ WhileClause -> {
-    type: "IterationStatement",
-    children: $0,
-    block: block
-  }
+  Do NoPostfixBracedBlock:block __ WhileClause:clause ->
+    return {
+      ...clause,
+      type: "IterationStatement",
+      subtype: "do-while",
+      children: $0,
+      block,
+    }
 
 DoStatement
   Do NoPostfixBracedBlock:block ->
@@ -4006,6 +4023,7 @@ WhileClause
 
     return {
       type: "IterationStatement",
+      subtype: kind.token,
       children: [kind, ws, condition],
       condition,
     }
@@ -5738,7 +5756,7 @@ LetOrConstOrVar
 Loop
   # NOTE: loop becomes while
   "loop" NonIdContinue ->
-    return { $loc, token: "while(true)" }
+    return { $loc, token: "while" }
 
 New
   "new" NonIdContinue ->

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -34,6 +34,7 @@ import {
   assert
   convertOptionalType
   isEmptyBareBlock
+  isExit
   isFunction
   isWhitespaceOrEmpty
   makeRef
@@ -239,10 +240,11 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       assignResults(node.block, collect)
       return
 
-  return  unless Array.isArray node
-
-  [, exp] .= node
+  return unless Array.isArray node
+  [, exp, semi] .= node
+  return if semi?.type is "SemicolonDelimiter"
   return unless exp
+  return if isExit exp
 
   outer := exp
   {type} .= exp
@@ -334,6 +336,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
   [, exp, semi] .= node
   return if semi?.type is "SemicolonDelimiter"
   return unless exp
+  return if isExit exp
 
   outer := exp
   {type} .= exp

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -39,9 +39,7 @@ function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule, ge
       // Remove inserted `break;` in `when` clauses that don't need them
       for c of clauses
         if c.type is "WhenClause" and c.break
-          last := c.block?.expressions?.-1?[1]
-          // [1] extracts statement from [indent, statement, delim]
-          if isExit last
+          if isExit c.block
             c.children.splice c.children.indexOf(c.break), 1
             c.break = undefined
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -10,6 +10,8 @@ export type ASTNode =
 */
 export type StatementNode =
   | BlockStatement
+  | BreakStatement
+  | ContinueStatement
   | DebuggerStatement
   | DeclarationStatement
   | DoStatement
@@ -171,6 +173,16 @@ export type IterationStatement
   parent: ASTNodeBase?
   condition: Condition
   block: BlockStatement
+
+export type BreakStatement
+  type: "BreakStatement"
+  children: Children
+  parent?: ASTNodeBase?
+
+export type ContinueStatement
+  type: "ContinueStatement"
+  children: Children
+  parent?: ASTNodeBase?
 
 export type DoStatement
   type: "DoStatement"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -108,16 +108,27 @@ function isWhitespaceOrEmpty(node): boolean {
 }
 
 /**
- * Does this statement force exit from normal flow, implying that the
- * line after this one can never execute?
+ * Does this statement force exit from normal flow, or loop forever,
+ * implying that the line after this one can never execute?
  */
 function isExit(node: ASTNode): boolean
-  node?.type is in [
-    "ReturnStatement",
-    "ThrowStatement",
-    "BreakStatement",
-    "ContinueStatement"
-  ]
+  node? and (or)
+    // Exit from normal flow
+    node.type is in [
+      "ReturnStatement"
+      "ThrowStatement"
+      "BreakStatement"
+      "ContinueStatement"
+    ]
+    // Infinite loops
+    (and)
+      node.type is "IterationStatement"
+      node.condition?.type is "ParenthesizedExpression"
+      node.condition.expression?.type is "Literal"
+      node.condition.expression?.raw is "true"
+      gatherRecursiveWithinFunction(node.block,
+        ({type}) => type is "BreakStatement").length is 0
+      // TODO: Distinguish between break of this loop vs. break of inner loops
 
 /**
  * Detects Comma, CommaDelimiter, and ParameterElementDelimiter

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -112,23 +112,30 @@ function isWhitespaceOrEmpty(node): boolean {
  * implying that the line after this one can never execute?
  */
 function isExit(node: ASTNode): boolean
-  node? and (or)
+  return false unless node?
+  switch node.type
     // Exit from normal flow
-    node.type is in [
-      "ReturnStatement"
-      "ThrowStatement"
-      "BreakStatement"
-      "ContinueStatement"
-    ]
+    when "ReturnStatement", "ThrowStatement", "BreakStatement", "ContinueStatement"
+      true
+    // if checks then and else clause
+    when "IfStatement"
+      (and)
+        isExit node.then
+        isExit node.else?.-1
+    when "BlockStatement"
+      // [1] extracts statement from [indent, statement, delim]
+      isExit node.expressions.-1?[1]
     // Infinite loops
-    (and)
-      node.type is "IterationStatement"
-      node.condition?.type is "ParenthesizedExpression"
-      node.condition.expression?.type is "Literal"
-      node.condition.expression?.raw is "true"
-      gatherRecursiveWithinFunction(node.block,
-        ({type}) => type is "BreakStatement").length is 0
-      // TODO: Distinguish between break of this loop vs. break of inner loops
+    when "IterationStatement"
+      (and)
+        node.condition?.type is "ParenthesizedExpression"
+        node.condition.expression?.type is "Literal"
+        node.condition.expression?.raw is "true"
+        gatherRecursiveWithinFunction(node.block,
+          ({type}) => type is "BreakStatement").length is 0
+        // TODO: Distinguish between break of this loop vs. break of inner loops
+    else
+      false
 
 /**
  * Detects Comma, CommaDelimiter, and ParameterElementDelimiter

--- a/test/function.civet
+++ b/test/function.civet
@@ -1166,8 +1166,57 @@ describe "function", ->
           x
       ---
       (function(x) {
+        while(true) {
+          x
+        }
+      })
+    """
+
+    testCase """
+      loop with break
+      ---
+      (x) ->
+        loop
+          if cond()
+            x
+          else
+            break
+      ---
+      (function(x) {
         const results=[];while(true) {
-          results.push(x)
+          if (cond()) {
+            results.push(x)
+          }
+          else {
+            break
+          }
+        };return results;
+      })
+    """
+
+    testCase """
+      loop with loop
+      ---
+      (x) ->
+        loop
+          break if done()
+          if cond()
+            x
+          else
+            loop
+              x
+      ---
+      (function(x) {
+        const results=[];while(true) {
+          if (done()) { break }
+          if (cond()) {
+            results.push(x)
+          }
+          else {
+            while(true) {
+              x
+            }
+          }
         };return results;
       })
     """
@@ -1177,10 +1226,12 @@ describe "function", ->
       ---
       (x) ->
         loop
+          break if cond()
           y := x
       ---
       (function(x) {
         const results=[];while(true) {
+          if (cond()) { break }
           const y = x;results.push(y)
         };return results;
       })

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -309,6 +309,11 @@ describe "switch", ->
         break
         continue
         console.log 'maybe'
+      when 6
+        if cond
+          break
+        else
+          throw e
     ---
     switch(x) {
       case 1: {
@@ -328,6 +333,14 @@ describe "switch", ->
         break
         continue
         console.log('maybe');break;
+      }
+      case 6: {
+        if (cond) {
+          break
+        }
+        else {
+          throw e
+        }
       }
     }
   """, wrapper: """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -336,6 +336,118 @@ describe "switch", ->
     }
   """
 
+  testCase """
+    when skips break after infinite loop
+    ---
+    switch x
+      when 1
+        loop
+          x
+      when 2
+        while true
+          x
+      when 3
+        while(true) {
+          x
+        }
+      when 4
+        while /*before*/ true /*after*/
+          x
+      when 5
+        while(/*before*/ true /*after*/)
+          x
+      when 6
+        do
+          x
+        while true
+    ---
+    switch(x) {
+      case 1: {
+        while(true) {
+          x
+        }
+      }
+      case 2: {
+        while (true) {
+          x
+        }
+      }
+      case 3: {
+        while(true) {
+          x
+        }
+      }
+      case 4: {
+        while /*before*/ (true) { /*after*/
+          x
+        }
+      }
+      case 5: {
+        while(/*before*/ true /*after*/) {
+          x
+        }
+      }
+      case 6: {
+        do {
+          x
+        }
+        while (true)
+      }
+    }
+  """
+
+  testCase """
+    when keeps break after infinite loop with break
+    ---
+    switch x
+      when 1
+        loop
+          break
+      when 2
+        while true
+          break if done()
+      when 3
+        do
+          if done()
+            break
+        while true
+      when 4
+        loop
+          f := :void =>
+            loop
+              break
+    ---
+    switch(x) {
+      case 1: {
+        while(true) {
+          break
+        };break;
+      }
+      case 2: {
+        while (true) {
+          if (done()) { break }
+        };break;
+      }
+      case 3: {
+        do {
+          if (done()) {
+            break
+          }
+        }
+        while (true);break;
+      }
+      case 4: {
+        while(true) {
+          const f = ():void => {
+            while(true) {
+              break
+            }
+          }
+        }
+      }
+    }
+  """
+
   // #1118
   testCase """
     break after pattern matching statement


### PR DESCRIPTION
Fixes #1161 by extending `isExit` and using it to omit implicit `return`/`push`.

* Basic infinite loop detection in `isExit`: `loop`/`while(true)`/`do..while(true)` without contained `break`.
  * Currently do not distinguish between `break` of this loop vs. other loops
  * Do correctly ignore `break` inside nested functions
* Extend `isExit` to handle `if/else` statements.
  * There might be other work to do here, e.g. `do` statements.
* Avoid implicit `return` of last statement when it is `isExit`.

We can continue to refine `isExit` to improve this mechanism.

One case I wasn't sure of: currently a block is considered `isExit` if its last statement is. So e.g. a block with a `break` in the middle but not end of the block is considered non-exiting. I don't *think* this case matters much, because then the author write inaccessible code, so more inaccessible code is probably fine? But it might be nicer to change the definition to "any line of the block `isExit`". I'm not sure.