### PR TITLE
Faster and robust config searching via `readdir` instead of `opendir`

### DIFF
--- a/source/config.civet
+++ b/source/config.civet
@@ -14,19 +14,17 @@ configFileNames := new Set [
 ]
 
 function findInDir(dirPath: string): Promise<string | undefined>
-  dir := await fs.opendir(dirPath)
-  for await entry of dir
-    if entry.isDirectory() and entry.name === ".config"
+  for entryName of await fs.readdir dirPath
+    entryPath := path.join dirPath, entryName
+
+    if entryName is ".config" and try fs.stat entryPath |> await |> .isDir()
       // scan for ./civet.json as well as ./.config/civet.json
-      const found = await findInDir(
-        path.join(dirPath, entry.name)
-      );
+      found := await findInDir entryPath
       return found if found
 
-    if entry.isFile()
-      const name = entry.name.replace(/^\./, ""); // allow both .civetconfig.civet and civetconfig.civet
-      if configFileNames.has name
-        return path.join dirPath, entry.name
+    name := entryName.replace(/^\./, "") // allow both .civetconfig.civet and civetconfig.civet
+    if configFileNames.has(name) and try fs.stat entryPath |> await |> .isFile()
+      return entryPath
 
   return
 

--- a/test/infra/config.civet
+++ b/test/infra/config.civet
@@ -4,8 +4,8 @@ assert from assert
 describe "loading config", ->
   it "should load from civetconfig.json", ->
     path := await findConfig("test/infra/config/")
+    assert path, "should have found civetconfig.json"
     config := await loadConfig(path)
-
     assert config.coffeeCompat
 
   it "should load specified custom files", ->


### PR DESCRIPTION
Performance: `fs.opendir` stats every file in a directory, I believe. We only need to stat names that match `.config` or `civetconfig.*`. I've restructured to use `fs.readdir` which just gets the listing, and only stat files we care about. On some file systems, this can be orders of magnitudes faster.

Also, `stat` can throw, and we can't really catch that from `fs.opendir`. MIT's UNIX machines use AFS (Andrew File System) which is ... particular. The parent directory of my home directory has 500 subdirectories, and some of them fail to stat. In particular, *every time I run the Civet CLI* (without `--no-config`) I get this error:

```
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: ENODEV: no such device, lstat 'xxx'] {
  errno: -19,
  code: 'ENODEV',
  syscall: 'lstat',
  path: 'xxx'
}
```

(where `xxx` is the parent of my home directory)

With this PR, I can finally run the CLI on these machines without `--no-config` 😄 