### PR TITLE
Fix & in applied (operator)

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -331,7 +331,7 @@ function processCallMemberExpression(node)
       children.splice 0, 2,
         commaCount ?
           type: "ParenthesizedExpression",
-          children: ["(", call, ")"]
+          children: ["(", ...call.children, ")"]
         : { ...call, type: "ParenthesizedExpression" }
 
   // Process globs and bind shorthand

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -566,6 +566,18 @@ describe "&. function block shorthand", ->
       (function() { return $ => $.x + $.y })
     """
 
+    testCase """
+      in (or)
+      ---
+      (or)
+        &.x
+        &.y
+      ---
+      $ => ((
+        $.x)||(
+        $.y))
+    """
+
   describe "typed &", ->
     testCase """
       identity


### PR DESCRIPTION
Fixes #1173 by removing stray `type: "Call"` node in AST (which should be eliminated during expansion of applied `(or)`).