### PR TITLE
Limit & to return/yield; support indented yield argument

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -875,7 +875,7 @@ function search<T>(list: T[]): T | undefined
 
 `&` acts as a placeholder for the argument of a single-argument function,
 with the function wrapper lifted to just inside the nearest function call,
-assignment, or pipeline.
+assignment, pipeline, `return`, or `yield`.
 
 <Playground>
 x.map &.name

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -570,7 +570,7 @@ ActualAssignment
       names: null,
       lhs: $1,
       assigned: $1[0][1],
-      exp: $2,
+      expression: $2,
     }
 
 NonPipelineActualAssignment
@@ -589,7 +589,7 @@ NonPipelineActualAssignment
       names: null,
       lhs: $1,
       assigned: $1[0][1],
-      exp: $2,
+      expression: $2,
     }
 
 # https://262.ecma-international.org/#prod-YieldExpression
@@ -2080,7 +2080,7 @@ FunctionExpression
         names: null,
         lhs,
         assigned: lhs[0][1],
-        exp: refB,
+        expression: refB,
       },
     })
     return {
@@ -5129,9 +5129,9 @@ LexicalBinding
 # https://262.ecma-international.org/#prod-Initializer
 Initializer
   # NOTE: Using ExtendedExpression to allow If/Switch expressions
-  __ Equals ExtendedExpression:exp -> {
+  __ Equals ExtendedExpression:expression -> {
     type: "Initializer",
-    exp,
+    expression,
     children: $0,
   }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -594,12 +594,20 @@ NonPipelineActualAssignment
 
 # https://262.ecma-international.org/#prod-YieldExpression
 YieldExpression
-  Yield YieldTail
-
-YieldTail
-  &EOS
-  # NOTE: Merged optional star
-  ( _? Star )? AssignmentExpression
+  Yield ( ( _? Star )? MaybeNestedExpression )? ->
+    if ($2) {
+      const [ star, expression ] = $2
+      return {
+        type: "YieldExpression",
+        star,
+        expression,
+        children: [ $1, star, expression ],
+      }
+    }
+    return {
+      type: "YieldExpression",
+      children: [ $1 ],
+    }
 
 # https://262.ecma-international.org/#prod-ArrowFunction
 ArrowFunction

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -68,7 +68,7 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
 
   initializer := makeNode
     type: "Initializer"
-    exp: e
+    expression: e
     children: [ws, assign, e]
   binding := makeNode {
     type: "Binding"
@@ -109,7 +109,7 @@ function processDeclarations(statements: StatementTuple[]): void
         prependStatementExpressionBlock initializer, statement
 
 function prependStatementExpressionBlock(initializer: Initializer, statement: {children: Children}): ASTRef?
-  {exp} .= initializer
+  {expression: exp} .= initializer
 
   // Handle nested statement expression
   let ws
@@ -132,7 +132,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
     blockStatement[1] = statement
 
     if statement.type is "DoStatement"
-      ref = initializer.exp = initializer.children[2] = makeRef()
+      ref = initializer.expression = initializer.children[2] = makeRef()
       assignResults blockStatement, (resultNode) =>
         //@ts-ignore
         makeNode
@@ -148,9 +148,9 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
       pre.unshift refDec
     else
       wrapIterationReturningResults statement, children: blockStatement, ->
-      ref = initializer.exp = initializer.children[2] = statement.resultsRef
+      ref = initializer.expression = initializer.children[2] = statement.resultsRef
   else
-    ref = initializer.exp = initializer.children[2] = makeRef()
+    ref = initializer.expression = initializer.children[2] = makeRef()
 
     assignResults blockStatement, (resultNode) =>
       //@ts-ignore
@@ -357,7 +357,7 @@ function dynamizeImportDeclaration(decl)
     else
       convertNamedImportsToObject(imports, true)
   c := "const"
-  exp := [
+  expression := [
     if justDefault then "("
     {type: "Await", children: ["await"]}
     " "
@@ -365,10 +365,10 @@ function dynamizeImportDeclaration(decl)
     dynamizeFromClause decl.from
     if justDefault then ").default"
   ]
-  initializer := {
+  initializer: Initializer := {
     type: "Initializer"
-    exp
-    children: [" ", "= ", exp]
+    expression
+    children: [" ", "= ", expression]
   }
   bindings := [{
     type: "Binding"
@@ -384,9 +384,9 @@ function dynamizeImportDeclaration(decl)
       pattern
       ".default"
     ]
-    initializer2 := {
+    initializer2: Initializer := {
       type: "Initializer"
-      exp
+      expression
       children: [" ", "= ", exp2]
     }
     bindings.push
@@ -396,9 +396,9 @@ function dynamizeImportDeclaration(decl)
       initializer: initializer2
       children: [pattern2, initializer2]
     pattern3 := convertNamedImportsToObject(imports.children.at(-1), true)
-    initializer3 := {
+    initializer3: Initializer := {
       type: "Initializer"
-      exp: pattern
+      expression: pattern
       children: [" ", "= ", pattern]
     }
     bindings.push

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -280,7 +280,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
         exp.then.children.push exp.then.semicolon = ";"
 
       // else block
-      if (exp.else)
+      if exp.else
         assignResults(exp.else[2], collect)
       else // Add else block pushing undefined if no else block
         exp.children.push([" else {", collect("undefined"), "}"])
@@ -361,7 +361,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
       return
     case "FunctionExpression":
       // Add return after function declaration if it has an id to not interfere with hoisting
-      if (exp.id)
+      if exp.id
         exp.children.push ["",
           type: "ReturnStatement"
           children: [";return ", exp.id]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1180,6 +1180,8 @@ function processPlaceholders(statements: StatementTuple[]): void
           type is "Initializer"
           // Right-hand side of assignment
           type is "AssignmentExpression" and ancestor.exp is child
+          type is "ReturnStatement"
+          type is "YieldExpression"
       switch ancestor?.type
         when "Call"
           i := findChildIndex ancestor.args, child
@@ -1212,7 +1214,14 @@ function processPlaceholders(statements: StatementTuple[]): void
             ancestor.exp = ancestor.children[i] = maybeWrap ancestor.exp, ancestor
             ancestor = ancestor.exp as ASTNodeObject
           else
-            ancestor =  undefined
+            ancestor = undefined
+        when "ReturnStatement", "YieldExpression"
+          i := findChildIndex ancestor, child
+          if i >= 0 and ancestor.expression is ancestor.children[i]
+            ancestor.expression = ancestor.children[i] = maybeWrap ancestor.expression, ancestor
+            ancestor = ancestor.expression as ASTNodeObject
+          else
+            ancestor = undefined
       unless ancestor
         replaceNode exp,
           type: "Error"
@@ -1255,6 +1264,8 @@ function processPlaceholders(statements: StatementTuple[]): void
           parent.children[2][findChildIndex parent.children[2], ancestor][3]
       when "AssignmentExpression", "Initializer"
         outer = ancestor is parent.exp
+      when "ReturnStatement", "YieldExpression"
+        outer = ancestor is parent.expression
     unless outer
       fnExp = makeLeftHandSideExpression fnExp
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -469,7 +469,7 @@ function replaceNode(node: ASTNodeObject, newNode: ASTNode, parent?: ASTNodePare
   unless recurse parent.children
     throw new Error "replaceNode failed: didn't find child node in parent"
 
-  // Adjust 'exp' etc. alias pointers
+  // Adjust 'expression' etc. alias pointers
   for key, value in parent
     if value is node
       parent[key] = newNode
@@ -500,11 +500,11 @@ function makeExpressionStatement(expression: ASTNode): ASTNode
 // before any calls like `(args)`, non-null assertions `!`, and optionals `?`.
 // The return value should have a `name` property (for "Identifier" and
 // "Index"), or have `type` of "Index" (for `[computed]`), or be undefined.
-function lastAccessInCallExpression(exp) {
+function lastAccessInCallExpression(exp)
   return exp if exp.type is "Identifier"
   let children, i
-  do {
-    ({ children } = exp)
+  do
+    { children } = exp
     i = children.length - 1
     while (i >= 0 and (
       children[i].type is "Call" ||
@@ -513,9 +513,8 @@ function lastAccessInCallExpression(exp) {
     )) i--
     if (i < 0) return
     // Recurse into nested MemberExpression, e.g. from `x.y()`
-  } while (children[i].type is "MemberExpression" and (exp = children[i]))
+  while children[i].type is "MemberExpression" and (exp = children[i])
   return children[i]
-}
 
 // Given a MethodDefinition, convert into a FunctionExpression.
 // Returns undefined if the method is a getter or setter.
@@ -756,14 +755,14 @@ function processAssignments(statements): void {
   replaceNodesRecursive statements,
     (n) => n.type is "AssignmentExpression" and n.names is null,
     (exp: AssignmentExpression): AssignmentExpression | BlockStatement | ExpressionNode => {
-      let { lhs: $1, exp: $2 } = exp, tail = [], i = 0, len = $1.length
+      let { lhs: $1, expression: $2 } = exp, tail = [], i = 0, len = $1.length
 
       let block?: BlockStatement
       // Extract StatementExpression as block
       if exp.parent?.type is "BlockStatement" and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
         block = makeBlockFragment()
         if ref := prependStatementExpressionBlock(
-          {type: "Initializer", exp: $2, children: [undefined, undefined, $2]}
+          {type: "Initializer", expression: $2, children: [undefined, undefined, $2]}
           block
         )
           exp.children = exp.children.map (c: ASTNode) -> if c is $2 then ref else c
@@ -781,7 +780,7 @@ function processAssignments(statements): void {
         index := exp.children.indexOf($2)
         if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
         exp.children.splice index, 1,
-          exp.exp = $2 = [call, "(", lhs, ", ", $2, ")"]
+          exp.expression = $2 = [call, "(", lhs, ", ", $2, ")"]
         if omitLhs
           return $2
 
@@ -1179,7 +1178,7 @@ function processPlaceholders(statements: StatementTuple[]): void
           // Declaration
           type is "Initializer"
           // Right-hand side of assignment
-          type is "AssignmentExpression" and ancestor.exp is child
+          type is "AssignmentExpression" and ancestor.expression is child
           type is "ReturnStatement"
           type is "YieldExpression"
       switch ancestor?.type
@@ -1208,14 +1207,7 @@ function processPlaceholders(statements: StatementTuple[]): void
             ancestor = ancestor.children[i][j][3] as ASTNodeObject
           else
             ancestor = undefined
-        when "AssignmentExpression", "Initializer"
-          i := findChildIndex ancestor, child
-          if i >= 0 and ancestor.exp is ancestor.children[i]
-            ancestor.exp = ancestor.children[i] = maybeWrap ancestor.exp, ancestor
-            ancestor = ancestor.exp as ASTNodeObject
-          else
-            ancestor = undefined
-        when "ReturnStatement", "YieldExpression"
+        when "AssignmentExpression", "Initializer", "ReturnStatement", "YieldExpression"
           i := findChildIndex ancestor, child
           if i >= 0 and ancestor.expression is ancestor.children[i]
             ancestor.expression = ancestor.children[i] = maybeWrap ancestor.expression, ancestor
@@ -1262,9 +1254,7 @@ function processPlaceholders(statements: StatementTuple[]): void
       when "PipelineExpression"
         outer = ancestor is
           parent.children[2][findChildIndex parent.children[2], ancestor][3]
-      when "AssignmentExpression", "Initializer"
-        outer = ancestor is parent.exp
-      when "ReturnStatement", "YieldExpression"
+      when "AssignmentExpression", "Initializer", "ReturnStatement", "YieldExpression"
         outer = ancestor is parent.expression
     unless outer
       fnExp = makeLeftHandSideExpression fnExp

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -1,3 +1,6 @@
+type {
+  AssignmentExpression
+} from ./types.civet
 { gatherRecursiveAll } from ./traversal.civet
 {
   addParentPointers
@@ -172,8 +175,8 @@ function processPipelineExpressions(statements): void {
               names: null,
               lhs,
               assigned: arg,
-              exp: children,
-            })
+              expression: children,
+            } satisfies AssignmentExpression)
 
             // Clone so that the same node isn't on the left and right because splice manipulation
             // moves things around and can cause a loop in the graph

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -46,6 +46,7 @@ export type ExpressionNode =
   | StatementExpression
   | TypeNode
   | UnaryExpression
+  | YieldExpression
 
 /**
 * Other nodes that aren't statements or expressions.
@@ -158,6 +159,13 @@ export type NewExpression
   type: "NewExpression"
   children: Children
   parent?: Parent
+
+export type YieldExpression
+  type: "YieldExpression"
+  children: Children
+  parent?: Parent
+  star?: ASTNode?
+  expression?: ASTNode?
 
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -130,7 +130,7 @@ export type AssignmentExpression
   names: null
   lhs: AssignmentExpressionLHS
   assigned: ???
-  exp: ExpressionNode
+  expression: ExpressionNode
 
 export type AssignmentExpressionLHS = [undefined, ASTNode, [WSNode, [string, WSNode]], ASTLeaf][]
 
@@ -331,7 +331,7 @@ export type Binding =
 
 export type Initializer =
   type: "Initializer"
-  exp: ASTNode
+  expression: ASTNode
   children: [ASTNode, ASTNode, ASTNode]
   parent?: Parent
 
@@ -431,7 +431,7 @@ export type PipelineExpression =
       ws1: Whitespace
       pipe: ASTLeaf
       ws2: Whitespace
-      exp: ASTNode
+      expression: ASTNode
     ][]
   ]
   parent?: Parent

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -434,6 +434,22 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    it works with return
+    ---
+    return &.foo
+    ---
+    return $ => $.foo
+  """
+
+  testCase """
+    it works with yield
+    ---
+    -> yield &.foo
+    ---
+    (function*() { return yield $ => $.foo })
+  """
+
+  testCase """
     await
     ---
     x.map & + await f()

--- a/test/yield.civet
+++ b/test/yield.civet
@@ -30,3 +30,14 @@ describe "yield expression", ->
     ---
     yield
   """
+
+  testCase """
+    indented
+    ---
+    yield
+      1+2
+    ---
+    yield (
+      1+2
+    )
+  """


### PR DESCRIPTION
* Limit `&` lifting to stop at `return` and `yield`, as it's not useful to `return` or `yield` inside a generated wrapper.
* Add support for `yield`ing an indented expression, like we already do with `return`.
* AST node for `"YieldExpression"`

As this PR makes clear: Some AST nodes use property `exp` (e.g. `"AssignmentExpression"`, `"Initializer"`) while some use property `expression` (e.g. `"ReturnStatement"` and new `"YieldExpression"`). Could we unify on one or the other? Preference which?