### PR TITLE
Assignment operator sections

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -985,6 +985,13 @@ The provided left- or right-hand side can include more binary operators:
 counts.map (* 2 + 1)
 </Playground>
 
+You can also build functions using assignment operators on the right:
+
+<Playground>
+new Promise (resolve =)
+callback := (sum +=)
+</Playground>
+
 ### Functions as Infix Operators
 
 You can "bless" an existing function to behave as an infix operator

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -560,7 +560,7 @@ ActualAssignment
   # NOTE: UpdateExpression instead of LeftHandSideExpression to allow
   # e.g. ++x *= 2 which we later convert to ++x, x *= 2
   ( NotDedented UpdateExpression WAssignmentOp )+ ExtendedExpression ->
-    $1 = $1.map((x) => [x[0], x[1], ...x[2]])
+    $1 = $1.map(x => [x[0], x[1], ...x[2]])
     $0 = [$1, $2]
     return {
       type: "AssignmentExpression",
@@ -2048,62 +2048,50 @@ FunctionExpression
 
   # Haskell-style sections
   OpenParen:open NonPipelineAssignmentExpression:lhs __:ws1 BinaryOp:op __:ws2 CloseParen:close ->
-    const refB = makeRef("b"),
-      body = processBinaryOpExpression([lhs, [
+    const refB = makeRef("b")
+    const fn = makeAmpersandFunction({
+      ref: refB,
+      body: processBinaryOpExpression([lhs, [
         [ws1, op, ws2, refB] // BinaryOpRHS
       ]])
-
-    const parameters = {
-      type: "Parameters",
-      children: ["(", refB, ")"],
-      names: [],
-    }
-
-    const block = {
-      expressions: [body],
-    }
-
+    })
     return {
-      type: "ArrowFunction",
-      signature: {
-        modifier: {},
-      },
-      children: [open, parameters, " => ", body, close],
-      body,
-      parenthesized: true,
-      ampersandBlock: true,
+      type: "ParenthesizedExpression",
+      children: [ open, fn, close ],
+      expression: fn,
+    }
+  # Assignment version based on ActualAssignment rule
+  OpenParen:open ( NotDedented UpdateExpression WAssignmentOp )+:lhs __:ws2 CloseParen:close ->
+    lhs = lhs.map(x => [x[0], x[1], ...x[2]])
+    const refB = makeRef("b")
+    const fn = makeAmpersandFunction({
       ref: refB,
-      block,
-      parameters,
+      body: {
+        type: "AssignmentExpression",
+        children: [ lhs, ws2, refB ],
+        names: null,
+        lhs,
+        assigned: lhs[0][1],
+        exp: refB,
+      },
+    })
+    return {
+      type: "ParenthesizedExpression",
+      children: [ open, fn, close ],
+      expression: fn,
     }
   OpenParen:open __:ws1 !/\+\+|--|[\+\-&]\S/ BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
-    const refA = makeRef("a"),
-      body = processBinaryOpExpression([refA, [
+    const refA = makeRef("a")
+    const fn = makeAmpersandFunction({
+      ref: refA,
+      body: processBinaryOpExpression([refA, [
         [ws1, op, ws2, rhs] // BinaryOpRHS
       ]])
-
-    const parameters = {
-      type: "Parameters",
-      children: ["(", refA, ")"],
-      names: [],
-    }
-
-    const block = {
-      expressions: [body],
-    }
-
+    })
     return {
-      type: "ArrowFunction",
-      signature: {
-        modifier: {},
-      },
-      children: [open, parameters, " => ", body, close],
-      body,
-      parenthesized: true,
-      ampersandBlock: true,
-      ref: refA,
-      block,
-      parameters,
+      type: "ParenthesizedExpression",
+      children: [ open, fn, close ],
+      expression: fn,
     }
 
 # NOTE: Dynamic infix operators

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -774,7 +774,7 @@ describe "operator sections", ->
     ---
     items.map (1+)
     ---
-    items.map(((b) => 1+b))
+    items.map((b => 1+b))
   """
 
   testCase """
@@ -782,7 +782,7 @@ describe "operator sections", ->
     ---
     items.map (1 + )
     ---
-    items.map(((b) => 1 + b))
+    items.map((b => 1 + b))
   """
 
   testCase """
@@ -790,7 +790,7 @@ describe "operator sections", ->
     ---
     items.map (length * width + )
     ---
-    items.map(((b) => length * width + b))
+    items.map((b => length * width + b))
   """
 
   testCase """
@@ -798,7 +798,7 @@ describe "operator sections", ->
     ---
     items.map (**2)
     ---
-    items.map(((a) => a**2))
+    items.map((a => a**2))
   """
 
   testCase """
@@ -806,7 +806,7 @@ describe "operator sections", ->
     ---
     items.map ( + 1)
     ---
-    items.map(((a) => a + 1))
+    items.map((a => a + 1))
   """
 
   testCase """
@@ -822,5 +822,21 @@ describe "operator sections", ->
     ---
     items.map ( + length * width)
     ---
-    items.map(((a) => a + length * width))
+    items.map((a => a + length * width))
+  """
+
+  testCase """
+    = section
+    ---
+    new Promise (resolve =)
+    ---
+    new Promise((b => resolve =b))
+  """
+
+  testCase """
+    += section
+    ---
+    callback := (sum += /*num*/)
+    ---
+    const callback = (b => sum += /*num*/b)
   """


### PR DESCRIPTION
A natural extension of Haskell-style operator sections to assignment operators. This seems quite useful, as in e.g. `new Promise (resolve =)`.