### PR TITLE
Optional ?:: for coffeePrototype

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1475,22 +1475,27 @@ PropertyAccess
     }
 
   # NOTE: Added CoffeeScript :: prototype shorthand only when enabled
-  CoffeePrototypeEnabled DoubleColon:p IdentifierName?:id ->
+  CoffeePrototypeEnabled PropertyAccessModifier?:modifier DoubleColon:p IdentifierName?:id ->
+    const dot = {token: ".", $loc: p.$loc}
+    // Based on AccessStart
+    const start = {
+      type: "AccessStart",
+      children: modifier ? [modifier, dot] : [dot],
+      optional: modifier?.token === "?",
+    }
     if (id) {
-      const dot = {token: ".prototype.", $loc: p.$loc}
       return {
         type: "PropertyAccess",
         name: id.name,
-        dot,
-        children: [ dot, id ],
+        dot: start,
+        children: [ start, "prototype.", id ],
       }
     } else {
-      const dot = {token: ".prototype", $loc: p.$loc}
       return {
         type: "PropertyAccess",
         name: "prototype",
-        dot,
-        children: [ dot ],
+        dot: start,
+        children: [ start, "prototype" ],
       }
     }
 

--- a/test/compat/coffee-prototype.civet
+++ b/test/compat/coffee-prototype.civet
@@ -64,3 +64,14 @@ describe "prototype shorthand", ->
     ---
     a?.prototype.b
   """
+
+  testCase """
+    non-null assertion
+    ---
+    'civet coffeeCompat'
+    a!::
+    a!::b
+    ---
+    a!.prototype
+    a!.prototype.b
+  """

--- a/test/compat/coffee-prototype.civet
+++ b/test/compat/coffee-prototype.civet
@@ -46,3 +46,21 @@ describe "prototype shorthand", ->
     ---
     T.prototype.void(() => x)
   """
+
+  testCase """
+    optional without identifier
+    ---
+    'civet coffeeCompat'
+    a?::
+    ---
+    a?.prototype
+  """
+
+  testCase """
+    optional with identifier
+    ---
+    'civet coffeeCompat'
+    a?::b
+    ---
+    a?.prototype.b
+  """


### PR DESCRIPTION
Fixes #1191

Turn out this notation is [supported by CoffeeScript](https://coffeescript.org/#try:x%20%3D%205%0Ay%20%3D%20x%3F%3A%3Ay) (though implemented without `?.`, seems to work just the same), so it's also good for compatibility.