### PR TITLE
Serialize typed arrays and well-known symbols

### DIFF
--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -125,7 +125,8 @@ function serialize(value: ???): string
               `new ${val.constructor.name}([${(val as any).join ','}])`
             when BigInt64Array::, BigUint64Array::
               `new ${val.constructor.name}([${Array.from(val as ArrayLike<bigint>, `${&}n`).join ','}])`
-            when Buffer::
+            // Spelled differently for browsers, where `Buffer` doesn't exist
+            when globalThis.Buffer?.prototype
               `Buffer.from([${(val as Buffer).join ','}])`
             else
               // One day we may handle other classes like so:

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -85,6 +85,12 @@ function serialize(value: ???): string
       <? "symbol"
         if key? := Symbol.keyFor val
           return `Symbol.for(${JSON.stringify key})`
+        // Handle well-known symbols
+        // for-in doesn't find them, but getOwnPropertyNames does
+        for name of Object.getOwnPropertyNames Symbol
+          sym := (Symbol as! Record<string, symbol>)[name]
+          if val is sym
+            return `Symbol.${name}`
         throw new TypeError "cannot serialize unique symbol"
       <? "object"
         if stack.has val
@@ -114,6 +120,13 @@ function serialize(value: ???): string
                 for own key, value in val as {[key: string]: ???}
                   `${JSON.stringify key}:${recurse value}`
               ).join(",") + "}"
+            when Int8Array::, Uint8Array::, Int16Array::, Uint16Array::, Int32Array::, Uint32Array::, Float32Array::, Float64Array::, Uint8ClampedArray::
+              // There's no "TypedArray" interface in TS
+              `new ${val.constructor.name}([${(val as any).join ','}])`
+            when BigInt64Array::, BigUint64Array::
+              `new ${val.constructor.name}([${Array.from(val as ArrayLike<bigint>, `${&}n`).join ','}])`
+            when Buffer::
+              `Buffer.from([${(val as Buffer).join ','}])`
             else
               // One day we may handle other classes like so:
               // str += `__proto__:${val.constructor.name}`

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -102,6 +102,7 @@ describe "serialize", ->
     assert.equal serialize(Symbol.for 'MyKeyedSymbol'),
       'Symbol.for("MyKeyedSymbol")'
     assert.throws (=> serialize Symbol()), /cannot serialize unique symbol/
+    assert.equal serialize(Symbol.iterator), "Symbol.iterator"
   it "regexps", =>
     assert.equal serialize(/a[b\s]c/), "/a[b\\s]c/"
     assert.equal serialize(/abc/gi), "/abc/gi"
@@ -146,3 +147,9 @@ describe "serialize", ->
     assert.equal serialize({ functionF() { } }.functionF), "function functionF() { }"
     assert.equal serialize({ async bar() { } }.bar), "async function bar() { }"
     assert.throws (=> serialize { [Math.sqrt 5]() {} }), /cannot serialize method with computed name/
+  it "typed arrays", =>
+    assert.equal serialize(new Uint32Array [1, 2, 3]), "new Uint32Array([1,2,3])"
+    assert.equal serialize(new Float64Array [1.0, 1.5, NaN]), "new Float64Array([1,1.5,NaN])"
+    assert.equal serialize(new BigInt64Array [1n, 2n, 3n]), "new BigInt64Array([1n,2n,3n])"
+    assert.equal serialize(Buffer.from [1, 2, 3]), "Buffer.from([1,2,3])"
+    assert.equal serialize(new Uint8ClampedArray [-1, 0, 2, 256]), "new Uint8ClampedArray([0,0,2,255])"


### PR DESCRIPTION
Typed arrays were briefly discussed on the discord last night. While I didn't mention well-known symbols, they seem useful and were also pretty straightforward to implement.

I believe symbol-keyed properties in objects are still not serialized, but that can be a separate issue.