### PR TITLE
Insert "function" into ES6 methods

### DIFF
--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -74,7 +74,10 @@ function serialize(value: ???): string
         if /\{\s+\[native code]\s+\}$/.test string
           // builtin, or returned from Function::bind
           throw new TypeError "cannot serialize native function"
-        // Check for ES6 methods that have been removed from the object, and add "function"
+        // Check for ES6 methods that have been removed from the object, and add "function" if possible
+        if string.0 is '['
+          // In general, the method name could be an arbitrary JS expression. This is not currently handled.
+          throw new Error "cannot serialize method with computed name"
         unless /^(?:async\s+)?(?:function(?!\p{ID_Continue})|\(|(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*\s*=>)/u.test string
           // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
           return string.replace /^(async\s+)?/u, (_, maybeAsync = '') => maybeAsync + 'function '

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -74,6 +74,12 @@ function serialize(value: ???): string
         if /\{\s+\[native code]\s+\}$/.test string
           // builtin, or returned from Function::bind
           throw new TypeError "cannot serialize native function"
+        // Check for ES6 methods that have been removed from the object, and add "function"
+        unless /^(?:async[\s\n]+)?(?:function|\(?(?:\w+(?:,[\s\n]*)?)*\)?[\s\n]*=>)/u.test string
+          // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
+          return string.replace
+            /^(async[\s\n]+)?(\w+)/u
+            (_, maybeAsync = '', name) => `${maybeAsync}function ${name}`
         string
       <? "symbol"
         if key? := Symbol.keyFor val

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -75,7 +75,7 @@ function serialize(value: ???): string
           // builtin, or returned from Function::bind
           throw new TypeError "cannot serialize native function"
         // Check for ES6 methods that have been removed from the object, and add "function"
-        unless /^(?:async[\s\n]+)?(?:function|\(?(?:\w+(?:,[\s\n]*)?)*\)?[\s\n]*=>)/u.test string
+        unless /^(?:async[\s\n]+)?(?:function|\(|\w+[\n\s]*=>)/u.test string
           // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
           return string.replace
             /^(async[\s\n]+)?(\w+)/u

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -75,11 +75,9 @@ function serialize(value: ???): string
           // builtin, or returned from Function::bind
           throw new TypeError "cannot serialize native function"
         // Check for ES6 methods that have been removed from the object, and add "function"
-        unless /^(?:async[\s\n]+)?(?:function|\(|\w+[\n\s]*=>)/u.test string
+        unless /^(?:async\s+)?(?:function(?!\p{ID_Continue})|\(|(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*\s*=>)/u.test string
           // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
-          return string.replace
-            /^(async[\s\n]+)?(\w+)/u
-            (_, maybeAsync = '', name) => `${maybeAsync}function ${name}`
+          return string.replace /^(async\s+)?/u, (_, maybeAsync = '') => maybeAsync + 'function '
         string
       <? "symbol"
         if key? := Symbol.keyFor val

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -145,3 +145,4 @@ describe "serialize", ->
   it "ES6 methods", =>
     assert.equal serialize({ functionF() { } }.functionF), "function functionF() { }"
     assert.equal serialize({ async bar() { } }.bar), "async function bar() { }"
+    assert.throws (=> serialize { [Math.sqrt 5]() {} }), /cannot serialize method with computed name/

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -139,3 +139,6 @@ describe "serialize", ->
     inner: never[] := []
     outer := [inner, inner]
     assert.equal serialize(outer), "[[],[]]"
+  it "ES6 method", =>
+    assert.equal serialize({ foo() { } }.foo), "function foo() { }"
+    assert.equal serialize({ async bar() { } }.bar), "async function bar() { }"

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -120,6 +120,9 @@ describe "serialize", ->
     assert.throws (=> serialize new Foo()), /cannot serialize object with prototype/
   it "arrow functions", =>
     assert.equal serialize((x: ???) => x), "(x) => x"
+    // Using match instead of equal so it's not sensitive to the rest of the file
+    // @ts-ignore Adding a type annotation adds parens to the output, so it's intentionally not typed
+    assert.match serialize(&), /^\$(\d*) => \$\1$/
   it "regular functions", =>
     assert.equal serialize((x: ???) -> x), "function (x) { return x; }"
   it "functions with properties", =>
@@ -139,6 +142,6 @@ describe "serialize", ->
     inner: never[] := []
     outer := [inner, inner]
     assert.equal serialize(outer), "[[],[]]"
-  it "ES6 method", =>
-    assert.equal serialize({ foo() { } }.foo), "function foo() { }"
+  it "ES6 methods", =>
+    assert.equal serialize({ functionF() { } }.functionF), "function functionF() { }"
     assert.equal serialize({ async bar() { } }.bar), "async function bar() { }"


### PR DESCRIPTION
Fixes #1182 

I just realized while typing this that my first regex doesn't handle default values in arguments to arrow functions, and since the default value can be an IIFE, I would basically have to fully parse JS in order to handle that. That's not a task that regex is sufficient for, so I'm marking this as a draft pending advice on what to do in that scenario.