### PR TITLE
Allow empty body in loops, if/else, do, comptime

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3959,7 +3959,7 @@ LabelledItem
 IfStatement
   # NOTE: Added paren-less condition
   # NOTE: Block isn't Statement so we can handle implied braces by nesting
-  ( IfClause / UnlessClause ):clause Block:block ElseClause?:e ->
+  ( IfClause / UnlessClause ):clause BlockOrEmpty:block ElseClause?:e ->
     return {
       type: "IfStatement",
       children: [...clause.children, block, e],
@@ -3969,8 +3969,8 @@ IfStatement
     }
 
 ElseClause
-  Nested Else Block
-  _? Else Block
+  Nested Else BlockOrEmpty
+  _? Else BlockOrEmpty
 
 IfClause
   If Condition:condition ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -303,6 +303,7 @@ ForbiddenImplicitCalls
   OmittedNegation _? Identifier:id ->
     if (state.operators.has(id.name)) return $0
     return $skip
+  PostfixStatement EmptyStatementBareBlock
   # `x ... y` is reserved for a range, but `x ...y` is an implicit call
   "... "
 
@@ -2380,10 +2381,26 @@ EmptyBlock
       empty: true,
     }
 
+# NOTE: We allow loop bodies to be empty, in which case they get a ; body
+BlockOrEmpty
+  Block
+  EmptyStatementBareBlock
+
 EmptyBareBlock
   # Implied empty block with no braces. Used in case statements.
   "" ->
     const expressions = []
+    return {
+      type: "BlockStatement",
+      expressions,
+      children: [expressions],
+      bare: true,
+    }
+
+EmptyStatementBareBlock
+  # Implied empty block with empty statement (;). Used for empty loop bodies.
+  &EOS !IndentedFurther InsertEmptyStatement:s ->
+    const expressions = [["", s]]
     return {
       type: "BlockStatement",
       expressions,
@@ -3908,6 +3925,10 @@ EmptyStatement
   _? &";" ->
     return { type: "EmptyStatement", children: $1 || [] }
 
+InsertEmptyStatement
+  InsertSemicolon ->
+    return { type: "EmptyStatement", children: [$1] }
+
 # https://262.ecma-international.org/#prod-BlockStatement
 BlockStatement
   # NOTE: Added lookahead for `=` to allow for destructuring assignment without parens
@@ -4003,7 +4024,7 @@ IterationExpression
 
 # NOTE: Added from CoffeeScript
 LoopStatement
-  LoopClause:clause Block:block ->
+  LoopClause:clause BlockOrEmpty:block ->
     return {
       ...clause,
       type: "IterationStatement",
@@ -4033,7 +4054,7 @@ LoopClause
 # https://262.ecma-international.org/#prod-DoWhileStatement
 DoWhileStatement
   # NOTE: Condition provides optional parens
-  Do NoPostfixBracedBlock:block __ WhileClause:clause ->
+  Do NoPostfixBracedOrEmptyBlock:block __ WhileClause:clause ->
     return {
       ...clause,
       type: "IterationStatement",
@@ -4043,7 +4064,7 @@ DoWhileStatement
     }
 
 DoStatement
-  Do NoPostfixBracedBlock:block ->
+  Do NoPostfixBracedOrEmptyBlock:block ->
     block = insertTrimmingSpace(block, "")
     return {
       type: "DoStatement",
@@ -4052,7 +4073,7 @@ DoStatement
     }
 
 ComptimeStatement
-  Comptime NoPostfixBracedBlock:block ->
+  Comptime NoPostfixBracedOrEmptyBlock:block ->
     block = insertTrimmingSpace(block, "")
     return {
       type: "ComptimeStatement",
@@ -4063,7 +4084,7 @@ ComptimeStatement
 # https://262.ecma-international.org/#prod-WhileStatement
 WhileStatement
   # NOTE: Condition provides optional parens
-  WhileClause:clause Block:block ->
+  WhileClause:clause BlockOrEmpty:block ->
     return {
       ...clause,
       children: [...clause.children, block],
@@ -4088,7 +4109,7 @@ WhileClause
 # https://262.ecma-international.org/#prod-ForInOfStatement
 # NOTE: Merged into single rule
 ForStatement
-  ForClause:clause Block:block ->
+  ForClause:clause BlockOrEmpty:block ->
     block = blockWithPrefix(clause.blockPrefix, block)
 
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -223,8 +223,16 @@ ExpressionizedStatement
 
 StatementExpression
   DebuggerStatement
-  IfStatement
-  IterationExpression
+  IfStatement ->
+    // Forbid expressionizing `if condition` with no then or else clause,
+    // because it might be a postfix `if`
+    if (!$1.else && isEmptyBareBlock($1.then)) return $skip
+    return $1
+  IterationExpression ->
+    // Forbid expressionizing `while condition` with no block,
+    // because it might be a postfix `while`
+    if (isEmptyBareBlock($1.block)) return $skip
+    return $1
   SwitchStatement
   ThrowStatement
   TryStatement
@@ -2406,6 +2414,7 @@ EmptyStatementBareBlock
       expressions,
       children: [expressions],
       bare: true,
+      semicolon: s.children[0],
     }
 
 # A nonempty block that must include braces

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -52,6 +52,22 @@ describe "comptime", ->
 
   describe "disabled", ->
     testCase """
+      empty
+      ---
+      comptime
+      ---
+      {}
+    """
+
+    testCase """
+      empty assigned
+      ---
+      x = comptime
+      ---
+      x = (()=>{})()
+    """
+
+    testCase """
       statement with indented block
       ---
       comptime

--- a/test/do.civet
+++ b/test/do.civet
@@ -28,6 +28,16 @@ describe "do..while/until", ->
   """
 
   testCase """
+    empty
+    ---
+    do
+    while i++ < 10
+    ---
+    do {}
+    while (i++ < 10)
+  """
+
+  testCase """
     until
     ---
     do
@@ -38,6 +48,16 @@ describe "do..while/until", ->
       console.log(i++)
     }
     while (!(i > 10))
+  """
+
+  testCase """
+    empty until
+    ---
+    do
+    until i++ < 10
+    ---
+    do {}
+    while (!(i++ < 10))
   """
 
   testCase """
@@ -78,6 +98,14 @@ describe "do", ->
       const y = x * x
       console.log(y * y)
     }
+  """
+
+  testCase """
+    empty
+    ---
+    do
+    ---
+    {}
   """
 
   testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -74,6 +74,14 @@ describe "for", ->
     }
   """
 
+  testCase """
+    empty body
+    ---
+    for x of y
+    ---
+    for (const x of y);
+  """
+
   // TODO: This is dubious
   testCase """
     optional parens inline

--- a/test/if.civet
+++ b/test/if.civet
@@ -37,6 +37,14 @@ describe "if", ->
   """
 
   testCase """
+    empty then
+    ---
+    if x
+    ---
+    if (x);
+  """
+
+  testCase """
     else
     ---
     if (true) {
@@ -50,6 +58,29 @@ describe "if", ->
     } else {
       return true
     }
+  """
+
+  testCase """
+    empty else
+    ---
+    if x
+      console.log 'yes'
+    else
+    ---
+    if (x) {
+      console.log('yes')
+    }
+    else;
+  """
+
+  testCase """
+    empty then and else
+    ---
+    if x
+    else
+    ---
+    if (x);
+    else;
   """
 
   testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -61,6 +61,16 @@ describe "if", ->
   """
 
   testCase """
+    empty then with else
+    ---
+    if x
+    else console.log 'no'
+    ---
+    if (x);
+    else console.log('no')
+  """
+
+  testCase """
     empty else
     ---
     if x
@@ -81,6 +91,35 @@ describe "if", ->
     ---
     if (x);
     else;
+  """
+
+  testCase """
+    empty then and else with comments
+    ---
+    if x
+      // yes
+    else
+      // no
+    ---
+    if (x);
+      // yes
+    else;
+      // no
+  """
+
+  testCase """
+    empty then with else with comments
+    ---
+    if x
+      // yes
+    else
+      console.log 'no'
+    ---
+    if (x);
+      // yes
+    else {
+      console.log('no')
+    }
   """
 
   testCase """
@@ -306,6 +345,14 @@ describe "if", ->
     return true if x
     ---
     if (x) { return true }
+  """
+
+  testCase """
+    postfix if that could be an expression
+    ---
+    return if x
+    ---
+    if (x) { return }
   """
 
   testCase """

--- a/test/loop.civet
+++ b/test/loop.civet
@@ -21,3 +21,11 @@ describe "loop", ->
     ---
     while(true) { run() }
   """
+
+  testCase """
+    empty
+    ---
+    loop
+    ---
+    while(true);
+  """

--- a/test/while.civet
+++ b/test/while.civet
@@ -45,6 +45,14 @@ describe "while", ->
   """
 
   testCase """
+    empty
+    ---
+    while f x++
+    ---
+    while (f(x++));
+  """
+
+  testCase """
     until
     ---
     until (x < 3)
@@ -53,6 +61,14 @@ describe "while", ->
     while (!(x < 3)) {
       x--
     }
+  """
+
+  testCase """
+    empty until
+    ---
+    until f x++
+    ---
+    while (!f(x++));
   """
 
   testCase """

--- a/test/while.civet
+++ b/test/while.civet
@@ -103,6 +103,14 @@ describe "while", ->
     while (!y) { x() };
   """
 
+  testCase """
+    postfix while that could be an expression
+    ---
+    return while x
+    ---
+    while (x) { return }
+  """
+
   describe "iteration results", ->
     testCase """
       semi-colon suppresses result push


### PR DESCRIPTION
I propose allowing for empty blocks in most settings. We already support them in `function`s, and `case`/`when`/pattern matching. This PR adds them to all loops, if/else, and for symmetry, do blocks and comptime.

CoffeeScript supports this in `if/else` expressions that have both `if` and `else`: [both empty](https://coffeescript.org/#try:if%20x%0Aelse), [empty if](https://coffeescript.org/#try:if%20x%0Aelse%0A%20%20y). I think this hints at why it is useful:

* Suppose you have code with an if/else construct, and you comment out the then or else block. Currently, that makes a parse error. Commenting out the else block is not too bad: just comment out the `else` keyword too. But commenting out the if block is hard: you need to comment out the `if` line, the `else` keyword, *and dedent the else block*. This makes for a lot of code changes if you want to debug removing some code (e.g. to isolate a bug).
* This is exacerbated by comments not counting as a block. So you can't do e.g.
  ```coffee
  if empty
    // don't need to do anything in this case
  else
    doStuff()
  ```
  I've wanted to write code like this at times. Currently it's a parse error in Civet.
* Related, as you're typing lines in VSCode, I feel like it's less likely that you have code with parse errors, so you keep the useful feedback in more situations.

My guess is that CoffeeScript couldn't handle empty `if` blocks without `else`, and loop blocks, because they are somewhat ambiguous with postfix if/loops. But a little work on the "ExpressionizedStatement" code made it easy to not expressionize in this case of empty blocks.

For example, this fixes #1162: the surprising behavior was the `loop` becoming a postfix after a semicolon, but when it can be an infinite loop by itself, the behavior is intuitive (though not very useful). Similarly, @bbrk24 mentioned `x := comptime loop` being counterintuitive: it [used to](https://civet.dev/playground?code=eCA6PSBjb21wdGltZSBsb29w) give an infinite array of `comptime` identifiers, but now it gives the more natural but not very useful behavior of adding an infinite loop to a comptime function.