### PR TITLE
First version of comptime (synchronous, no outer scope)

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -95,7 +95,7 @@ for esm of [false, true]
     outfile: `dist/main.${if esm then 'mjs' else 'js'}`
     plugins: [
       resolveExtensions
-      heraPlugin
+      heraPlugin module: true
       civetPlugin()
     ]
   }).catch -> process.exit 1
@@ -110,7 +110,7 @@ build({
   external: ['fs']
   plugins: [
     resolveExtensions
-    heraPlugin
+    heraPlugin module: true
     civetPlugin()
   ]
 }).catch -> process.exit 1

--- a/civet.dev/.vitepress/components/Playground.vue
+++ b/civet.dev/.vitepress/components/Playground.vue
@@ -12,6 +12,8 @@ const props = defineProps<{
   clearTrigger?: boolean;
   hideLink?: boolean;
   showPrettier?: boolean;
+  raw?: boolean;
+  comptime?: boolean;
 }>();
 
 const userCode = ref(b64.decode(props.b64Code));
@@ -47,11 +49,14 @@ const showPrettier = props.showPrettier;
 const prettier = ref(true);
 watch(prettier, compile);
 
+const comptime = props.comptime;
+
 async function compile() {
   const snippet = await compileCivetToHtml({
     code: userCode.value + '\n',
     jsOutput: props.emitJsOutput,
-    prettierOutput: showPrettier && prettier.value,
+    prettierOutput: !props.raw && showPrettier && prettier.value,
+    parseOptions: { comptime },
   });
 
   emit('input', userCode.value, snippet.jsCode);

--- a/civet.dev/.vitepress/components/PlaygroundFull.vue
+++ b/civet.dev/.vitepress/components/PlaygroundFull.vue
@@ -98,6 +98,7 @@ function clear() {
     emit-js-output
     hide-link
     show-prettier
+    show-comptime
     :b64-code="b64Code"
     :clear-trigger="clearTrigger"
   />

--- a/civet.dev/.vitepress/config.mjs
+++ b/civet.dev/.vitepress/config.mjs
@@ -59,12 +59,14 @@ export default async function vitePressConfig() {
           if (token.content.startsWith('<Playground')) {
             const lines = token.content.trim().split('\n');
             const raw = /\braw\b/.test(lines[0]);
+            const comptime = /\bcomptime\b/.test(lines[0]);
             const code = lines.slice(1, -1).join('\n');
-            const { tsCode } = compileCivet(code, civet, raw ? null : prettier);
+            const { tsCode } = compileCivet(code, civet, raw ? null : prettier,
+              { comptime });
             const inputHtml = highlighter.codeToHtml(code, { lang: 'coffee' });
             const outputHtml = highlighter.codeToHtml(tsCode, { lang: 'tsx' });
 
-            return `<Playground b64-code="${b64.encode(code)}">
+            return `<Playground b64-code="${b64.encode(code)}"${raw ? " raw" : ""}${comptime ? " comptime" : ""}>
               <template #input>${inputHtml}</template>
               <template #output>${outputHtml}</template>
             </Playground>`;

--- a/civet.dev/.vitepress/utils/compileCivet.ts
+++ b/civet.dev/.vitepress/utils/compileCivet.ts
@@ -2,9 +2,10 @@
 export function compileCivet(
   code: string,
   civetInstance: any,
-  prettierInstance: any
+  prettierInstance: any,
+  parseOptions: any
 ) {
-  let tsCode = civetInstance.compile(code);
+  let tsCode = civetInstance.compile(code, { parseOptions });
   const tsRawCode = tsCode;
 
   if (prettierInstance) {

--- a/civet.dev/.vitepress/utils/compileCivetToHtml.ts
+++ b/civet.dev/.vitepress/utils/compileCivetToHtml.ts
@@ -17,6 +17,7 @@ export function compileCivetToHtml({
   code = '',
   prettierOutput = true,
   jsOutput = false,
+  parseOptions = {},
 }): Promise<{
   inputHtml: string;
   outputHtml?: string;
@@ -24,7 +25,7 @@ export function compileCivetToHtml({
   jsCode?: string;
 }> {
   uid++;
-  playgroundWorker.postMessage({ uid, code, prettierOutput, jsOutput });
+  playgroundWorker.postMessage({ uid, code, prettierOutput, jsOutput, parseOptions });
   return new Promise((resolve) => {
     msgMap[uid] = { resolve };
   });

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -196,6 +196,7 @@ esbuild.build({
       // outputExtension: '.tsx',        // appended to .civet in output
       // ts: 'civet',                    // TS -> JS transpilation mode
       // typecheck: false,               // check types via tsc
+      // comptime: false,                // evaluate comptime blocks
     })
   ]
 }).catch(() => process.exit(1))

--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -4,13 +4,13 @@ importScripts('https://cdn.jsdelivr.net/npm/shiki@0.14.7');
 importScripts('/__civet.js');
 
 onmessage = async (e) => {
-  const { uid, code, prettierOutput, jsOutput } = e.data;
+  const { uid, code, prettierOutput, jsOutput, parseOptions } = e.data;
   const highlighter = await getHighlighter();
   const inputHtml = highlighter.codeToHtml(code, { lang: 'coffee' });
 
   let tsCode, ast, errors = []
   try {
-    ast = Civet.compile(code, { ast: true });
+    ast = Civet.compile(code, { ast: true, parseOptions });
     tsCode = Civet.generate(ast, { errors });
     if (errors.length) {
       // TODO: Better error display; copied from main.civet
@@ -51,7 +51,7 @@ onmessage = async (e) => {
           (coffee ? '(do ->\n' : 'async do\n') +
           rest.replace(/^/gm, ' ') +
           (coffee ? ')' : ''),
-          { ast: true }
+          { ast: true, parseOptions }
         );
         // Hoist top-level declarations outside the IIFE wrapper
         Civet.lib.gatherRecursive(ast, (p) => p.type === 'BlockStatement')

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1564,7 +1564,7 @@ console.log "3rd triangular number is", comptime
   triangle 3
 </Playground>
 
-Note that comptime blocks are executed as separate scripts, so they have no
+Note that `comptime` blocks are executed as separate scripts, so they have no
 access to variables in outer scopes.  The block must also run synchronously.
 For serialization, the result must consist of built-in JavaScript types
 (including `Date`, `RegExp`, `Set`, and `Map`),
@@ -1574,10 +1574,22 @@ and there cannot be reference loops.
 Some of these restrictions may be lifted in the future.
 
 ::: info
-Inspired by [Rust's comptime crate](https://docs.rs/comptime/latest/comptime/),
-which is a simplified version of
-[Zig's comptime](https://ziglang.org/documentation/master/#comptime).
+Inspired by Rust crates
+[comptime](https://crates.io/crates/comptime) and
+[constime](https://crates.io/crates/constime),
+which are a simplified version of
+[Zig's comptime](https://ziglang.org/documentation/master/#comptime);
+and other similar compile-time features (sometimes called "macros")
+such as [C++'s constexpr](https://en.cppreference.com/w/cpp/language/constexpr).
 :::
+
+Because comptime enables execution of arbitrary code during compilation,
+it is not enabled by default, nor can it be enabled via a directive.
+In particular, the VSCode language server will not execute `comptime` blocks.
+You can enable `comptime` evaluation in the CLI using `civet --comptime`,
+and in the
+[unplugin](https://github.com/DanielXMoore/Civet/tree/main/integration/unplugin)
+using the `comptime: true` option.
 
 ## Classes
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1583,13 +1583,14 @@ and other similar compile-time features (sometimes called "macros")
 such as [C++'s constexpr](https://en.cppreference.com/w/cpp/language/constexpr).
 :::
 
-Because comptime enables execution of arbitrary code during compilation,
-it is not enabled by default, nor can it be enabled via a directive.
+Because `comptime` enables execution of arbitrary code during compilation, it
+is not enabled by default, nor can it be enabled via a directive or config file.
 In particular, the VSCode language server will not execute `comptime` blocks.
 You can enable `comptime` evaluation in the CLI using `civet --comptime`,
 and in the
 [unplugin](https://github.com/DanielXMoore/Civet/tree/main/integration/unplugin)
 using the `comptime: true` option.
+If not enabled, `comptime` blocks will execute at runtime.
 
 ## Classes
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1554,11 +1554,11 @@ await Promise.allSettled for url of urls
 *at Civet compilation time*.  The result of `eval`ing the block gets
 embedded into the output JavaScript code.
 
-<Playground>
+<Playground comptime>
 value := comptime 1+2+3
 </Playground>
 
-<Playground>
+<Playground comptime>
 console.log "3rd triangular number is", comptime
   function triangle(n) do n and n + triangle n-1
   triangle 3

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1483,6 +1483,28 @@ do
 while item?
 </Playground>
 
+### Labels
+
+<Playground>
+:outer while (list = next())?
+  for item of list
+    if finale item
+      break outer
+  continue :outer
+</Playground>
+
+::: info
+Labels have the colon on the left to avoid conflict with implicit object
+literals.  The colons are optional in `break` and `continue`.
+As a special case, Svelte's `$:` can be used with the colon on the right.
+:::
+
+<Playground>
+$: document.title = title
+</Playground>
+
+## Other Blocks
+
 ### Do Blocks
 
 To put multiple lines in a scope and possibly an expression,
@@ -1526,25 +1548,33 @@ await Promise.allSettled for url of urls
     await result.json()
 </Playground>
 
-### Labels
+### Comptime Blocks
+
+`comptime` blocks are similar to [`do` blocks](#do-blocks), but they execute
+*at Civet compilation time*.  The result of `eval`ing the block gets
+embedded (via `JSON.stringify`) into the output JavaScript code.
 
 <Playground>
-:outer while (list = next())?
-  for item of list
-    if finale item
-      break outer
-  continue :outer
+value := comptime 1+2+3
 </Playground>
+
+<Playground>
+console.log "3rd triangular number is", comptime
+  function triangle(n) do n and n + triangle n-1
+  triangle 3
+</Playground>
+
+Note that comptime blocks are executed as separate scripts, so they have no
+access to variables in outer scopes.  The block must also run synchronously,
+and the result must not have reference loops so it can be serialized via
+`JSON.stringify`.
+Some of these restrictions may be lifted in the future.
 
 ::: info
-Labels have the colon on the left to avoid conflict with implicit object
-literals.  The colons are optional in `break` and `continue`.
-As a special case, Svelte's `$:` can be used with the colon on the right.
+Inspired by [Rust's comptime crate](https://docs.rs/comptime/latest/comptime/),
+which is a simplified version of
+[Zig's comptime](https://ziglang.org/documentation/master/#comptime).
 :::
-
-<Playground>
-$: document.title = title
-</Playground>
 
 ## Classes
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1552,7 +1552,7 @@ await Promise.allSettled for url of urls
 
 `comptime` blocks are similar to [`do` blocks](#do-blocks), but they execute
 *at Civet compilation time*.  The result of `eval`ing the block gets
-embedded (via `JSON.stringify`) into the output JavaScript code.
+embedded into the output JavaScript code.
 
 <Playground>
 value := comptime 1+2+3
@@ -1565,9 +1565,11 @@ console.log "3rd triangular number is", comptime
 </Playground>
 
 Note that comptime blocks are executed as separate scripts, so they have no
-access to variables in outer scopes.  The block must also run synchronously,
-and the result must not have reference loops so it can be serialized via
-`JSON.stringify`.
+access to variables in outer scopes.  The block must also run synchronously.
+For serialization, the result must
+consist of built-in JavaScript types (including `Set` and `Map`),
+functions cannot have properties or call other custom functions, and
+there cannot be reference loops.
 Some of these restrictions may be lifted in the future.
 
 ::: info

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1566,10 +1566,11 @@ console.log "3rd triangular number is", comptime
 
 Note that comptime blocks are executed as separate scripts, so they have no
 access to variables in outer scopes.  The block must also run synchronously.
-For serialization, the result must
-consist of built-in JavaScript types (including `Set` and `Map`),
-functions cannot have properties or call other custom functions, and
-there cannot be reference loops.
+For serialization, the result must consist of built-in JavaScript types
+(including `Date`, `RegExp`, `Set`, and `Map`),
+functions cannot have properties or refer to variables/functions in an
+outer scope other than global,
+and there cannot be reference loops.
 Some of these restrictions may be lifted in the future.
 
 ::: info

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -96,6 +96,7 @@ interface PluginOptions {
   outputExtension?: string;
   ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
   typecheck?: boolean | string;
+  comptime?: boolean;
   transformOutput?: (
     code: string,
     id: string
@@ -118,4 +119,7 @@ interface PluginOptions {
     Note that some bundlers require additional plugins to handle TS.
     For example, for Webpack, you would need to install `ts-loader` and add it to your webpack config.
     Unfortunately, Rollup's TypeScript plugin is incompatible with this plugin, so you need to set `ts` to another option.
+- `comptime`: Whether to evaluate
+  [`comptime` blocks](https://civet.dev/reference#comptime-blocks)
+  at compile time.  Default: `false`.
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -38,6 +38,7 @@ export type PluginOptions = {
   js?: boolean;
   /** @deprecated Use "emitDeclaration" instead */
   dts?: boolean;
+  comptime?: boolean;
 };
 
 const isCivetTranspiled = /(\.civet)(\.[jt]sx)([?#].*)?$/;
@@ -189,6 +190,9 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           const compiledTS = civet.compile(rawCivetSource, {
             filename,
             js: false,
+            parseOptions: {
+              comptime: Boolean(options.comptime)
+            },
           });
           fsMap.set(filename, compiledTS)
           return compiledTS
@@ -351,18 +355,23 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         code: string;
         sourceMap: SourceMap | string | undefined;
       };
+      const civetOptions = {
+        filename: id,
+        sourceMap: true,
+        parseOptions: {
+          comptime: Boolean(options.comptime)
+        },
+      } as const;
 
       if (options.ts === 'civet' && !transformTS) {
         compiled = civet.compile(rawCivetSource, {
-          filename: id,
+          ...civetOptions,
           js: true,
-          sourceMap: true,
         });
       } else {
         const compiledTS = civet.compile(rawCivetSource, {
-          filename: id,
+          ...civetOptions,
           js: false,
-          sourceMap: true,
         });
 
         const resolved = filename + outExt;
@@ -413,9 +422,8 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           case 'civet':
           default: {
             compiled = civet.compile(rawCivetSource, {
-              filename: id,
+              ...civetOptions,
               js: true,
-              sourceMap: true,
             });
 
             if (options.ts == undefined) {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "unplugin": "^1.6.0"
   },
   "devDependencies": {
-    "@danielx/civet": "0.6.73",
+    "@danielx/civet": "0.7.1",
     "@danielx/hera": "^0.8.11",
     "@prettier/sync": "^0.3.0",
     "@types/assert": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@danielx/civet": "0.7.1",
-    "@danielx/hera": "^0.8.11",
+    "@danielx/hera": "^0.8.13",
     "@prettier/sync": "^0.3.0",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^9.1.1",

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -44,6 +44,7 @@ if process.argv.includes "--help"
       -c / --compile   Compile input files to TypeScript (or JavaScript)
       --config XX      Specify a config file (default scans for a config.civet, civet.json, civetconfig.civet or civetconfig.json file, optionally in a .config directory, or starting with a .)
       --civet XX       Specify civet compiler flag, as in "civet XX" prologue
+      --comptime       Enable execution of code during compilation via comptime
       --no-config      Don't scan for a config file
       --js             Strip out all type annotations; default to .jsx extension
       --ast            Print the AST instead of the compiled code
@@ -77,10 +78,6 @@ interface Options extends CompileOptions
   output?: string
   config?: string | boolean | undefined
   ast?: boolean
-  noCache?: boolean
-  inlineMap?: boolean
-  hits?: string
-  trace?: string
   repl?: boolean
   typecheck?: boolean
   emitDeclaration?: boolean
@@ -128,6 +125,10 @@ export function parseArgs(args: string[]): ParsedArgs
           parse `civet ${args[++i]}`,
             startRule: 'CivetPrologueContent'
           |> .config
+      when '--comptime'
+        (options.parseOptions ??= {}).comptime = true
+      when '--no-comptime'
+        (options.parseOptions ??= {}).comptime = false
       when '--ast'
         options.ast = true
       when '--no-cache'

--- a/source/config.civet
+++ b/source/config.civet
@@ -47,18 +47,28 @@ export function findConfig(startDir: string): Promise<string | undefined>
 export function loadConfig(path: string): Promise<CompileOptions>
   config := await fs.readFile path, "utf8"
 
+  let data: CompileOptions = {}
   if path.endsWith ".json"
-    JSON.parse config
+    try
+      data = JSON.parse config
+    catch e
+      throw new Error `Error parsing JSON config file ${path}: ${e}`
   else
-    js := compile config, js: true
-    let exports
+    let js
+    try
+      js = compile config, js: true
+    catch e
+      throw new Error `Error compiling Civet config file ${path}: ${e}`
 
     try
-      exports = await import `data:text/javascript,${ encodeURIComponent js }`
+      exports := await import `data:text/javascript,${ encodeURIComponent js }`
+      data = exports?.default
     catch e
-      console.error "Error loading config file", path, e
+      throw new Error `Error running Civet config file ${path}: ${e}`
 
-    if typeof exports.default !== "object" or exports.default === null
-      throw new Error "civet config file must export an object"
+  unless data? <? "object" and not Array.isArray data
+    throw new Error `Civet config file must export an object, not ${Array.isArray(data) ? 'array' : data? ? typeof data : 'null'}`
 
-    exports.default
+  // Forbid enabling comptime in the config file
+  delete data?.parseOptions?.comptime
+  data

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -6,7 +6,7 @@
 
 import { removeParentPointers } from './parser/util.civet'
 
-type Options =
+export type Options =
   updateSourceMap?: (token: string, pos?: number) => void
   js?: boolean
   errors?: unknown[]

--- a/source/main.civet
+++ b/source/main.civet
@@ -67,6 +67,7 @@ export type CompilerOptions
   trace?: string
   parseOptions?:
     coffeeCompat?: boolean
+    comptime?: boolean
   updateSourceMap?: (output: string, inputPos?: number) => void
   errors?: unknown[]
 

--- a/source/main.civet
+++ b/source/main.civet
@@ -1,4 +1,4 @@
-import { parse } from "./parser.hera"
+import { parse, getConfig, setInitialConfig } from "./parser.hera"
 import generate, { prune } from "./generate.civet"
 import * as lib from "./parser/lib.civet"
 import * as util from "./util.civet"
@@ -95,15 +95,16 @@ export compile := (src: string, options?: CompilerOptions) ->
 
   let ast
 
+  setInitialConfig(options.parseOptions)
   try
     //@ts-ignore
-    parse.config = options.parseOptions or {}
     ast = parse(src, {
       filename
       events
     })
     ast = prune ast unless options.ast is "raw"
   finally
+    setInitialConfig(undefined)
     if hits or trace
       import('fs').then ({ writeFileSync }) ->
         if { logs } := events?.meta
@@ -235,7 +236,7 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
         stateCache.set(key, result)
 
       //@ts-ignore
-      if parse.config.verbose and result
+      if getConfig().verbose and result
         console.log `Parsed ${JSON.stringify state.input[state.pos...result.pos]} [pos ${state.pos}-${result.pos}] as ${ruleName}`//, JSON.stringify(result.value)
 
       if trace

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -22,6 +22,7 @@ import {
   forRange,
   gatherBindingCode,
   gatherRecursive,
+  getHelperRef,
   getIndentLevel,
   getPrecedence,
   getTrimmingSpace,
@@ -57,11 +58,56 @@ import {
 } from "./parser/lib.civet"
 
 /**
- * A global object to hold methods used in rule handlers
- * We can probably transition away from this now that Hera
- * supports importing from other files as well as inline JS.
+ * Globals
  */
-const module = {};
+let config;  // parser config options
+export const state = {};  // parser state
+
+Object.defineProperties(state, {
+  currentIndent: {
+    get() {
+      const {indentLevels: l} = state
+      return l[l.length-1]
+    },
+  },
+  classImplicitCallForbidden: {
+    get() {
+      const {forbidClassImplicitCall: s} = state
+      return s[s.length-1]
+    },
+  },
+  indentedApplicationForbidden: {
+    get() {
+      const {forbidIndentedApplication: s} = state
+      return s[s.length-1]
+    },
+  },
+  bracedApplicationForbidden: {
+    get() {
+      const {forbidBracedApplication: s} = state
+      return s[s.length-1]
+    },
+  },
+  trailingMemberPropertyForbidden: {
+    get() {
+      const {forbidTrailingMemberProperty: s} = state
+      return s[s.length-1]
+    },
+  },
+  newlineBinaryOpForbidden: {
+    get() {
+      const {forbidNewlineBinaryOp: s} = state
+      return s[s.length-1]
+    },
+  },
+  currentJSXTag: {
+    get() {
+      const {JSXTagStack: s} = state
+      return s[s.length-1]
+    },
+  },
+})
+
 ```
 
 Program
@@ -75,7 +121,7 @@ Program
       children: [statements],
       bare: true,
       root: true,
-    }, module.config, module, ReservedWord)
+    }, config, state, ReservedWord)
     return $0
 
 TopLevelStatements
@@ -246,10 +292,10 @@ ForbiddenImplicitCalls
   Identifier "=" Whitespace
   # NOTE: Custom operators created via `operator`
   Identifier:id !"(" ->
-    if (module.operators.has(id.name)) return $0
+    if (state.operators.has(id.name)) return $0
     return $skip
   OmittedNegation _? Identifier:id ->
-    if (module.operators.has(id.name)) return $0
+    if (state.operators.has(id.name)) return $0
     return $skip
   # `x ... y` is reserved for a range, but `x ...y` is an implicit call
   "... "
@@ -2101,14 +2147,14 @@ FunctionExpression
 OperatorDeclaration
   # `operator {x, y} := ...` declaration while blessing
   Operator:op OperatorBehavior?:behavior _:w LexicalDeclaration:decl ->
-    decl.names.forEach((name) => module.operators.set(name, behavior))
+    decl.names.forEach((name) => state.operators.set(name, behavior))
     return {
       ...decl,
       children: [ insertTrimmingSpace(w, ""), ...decl.children ]
     }
   # `operator id(a, b) {...}` defines a function
   OperatorSignature:signature BracedBlock:block ->
-    module.operators.set(signature.id.name, signature.behavior)
+    state.operators.set(signature.id.name, signature.behavior)
     return {
       ...signature,
       type: "FunctionExpression",
@@ -2119,8 +2165,8 @@ OperatorDeclaration
     }
   # `operator id` alone blesses `id` as an operator
   Operator:op _:w1 Identifier:id OperatorBehavior?:behavior ( CommaDelimiter _? Identifier OperatorBehavior? )*:ids ->
-    module.operators.set(id.name, behavior)
-    ids.forEach(([, , id2, behavior2]) => module.operators.set(id2.name, behavior2))
+    state.operators.set(id.name, behavior)
+    ids.forEach(([, , id2, behavior2]) => state.operators.set(id2.name, behavior2))
     return {
       id,
       children: [],
@@ -2158,7 +2204,7 @@ OperatorPrecedence
   # inspired by https://docs.raku.org/language/functions#Precedence
   _? ( "tighter" / "looser" / "same" ):mod NonIdContinue _? ( Identifier / ( OpenParen BinaryOp CloseParen ) ):op ->
     let prec = op.type === "Identifier"
-      ? module.operators.get(op.name).prec
+      ? state.operators.get(op.name).prec
       : getPrecedence(op[1])
     switch (mod) {
       case "tighter": prec += 1/64; break
@@ -3443,13 +3489,13 @@ OperatorAssignmentOp
   Xor "=" _? ->
     return {
       special: true,
-      call: module.getRef("xor"),
+      call: getHelperRef("xor"),
       children: [$2, ...$3 || []]
     }
   Xnor "=" _? ->
     return {
       special: true,
-      call: module.getRef("xnor"),
+      call: getHelperRef("xnor"),
       children: [$2, ...$3 || []]
     }
   Identifier "=" _? ->
@@ -3467,7 +3513,7 @@ AssignmentOpSymbol
   ( "++" / "⧺" ) Equals ->
     return {
       special: true,
-      call: module.getRef("concatAssign"),
+      call: getHelperRef("concatAssign"),
       omitLhs: true,
       children: [$2],
     }
@@ -3506,7 +3552,7 @@ NotDedentedBinaryOp
 
 IdentifierBinaryOp
   Identifier:id ->
-    if (module.operators.has(id.name)) return id
+    if (state.operators.has(id.name)) return id
     return $skip
 
 BinaryOp
@@ -3517,19 +3563,19 @@ _BinaryOp
     if (typeof $1 === "string") return { $loc, token: $1 }
     return $1
   Identifier:id ->
-    if (!module.operators.has(id.name)) return $skip
+    if (!state.operators.has(id.name)) return $skip
     return {
       call: id,
       special: true,
-      ...module.operators.get(id.name),
+      ...state.operators.get(id.name),
     }
   OmittedNegation __ Identifier:id ->
-    if (!module.operators.has(id.name)) return $skip
+    if (!state.operators.has(id.name)) return $skip
     return {
       call: id,
       special: true,
       negated: true,
-      ...module.operators.get(id.name),
+      ...state.operators.get(id.name),
     }
 
 # NOTE: Condensed binary operator symbols into one rule
@@ -3539,7 +3585,7 @@ BinaryOpSymbol
   "/"
   "%%" ->
     return {
-      call: module.getRef("modulo"),
+      call: getHelperRef("modulo"),
       special: true,
     }
   # NOTE: %% must be above %
@@ -3585,17 +3631,17 @@ BinaryOpSymbol
   # NOTE: CoffeeScript converts "!=" -> "!=="
   # Convert if CoffeeScript compat flag is set
   "!=" / "≠" ->
-    if(module.config.coffeeEq) return "!=="
+    if(config.coffeeEq) return "!=="
     return "!="
   "isnt" NonIdContinue ->
-    if(module.config.coffeeIsnt) return "!=="
+    if(config.coffeeIsnt) return "!=="
     return $skip
   "==="
   "≣" / "⩶" -> "==="
   # NOTE: CoffeeScript converts "==" -> "==="
   # Convert if CoffeeScript compat flag is set
   "==" / "≡" / "⩵" ->
-    if(module.config.coffeeEq) return "==="
+    if(config.coffeeEq) return "==="
     return "=="
   "and" NonIdContinue -> "&&"
   "&&"
@@ -3605,13 +3651,13 @@ BinaryOpSymbol
   # NOTE: ^^ must be above ^
   "^^" / ( "xor" NonIdContinue ) ->
     return {
-      call: module.getRef("xor"),
+      call: getHelperRef("xor"),
       special: true,
       prec: '^^',
     }
   /!\^\^?/ / ( "xnor" NonIdContinue ) ->
     return {
-      call: module.getRef("xnor"),
+      call: getHelperRef("xnor"),
       special: true,
       prec: '^^',
     }
@@ -3658,9 +3704,9 @@ BinaryOpSymbol
     }
   # NOTE: "is not" must come after "is not in"
   !CoffeeNotEnabled Is __ Not ->
-    if (module.config.objectIs) {
+    if (config.objectIs) {
       return {
-        call: module.getRef("is"),
+        call: getHelperRef("is"),
         relational: true,
         special: true,
         asConst: true,
@@ -3670,9 +3716,9 @@ BinaryOpSymbol
     return "!=="
   # NOTE: "is" must come after "is not" and "is in"
   Is ->
-    if (module.config.objectIs) {
+    if (config.objectIs) {
       return {
-        call: module.getRef("is"),
+        call: getHelperRef("is"),
         relational: true,
         special: true,
         asConst: true,
@@ -3692,7 +3738,7 @@ CoffeeOfOp
   Of -> "in"
   In ->
     return {
-      call: [module.getRef("indexOf"), ".call"],
+      call: [getHelperRef("indexOf"), ".call"],
       relational: true,
       reversed: true,
       suffix: " >= 0",
@@ -3707,7 +3753,7 @@ CoffeeOfOp
     }
   OmittedNegation __ In ->
     return {
-      call: [module.getRef("indexOf"), ".call"],
+      call: [getHelperRef("indexOf"), ".call"],
       relational: true,
       reversed: true,
       suffix: " < 0",
@@ -4101,7 +4147,7 @@ CoffeeForStatementParameters
       // TODO: Exp ref if exp is not a literal or identifier
 
       if (declaration.own) {
-        const hasPropRef = module.getRef("hasProp")
+        const hasPropRef = getHelperRef("hasProp")
 
         blockPrefix./**/push(["", ["if (!", hasPropRef, "(", exp, ", ", declaration, ")) continue"], ";"])
       }
@@ -4233,10 +4279,10 @@ ForStatementParameters
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
   ( Await __ )? ( (Each / Own) __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
-    return processForInOf($0, module.getRef)
+    return processForInOf($0, getHelperRef)
   # NOTE: Added optional parens
   ( Await __ )? ( (Each / Own) __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
-    return processForInOf($0, module.getRef)
+    return processForInOf($0, getHelperRef)
   ForRangeParameters
 
 ForRangeParameters
@@ -4554,98 +4600,98 @@ LeftHandSideExpressionWithObjectApplicationForbidden
 
 ForbidClassImplicitCall
   "" ->
-    module.forbidClassImplicitCall.push(true)
+    state.forbidClassImplicitCall.push(true)
 
 AllowClassImplicitCall
   "" ->
-    module.forbidClassImplicitCall.push(false)
+    state.forbidClassImplicitCall.push(false)
 
 RestoreClassImplicitCall
   "" ->
-    module.forbidClassImplicitCall.pop()
+    state.forbidClassImplicitCall.pop()
 
 ClassImplicitCallForbidden
   "" ->
-    if (!module.classImplicitCallForbidden) return $skip
+    if (!state.classImplicitCallForbidden) return $skip
     return
 
 ForbidBracedApplication
   "" ->
-    module.forbidBracedApplication.push(true)
+    state.forbidBracedApplication.push(true)
 
 AllowBracedApplication
   "" ->
-    module.forbidBracedApplication.push(false)
+    state.forbidBracedApplication.push(false)
 
 RestoreBracedApplication
   "" ->
-    module.forbidBracedApplication.pop()
+    state.forbidBracedApplication.pop()
 
 BracedApplicationAllowed
   "" ->
-    if (module.config.verbose) {
-      console.log("forbidBracedApplication:", module.forbidBracedApplication)
+    if (config.verbose) {
+      console.log("forbidBracedApplication:", state.forbidBracedApplication)
     }
-    if (module.bracedApplicationForbidden) return $skip
+    if (state.bracedApplicationForbidden) return $skip
     return
 
 ForbidIndentedApplication
   "" ->
-    module.forbidIndentedApplication.push(true)
+    state.forbidIndentedApplication.push(true)
 
 AllowIndentedApplication
   "" ->
-    module.forbidIndentedApplication.push(false)
+    state.forbidIndentedApplication.push(false)
 
 RestoreIndentedApplication
   "" ->
-    module.forbidIndentedApplication.pop()
+    state.forbidIndentedApplication.pop()
 
 IndentedApplicationAllowed
   "" ->
-    if (module.config.verbose) {
-      console.log("forbidIndentedApplication:", module.forbidIndentedApplication)
+    if (config.verbose) {
+      console.log("forbidIndentedApplication:", state.forbidIndentedApplication)
     }
-    if (module.indentedApplicationForbidden) return $skip
+    if (state.indentedApplicationForbidden) return $skip
     return
 
 ForbidTrailingMemberProperty
   "" ->
-    module.forbidTrailingMemberProperty.push(true)
+    state.forbidTrailingMemberProperty.push(true)
 
 AllowTrailingMemberProperty
   "" ->
-    module.forbidTrailingMemberProperty.push(false)
+    state.forbidTrailingMemberProperty.push(false)
 
 RestoreTrailingMemberProperty
   "" ->
-    module.forbidTrailingMemberProperty.pop()
+    state.forbidTrailingMemberProperty.pop()
 
 TrailingMemberPropertyAllowed
   "" ->
-    if (module.config.verbose) {
-      console.log("forbidTrailingMemberProperty:", module.forbidTrailingMemberProperty)
+    if (config.verbose) {
+      console.log("forbidTrailingMemberProperty:", state.forbidTrailingMemberProperty)
     }
-    if (module.trailingMemberPropertyForbidden) return $skip
+    if (state.trailingMemberPropertyForbidden) return $skip
 
 AllowNewlineBinaryOp
   "" ->
-    module.forbidNewlineBinaryOp.push(false)
+    state.forbidNewlineBinaryOp.push(false)
 
 ForbidNewlineBinaryOp
   "" ->
-    module.forbidNewlineBinaryOp.push(true)
+    state.forbidNewlineBinaryOp.push(true)
 
 RestoreNewlineBinaryOp
   "" ->
-    module.forbidNewlineBinaryOp.pop()
+    state.forbidNewlineBinaryOp.pop()
 
 NewlineBinaryOpAllowed
   "" ->
-    if (module.config.verbose) {
-      console.log("forbidNewlineBinaryOp:", module.forbidNewlineBinaryOp)
+    if (config.verbose) {
+      console.log("forbidNewlineBinaryOp:", state.forbidNewlineBinaryOp)
     }
-    if (module.newlineBinaryOpForbidden) return $skip
+    if (state.newlineBinaryOpForbidden) return $skip
 
 AllowAll
   AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNewlineBinaryOp
@@ -4852,7 +4898,7 @@ TypeAndImportSpecifier
     if (spec.binding.type !== "Identifier") {
       throw new Error("Expected identifier after `operator`")
     }
-    module.operators.set(spec.binding.name, spec.behavior)
+    state.operators.set(spec.binding.name, spec.behavior)
     return {
       ...spec,
       children: [
@@ -4917,7 +4963,7 @@ ModuleExportName
 ModuleSpecifier
   UnprocessedModuleSpecifier ImportAssertion?:a ->
     let { token } = $1
-    if (module.config.rewriteTsImports) {
+    if (config.rewriteTsImports) {
       // Workaround to fix:
       // https://github.com/microsoft/TypeScript/issues/42151
       // import t.ts
@@ -4925,9 +4971,9 @@ ModuleSpecifier
       // convert .[mc]?ts to .[mc]?js
       token = token.replace(/\.([mc])?ts(['"])$/, ".$1js$2")
     }
-    if (module.config.rewriteCivetImports) {
+    if (config.rewriteCivetImports) {
       token = token.replace(/\.civet(['"])$/,
-        `${module.config.rewriteCivetImports.replace(/\$/g, '$$')}$1`)
+        `${config.rewriteCivetImports.replace(/\$/g, '$$')}$1`)
     }
 
     if (a)
@@ -5380,7 +5426,7 @@ TemplateLiteral
 
 _TemplateLiteral
   TripleTick ( TemplateBlockCharacters / TemplateSubstitution )* TripleTick ->
-    return dedentBlockSubstitutions($0, module.config.tab)
+    return dedentBlockSubstitutions($0, config.tab)
 
   Backtick ( TemplateCharacters / TemplateSubstitution )* Backtick ->
     return {
@@ -5390,7 +5436,7 @@ _TemplateLiteral
 
   # NOTE: actual CoffeeScript """ string behaviors are pretty weird, this is simplified
   TripleDoubleQuote ( TripleDoubleStringCharacters / CoffeeStringSubstitution )* TripleDoubleQuote ->
-    return dedentBlockSubstitutions($0, module.config.tab)
+    return dedentBlockSubstitutions($0, config.tab)
 
   # NOTE: ''' don't have interpolation so could be converted into a regular
   # String, but currently we use `template`s so the output looks similar to
@@ -5399,7 +5445,7 @@ _TemplateLiteral
   TripleSingleQuote:s TripleSingleStringCharacters:str TripleSingleQuote:e ->
     return {
       type: "TemplateLiteral",
-      children: [s, dedentBlockString(str, module.config.tab), e]
+      children: [s, dedentBlockString(str, config.tab), e]
     }
 
   # CoffeeScript Interpolation is enabled when "civet coffee-compat" or "civet coffee-interpolation" directive is present
@@ -5970,15 +6016,15 @@ JSXImplicitFragment
       type: "JSXFragment",
       children: [
         "<>\n",
-        module.currentIndent.token,
+        state.currentIndent.token,
         ...$0,
         "\n",
-        module.currentIndent.token,
+        state.currentIndent.token,
         "</>",
       ],
       jsxChildren: [$1].concat($2.map(([, tag]) => tag)),
     }
-    const type = typeOfJSX(jsx, module.config, module.getRef)
+    const type = typeOfJSX(jsx, config, getHelperRef)
     return type ? [
       { ts: true, children: ["("] },
       jsx,
@@ -6009,7 +6055,7 @@ JSXElement
       parts = [
         ...$0,
         "\n", // InsertNewline
-        module.currentIndent.token, // InsertIndent
+        state.currentIndent.token, // InsertIndent
         ["</", open[1], ">"],
       ]
     } else {
@@ -6031,12 +6077,12 @@ JSXSelfClosingElement
 
 PushJSXOpeningElement
   JSXOpeningElement ->
-    module.JSXTagStack.push($1[1])
+    state.JSXTagStack.push($1[1])
     return $1
 
 PopJSXStack
   "" ->
-    module.JSXTagStack.pop()
+    state.JSXTagStack.pop()
 
 # https://facebook.github.io/jsx/#prod-JSXOpeningElement
 JSXOpeningElement
@@ -6044,7 +6090,7 @@ JSXOpeningElement
 
 JSXOptionalClosingElement
   Whitespace? JSXClosingElement:close ->
-    if (module.currentJSXTag !== close[2]) return $skip
+    if (state.currentJSXTag !== close[2]) return $skip
     return $0
   ""
 
@@ -6063,7 +6109,7 @@ JSXFragment
       [
         ...$0,
         "\n", // InsertNewline
-        module.currentIndent.token, // InsertIndent
+        state.currentIndent.token, // InsertIndent
         "</>",
       ]
     return { type: "JSXFragment", children: parts, jsxChildren: children.jsxChildren }
@@ -6079,12 +6125,12 @@ JSXFragment
 
 PushJSXOpeningFragment
   "<>" ->
-    module.JSXTagStack.push("")
+    state.JSXTagStack.push("")
     return $1
 
 JSXOptionalClosingFragment
   Whitespace? JSXClosingFragment ->
-    if (module.currentJSXTag !== "") return $skip
+    if (state.currentJSXTag !== "") return $skip
     return $0
   ""
 
@@ -6095,7 +6141,7 @@ JSXClosingFragment
 JSXElementName
   # Implicit element name
   &( ( "#" / Dot ) JSXShorthandString ) ->
-    return module.config.defaultElement
+    return config.defaultElement
   # Merged in https://facebook.github.io/jsx/#prod-JSXNamespacedName
   # Merged in https://facebook.github.io/jsx/#prod-JSXMemberExpression
   $( JSXIdentifierName ( (Colon JSXIdentifierName) / ( Dot JSXIdentifierName )* ) )
@@ -6120,7 +6166,7 @@ JSXAttributes
     })
     if (classes.length) {
       // Check for non-shorthand class or className attribute
-      let className = module.config.react ? "className" : "class"
+      let className = config.react ? "className" : "class"
       attrs = attrs.filter((pair) => {
         const [, attr] = pair
         if ((attr[0][0] === "class" || attr[0][0] === "className") &&
@@ -6519,7 +6565,7 @@ JSXEOS
 JSXNested
   JSXEOS:eos Indent:indent ->
     const { level } = indent
-    const currentIndent = module.currentIndent
+    const currentIndent = state.currentIndent
     if (level !== currentIndent.level) return $skip
     return $0
 
@@ -7398,7 +7444,7 @@ InsertNewline
 
 InsertIndent
   "" ->
-    return module.currentIndent.token
+    return state.currentIndent.token
 
 InsertSpace
   "" ->
@@ -7422,141 +7468,96 @@ InsertType
 
 CoffeeBinaryExistentialEnabled
   "" ->
-    if(module.config.coffeeBinaryExistential) return
+    if(config.coffeeBinaryExistential) return
     return $skip
 
 CoffeeBooleansEnabled
   "" ->
-    if(module.config.coffeeBooleans) return
+    if(config.coffeeBooleans) return
     return $skip
 
 CoffeeClassesEnabled
   "" ->
-    if(module.config.coffeeClasses) return
+    if(config.coffeeClasses) return
     return $skip
 
 CoffeeCommentEnabled
   "" ->
-    if(module.config.coffeeComment) return
+    if(config.coffeeComment) return
     return $skip
 
 CoffeeDoEnabled
   "" ->
-    if(module.config.coffeeDo) return
+    if(config.coffeeDo) return
     return $skip
 
 CoffeeForLoopsEnabled
   "" ->
-    if(module.config.coffeeForLoops) return
+    if(config.coffeeForLoops) return
     return $skip
 
 CoffeeInterpolationEnabled
   "" ->
-    if(module.config.coffeeInterpolation) return
+    if(config.coffeeInterpolation) return
     return $skip
 
 CoffeeIsntEnabled
   "" ->
-    if(module.config.coffeeIsnt) return
+    if(config.coffeeIsnt) return
     return $skip
 
 CoffeeJSXEnabled
   "" ->
-    if(module.config.coffeeJSX) return
+    if(config.coffeeJSX) return
     return $skip
 
 CoffeeLineContinuationEnabled
   "" ->
-    if(module.config.coffeeLineContinuation) return
+    if(config.coffeeLineContinuation) return
     return $skip
 
 CoffeeNotEnabled
   "" ->
-    if(module.config.coffeeNot) return
+    if(config.coffeeNot) return
     return $skip
 
 CoffeeOfEnabled
   "" ->
-    if(module.config.coffeeOf) return
+    if(config.coffeeOf) return
     return $skip
 
 CoffeePrototypeEnabled
   "" ->
-    if(module.config.coffeePrototype) return
+    if(config.coffeePrototype) return
     return $skip
 
 ObjectIsEnabled
   "" ->
-    if(module.config.objectIs) return
+    if(config.objectIs) return
     return $skip
 
 # Reset module level data
 Reset
   "" ->
     // Storage for PushIndent/PopIndent
-    module.indentLevels = [{
+    state.indentLevels = [{
       level: 0,
       token: "",
     }]
 
-    module.forbidClassImplicitCall = [false]
-    module.forbidIndentedApplication = [false]
-    module.forbidBracedApplication = [false]
-    module.forbidTrailingMemberProperty = [false]
-    module.forbidNewlineBinaryOp = [false]
-    module.JSXTagStack = [undefined]
+    state.forbidClassImplicitCall = [false]
+    state.forbidIndentedApplication = [false]
+    state.forbidBracedApplication = [false]
+    state.forbidTrailingMemberProperty = [false]
+    state.forbidNewlineBinaryOp = [false]
+    state.JSXTagStack = [undefined]
 
-    module.operators = new Map
+    state.operators = new Map
 
-    if (!module._init) {
-      module._init = true
-      Object.defineProperties(module, {
-        currentIndent: {
-          get() {
-            const {indentLevels: l} = module
-            return l[l.length-1]
-          },
-        },
-        classImplicitCallForbidden: {
-          get() {
-            const {forbidClassImplicitCall: s} = module
-            return s[s.length-1]
-          },
-        },
-        indentedApplicationForbidden: {
-          get() {
-            const {forbidIndentedApplication: s} = module
-            return s[s.length-1]
-          },
-        },
-        bracedApplicationForbidden: {
-          get() {
-            const {forbidBracedApplication: s} = module
-            return s[s.length-1]
-          },
-        },
-        trailingMemberPropertyForbidden: {
-          get() {
-            const {forbidTrailingMemberProperty: s} = module
-            return s[s.length-1]
-          },
-        },
-        newlineBinaryOpForbidden: {
-          get() {
-            const {forbidNewlineBinaryOp: s} = module
-            return s[s.length-1]
-          },
-        },
-        currentJSXTag: {
-          get() {
-            const {JSXTagStack: s} = module
-            return s[s.length-1]
-          },
-        },
-      })
-    }
+    state.helperRefs = {}
+    state.prelude = []
 
-    module.config = {
+    config = {
       autoConst: false,
       autoVar: false,
       autoLet: false,
@@ -7586,174 +7587,16 @@ Reset
       verbose: false,
     }
 
-    const asAny = {
-      ts: true,
-      children: [" as any"]
-    }
-    module.prelude = []
-
-    const preludeVar = "var "
-    const declareRef = {
-      indexOf(indexOfRef) {
-        const typeSuffix = {
-          ts: true,
-          children: [": <T>(this: T[], searchElement: T) => number"]
-        }
-        // [indent, statement]
-        module.prelude.push(["", [preludeVar, indexOfRef, typeSuffix, " = [].indexOf", asAny, ";\n"]])
-      },
-      hasProp(hasPropRef) {
-        const typeSuffix = {
-          ts: true,
-          children: [": <T>(object: T, prop: PropertyKey) => boolean"]
-        }
-        // [indent, statement]
-        module.prelude.push(["", [preludeVar, hasPropRef, typeSuffix, " = ({}.constructor", asAny, ").hasOwn;\n"]])
-      },
-      is(isRef) {
-        // Thanks to @thetarnav for help with this TypeScript magic.
-        // If the second argument is more general, narrow it.
-        // Otherwise (including when the first argument is more general,
-        // or partial overlap), always narrow the first argument,
-        // as that's usually the one that matters.
-        // Waiting on https://github.com/Microsoft/TypeScript/issues/26916
-        // for proper narrowing of both arguments.
-        const typeSuffix = {
-          ts: true,
-          children: [": { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B }"]
-        }
-        // [indent, statement]
-        module.prelude.push(["", [preludeVar, isRef, typeSuffix, " = Object.is", asAny, ";\n"]])
-      },
-      /**
-       * Array length check with type guard.
-       * From tlgreg https://discord.com/channels/933472021310996512/1012166187196629113/1157386582546976873
-       */
-      len(lenRef) {
-        module.prelude.push(["", [{
-          ts: true,
-          children: [ "function ", lenRef, "<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }" ]
-        }, {
-          js: true,
-          children: [ "function ", lenRef, "(arr, length) { return arr.length === length }" ]
-        }], "\n"])
-      },
-      modulo(moduloRef) {
-        const typeSuffix = {
-          ts: true,
-          children: [": (a: number, b: number) => number"]
-        }
-        // [indent, statement]
-        module.prelude.push(["", [preludeVar, moduloRef, typeSuffix, " = (a, b) => (a % b + b) % b;", "\n"]])
-      },
-      Falsy(FalsyRef) {
-        module.prelude.push(["", [{
-          ts: true,
-          children: ["type ", FalsyRef, " = false | 0 | '' | 0n | null | undefined;", "\n"]
-        }]])
-      },
-      xor(xorRef) {
-        const Falsy = module.getRef("Falsy")
-        const typeSuffix = {
-          ts: true,
-          children: [
-            ": <A, B>(a: A, b: B) => A extends ",
-            Falsy,
-            " ? B : B extends ",
-            Falsy,
-            " ? A : (false | (A & ",
-            Falsy,
-            " extends never ? never : B) | (B & ",
-            Falsy,
-            " extends never ? never : A))"
-          ]
-        }
-        // [indent, statement]
-        module.prelude.push(["", [preludeVar, xorRef, typeSuffix, " = (a, b) => (a ? !b && a : b)", asAny, ";", "\n"]])
-      },
-      xnor(xnorRef) {
-        const Falsy = module.getRef("Falsy")
-        const typeSuffix = {
-          ts: true,
-          children: [
-            ": <A, B>(a: A, b: B) => A & ",
-            Falsy,
-            " extends never ? B : (true | (B extends ",
-            Falsy,
-            " ? never : A) | (A extends ",
-            Falsy,
-            " ? never : B))"
-          ]
-        }
-        // [indent, statement]
-        module.prelude.push(["", [preludeVar, xnorRef, typeSuffix, " = (a, b) => (a ? b : !b || a)", asAny, ";", "\n"]])
-      },
-      returnSymbol(ref) {
-        module.prelude.push({
-          children: [
-            preludeVar, ref, " = Symbol(\"return\")';\n",
-          ],
-        })
-      },
-      concatAssign(ref) {
-        const typeSuffix = {
-          ts: true,
-          children: [
-            ": <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A",
-          ]
-        }
-        module.prelude.push({
-          children: [
-            preludeVar, ref, typeSuffix,
-            " = (lhs, rhs) => (((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
-          ]
-        })
-      },
-      JSX(jsxRef) {
-        module.prelude.push({
-          ts: true,
-          children: [
-            "import type { JSX as ", jsxRef, " } from 'solid-js';\n",
-          ],
-        })
-      },
-      IntrinsicElements(intrinsicElementsRef) {
-        // JSX.IntrinsicElements[TagName] gives HTMLAttributes<ElementType> or
-        // SVGCoreAttributes<ElementType> or various subinterfaces of those.
-        // All of them extend DOMAttributes<ElementType>, though.  See
-        // https://raw.githubusercontent.com/ryansolid/dom-expressions/main/packages/dom-expressions/src/jsx.d.ts
-        // Thanks to @thetarnav for the TypeScript magic to extract ElementType.
-        // (TypeScript's HTMLElementTagNameMap and SVGElementTagNameMap are an
-        // alternative, but don't necessary match Solid's IntrinsicElements.)
-        const JSX = module.getRef("JSX")
-        module.prelude.push({
-          ts: true,
-          children: [
-            "type ", intrinsicElementsRef, "<K extends keyof ", JSX, ".IntrinsicElements> =\n",
-            "  ", JSX, ".IntrinsicElements[K] extends ", JSX, ".DOMAttributes<infer T> ? T : unknown;\n",
-          ],
-        })
-      },
-    }
-    const refs = {}
-
-    module.getRef = function (base) {
-      if (refs.hasOwnProperty(base)) return refs[base]
-      const ref = makeRef(base)
-      if (declareRef.hasOwnProperty(base)) declareRef[base](ref)
-      return refs[base] = ref
-    }
-
-    Object.defineProperty(module.config, "deno", {
+    Object.defineProperty(config, "deno", {
       set(b) {
-        module.config.rewriteTsImports = !b
+        config.rewriteTsImports = !b
       }
     })
     // default to deno compatibility if running in deno
-    module.config.deno = typeof Deno !== "undefined"
+    config.deno = typeof Deno !== "undefined"
 
     // Expand setting coffeeCompat to the individual options
-    Object.defineProperty(module.config, "coffeeCompat", {
+    Object.defineProperty(config, "coffeeCompat", {
       set(b) {
         for (const option of [
           "autoVar",
@@ -7772,21 +7615,21 @@ Reset
           "coffeeOf",
           "coffeePrototype",
         ]) {
-          module.config[option] = b
+          config[option] = b
         }
         if (b) {
-          module.config.objectIs = false
+          config.objectIs = false
         }
       }
     })
 
     // Hack to pass in parser config from main
     if (typeof parse !== "undefined") {
-      Object.assign(module.config, parse.config)
-      parse.config = module.config
+      Object.assign(config, parse.config)
+      parse.config = config
     } else {
-      Object.assign(module.config, exports.parse.config)
-      exports.parse.config = module.config
+      Object.assign(config, exports.parse.config)
+      exports.parse.config = config
     }
 
     // Hack to pass parser state to cache key
@@ -7795,20 +7638,20 @@ Reset
       children: [],
       getStateKey() {
         const stateInt =
-          ((module.currentIndent.level % 256) << 8) |
-          (module.classImplicitCallForbidden << 7) |
-          (module.indentedApplicationForbidden << 6) |
-          (module.bracedApplicationForbidden << 5) |
-          (module.trailingMemberPropertyForbidden << 4) |
-          (module.newlineBinaryOpForbidden << 3) |
+          ((state.currentIndent.level % 256) << 8) |
+          (state.classImplicitCallForbidden << 7) |
+          (state.indentedApplicationForbidden << 6) |
+          (state.bracedApplicationForbidden << 5) |
+          (state.trailingMemberPropertyForbidden << 4) |
+          (state.newlineBinaryOpForbidden << 3) |
           // This is slightly different than the rest of the state,
           // since it is affected by the directive prologue and may be hit
           // by the EOL rule early in the parse. Later if we wanted to
           // allow block scoping of the compat directives we would need to
           // add them all here.
-          (module.config.coffeeComment << 2)
+          (config.coffeeComment << 2)
 
-        return [stateInt, module.currentJSXTag]
+        return [stateInt, state.currentJSXTag]
       },
     }
 
@@ -7816,7 +7659,7 @@ Init
   Shebang? Prologue:directives ->
     directives.forEach((directive) => {
       if (directive.type === "CivetPrologue") {
-        Object.assign(module.config, directive.config)
+        Object.assign(config, directive.config)
       }
     })
 
@@ -7831,13 +7674,13 @@ ProloguePrefix
 
 # Indentation
 
-# Holds the last indent level in `module.lastIndent`
+# Holds the last indent level in `state.lastIndent`
 # Can get weird with backtracking but should work out as long as
 # EOS/Nested rules are used carefully and if we only compare to the
 # pushed value.
 Indent
   /[ \t]*/ ->
-    const level = getIndentLevel($0, module.config.tab)
+    const level = getIndentLevel($0, config.tab)
 
     return {
       $loc,
@@ -7850,14 +7693,14 @@ TrackIndented
   Indent:indent ->
     const {level} = indent
 
-    if (level <= module.currentIndent.level) {
+    if (level <= state.currentIndent.level) {
       return $skip
     }
-    if (module.config.verbose) {
+    if (config.verbose) {
       console.log("pushing indent", indent)
     }
 
-    module.indentLevels.push(indent)
+    state.indentLevels.push(indent)
     return $1
 
 # Indents one level deeper,
@@ -7870,10 +7713,10 @@ PushIndent
 
 PopIndent
   "" ->
-    if (module.config.verbose) {
-      console.log("popping indent", module.indentLevels[module.indentLevels.length-1], "->", module.indentLevels[module.indentLevels.length-2])
+    if (config.verbose) {
+      console.log("popping indent", state.indentLevels[state.indentLevels.length-1], "->", state.indentLevels[state.indentLevels.length-2])
     }
-    module.indentLevels./**/pop()
+    state.indentLevels./**/pop()
 
 # "Nested" actually means "new line at current indentation level",
 # where the current indentation level is set by TrackIndented / PushIndent
@@ -7881,20 +7724,20 @@ PopIndent
 # Consumes and returns the newline and indentation
 Nested
   EOS Indent:indent ->
-    if (indent.level === module.currentIndent.level) return $0
-    if (module.config.verbose) {
-      console.log(`failing Nested: ${indent.level} does not match current indent level ${module.currentIndent.level}`)
+    if (indent.level === state.currentIndent.level) return $0
+    if (config.verbose) {
+      console.log(`failing Nested: ${indent.level} does not match current indent level ${state.currentIndent.level}`)
     }
     return $skip
 
 IndentedFurther
   EOS Indent:indent ->
-    if (indent.level > module.currentIndent.level) return $0
+    if (indent.level > state.currentIndent.level) return $0
     return $skip
 
 IndentedAtLeast
   EOS Indent:indent ->
-    if (indent.level >= module.currentIndent.level) return $0
+    if (indent.level >= state.currentIndent.level) return $0
     return $skip
 
 NotDedented

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -167,7 +167,7 @@ ExpressionizedStatementWithTrailingCallExpressions
 
 ExpressionizedStatement
   # perf: assertion to exit early
-  /(?=async|debugger|if|unless|do|for|loop|until|while|switch|throw|try)/ StatementExpression:statement ->
+  /(?=async|debugger|if|unless|comptime|do|for|loop|until|while|switch|throw|try)/ StatementExpression:statement ->
     return {
       type: "StatementExpression",
       statement,
@@ -3931,7 +3931,7 @@ UnlessClause
 
 # https://262.ecma-international.org/#prod-IterationStatement
 IterationStatement
-  /(?=loop|do|for|until|while)/ _IterationStatement -> $2
+  /(?=loop|comptime|do|for|until|while)/ _IterationStatement -> $2
 
 _IterationStatement
   # NOTE: Added `loop` from CoffeeScript
@@ -3939,6 +3939,7 @@ _IterationStatement
   !CoffeeDoEnabled DoWhileStatement -> $2
   # DoStatement must come after DoWhile statement
   !CoffeeDoEnabled DoStatement -> $2
+  ComptimeStatement
   WhileStatement
   ForStatement
 
@@ -3999,6 +4000,15 @@ DoStatement
     block = insertTrimmingSpace(block, "")
     return {
       type: "DoStatement",
+      children: [block],
+      block,
+    }
+
+ComptimeStatement
+  Comptime NoPostfixBracedBlock:block ->
+    block = insertTrimmingSpace(block, "")
+    return {
+      type: "ComptimeStatement",
       children: [block],
       block,
     }
@@ -5620,6 +5630,10 @@ Colon
 
 Comma
   "," ->
+    return { $loc, token: $1 }
+
+Comptime
+  "comptime" NonIdContinue ->
     return { $loc, token: $1 }
 
 ConstructorShorthand

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -60,8 +60,14 @@ import {
 /**
  * Globals
  */
-let config;  // parser config options
+let initialConfig;        // input for parser config
+let config;               // current parser config after directives
 export const state = {};  // parser state
+
+export const getState = () => state;
+export const getConfig = () => config;
+export const getInitialConfig = () => initialConfig;
+export const setInitialConfig = (c) => initialConfig = c;
 
 Object.defineProperties(state, {
   currentIndent: {
@@ -121,7 +127,7 @@ Program
       children: [statements],
       bare: true,
       root: true,
-    }, config, state, ReservedWord)
+    }, ReservedWord)
     return $0
 
 TopLevelStatements
@@ -7624,13 +7630,7 @@ Reset
     })
 
     // Hack to pass in parser config from main
-    if (typeof parse !== "undefined") {
-      Object.assign(config, parse.config)
-      parse.config = config
-    } else {
-      Object.assign(config, exports.parse.config)
-      exports.parse.config = config
-    }
+    Object.assign(config, initialConfig)
 
     // Hack to pass parser state to cache key
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -136,12 +136,7 @@ NonAssignmentExtendedExpression
   # Check for nested expressionized statements first
   NestedNonAssignmentExtendedExpression
   __ ExpressionizedStatementWithTrailingCallExpressions ->
-    if ($2.length) {
-      return [...$1, ...$2]
-    }
-    return {...$2,
-      children: [...$1, ...$2.children]
-    }
+    return prepend($1, $2)
 
 NestedNonAssignmentExtendedExpression
   &EOS PushIndent ( Nested ExpressionizedStatementWithTrailingCallExpressions )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -145,21 +145,19 @@ function getIndent(statement: StatementTuple) {
 
 function hoistRefDecs(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (s) => s.hoistDec)
-    .forEach((node) => {
+    .forEach (node) =>
       let { hoistDec } = node
       node.hoistDec = null
 
       const { ancestor, child } = findAncestor node, (ancestor) =>
         ancestor.type is "BlockStatement" and (!ancestor.bare or ancestor.root)
 
-      if (ancestor) {
+      if ancestor
         insertHoistDec(ancestor, child, hoistDec)
-      } else {
+      else
         throw new Error("Couldn't find block to hoist declaration into.")
-      }
 
       return
-    })
 
 function insertHoistDec(block: BlockStatement, node: ASTNode | StatementTuple, dec: ASTNode): void
   // NOTE: This is more accurately 'statements'

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -76,8 +76,6 @@ function serialize(value: ???): string
       <? "object"
         if stack.has val
           throw new Error "circular reference detected"
-        if Array.isArray val
-          return `[${val.map(serialize).join ","}]`
         stack.add val
         str :=
           switch Object.getPrototypeOf val
@@ -89,22 +87,24 @@ function serialize(value: ???): string
             when Set::
               "new Set([" + (
                 for item of val as Set<???>
-                  serialize item
+                  recurse item
               ).join(",") + "])"
             when Map::
               "new Map([" + (
                 for [key, value] of val as Map<???, ???>
-                  `[${serialize key},${serialize value}]`
+                  `[${recurse key},${recurse value}]`
               ).join(",") + "])"
+            when Array::
+              `[${(val as ???[]).map(recurse).join ","}]`
             when Object::
               "{" + (
                 for own key, value in val as {[key: string]: ???}
-                  `${JSON.stringify key}:${serialize value}`
+                  `${JSON.stringify key}:${recurse value}`
               ).join(",") + "}"
             else
               // One day we may handle other classes like so:
               // str += `__proto__:${val.constructor.name}`
-              throw new TypeError `cannot serialize value with prototype ${Object.getPrototypeOf val}`
+              throw new TypeError `cannot serialize object with prototype ${Object.getPrototypeOf val}`
         stack.delete val
         str
       else

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -1,0 +1,42 @@
+import type {
+  ComptimeExpression
+  ComptimeStatement
+  StatementTuple
+} from ./types.civet
+
+import {
+  gatherRecursive
+} from "./traversal.civet"
+
+generate, { prune, type Options } from "../generate.civet"
+
+function processComptime(statements: StatementTuple[]): void
+  gatherRecursive statements,
+    (node): node is (ComptimeStatement | ComptimeExpression) =>
+      node.type is "ComptimeStatement" or node.type is "ComptimeExpression"
+  .forEach (exp) =>
+    content := exp.type is "ComptimeStatement" ? exp.block : exp.expression
+    // Convert the comptime block into JS code
+    options: Options := js: true
+    js := generate prune(content), options
+    // If there are any errors, leave the comptime subtree alone
+    // (so there's still an error).
+    return if options.errors?
+    output := eval?.(`"use strict";${js}`)
+    if exp.type is "ComptimeExpression"
+      let string
+      try
+        string = JSON.stringify output
+      catch e
+        exp.children = [
+          type: "Error"
+          message: `comptime result ${output} not JSON serializable: ${e}`
+        ]
+        return
+      exp.children = [string]
+    else
+      exp.children = []
+
+export {
+  processComptime
+}

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -81,6 +81,11 @@ function serialize(value: ???): string
         stack.add val
         str :=
           switch Object.getPrototypeOf val
+            when RegExp::
+              re := val as RegExp
+              `/${re.source}/${re.flags}`
+            when Date::
+              `new Date(${(val as Date).getTime()})`
             when Set::
               "new Set([" + (
                 for item of val as Set<???>

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -1,3 +1,5 @@
+"civet coffeePrototype"
+
 import type {
   ComptimeExpression
   ComptimeStatement
@@ -26,7 +28,7 @@ function processComptime(statements: StatementTuple[]): void
     if exp.type is "ComptimeExpression"
       let string
       try
-        string = JSON.stringify output
+        string = serialize output
       catch e
         exp.children = [
           type: "Error"
@@ -37,6 +39,74 @@ function processComptime(statements: StatementTuple[]): void
     else
       exp.children = []
 
+function serialize(value: ???): string
+  stack := new Set<object>
+  function recurse(val: ???): string
+    switch val
+      <? "string"
+        // Using JSON.stringify to handle escape sequences
+        JSON.stringify val
+      <? "number", <? "boolean", == null
+        String val // not toString to accomodate null/undefined
+      <? "bigint"
+        `${val}n`
+      <? "function"
+        // Some functions can actually be serialized
+        hasNoProps := (and)
+          Object.getOwnPropertyNames(val).every & is in ["length", "name", "arguments", "caller", "prototype"]
+          Object.getOwnPropertySymbols(val)# is 0
+          (or)
+            val:: is undefined
+            (and)
+              Object:: is Object.getPrototypeOf val::
+              Object.getOwnPropertyNames(val::)# is 1 // constructor
+              Object.getOwnPropertySymbols(val::)# is 0
+              val::constructor is val
+        unless hasNoProps
+          throw new TypeError "cannot serialize function with properties"
+        string := Function::toString.call val
+        if /\{\s+\[native code]\s+\}$/.test string
+          // builtin, or returned from Function::bind
+          throw new TypeError "cannot serialize native function"
+        string
+      <? "symbol"
+        if key? := Symbol.keyFor val
+          return `Symbol.for(${JSON.stringify key})`
+        throw new TypeError "cannot serialize unique symbol"
+      <? "object"
+        if stack.has val
+          throw new Error "circular reference detected"
+        if Array.isArray val
+          return `[${val.map(serialize).join ","}]`
+        stack.add val
+        str :=
+          switch Object.getPrototypeOf val
+            when Set::
+              "new Set([" + (
+                for item of val as Set<???>
+                  serialize item
+              ).join(",") + "])"
+            when Map::
+              "new Map([" + (
+                for [key, value] of val as Map<???, ???>
+                  `[${serialize key},${serialize value}]`
+              ).join(",") + "])"
+            when Object::
+              "{" + (
+                for own key, value in val as {[key: string]: ???}
+                  `${JSON.stringify key}:${serialize value}`
+              ).join(",") + "}"
+            else
+              // One day we may handle other classes like so:
+              // str += `__proto__:${val.constructor.name}`
+              throw new TypeError `cannot serialize value with prototype ${Object.getPrototypeOf val}`
+        stack.delete val
+        str
+      else
+        throw new TypeError `cannot serialize ${typeof val} value`
+  recurse value
+
 export {
   processComptime
+  serialize
 }

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -10,9 +10,15 @@ import {
   gatherRecursive
 } from "./traversal.civet"
 
+{ getInitialConfig } from "../parser.hera"
+
 generate, { prune, type Options } from "../generate.civet"
 
 function processComptime(statements: StatementTuple[]): void
+  // Prevent comptime setting from being overridden by directives
+  // by looking at initialConfig instead of config
+  return unless getInitialConfig()?.comptime
+
   gatherRecursive statements,
     (node): node is (ComptimeStatement | ComptimeExpression) =>
       node.type is "ComptimeStatement" or node.type is "ComptimeExpression"

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -131,6 +131,9 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
     statement := statementExp.statement
     blockStatement[1] = statement
 
+    // Leave comptime statements wrapped in IIFE
+    return if statement.type is "ComptimeStatement"
+
     if statement.type is "DoStatement"
       ref = initializer.expression = initializer.children[2] = makeRef()
       assignResults blockStatement, (resultNode) =>

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -5,7 +5,6 @@ import type {
   Binding
   Children
   DeclarationStatement
-  GetRef
   IfStatement
   Initializer
   IterationStatement
@@ -234,17 +233,17 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
       ...thisAssignments
     ]
 
-function processDeclarationConditions(node: ASTNode, getRef: GetRef): void
+function processDeclarationConditions(node: ASTNode): void
   gatherRecursiveAll node, (n) =>
     n.type is "IfStatement" or n.type is "IterationStatement" or n.type is "SwitchStatement"
   .forEach (s) =>
-    processDeclarationConditionStatement s, getRef
+    processDeclarationConditionStatement s
 
 /**
  * Processes adding additional conditions when declarations are used as a condition in IfStatements, WhileStatements, and SwitchStatements.
  * Also does additional processing for IfStatements that used to be in the parser (inserting semi-colon on bare-block consequent with else).
  */
-function processDeclarationConditionStatement(s: IfStatement | IterationStatement | SwitchStatement, getRef: GetRef): void
+function processDeclarationConditionStatement(s: IfStatement | IterationStatement | SwitchStatement): void
   { condition } := s
   return unless condition?.expression
   { expression } .= condition
@@ -258,7 +257,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
 
   if pattern
     conditions .= []
-    getPatternConditions(pattern, ref, conditions, getRef)
+    getPatternConditions(pattern, ref, conditions)
 
     conditions = conditions.filter (c) =>
       !(c.length is 3 and c[0] is "typeof " and c[1] is ref and c[2] is " === 'object'") and

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -532,7 +532,7 @@ function expressionizeIteration(exp: IterationExpression): void
 
   if subtype is "DoStatement" or subtype is "ComptimeStatement"
     // Just wrap with IIFE; insertReturn will apply to the resulting function
-    children.splice(i, 1, ...wrapIIFE([["", statement, undefined]], async))
+    children.splice(i, 1, wrapIIFE([["", statement, undefined]], async))
     updateParentPointers exp
     return
 
@@ -548,7 +548,7 @@ function expressionizeIteration(exp: IterationExpression): void
   // Wrap with IIFE
   children.splice(i,
     1,
-    ...wrapIIFE([
+    wrapIIFE([
       ["", ["const ", resultsRef, "=[]"], ";"],
       ...children.map((c) => ["", c, undefined]),
       ["", wrapWithReturn(resultsRef)],

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,11 +1,9 @@
 import type {
   ASTNode
   ASTNodeBase
-  DoStatement
-  ForStatement
   FunctionNode
   IterationExpression
-  IterationStatement
+  IterationFamily
   LabeledStatement
   StatementTuple
   TypeIdentifierNode
@@ -267,6 +265,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
     case "ForStatement":
     case "IterationStatement":
     case "DoStatement":
+    case "ComptimeStatement":
       wrapIterationReturningResults(exp, outer, collect)
       return
     case "BlockStatement":
@@ -374,6 +373,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
     case "ForStatement":
     case "IterationStatement":
     case "DoStatement":
+    case "ComptimeStatement":
       wrapIterationReturningResults(exp, outer)
       return
     case "BlockStatement":
@@ -419,11 +419,11 @@ function insertSwitchReturns(exp): void
     insertReturn clause
 
 function wrapIterationReturningResults(
-  statement: ForStatement | IterationStatement | DoStatement,
+  statement: IterationFamily,
   outer: { children: StatementTuple[] },
   collect?: (node: ASTNode) => ASTNode
 ): void
-  if statement.type is "DoStatement"
+  if statement.type is "DoStatement" or statement.type is "ComptimeStatement"
     if collect
       assignResults(statement.block, collect)
     else
@@ -530,7 +530,7 @@ function expressionizeIteration(exp: IterationExpression): void
   if i < 0
     throw new Error("Could not find iteration statement in iteration expression")
 
-  if subtype is "DoStatement"
+  if subtype is "DoStatement" or subtype is "ComptimeStatement"
     // Just wrap with IIFE; insertReturn will apply to the resulting function
     children.splice(i, 1, ...wrapIIFE([["", statement, undefined]], async))
     updateParentPointers exp

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -1,0 +1,159 @@
+// Helper functions added to preamble of output code
+
+type { ASTNode, ASTRef, StatementTuple } from './types.civet'
+{ makeRef } from './util.civet'
+{ state } from "../parser.hera"
+declare var state: {
+  prelude: StatementTuple[]
+  helperRefs: Record<HelperName, ASTRef>
+}
+
+preludeVar := "var "
+
+function ts(children: string | ASTNode[]): ASTNode
+  ts: true
+  children: Array.isArray(children) ? children : [children]
+
+asAny := ts " as any"
+
+declareHelper := {
+  indexOf(indexOfRef): void
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      indexOfRef
+      ts [": <T>(this: T[], searchElement: T) => number"]
+      " = [].indexOf"
+      asAny
+    ], ";\n"]
+  hasProp(hasPropRef): void
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      hasPropRef
+      ts ": <T>(object: T, prop: PropertyKey) => boolean"
+      " = ({}.constructor"
+      asAny
+      ").hasOwn;\n"
+    ]]
+  is(isRef): void
+    // Thanks to @thetarnav for help with this TypeScript magic.
+    // If the second argument is more general, narrow it.
+    // Otherwise (including when the first argument is more general,
+    // or partial overlap), always narrow the first argument,
+    // as that's usually the one that matters.
+    // Waiting on https://github.com/Microsoft/TypeScript/issues/26916
+    // for proper narrowing of both arguments.
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      isRef
+      ts ": { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B }"
+      " = Object.is"
+      asAny
+      ";\n"
+    ]]
+  /**
+   * Array length check with type guard.
+   * From tlgreg https://discord.com/channels/933472021310996512/1012166187196629113/1157386582546976873
+   */
+  len(lenRef): void
+    state.prelude.push ["", [
+      ts [ "function ", lenRef, "<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }" ]
+      {
+        js: true
+        children: [ "function ", lenRef, "(arr, length) { return arr.length === length }" ]
+      }
+      "\n"
+    ]]
+  modulo(moduloRef): void
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      moduloRef
+      ts ": (a: number, b: number) => number"
+      " = (a, b) => (a % b + b) % b;\n"
+    ]]
+  Falsy(FalsyRef): void
+    state.prelude.push ["", // [indent, statement]
+      ts ["type ", FalsyRef, " = false | 0 | '' | 0n | null | undefined;\n"]
+    ]
+  xor(xorRef): void
+    Falsy := getHelperRef "Falsy"
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      xorRef
+      ts [
+        ": <A, B>(a: A, b: B) => A extends ", Falsy
+        " ? B : B extends ", Falsy
+        " ? A : (false | (A & ", Falsy
+        " extends never ? never : B) | (B & ", Falsy
+        " extends never ? never : A))"
+      ]
+      " = (a, b) => (a ? !b && a : b)"
+      asAny
+      ";\n"
+    ]]
+  xnor(xnorRef): void
+    Falsy := getHelperRef "Falsy"
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      xnorRef
+      ts [
+        ": <A, B>(a: A, b: B) => A & ", Falsy,
+        " extends never ? B : (true | (B extends ", Falsy,
+        " ? never : A) | (A extends ", Falsy,
+        " ? never : B))"
+      ]
+      " = (a, b) => (a ? b : !b || a)"
+      asAny
+      ";\n"
+    ]]
+  returnSymbol(ref): void
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      ref
+      " = Symbol(\"return\")';\n"
+    ]]
+  concatAssign(ref): void
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      ref
+      ts [
+        ": <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A"
+      ]
+      " = (lhs, rhs) => (((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
+    ]]
+  JSX(jsxRef): void
+    state.prelude.push ["", // [indent, statement]
+      ts ["import type { JSX as ", jsxRef, " } from 'solid-js'"]
+      ";\n"
+    ]
+  IntrinsicElements(intrinsicElementsRef): void
+    // JSX.IntrinsicElements[TagName] gives HTMLAttributes<ElementType> or
+    // SVGCoreAttributes<ElementType> or various subinterfaces of those.
+    // All of them extend DOMAttributes<ElementType>, though.  See
+    // https://raw.githubusercontent.com/ryansolid/dom-expressions/main/packages/dom-expressions/src/jsx.d.ts
+    // Thanks to @thetarnav for the TypeScript magic to extract ElementType.
+    // (TypeScript's HTMLElementTagNameMap and SVGElementTagNameMap are an
+    // alternative, but don't necessary match Solid's IntrinsicElements.)
+    JSX := getHelperRef "JSX"
+    state.prelude.push ["", // [indent, statement, delim]
+      ts [
+        "type ", intrinsicElementsRef
+        "<K extends keyof ", JSX, ".IntrinsicElements> =\n"
+        "  ", JSX, ".IntrinsicElements[K] extends ", JSX, ".DOMAttributes<infer T> ? T : unknown"
+      ]
+      ";\n"
+    ]
+} satisfies Record<string, (ref: ASTRef) => void>
+
+export type HelperName = keyof typeof declareHelper
+
+function getHelperRef(base: HelperName): ASTRef
+  return state.helperRefs[base] if base in state.helperRefs
+  ref := makeRef base
+  if base not in declareHelper
+    throw new Error `Unknown helper function: ${base}`
+  declareHelper[base](ref)
+  state.helperRefs[base] = ref
+
+export {
+  getHelperRef
+}

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -121,6 +121,11 @@ import {
   quoteString
 } from ./string.civet
 
+import {
+  getConfig
+  getState
+  getInitialConfig
+} from ../parser.hera
 
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   expressions := [
@@ -1074,7 +1079,10 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
         ".length"
       ]
 
-function processProgram(root: BlockStatement, config, state, ReservedWord: ParseRule): void
+function processProgram(root: BlockStatement, ReservedWord: ParseRule): void
+  state := getState()
+  config := getConfig()
+
   // invariants
   assert.equal(state.forbidBracedApplication.length, 1, "forbidBracedApplication")
   assert.equal(state.forbidClassImplicitCall.length, 1, "forbidClassImplicitCall")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -110,6 +110,7 @@ import {
 import { processUnaryExpression } from ./unary.civet
 import { createConstLetDecs, createVarDecs } from ./auto-dec.civet
 import { processComptime } from ./comptime.civet
+import { getHelperRef } from ./helper.civet
 
 import {
   dedentBlockString
@@ -1073,14 +1074,14 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
         ".length"
       ]
 
-function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule): void
+function processProgram(root: BlockStatement, config, state, ReservedWord: ParseRule): void
   // invariants
-  assert.equal(m.forbidBracedApplication.length, 1, "forbidBracedApplication")
-  assert.equal(m.forbidClassImplicitCall.length, 1, "forbidClassImplicitCall")
-  assert.equal(m.forbidIndentedApplication.length, 1, "forbidIndentedApplication")
-  assert.equal(m.forbidNewlineBinaryOp.length, 1, "forbidNewlineBinaryOp")
-  assert.equal(m.forbidTrailingMemberProperty.length, 1, "forbidTrailingMemberProperty")
-  assert.equal(m.JSXTagStack.length, 1, "JSXTagStack")
+  assert.equal(state.forbidBracedApplication.length, 1, "forbidBracedApplication")
+  assert.equal(state.forbidClassImplicitCall.length, 1, "forbidClassImplicitCall")
+  assert.equal(state.forbidIndentedApplication.length, 1, "forbidIndentedApplication")
+  assert.equal(state.forbidNewlineBinaryOp.length, 1, "forbidNewlineBinaryOp")
+  assert.equal(state.forbidTrailingMemberProperty.length, 1, "forbidTrailingMemberProperty")
+  assert.equal(state.JSXTagStack.length, 1, "JSXTagStack")
 
   addParentPointers(root)
 
@@ -1089,12 +1090,12 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
   processPlaceholders(statements)
   processNegativeIndexAccess(statements)
   processTypes(statements)
-  processDeclarationConditions(statements, m.getRef)
+  processDeclarationConditions(statements)
   processPipelineExpressions(statements)
   processDeclarations(statements)
   processAssignments(statements)
   processStatementExpressions(statements)
-  processPatternMatching(statements, ReservedWord, m.getRef)
+  processPatternMatching(statements, ReservedWord)
 
   // Modify iteration expressions
   gatherRecursiveAll(statements, (n) => n.type is "IterationExpression")
@@ -1110,7 +1111,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
   processFunctions(statements, config)
 
   // Insert prelude
-  statements.unshift(...m.prelude)
+  statements.unshift(...state.prelude)
 
   if (config.autoLet) {
     createConstLetDecs(statements, [], "let")
@@ -1125,7 +1126,7 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
   populateRefs(statements)
   adjustAtBindings(statements)
 
-  processComptime(statements)
+  processComptime(statements, state.comptime)
 
 function populateRefs(statements: ASTNode): void {
   const refNodes = gatherRecursive(statements, ({ type }) => type is "Ref")
@@ -1390,16 +1391,16 @@ function replaceNodesRecursive(root, predicate, replacer)
 
   return root
 
-function typeOfJSX(node, config, getRef) {
+function typeOfJSX(node, config) {
   switch (node.type) {
     case "JSXElement":
-      return typeOfJSXElement(node, config, getRef)
+      return typeOfJSXElement(node, config)
     case "JSXFragment":
-      return typeOfJSXFragment(node, config, getRef)
+      return typeOfJSXFragment(node, config)
   }
 }
 
-function typeOfJSXElement(node, config, getRef) {
+function typeOfJSXElement(node, config) {
   if (config.solid) {
     if (config.server and !config.client) {  // server only
       return ["string"]
@@ -1410,7 +1411,7 @@ function typeOfJSXElement(node, config, getRef) {
     // [https://www.typescriptlang.org/docs/handbook/jsx.html]
     const clientType =
       tag[0] is tag[0].toLowerCase() ?
-        [getRef("IntrinsicElements"), '<"', tag, '">'] :
+        [getHelperRef("IntrinsicElements"), '<"', tag, '">'] :
         ['ReturnType<typeof ', tag, '>']
     if (config.server) {  // isomorphic code for client + server
       return ["string", " | ", clientType]
@@ -1420,7 +1421,7 @@ function typeOfJSXElement(node, config, getRef) {
   }
 }
 
-function typeOfJSXFragment(node, config, getRef) {
+function typeOfJSXFragment(node, config) {
   if (config.solid) {
     let type = []
     let lastType
@@ -1433,11 +1434,11 @@ function typeOfJSXFragment(node, config, getRef) {
           }
           break
         case "JSXElement":
-          type.push(typeOfJSXElement(child, config, getRef))
+          type.push(typeOfJSXElement(child, config))
           break
         case "JSXFragment":
           // Solid flattens fragments of fragments into one array.
-          type.push(...typeOfJSXFragment(child, config, getRef))
+          type.push(...typeOfJSXFragment(child, config))
           break
         case "JSXChildExpression":
           // Solid discards empty expressions
@@ -1480,6 +1481,7 @@ export {
   gatherRecursive
   gatherRecursiveAll
   gatherRecursiveWithinFunction
+  getHelperRef
   getIndentLevel
   getPrecedence
   getTrimmingSpace

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1079,7 +1079,7 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
         ".length"
       ]
 
-function processProgram(root: BlockStatement, ReservedWord: ParseRule): void
+function processProgram(root: BlockStatement): void
   state := getState()
   config := getConfig()
 
@@ -1103,7 +1103,7 @@ function processProgram(root: BlockStatement, ReservedWord: ParseRule): void
   processDeclarations(statements)
   processAssignments(statements)
   processStatementExpressions(statements)
-  processPatternMatching(statements, ReservedWord)
+  processPatternMatching(statements)
 
   // Modify iteration expressions
   gatherRecursiveAll(statements, (n) => n.type is "IterationExpression")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -223,7 +223,7 @@ function expressionizeBlock(blockOrExpression: ASTNode)
   else
     blockOrExpression
 
-function expressionizeIfStatement(statement: IfStatement)
+function expressionizeIfStatement(statement: IfStatement): ASTNode
   { condition, then: b, else: e } := statement
   [ ...condRest, closeParen ] := condition.children  // separate ')'
 
@@ -249,8 +249,8 @@ function expressionizeIfStatement(statement: IfStatement)
   children.push closeParen
 
   {
-    type: "IfExpression",
-    children,
+    type: "IfExpression"
+    children
   }
 
 function expressionizeTypeIf([ws, ifOp, condition, t, e])
@@ -475,7 +475,6 @@ function replaceNode(node: ASTNodeObject, newNode: ASTNode, parent?: ASTNodePare
   for key, value in parent
     if value is node
       parent[key] = newNode
-      return
 
   if isASTNodeObject newNode
     newNode.parent = parent
@@ -1013,23 +1012,17 @@ function processStatementExpressions(statements: StatementTuple[]): void
     .forEach (_exp) =>
       exp := _exp as! StatementExpression
       { statement } := exp
-      let ws
-      unless exp.children[0] is exp.statement
-        ws = exp.children[0]
 
       switch statement.type
         when "IfStatement"
           if expression := expressionizeIfStatement(statement)
-            exp.statement = expression
-            exp.children = [exp.statement]
+            replaceNode statement, expression, exp
           else
-            exp.children = wrapIIFE([["", statement]])
+            replaceNode statement, wrapIIFE([["", statement]]), exp
         when "IterationExpression"
           // Do nothing, handled separately currently
         else
-          exp.children = wrapIIFE([["", statement]])
-
-      exp.children.unshift(ws) if ws
+          replaceNode statement, wrapIIFE([["", statement]]), exp
 
 function processNegativeIndexAccess(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (n) => n.type is "NegativeIndex")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -118,6 +118,8 @@ import {
   quoteString
 } from ./string.civet
 
+generate, { prune } from "../generate.civet"
+
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   expressions := [
     ...post.blockPrefix or []
@@ -958,9 +960,7 @@ function attachPostfixStatementAsExpression(exp, post: [WSNode, IfStatement | It
   postfixStatement := post[1]
 
   switch postfixStatement.type
-    case "ForStatement":
-    case "IterationStatement":
-    case "DoStatement": {
+    when "ForStatement", "IterationStatement", "DoStatement"
       statement := addPostfixStatement(exp, ...post)
       return {
         type: "IterationExpression",
@@ -968,10 +968,9 @@ function attachPostfixStatementAsExpression(exp, post: [WSNode, IfStatement | It
         block: statement.block,
         statement,
       }
-    }
-    case "IfStatement":
+    when "IfStatement"
       return expressionizeIfStatement { ...postfixStatement, then: exp }
-    default:
+    else
       throw new Error("Unknown postfix statement")
 
 function processTypes(node: ASTNode)
@@ -1115,6 +1114,8 @@ function processProgram(root: BlockStatement, config, m, ReservedWord: ParseRule
 
   populateRefs(statements)
   adjustAtBindings(statements)
+
+  processComptime(statements)
 
 function populateRefs(statements: ASTNode): void {
   const refNodes = gatherRecursive(statements, ({ type }) => type is "Ref")
@@ -1267,6 +1268,27 @@ function processPlaceholders(statements: StatementTuple[]): void
       inplacePrepend ws, fnExp
 
   return
+
+function processComptime(statements: StatementTuple[]): void
+  gatherRecursive statements, .type is "ComptimeStatement"
+  .forEach (exp) =>
+    console.log exp, exp.parent?.expressions
+    // Convert the comptime block into JS code
+    options := js: true
+    js := generate prune(exp.block), options
+    console.log js
+    // If there are any errors, leave the comptime subtree alone
+    // (so there's still an error).
+    return if options.errors?
+    data .= eval?.(`"use strict";${js}`)
+    try
+      data = JSON.stringify data
+    catch e
+      replaceNode exp,
+        type: "Error"
+        message: `comptime result ${data} not JSON serializable: ${e}`
+      return
+    exp.children = [data]
 
 function reorderBindingRestProperty(props) {
   const names = props.flatMap((p) => p.names)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -16,6 +16,8 @@ import type {
   AssignmentExpression
   BlockStatement
   CallExpression
+  ComptimeExpression
+  ComptimeStatement
   DoStatement
   ExpressionNode
   ForStatement
@@ -118,7 +120,7 @@ import {
   quoteString
 } from ./string.civet
 
-generate, { prune } from "../generate.civet"
+generate, { prune, type Options } from "../generate.civet"
 
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   expressions := [
@@ -1020,7 +1022,16 @@ function processStatementExpressions(statements: StatementTuple[]): void
           else
             replaceNode statement, wrapIIFE([["", statement]]), exp
         when "IterationExpression"
-          // Do nothing, handled separately currently
+          if statement.subtype is "ComptimeStatement"
+            // Transform ComptimeStatement into ComptimeExpression,
+            // with IIFE wrapper inside the ComptimeExpression
+            expression := wrapIIFE(statement.statement.block.expressions)
+            replaceNode statement, makeNode({
+              type: "ComptimeExpression"
+              expression
+              children: [expression]
+            }), exp
+          // else do nothing, handled separately currently
         else
           replaceNode statement, wrapIIFE([["", statement]]), exp
 
@@ -1263,25 +1274,31 @@ function processPlaceholders(statements: StatementTuple[]): void
   return
 
 function processComptime(statements: StatementTuple[]): void
-  gatherRecursive statements, .type is "ComptimeStatement"
+  gatherRecursive statements,
+    (node): node is (ComptimeStatement | ComptimeExpression) =>
+      node.type is "ComptimeStatement" or node.type is "ComptimeExpression"
   .forEach (exp) =>
-    console.log exp, exp.parent?.expressions
+    content := exp.type is "ComptimeStatement" ? exp.block : exp.expression
     // Convert the comptime block into JS code
-    options := js: true
-    js := generate prune(exp.block), options
-    console.log js
+    options: Options := js: true
+    js := generate prune(content), options
     // If there are any errors, leave the comptime subtree alone
     // (so there's still an error).
     return if options.errors?
-    data .= eval?.(`"use strict";${js}`)
-    try
-      data = JSON.stringify data
-    catch e
-      replaceNode exp,
-        type: "Error"
-        message: `comptime result ${data} not JSON serializable: ${e}`
-      return
-    exp.children = [data]
+    output := eval?.(`"use strict";${js}`)
+    if exp.type is "ComptimeExpression"
+      let string
+      try
+        string = JSON.stringify output
+      catch e
+        exp.children = [
+          type: "Error"
+          message: `comptime result ${output} not JSON serializable: ${e}`
+        ]
+        return
+      exp.children = [string]
+    else
+      exp.children = []
 
 function reorderBindingRestProperty(props) {
   const names = props.flatMap((p) => p.names)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1134,7 +1134,7 @@ function processProgram(root: BlockStatement): void
   populateRefs(statements)
   adjustAtBindings(statements)
 
-  processComptime(statements, state.comptime)
+  processComptime(statements)
 
 function populateRefs(statements: ASTNode): void {
   const refNodes = gatherRecursive(statements, ({ type }) => type is "Ref")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -8,6 +8,7 @@
 
 import type {
   AccessStart
+  ASTLeaf
   ASTNode
   ASTNodeBase
   ASTNodeObject
@@ -308,7 +309,7 @@ function handleThisPrivateShorthands(value)
 /**
  * Process globs, bind shorthand, and call shortcuts, in Call/MemberExpression
  */
-function processCallMemberExpression(node)
+function processCallMemberExpression(node: ASTNodeParent): ASTNode
   { children } := node
 
   // Parenthesized operator like (+), immediately called, expands to
@@ -317,16 +318,22 @@ function processCallMemberExpression(node)
     op := children[0].parenthesizedOp
     call .= children[1]
     args := [...call.args] // shallow copy
-    call = { ...call, args }
+    call = {
+      ...call
+      args
+      children: call.children.map (x) => x is call.args ? args : x
+    }
     // Remove trailing comma
-    if comma := isComma args.-1
-      comma.token = ''
+    if isComma args.-1
+      args.-1 = deepCopy args.-1
+      (isComma(args.-1) as ASTLeaf).token = ''
     // Arguments already start and end with open and close parentheses.
     // Replace each comma with an instance of the operator and matching parens.
     commaCount .= 0
-    for each arg of args
-      if comma := isComma arg
-        comma.token = `)${op.token}(`
+    for each let arg, i of args
+      if isComma arg
+        arg = args[i] = deepCopy arg
+        (isComma(arg) as ASTLeaf).token = `)${op.token}(`
         commaCount++
     // Don't mess with (+)()
     if args.length

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -16,8 +16,6 @@ import type {
   AssignmentExpression
   BlockStatement
   CallExpression
-  ComptimeExpression
-  ComptimeStatement
   DoStatement
   ExpressionNode
   ForStatement
@@ -110,6 +108,7 @@ import {
 } from ./op.civet
 import { processUnaryExpression } from ./unary.civet
 import { createConstLetDecs, createVarDecs } from ./auto-dec.civet
+import { processComptime } from ./comptime.civet
 
 import {
   dedentBlockString
@@ -120,7 +119,6 @@ import {
   quoteString
 } from ./string.civet
 
-generate, { prune, type Options } from "../generate.civet"
 
 function addPostfixStatement(statement: StatementTuple, ws: ASTNode, post)
   expressions := [
@@ -1273,33 +1271,6 @@ function processPlaceholders(statements: StatementTuple[]): void
       inplacePrepend ws, fnExp
 
   return
-
-function processComptime(statements: StatementTuple[]): void
-  gatherRecursive statements,
-    (node): node is (ComptimeStatement | ComptimeExpression) =>
-      node.type is "ComptimeStatement" or node.type is "ComptimeExpression"
-  .forEach (exp) =>
-    content := exp.type is "ComptimeStatement" ? exp.block : exp.expression
-    // Convert the comptime block into JS code
-    options: Options := js: true
-    js := generate prune(content), options
-    // If there are any errors, leave the comptime subtree alone
-    // (so there's still an error).
-    return if options.errors?
-    output := eval?.(`"use strict";${js}`)
-    if exp.type is "ComptimeExpression"
-      let string
-      try
-        string = JSON.stringify output
-      catch e
-        exp.children = [
-          type: "Error"
-          message: `comptime result ${output} not JSON serializable: ${e}`
-        ]
-        return
-      exp.children = [string]
-    else
-      exp.children = []
 
 function reorderBindingRestProperty(props) {
   const names = props.flatMap((p) => p.names)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -480,7 +480,8 @@ function replaceNode(node: ASTNodeObject, newNode: ASTNode, parent?: ASTNodePare
 
   if isASTNodeObject newNode
     newNode.parent = parent
-  node.parent = undefined
+  // Don't destroy node's parent, as we often include it within newNode
+  //node.parent = undefined
 
 // Wrap expression in parentheses to make into a statement when:
 // * object literal expression

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -33,7 +33,12 @@ import {
   getHelperRef
 } from ./helper.civet
 
-function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule): void {
+import {
+  ReservedWord
+} from ../parser.hera
+declare var ReservedWord: ParseRule
+
+function processPatternMatching(statements: ASTNode): void {
   gatherRecursiveAll(statements, .type is "SwitchStatement")
     .forEach((s: SwitchStatement) => {
       { caseBlock } := s
@@ -132,7 +137,7 @@ function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule): v
             splices = splices.map((s) => [", ", nonMatcherBindings(s)])
             thisAssignments = thisAssignments.map((a) => [indent, a, ";"])
 
-            const duplicateDeclarations = aggregateDuplicateBindings([patternBindings, splices], ReservedWord)
+            const duplicateDeclarations = aggregateDuplicateBindings([patternBindings, splices])
 
             prefix.push([indent, "const ", patternBindings, " = ", ref, splices, ";"])
             prefix.push(...thisAssignments)
@@ -377,7 +382,7 @@ function nonMatcherBindings(pattern) {
   }
 }
 
-function aggregateDuplicateBindings(bindings, ReservedWord: ParseRule) {
+function aggregateDuplicateBindings(bindings) {
   props := gatherRecursiveAll bindings, .type is "BindingProperty"
   arrayBindings := gatherRecursiveAll bindings, .type is "ArrayBindingPattern"
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -1,7 +1,6 @@
 import type {
   ASTNode
   ASTRef
-  GetRef
   ParenthesizedExpression
   ParseRule
   SwitchStatement
@@ -30,7 +29,11 @@ import {
   processBinaryOpExpression
 } from ./op.civet
 
-function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule, getRef: GetRef): void {
+import {
+  getHelperRef
+} from ./helper.civet
+
+function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule): void {
   gatherRecursiveAll(statements, .type is "SwitchStatement")
     .forEach((s: SwitchStatement) => {
       { caseBlock } := s
@@ -93,7 +96,7 @@ function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule, ge
 
         const alternativeConditions = patterns.map((pattern, i) => {
           const conditions = []
-          getPatternConditions(pattern, ref, conditions, getRef)
+          getPatternConditions(pattern, ref, conditions)
           return conditions
         })
 
@@ -172,7 +175,6 @@ function getPatternConditions(
   pattern,
   ref,
   conditions,
-  getRef: GetRef
 ): void {
   if (pattern.rest) return // No conditions for rest elements
 
@@ -183,7 +185,7 @@ function getPatternConditions(
         l = (length - hasRest).toString(),
         lengthCheck = hasRest
         ? [ref, ".length >= ", l]
-        : [getRef("len"), "(", ref, ", ", l, ")"]
+        : [getHelperRef("len"), "(", ref, ", ", l, ")"]
 
       conditions.push(
         ["Array.isArray(", ref, ")"],
@@ -193,7 +195,7 @@ function getPatternConditions(
       // recursively collect nested conditions
       elements.forEach(({ children: [, e] }, i) => {
         const subRef = [ref, "[", i.toString(), "]"]
-        getPatternConditions(e, subRef, conditions, getRef)
+        getPatternConditions(e, subRef, conditions)
       })
 
       // collect post rest conditions
@@ -204,7 +206,7 @@ function getPatternConditions(
 
         postElements.forEach(({ children: [, e] }, i) => {
           const subRef = [ref, "[", ref, ".length - ", (postLength + i).toString(), "]"]
-          getPatternConditions(e, subRef, conditions, getRef)
+          getPatternConditions(e, subRef, conditions)
         })
       }
 
@@ -239,7 +241,7 @@ function getPatternConditions(
             }
 
             if (value) {
-              getPatternConditions(value, subRef, conditions, getRef)
+              getPatternConditions(value, subRef, conditions)
             }
 
             break

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -149,13 +149,13 @@ function processPatternMatching(statements: ASTNode, ReservedWord: ParseRule, ge
         // Insert else if there are more branches
         if (i < l - 1) next.push("\n", "else ")
 
-        prev.push(["", {
-          type: "IfStatement",
-          children: ["if", condition, block, next],
-          then: block,
-          else: next,
-          hoistDec,
-        }])
+        prev.push ["", {
+          type: "IfStatement"
+          children: ["if", condition, block, next]
+          then: block
+          else: next
+          hoistDec
+        }]
         hoistDec = undefined
         refAssignment = []
         prev = next

--- a/source/parser/traversal.civet
+++ b/source/parser/traversal.civet
@@ -5,9 +5,9 @@ import type {
 } from ./types.civet
 import { isFunction } from ./util.civet
 
-type Predicate<T, U extends T> = (arg: T) => arg is U;
+export type Predicate<T extends ASTNodeObject> = (arg: ASTNodeObject) => arg is T
 
-function gatherRecursiveWithinFunction<T extends ASTNode, U extends T>(node: T, predicate: Predicate<T, U>)
+function gatherRecursiveWithinFunction<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>)
   gatherRecursive(node, predicate, isFunction)
 
 /**
@@ -55,7 +55,7 @@ function findAncestor(
 // while recursing into nested expressions
 // without recursing into nested blocks/for loops
 
-function gatherNodes<T extends ASTNode, U extends NonNullable<T>>(node: T, predicate: Predicate<NonNullable<T>, U>): U[]
+function gatherNodes<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>): T[]
   if (node == null) return []
 
   if (Array.isArray(node)) {
@@ -82,7 +82,7 @@ function gatherNodes<T extends ASTNode, U extends NonNullable<T>>(node: T, predi
 
 // Gather nodes that match a predicate recursing into all unmatched children
 // i.e. if the predicate matches a node it is not recursed into further
-function gatherRecursive<T extends ASTNode, U extends T, V extends T>(node: T, predicate: Predicate<T, U>, skipPredicate?: Predicate<T, V>): Exclude<U, V>[]
+function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = never>(node: ASTNode, predicate: Predicate<T>, skipPredicate?: Predicate<S>): Exclude<T, S>[]
   if (node == null) return []
 
   if (Array.isArray(node)) {
@@ -97,7 +97,7 @@ function gatherRecursive<T extends ASTNode, U extends T, V extends T>(node: T, p
 
   return gatherRecursive(node.children, predicate, skipPredicate)
 
-function gatherRecursiveAll<T extends ASTNode, U=NonNullable<T extends (infer U)[] ? U : T>>(node: T, predicate: Predicate<U, U>): U[]
+function gatherRecursiveAll<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>): T[]
   if (node == null) return []
 
   if Array.isArray node

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -36,9 +36,12 @@ export type StatementNode =
 export type ExpressionNode =
   | AssignmentExpression
   | BinaryOp
+  | CallExpression
+  | ComptimeExpression
   | Existence
   | FunctionNode
   | Identifier
+  | IfExpression
   | IterationExpression
   | Literal
   | MethodDefinition
@@ -194,6 +197,11 @@ export type IfStatement
   then: BlockStatement
   else: [ ASTNode, ElseToken, BlockStatement ]?
 
+export type IfExpression
+  type: "IfExpression"
+  children: Children
+  parent?: Parent
+
 export type IterationExpression
   type: "IterationExpression"
   children: Children
@@ -223,6 +231,12 @@ export type ComptimeStatement
   children: Children
   parent?: Parent
   block: BlockStatement
+
+export type ComptimeExpression
+  type: "ComptimeExpression"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
 
 export type ContinueStatement
   type: "ContinueStatement"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -568,6 +568,3 @@ export type VoidType = ASTLeaf & type: "VoidType"
 export type TypeLiteralNode = ASTLeaf | VoidType
 
 export type ThisAssignments = [string, ASTRef][]
-
-// TODO: Limit to keyof actual ref names
-export type GetRef = (refName: string) => ASTRef

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -15,6 +15,7 @@ export type ASTNodeObject = Exclude<StatementNode | OtherNode, string>
 export type StatementNode =
   | BlockStatement
   | BreakStatement
+  | ComptimeStatement
   | ContinueStatement
   | DebuggerStatement
   | DeclarationStatement
@@ -199,9 +200,11 @@ export type IterationExpression
   parent?: Parent
   subtype: IterationExpression["statement"]["type"]
   block: BlockStatement,
-  statement: IterationStatement | DoStatement | ForStatement
+  statement: IterationFamily
   async: boolean
   resultsRef: ASTRef?
+
+export type IterationFamily = ForStatement | IterationStatement | DoStatement | ComptimeStatement
 
 export type IterationStatement
   type: "IterationStatement"
@@ -214,6 +217,12 @@ export type BreakStatement
   type: "BreakStatement"
   children: Children
   parent?: Parent
+
+export type ComptimeStatement
+  type: "ComptimeStatement"
+  children: Children
+  parent?: Parent
+  block: BlockStatement
 
 export type ContinueStatement
   type: "ContinueStatement"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -139,6 +139,7 @@ function isFunction(node: ASTNode & { type: unknown, async?: boolean }): boolean
 statementTypes := new Set [
   "BlockStatement"
   "BreakStatement"
+  "ComptimeStatement"
   "ContinueStatement"
   "DebuggerStatement"
   "Declaration"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -590,7 +590,7 @@ function parenthesizeType(type: ASTNodeBase)
  * uses await, or just adding async if specified.
  * Returns an Array suitable for `children`.
  */
-function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean): ASTNode[]
+function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean): ASTNode
   let prefix
 
   let async
@@ -637,9 +637,9 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean): ASTNode[]
     children: [ makeLeftHandSideExpression(fn), "()" ]
 
   if prefix
-    return [ makeLeftHandSideExpression [prefix, exp] ]
+    return makeLeftHandSideExpression [prefix, exp]
 
-  return [ exp ]
+  return exp
 
 function wrapWithReturn(expression?: ASTNode): ASTNode
   const children = expression ? ["return ", expression] : ["return"]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -442,7 +442,7 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
  * More generally wrap in parentheses if necessary.
  * (Consider renaming and making parentheses depend on context.)
  */
-function makeLeftHandSideExpression(expression)
+function makeLeftHandSideExpression(expression: ASTNodeObject)
   return expression if expression.parenthesized
   switch (expression.type)
     case "AmpersandRef":
@@ -464,7 +464,6 @@ function makeLeftHandSideExpression(expression)
     children: ["(", expression, ")"]
     expression
     implicit: true
-    parent: undefined
   }
 
 /**
@@ -478,14 +477,14 @@ function updateParentPointers(node: ASTNode, parent?: ASTNodeParent, depth = 1):
 
   // NOTE: Arrays are transparent and skipped when traversing via parent
   if Array.isArray(node)
-    for child of node
+    for each child of node
       updateParentPointers(child, parent, depth)
     return
 
   node = node as ASTNodeObject
   node.parent = parent if parent?
   if depth and isParent node
-    for child of node.children
+    for each child of node.children
       updateParentPointers(child, node, depth-1)
 
 function makeNode<T extends ASTNodeObject>(node: T): T

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -1,0 +1,45 @@
+{ testCase, throws } from ./helper.civet
+{ compile } from ../source/main.civet
+assert from assert
+
+describe "comptime", ->
+  testCase """
+    statement with indented block
+    ---
+    comptime
+      x := 5
+      x * x
+    ---
+
+  """
+
+  testCase """
+    one-line statement
+    ---
+    comptime x := 5
+    ---
+
+  """
+
+  it "statement has side effect", =>
+    global.outside = 0
+    compile "comptime global.outside = 7"
+    assert.equal global.outside, 7
+
+  testCase """
+    one-line expression
+    ---
+    value := comptime 1+2
+    ---
+    const value = 3
+  """
+
+  testCase """
+    expression with indented block
+    ---
+    value := comptime
+      x := 5
+      x * x
+    ---
+    const value = 25
+  """

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -55,6 +55,8 @@ describe "serialize", ->
     assert.equal serialize(Infinity), "Infinity"
     assert.equal serialize(-Infinity), "-Infinity"
     assert.equal serialize(NaN), "NaN"
+  it "big numbers", =>
+    assert.equal serialize(1000000000000000n), "1000000000000000n"
   it "arrays and nulls", =>
     assert.equal serialize([1, undefined, 3, null]), "[1,undefined,3,null]"
   it "strings", =>
@@ -62,7 +64,7 @@ describe "serialize", ->
   it "symbols", =>
     assert.equal serialize(Symbol.for 'MyKeyedSymbol'),
       'Symbol.for("MyKeyedSymbol")'
-    assert.throws => serialize Symbol()
+    assert.throws (=> serialize Symbol()), /cannot serialize unique symbol/
   it "regexps", =>
     assert.equal serialize(/a[b\s]c/), "/a[b\\s]c/"
     assert.equal serialize(/abc/gi), "/abc/gi"
@@ -78,7 +80,7 @@ describe "serialize", ->
       'new Map([["a",1],["b",2],["c",3]])'
   it "custom classes", =>
     class Foo {}
-    assert.throws => serialize new Foo()
+    assert.throws (=> serialize new Foo()), /cannot serialize object with prototype/
   it "arrow functions", =>
     assert.equal serialize((x: ???) => x), "(x) => x"
   it "regular functions", =>
@@ -86,16 +88,16 @@ describe "serialize", ->
   it "functions with properties", =>
     func: any := (x: ???) => x
     func.a = 1
-    assert.throws => serialize func
+    assert.throws (=> serialize func), /cannot serialize function with properties/
   it "native functions", =>
-    assert.throws => serialize parseInt
+    assert.throws (=> serialize parseInt), /cannot serialize native function/
   it "circular", =>
     object: any := {}
     object.circular = object
-    assert.throws => serialize object
+    assert.throws (=> serialize object), /circular reference detected/
     array: any := []
     array.push array
-    assert.throws => serialize array
+    assert.throws (=> serialize array), /circular reference detected/
   it "aliasing", =>
     inner: never[] := []
     outer := [inner, inner]

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -1,6 +1,10 @@
 { testCase, throws } from ./helper.civet
 { compile } from ../source/main.civet
+{ serialize } from ../source/parser/comptime.civet
 assert from assert
+
+declare global
+  var outside: number
 
 describe "comptime", ->
   testCase """
@@ -43,3 +47,45 @@ describe "comptime", ->
     ---
     const value = 25
   """
+
+describe "serialize", ->
+  it "arrays and nulls", =>
+    assert.equal serialize([1, undefined, 3, null]), "[1,undefined,3,null]"
+  it "strings", =>
+    assert.equal serialize('Hello, "world"!'), '"Hello, \\"world\\"!"'
+  it "symbols", =>
+    assert.equal serialize(Symbol.for 'MyKeyedSymbol'),
+      'Symbol.for("MyKeyedSymbol")'
+    assert.throws => serialize Symbol()
+  it "objects", =>
+    assert.equal serialize(foo: true, bar: baz: false),
+      '{"foo":true,"bar":{"baz":false}}'
+  it "Sets", =>
+    assert.equal serialize(new Set([1, 2, 3])), "new Set([1,2,3])"
+  it "Maps", =>
+    assert.equal serialize(new Map([["a", 1], ["b", 2], ["c", 3]])),
+      'new Map([["a",1],["b",2],["c",3]])'
+  it "custom classes", =>
+    class Foo {}
+    assert.throws => serialize new Foo()
+  it "arrow functions", =>
+    assert.equal serialize((x: ???) => x), "(x) => x"
+  it "regular functions", =>
+    assert.equal serialize((x: ???) -> x), "function (x) { return x; }"
+  it "functions with properties", =>
+    func: any := (x: ???) => x
+    func.a = 1
+    assert.throws => serialize func
+  it "native functions", =>
+    assert.throws => serialize parseInt
+  it "circular", =>
+    object: any := {}
+    object.circular = object
+    assert.throws => serialize object
+    array: any := []
+    array.push array
+    assert.throws => serialize array
+  it "aliasing", =>
+    inner: never[] := []
+    outer := [inner, inner]
+    assert.equal serialize(outer), "[[],[]]"

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -49,6 +49,12 @@ describe "comptime", ->
   """
 
 describe "serialize", ->
+  it "numbers", =>
+    assert.equal serialize(1), "1"
+    assert.equal serialize(1.5), "1.5"
+    assert.equal serialize(Infinity), "Infinity"
+    assert.equal serialize(-Infinity), "-Infinity"
+    assert.equal serialize(NaN), "NaN"
   it "arrays and nulls", =>
     assert.equal serialize([1, undefined, 3, null]), "[1,undefined,3,null]"
   it "strings", =>
@@ -57,6 +63,11 @@ describe "serialize", ->
     assert.equal serialize(Symbol.for 'MyKeyedSymbol'),
       'Symbol.for("MyKeyedSymbol")'
     assert.throws => serialize Symbol()
+  it "regexps", =>
+    assert.equal serialize(/a[b\s]c/), "/a[b\\s]c/"
+    assert.equal serialize(/abc/gi), "/abc/gi"
+  it "dates", =>
+    assert.equal serialize(new Date(1659916697000)), 'new Date(1659916697000)'
   it "objects", =>
     assert.equal serialize(foo: true, bar: baz: false),
       '{"foo":true,"bar":{"baz":false}}'

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -7,6 +7,8 @@ declare global
   var outside: number
 
 describe "comptime", ->
+  options := parseOptions: comptime: true
+
   testCase """
     statement with indented block
     ---
@@ -15,7 +17,7 @@ describe "comptime", ->
       x * x
     ---
 
-  """
+  """, options
 
   testCase """
     one-line statement
@@ -23,11 +25,11 @@ describe "comptime", ->
     comptime x := 5
     ---
 
-  """
+  """, options
 
   it "statement has side effect", =>
     global.outside = 0
-    compile "comptime global.outside = 7"
+    compile "comptime global.outside = 7", options
     assert.equal global.outside, 7
 
   testCase """
@@ -36,7 +38,7 @@ describe "comptime", ->
     value := comptime 1+2
     ---
     const value = 3
-  """
+  """, options
 
   testCase """
     expression with indented block
@@ -46,7 +48,42 @@ describe "comptime", ->
       x * x
     ---
     const value = 25
-  """
+  """, options
+
+  describe "disabled", ->
+    testCase """
+      statement with indented block
+      ---
+      comptime
+        x := 5
+        x * x
+      ---
+      {
+        const x = 5
+        x * x
+      }
+    """
+
+    testCase """
+      expression with indented block
+      ---
+      value := comptime
+        x := 5
+        x * x
+      ---
+      const value = (()=>{
+        const x = 5
+        return x * x})()
+    """
+
+    testCase """
+      attempt to override
+      ---
+      "civet comptime"
+      x := comptime 1+2
+      ---
+      const x = (()=>{ return 1+2})()
+    """
 
 describe "serialize", ->
   it "numbers", =>

--- a/test/do.civet
+++ b/test/do.civet
@@ -106,7 +106,7 @@ describe "do", ->
     ---
     function f(x) {
       x = x * x
-      return  (()=>{{
+      return (()=>{{
         const y = x * x
         return y * y
       }})()
@@ -157,7 +157,7 @@ describe "do", ->
         y * y
     ---
     async function f(x) {
-      return  (await (async ()=>{{
+      return (await (async ()=>{{
         const y = await x
         return y * y
       }})())
@@ -218,7 +218,7 @@ describe "do", ->
       result := await fetch url
       await result.json()
     ---
-    const promise =  (async ()=>{{
+    const promise = (async ()=>{{
       const result = await fetch(url)
       return await result.json()
     }})()

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -629,6 +629,18 @@ describe "switch", ->
     """
 
     testCase """
+      return expression
+      ---
+      =>
+        return switch x()
+          1 "one"
+      ---
+      () => {
+        return (()=>{let m;if(m = x(),m === 1) { return "one"};return})()
+      }
+    """
+
+    testCase """
       with else
       ---
       switch x

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -29,6 +29,7 @@ declare module "@danielx/civet" {
     server: boolean
     tab: number
     verbose: boolean
+    comptime: boolean
   }>
   export type CompileOptions = {
     filename?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,10 +159,10 @@
     "@typescript/vfs" "^1.5.0"
     unplugin "^1.6.0"
 
-"@danielx/hera@^0.8.11":
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/@danielx/hera/-/hera-0.8.11.tgz#ccf8ba4a231a0b1308bb0ee24b03c1c25d5b3488"
-  integrity sha512-1AQVUh0uji4ExSZk62vYQ6K152j+CZN1E6i39/Jb3z3A4b3VqYByezHwcg4mZloT4RWaPo35zT5pwtnwutNIcQ==
+"@danielx/hera@^0.8.13":
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/@danielx/hera/-/hera-0.8.13.tgz#cae224d94924a78453a39b751a7068e239c7e586"
+  integrity sha512-/jBqU2AGweqRWJx+j7Y/fnTxuPGfTjukwCg6xjj0LaOnItACUwYbdYW+URvUGNfBRt2kcb1a7+E0lVtqsrq4kQ==
 
 "@docsearch/css@3.5.2", "@docsearch/css@^3.5.2":
   version "3.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,10 +150,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@0.6.73":
-  version "0.6.73"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.6.73.tgz#4c46b79e4552f9ac5596d197ad0963b4fcc69de0"
-  integrity sha512-VOq02JgXNArsLzq/I2OnZtn16exiF8/mIhpR5O6Tsc+97RU6Qe8EP8XJskh/Hm9koUODzWUW8UuFpFdVzm7wTA==
+"@danielx/civet@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.1.tgz#b12f5268cb9f4336fa342ae551e18b3989900c6c"
+  integrity sha512-CpgSIsvP8ZboPFVVXmClCFFg6ar2ohwL7wJW6KdfAcwCrdKM41P0XuQ2Bt2L0CO+Q0ewG9F+fcgIJ3WMdWxgYQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
     "@typescript/vfs" "^1.5.0"


### PR DESCRIPTION
This is a first version of `comptime` blocks based on [Rust's comptime crate](https://docs.rs/comptime/latest/comptime/). Limitations:

* Block must be run synchronously. To allow for async code, I realize we need to change the compilation API to allow async at some stage.
* Output must `JSON.stringify`able, so must have no reference cycles.
* No access to outer scopes. We could add this some day, but we don't have any variable tracking whatsoever, so it's probably a longer term thing.

The elephant in the room is security. `eval` always feels dangerous. On the other hand, I can't immediately think of a threat model where you're running an NPM script that runs `civet` for compilation and it couldn't run any other command. Still, if feels a little weird that compiling with the `civet` CLI could run arbitrary code. But this is also inherent to macros; see e.g. how [Rust's comptime crate is implemented](https://docs.rs/comptime/latest/src/comptime/lib.rs.html): it runs an external copy of Rust.

Another example is editing in VSCode. As you're typing code, it will *immediately run the comptime blocks on every keystroke* which could take down the language server (infinite loop) or other "fun" accidents.

I feel like, at the least, we need a flag that controls `comptime`, and maybe the default should be off. So maybe `civet --comptime` to enable, or in the unplugin there's a `{comptime: true}` option. I haven't added this yet because I wanted to get input first on what you think is best, but it's my current thoughts.

Alternatively, we could add a `comptime` phase separate in between `parse`/`prune` and `generate`. This would have the potential advantage of keeping those phases synchronous, so only the `comptime` phase needs to be asynchronous. But it would make it harder to use from an API perspective. Or maybe we offer multiple top-level APIs, synchronous which forbid comptime, and asynchronous which allows it?

Also:
* Fix two significant bugs in `replaceNode` (premature `return` and bad resetting of `parent`)
* Get the `Predicate` stuff actually working. Previously was assuming that the first argument has a relevant type, but it can really be anything.