### PR TITLE
Brace block improvements, including `&` statements

### DIFF
--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -1,5 +1,6 @@
 import type {
   ASTNode
+  BlockStatement
 } from ./types.civet
 
 import {
@@ -12,6 +13,7 @@ import {
 } from ./util.civet
 
 import {
+  braceBlock
   getIndent
 } from ./block.civet
 
@@ -125,7 +127,7 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
 }
 
 // CoffeeScript compatible automatic var insertion
-function createVarDecs(statements, scopes, pushVar?): void
+function createVarDecs(block: BlockStatement, scopes, pushVar?): void
   // NOTE: var and let/const have different scoping rules
   // need to keep var scopes when entering functions and within a var scope keep
   // track of lexical scopes within blocks
@@ -155,6 +157,7 @@ function createVarDecs(statements, scopes, pushVar?): void
     }
   }
 
+  { expressions: statements } := block
   decs := findDecs statements
   scopes.push decs
   varIds := []
@@ -176,33 +179,32 @@ function createVarDecs(statements, scopes, pushVar?): void
 
   // recurse into nested blocks
   blockNodes.forEach (block) =>
-    createVarDecs(block.expressions, scopes, pushVar)
+    createVarDecs(block, scopes, pushVar)
 
   // recurse into for loops
   forNodes.forEach ({ block, declaration }) =>
     scopes.push(new Set(declaration.names))
-    createVarDecs(block.expressions, scopes, pushVar)
+    createVarDecs(block, scopes, pushVar)
     scopes.pop()
 
   // recurse into nested functions
   fnNodes.forEach ({ block, parameters }) =>
     scopes.push(new Set(parameters.names))
-    createVarDecs(block.expressions, scopes)
+    createVarDecs(block, scopes)
     scopes.pop()
 
-  if (varIds.length) {
+  if varIds.length
     // get indent from first statement
     const indent = getIndent(statements[0])
     let delimiter = ";"
-    if (statements[0][1]?.parent?.root) {
+    if statements[0][1]?.parent?.root
       delimiter = ";\n"
-    }
     // TODO: Declaration ast node
+    braceBlock block
     statements.unshift([indent, {
       type: "Declaration"
       children: ["var ", varIds.join(", ")]
     }, delimiter])
-  }
 
   scopes.pop()
 

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -54,12 +54,12 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
   return block
 
 // Add braces if block lacks them
-function braceBlock(block: BlockStatement, spaceAtEnd?: boolean)
+function braceBlock(block: BlockStatement)
   if block.bare
     if block.children is block.expressions
       block.children = [block.expressions]
     block.children.unshift(" {")
-    block.children.push spaceAtEnd ? " }" : "}"
+    block.children.push "}"
     { implicitlyReturned } := block
     block.bare = block.implicitlyReturned = false
     if implicitlyReturned

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -17,6 +17,10 @@ import {
   gatherRecursive
 } from ./traversal.civet
 
+import {
+  insertReturn
+} from ./function.civet
+
 /**
  * Duplicate a block and attach statements prefixing the block.
  * Adds braces if the block is bare.
@@ -54,8 +58,12 @@ function braceBlock(block: BlockStatement)
     if block.children is block.expressions
       block.children = [block.expressions]
     block.children.unshift(" {")
+    //block.children.push(" }")
     block.children.push("}")
-    block.bare = false
+    { implicitlyReturned } := block
+    block.bare = block.implicitlyReturned = false
+    if implicitlyReturned
+      insertReturn block
 
 function duplicateBlock(block: BlockStatement): BlockStatement
   expressions := [...block.expressions]

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -2,6 +2,7 @@ import type {
   ASTNode
   ASTNodeBase
   BlockStatement
+  FunctionNode
   StatementTuple
 } from ./types.civet
 
@@ -18,7 +19,7 @@ import {
 } from ./traversal.civet
 
 import {
-  insertReturn
+  processReturn
 } from ./function.civet
 
 /**
@@ -53,20 +54,16 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
   return block
 
 // Add braces if block lacks them
-function braceBlock(block: BlockStatement)
+function braceBlock(block: BlockStatement, spaceAtEnd?: boolean)
   if block.bare
     if block.children is block.expressions
       block.children = [block.expressions]
-    if block.implicitlyReturned
-      block.children.unshift("{ ")
-    else
-      block.children.unshift(" {")
-    //block.children.push(" }")
-    block.children.push("}")
+    block.children.unshift(" {")
+    block.children.push spaceAtEnd ? " }" : "}"
     { implicitlyReturned } := block
     block.bare = block.implicitlyReturned = false
     if implicitlyReturned
-      insertReturn block
+      processReturn block.parent as FunctionNode, true
 
 function duplicateBlock(block: BlockStatement): BlockStatement
   expressions := [...block.expressions]

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -57,7 +57,10 @@ function braceBlock(block: BlockStatement)
   if block.bare
     if block.children is block.expressions
       block.children = [block.expressions]
-    block.children.unshift(" {")
+    if block.implicitlyReturned
+      block.children.unshift("{ ")
+    else
+      block.children.unshift(" {")
     //block.children.push(" }")
     block.children.push("}")
     { implicitlyReturned } := block

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -87,7 +87,7 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
   if returnType and returnType.optional
     convertOptionalType returnType
 
-  if (!processReturnValue(f) and implicitReturns)
+  if not processReturnValue(f) and implicitReturns
     { signature, block } := f
     { modifier, name, returnType } := signature
     { async, generator, set } := modifier
@@ -108,6 +108,7 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
     if block?.type is "BlockStatement"
       if isVoid or set or isConstructor
         if block.bare and block.implicitlyReturned
+          //braceBlock block
           block.children = [ " {", ...block.children, " }" ]
           block.bare = block.implicitlyReturned = false
       else
@@ -581,7 +582,9 @@ function skipImplicitArguments(args: unknown[]): boolean
 export {
   assignResults
   expressionizeIteration
+  insertReturn
   processFunctions
+  processReturn
   skipImplicitArguments
   wrapIterationReturningResults
 }

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -108,7 +108,7 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
     if block?.type is "BlockStatement"
       if isVoid or set or isConstructor
         if block.bare and block.implicitlyReturned
-          braceBlock block, true
+          braceBlock block
       else
         unless block.implicitlyReturned
           insertReturn(block)

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -108,9 +108,7 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
     if block?.type is "BlockStatement"
       if isVoid or set or isConstructor
         if block.bare and block.implicitlyReturned
-          //braceBlock block
-          block.children = [ " {", ...block.children, " }" ]
-          block.bare = block.implicitlyReturned = false
+          braceBlock block, true
       else
         unless block.implicitlyReturned
           insertReturn(block)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1075,7 +1075,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
 
   addParentPointers(root)
 
-  const { expressions: statements } = root
+  { expressions: statements } := root
 
   processPlaceholders(statements)
   processNegativeIndexAccess(statements)
@@ -1108,7 +1108,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
   } else if(config.autoConst) {
     createConstLetDecs(statements, [], "const")
   } else if (config.autoVar) {
-    createVarDecs(statements, [])
+    createVarDecs(root, [])
   }
 
   processBlocks(statements)

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -10,6 +10,7 @@ export type ASTNodeObject = Exclude<StatementNode | OtherNode, string>
 
 /**
 * Nodes that represent statements.
+* Keep this in sync with isStatement in util.civet
 */
 export type StatementNode =
   | BlockStatement
@@ -61,6 +62,7 @@ export type OtherNode =
   | CommentNode
   | Index
   | Initializer
+  | ParametersNode
   | Placeholder
   | PropertyAccess
 
@@ -305,8 +307,9 @@ export type BlockStatement =
   type: "BlockStatement"
   children: Children
   expressions: StatementTuple[]
-  bare: boolean
-  root: boolean
+  bare: boolean  // has no braces
+  implicitlyReturned?: boolean  // fat arrow function with no braces
+  root?: boolean
   parent?: Parent
 
 export type DeclarationStatement =
@@ -409,7 +412,7 @@ export type ObjectBindingPattern =
   properties: BindingPatternContent,
 
 export type FunctionExpression =
-  type: "ArrowFunction"
+  type: "FunctionExpression"
   children: Children
   parent?: Parent
   name: string
@@ -453,6 +456,8 @@ export type ArrowFunction =
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
+  ampersandBlock?: boolean  // unrollable single-argument function
+  body?: ASTNode
 
 export type FunctionSignature =
   type: "MethodSignature" | "FunctionSignature"
@@ -485,13 +490,14 @@ export type MethodModifier =
   get?: boolean
   set?: boolean
   async?: boolean
+  generator?: boolean
 
 export type ParametersNode =
   type: "Parameters"
   children: Children
   parent?: Parent
   names: string[]
-  tp: TypeParameters?
+  tp?: TypeParameters?
 
 export type TypeParameters = unknown
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -400,7 +400,7 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
     children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref]
     names: []
   } as ParametersNode
-  expressions := [['', body]] satisfies StatementTuple[]
+  expressions := [[' ', body]] satisfies StatementTuple[]
   block := makeNode {
     type: "BlockStatement"
     bare: true
@@ -409,7 +409,7 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
     implicitlyReturned: true
   } as BlockStatement
 
-  children := [ parameters, " => ", block ]
+  children := [ parameters, " =>", block ]
   async := hasAwait(body)
   if async
     children.unshift("async ")

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -1,31 +1,34 @@
 import type {
   AmpersandBlockBody
+  ArrowFunction
   ASTRef
   ASTLeaf
   ASTNode
   ASTNodeBase
   ASTNodeObject
   ASTNodeParent
+  BlockStatement
   IsParent
   IsToken
   Literal
-  Whitespace
+  ParametersNode
+  StatementNode
   TypeSuffix
   ReturnTypeAnnotation
   StatementTuple
 } from ./types.civet
 
 import {
+  braceBlock
+} from ./block.civet
+
+import {
   gatherRecursiveWithinFunction
 } from ./traversal.civet
 
 import {
-  processBinaryOpExpression
-} from ./op.civet
-
-import {
-  processUnaryExpression
-} from ./unary.civet
+  insertReturn
+} from ./function.civet
 
 assert := {
   equal(a: unknown, b: unknown, msg: string): void
@@ -115,14 +118,13 @@ function isParent(node: ASTNode): node is IsParent
 function isToken(node: ASTNode): node is IsToken
   node? and node.token?
 
-function isEmptyBareBlock(node: ASTNode): boolean {
+function isEmptyBareBlock(node: ASTNode): boolean
   if (node?.type !== "BlockStatement") return false
-  const { bare, expressions } = node
+  { bare, expressions } := node
   return bare &&
     (expressions.length is 0 ||
       (expressions.length is 1 &&
         expressions[0][1]?.type is "EmptyStatement"))
-}
 
 function isFunction(node: ASTNode & { type: unknown, async?: boolean }): boolean
   { type } := node
@@ -132,6 +134,29 @@ function isFunction(node: ASTNode & { type: unknown, async?: boolean }): boolean
     type is "MethodDefinition"
     !!node.async
     // do blocks can be marked async to prevent automatic await
+
+// Keep this in sync with StatementNode in types.civet
+statementTypes := new Set [
+  "BlockStatement"
+  "BreakStatement"
+  "ContinueStatement"
+  "DebuggerStatement"
+  "Declaration"
+  "DoStatement"
+  "ForStatement"
+  "IfStatement"
+  "IterationStatement"
+  "LabeledStatement"
+  "ReturnStatement"
+  "SwitchStatement"
+  "ThrowStatement"
+  "TryStatement"
+]
+function isStatement(node: ASTNode): node is StatementNode
+  (and)
+    isASTNodeObject node
+    node.type?  // forbid leaf
+    statementTypes.has node.type
 
 function isWhitespaceOrEmpty(node): boolean {
   if (!node) return true
@@ -374,33 +399,42 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
     type: "Parameters"
     children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref]
     names: []
-  }
-  expressions := [body]
+  } as ParametersNode
+  expressions := [['', body]] satisfies StatementTuple[]
   block := makeNode {
+    type: "BlockStatement"
     bare: true
     expressions
     children: [expressions]
-  }
+    implicitlyReturned: true
+  } as BlockStatement
 
   children := [ parameters, " => ", block ]
   async := hasAwait(body)
   if async
     children.unshift("async ")
 
-  return makeNode {
+  fn := makeNode {
     type: "ArrowFunction"
-    signature: {
+    signature:
       modifier: {
         async
       }
-    }
     children
     ref
-    body
-    ampersandBlock: true
     block
     parameters
-  }
+    ampersandBlock: true
+    body
+  } as ArrowFunction
+
+  if isStatement body
+    braceBlock block
+    // Prevent unrolling braced block
+    fn.ampersandBlock = false
+    delete fn.body
+
+  fn
 
 /**
  * Convert general ExtendedExpression into LeftHandSideExpression.
@@ -634,6 +668,7 @@ export {
   isEmptyBareBlock
   isExit
   isFunction
+  isStatement
   isWhitespaceOrEmpty
   literalValue
   makeAmpersandFunction

--- a/test/compat/coffee-prototype.civet
+++ b/test/compat/coffee-prototype.civet
@@ -34,7 +34,7 @@ describe "prototype shorthand", ->
     'civet coffeeCompat'
     Array::map.call &+(a=1)
     ---
-    Array.prototype.map.call($ =>  {var a;return $+(a=1)})
+    Array.prototype.map.call($ => { var a;return $+(a=1)})
   """
 
   // #1124

--- a/test/compat/coffee-prototype.civet
+++ b/test/compat/coffee-prototype.civet
@@ -34,8 +34,7 @@ describe "prototype shorthand", ->
     'civet coffeeCompat'
     Array::map.call &+(a=1)
     ---
-    var a;
-    Array.prototype.map.call($ => $+(a=1))
+    Array.prototype.map.call($ =>  {var a;return $+(a=1)})
   """
 
   // #1124

--- a/test/compat/coffee-prototype.civet
+++ b/test/compat/coffee-prototype.civet
@@ -34,7 +34,7 @@ describe "prototype shorthand", ->
     'civet coffeeCompat'
     Array::map.call &+(a=1)
     ---
-    Array.prototype.map.call($ => { var a;return $+(a=1)})
+    Array.prototype.map.call($ => { var a; return $+(a=1)})
   """
 
   // #1124

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -422,7 +422,7 @@ describe "&. function block shorthand", ->
       if & then x else y
     ---
     () => {
-      return $ =>  {if ($) return x; else return y}
+      return $ => { if ($) return x; else return y}
     }
   """
 
@@ -538,6 +538,25 @@ describe "&. function block shorthand", ->
     & + f .
     ---
     $ => $ + ($1 => f($1))
+  """
+
+  testCase """
+    autoVar
+    ---
+    'civet autoVar'
+    & + x = 5
+    ---
+    $ => { var x;return $ + (x = 5)}
+  """
+
+  testCase """
+    autoLet
+    ---
+    'civet autoLet'
+    & + x = 5
+    ---
+    let x;
+    $ => $ + (x = 5)
   """
 
   describe "multiple &", ->

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -546,7 +546,7 @@ describe "&. function block shorthand", ->
     'civet autoVar'
     & + x = 5
     ---
-    $ => { var x;return $ + (x = 5)}
+    $ => { var x; return $ + (x = 5)}
   """
 
   testCase """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -408,6 +408,25 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    if expression
+    ---
+    check := if & then x else y
+    ---
+    const check = $ => ($? x : y)
+  """
+
+  testCase """
+    if statement
+    ---
+    =>
+      if & then x else y
+    ---
+    () => {
+      return $ =>  {if ($) return x; else return y}
+    }
+  """
+
+  testCase """
     it works with assignment
     ---
     x = &.name

--- a/test/function.civet
+++ b/test/function.civet
@@ -1478,7 +1478,7 @@ describe "function", ->
       ---
       (x): void => console.log x
       ---
-      (x): void => { console.log(x) }
+      (x): void => { console.log(x)}
     """
 
     testCase """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -109,7 +109,7 @@ describe "[TS] function", ->
     ---
     const ignore = <T, U>(a: T, b: U) : void => null
     ---
-    const ignore = <T, U>(a: T, b: U) : void => { null }
+    const ignore = <T, U>(a: T, b: U) : void => { null}
   """
 
   testCase """


### PR DESCRIPTION
Fixes #1176 

I unified a place where we were manually bracing a block into a call to `braceBlock`. But they differed in the closing brace: the new use ended with ` }` while other instances ended with `}`. I'm somewhat tempted to switch to the spaced version throughout, which would lead to changes like this:

```diff
switch x
  {a: y, b: y}
    y
↓↓↓
   if(typeof x === 'object' && x != null && 'a' in x && 'b' in x) {
     const {a: y1, b: y2} = x;
     const y = [y1, y2];
-    y }
+    y}
```

But this would involve changing ~70 tests. Do you think it's worth it?