### PR TITLE
Improve ASI algorithm

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -870,17 +870,21 @@ ImplementsTarget
 # https://262.ecma-international.org/#prod-ClassBody
 # NOTE: Nesting and indentation sensitive
 ClassBody
-  __ OpenBrace NestedClassElements?:elements __ CloseBrace  ->
+  __ OpenBrace NestedClassElements?:expressions __ CloseBrace  ->
+    if (!expressions) expressions = $0[2] = []
     return {
-      type: "ClassBody",
+      type: "BlockStatement",
+      subtype: "ClassBody",
       children: $0,
-      elements,
+      expressions,
     }
-  InsertOpenBrace NestedClassElements?:elements InsertNewline InsertIndent InsertCloseBrace ->
+  InsertOpenBrace NestedClassElements?:expressions InsertNewline InsertIndent InsertCloseBrace ->
+    if (!expressions) expressions = $0[1] = []
     return {
-      type: "ClassBody",
+      type: "BlockStatement",
+      subtype: "ClassBody",
       children: $0,
-      elements,
+      expressions,
     }
 
 NestedClassElements

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -1,4 +1,5 @@
 import type {
+  ASTNode
   ASTNodeBase
   BlockStatement
   StatementTuple
@@ -168,13 +169,14 @@ function insertHoistDec(block: BlockStatement, node: ASTNode | StatementTuple, d
   // hoistDec wasn't previously a child, so now needs parent pointers
   addParentPointers dec, block
 
-function processBlocks(statements): void
+function processBlocks(statements: StatementTuple[]): void
   insertSemicolon(statements)
   gatherRecursive statements, .type is "BlockStatement"
-  .forEach ({ expressions }) ->
+  .forEach ({ expressions }) =>
     processBlocks expressions
 
 /**
+* Automatic Semicolon Insertion (ASI):
 * Avoid automatic continuation onto lines that start with
 * certain characters by adding an explicit semicolon. See
 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion
@@ -183,7 +185,7 @@ function insertSemicolon(statements: StatementTuple[]): void
   l := statements.length
   for each s, i of statements
     if i < l - 1
-      if needsPrecedingSemicolon(statements[i + 1])
+      if needsPrecedingSemicolon(statements[i + 1][1])
         delim := s[2]
         if !delim
           s[2] = ";"
@@ -192,37 +194,36 @@ function insertSemicolon(statements: StatementTuple[]): void
         else if typeof delim is "string" and !delim.match(/;/)
           s[2] = `;${delim}`
 
-function needsPrecedingSemicolon(exp)
-  let following: ASTNode
-  if Array.isArray exp
-    [,following] = exp
-  else
-    // Ideally this would be a StatementTuple but js only public/protected param items don't quite fit into that yet
-    // since the js: true is on the AST node the semicolon delimiters will stack up with empty nodes in between
-    following = exp
+function needsPrecedingSemicolon(exp: ASTNode)
+  return false unless exp
 
-  return false unless following
+  if Array.isArray exp // for chained conditionals
+    // Recurse into first non-null element of array
+    for each child of exp
+      continue unless child?
+      return needsPrecedingSemicolon child
+    return false
+  
+  if exp <? "string"
+    return /^\s*[\(\[\`\+\-\/]/.test exp
 
-  if Array.isArray following // for chained conditionals
-    return needsPrecedingSemicolon following[0]
-
-  switch following.type
-    when "ParenthesizedExpression", "ArrayExpression", "ArrowFunction", "TemplateLiteral", "RegularExpressionLiteral", "RangeExpression"
+  switch exp.type
+    when "ParenthesizedExpression", "ArrayExpression", "ArrowFunction", "TemplateLiteral", "RegularExpressionLiteral", "RangeExpression", "ComputedPropertyName"
       true
     when "AssignmentExpression"
-      startsWith(following, /^(\[|\()/)
+      startsWith(exp, /^(\[|\()/)
     when "Literal"
-      following.raw?.startsWith('-') or following.raw?.startsWith('+')
+      exp.raw?.startsWith('-') or exp.raw?.startsWith('+')
     when "PipelineExpression", "UnwrappedExpression"
       // skip first child which is whitespace
-      needsPrecedingSemicolon following.children[1]
+      needsPrecedingSemicolon exp.children[1]
     else
-      // descend into first child for things like:
+      // descend into children for things like:
       // IterationExpression
       //   CallExpression
       //     ParenthesizedExpression
-      if following.children
-        return needsPrecedingSemicolon following.children[0]
+      if exp.children
+        needsPrecedingSemicolon exp.children
 
 export {
   blockWithPrefix

--- a/test/class.civet
+++ b/test/class.civet
@@ -40,6 +40,19 @@ describe "class", ->
   """
 
   testCase """
+    member fields needing semicolon
+    ---
+    class Foo
+      [Symbol.toStringTag] = 'Foo'
+      [Symbol.isConcatSpreadable] = true
+    ---
+    class Foo {
+      [Symbol.toStringTag] = 'Foo';
+      [Symbol.isConcatSpreadable] = true
+    }
+  """
+
+  testCase """
     private field
     ---
     class X {

--- a/test/jsx/solid.civet
+++ b/test/jsx/solid.civet
@@ -193,7 +193,7 @@ describe "JSX for Solid", ->
     import type { JSX as JSX1 } from 'solid-js';
     type IntrinsicElements<K extends keyof JSX1.IntrinsicElements> =
       JSX1.IntrinsicElements[K] extends JSX1.DOMAttributes<infer T> ? T : unknown;
-    import { JSX } from "solid-js"
+    import { JSX } from "solid-js";
     (<div /> as any as IntrinsicElements<"div">)
   """
 
@@ -207,7 +207,7 @@ describe "JSX for Solid", ->
     import type { JSX as JSX1 } from 'solid-js';
     type IntrinsicElements<K extends keyof JSX1.IntrinsicElements> =
       JSX1.IntrinsicElements[K] extends JSX1.DOMAttributes<infer T> ? T : unknown;
-    import type { JSX } from "solid-js"
+    import type { JSX } from "solid-js";
     (<div /> as any as IntrinsicElements<"div">)
   """
 
@@ -221,7 +221,7 @@ describe "JSX for Solid", ->
     import type { JSX as JSX1 } from 'solid-js';
     type IntrinsicElements<K extends keyof JSX1.IntrinsicElements> =
       JSX1.IntrinsicElements[K] extends JSX1.DOMAttributes<infer T> ? T : unknown;
-    type JSX = unknown
+    type JSX = unknown;
     (<div /> as any as IntrinsicElements<"div">)
   """
 
@@ -235,6 +235,6 @@ describe "JSX for Solid", ->
     import type { JSX as JSX1 } from 'solid-js';
     type IntrinsicElements<K extends keyof JSX1.IntrinsicElements> =
       JSX1.IntrinsicElements[K] extends JSX1.DOMAttributes<infer T> ? T : unknown;
-    class JSX {}
+    class JSX {};
     (<div /> as any as IntrinsicElements<"div">)
   """


### PR DESCRIPTION
* Run ASI algorithm in class bodies; previously they were `type: "ClassBody"` so completely ignored. Now they're `type: "BlockStatement"` with `subtype: "ClassBody"` (in case we need to know someday).
* Recurse into first non-null child/array element instead of just first, and add a string base case. This seems like a better-behaved recursion. Probably some cases of the `switch` could now be eliminated, but I didn't try.

Fixes #1169