### PR TITLE
Pipe assignment to index

### DIFF
--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -6,6 +6,7 @@
   makeNode
   makeRef
   needsRef
+  removeHoistDecs
   skipIfOnlyWS
   updateParentPointers
 } from ./util.civet
@@ -131,6 +132,7 @@ function processPipelineExpressions(statements): void {
                 switch (access.type) {
                   case "PropertyAccess":
                   case "SliceExpression":
+                  case "Index":
                     break
                   default:
                     children.unshift({
@@ -175,7 +177,8 @@ function processPipelineExpressions(statements): void {
 
             // Clone so that the same node isn't on the left and right because splice manipulation
             // moves things around and can cause a loop in the graph
-            arg = clone(arg)
+            arg = clone arg
+            removeHoistDecs arg
 
             // except keep the ref the same
             if (arg.children[0].type is "Ref") {

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -249,22 +249,46 @@ function hasYield(exp)
 function hasImportDeclaration(exp)
   gatherRecursiveWithinFunction(exp, ({ type }) => type is "ImportDeclaration").length > 0
 
-function deepCopy(node: ASTNode): ASTNode {
+/**
+* Copy an AST node deeply, including children.
+* Ref nodes maintain identity
+*/
+function deepCopy(node: ASTNode): ASTNode
   if (node == null) return node
   if (typeof node !== "object") return node
 
-  if (Array.isArray(node)) {
-    return node.map(deepCopy)
-  }
+  if Array.isArray node
+    return node.map deepCopy
+
+  if node?.type is "Ref" return node
 
   // Use from entries to clone objects
   // map the values to clone the children
   return Object.fromEntries(
-    Object.entries(node).map(([key, value]) => {
+    Object.entries(node).map [key, value] =>
       return [key, deepCopy(value)]
-    })
+
   ) as any
-}
+
+/**
+* When cloning subtrees sometimes we need to remove hoistDecs
+*/
+function removeHoistDecs(node: ASTNode): void
+  if (not node?) return
+  if (typeof node !== "object") return
+
+  if "hoistDec" in node
+    node.hoistDec = undefined
+
+  // NOTE: Arrays are transparent and skipped when traversing via parent
+  if Array.isArray(node)
+    for child of node
+      removeHoistDecs(child)
+    return
+
+  if node.children
+    for child of node.children
+      removeHoistDecs(child)
 
 function makeAmpersandFunction(bodyAfterRef = []): ASTNode
   ref := makeRef("$")
@@ -630,6 +654,7 @@ export {
   maybeRef
   needsRef
   parenthesizeType
+  removeHoistDecs
   skipIfOnlyWS
   startsWith
   updateParentPointers

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -530,6 +530,22 @@ describe "pipe", ->
       foo.bar = await Promise.all(foo.bar?.baz())
     """
 
+    testCase """
+      assign to index
+      ---
+      body.children[1] |>= .filter [, e] => !exps.includes e
+      ---
+      let ref;ref = body.children,ref[1] = ref[1].filter(([, e]) => !exps.includes(e))
+    """
+
+    testCase """
+      assign to negative index
+      ---
+      body.children.-1 |>= .filter [, e] => !exps.includes e
+      ---
+      let ref;(ref = body.children)[ref.length-1] = (ref = body.children)[ref.length-1].filter(([, e]) => !exps.includes(e))
+    """
+
   describe "assignment outside of first position", ->
     throws """
       pipe then assign


### PR DESCRIPTION
Allow for pipe assignment with index properties like:

```
body.children[1] |>= .filter [, e] => !exps.includes e
body.children.-1 |>= .filter [, e] => !exps.includes e
```