### PR TITLE
Comptime classes and generators

### DIFF
--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -73,6 +73,18 @@ function serialize(value: ???): string
         if /^(?:async\s*)?(?:\*\s*)?\[/.test string
           // In general, the method name could be an arbitrary JS expression. This is not currently handled.
           throw new Error "cannot serialize method with computed name"
+        // Test for old-style classes done by creating a regular function and assigning to its prototype
+        protoHasProps := not (or)
+          val:: is undefined
+          (and)
+            Object:: is Object.getPrototypeOf val::
+            Object.getOwnPropertyNames(val::)# <= 1 // constructor
+            Object.getOwnPropertySymbols(val::)# is 0
+            val::constructor is in [val, undefined]
+        isClass := /^class[\s{]/u.test string
+        isGenerator := /^(?:async\s*)?(?:function\s*)?\*/u.test string
+        if protoHasProps and not (isClass or isGenerator)
+          throw new TypeError "cannot serialize function with modified prototype"
         unless /^(?:async\s+)?(?:(function|class)(?!\p{ID_Continue})|\(|(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*\s*=>)/u.test string
           // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
           return string.replace /^(async\s+)?/u, (_, maybeAsync = '') => maybeAsync + 'function '

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -63,13 +63,6 @@ function serialize(value: ???): string
         hasNoProps := (and)
           Object.getOwnPropertyNames(val).every & is in ["length", "name", "arguments", "caller", "prototype"]
           Object.getOwnPropertySymbols(val)# is 0
-          (or)
-            val:: is undefined
-            (and)
-              Object:: is Object.getPrototypeOf val::
-              Object.getOwnPropertyNames(val::)# is 1 // constructor
-              Object.getOwnPropertySymbols(val::)# is 0
-              val::constructor is val
         unless hasNoProps
           throw new TypeError "cannot serialize function with properties"
         string := Function::toString.call val
@@ -77,10 +70,10 @@ function serialize(value: ???): string
           // builtin, or returned from Function::bind
           throw new TypeError "cannot serialize native function"
         // Check for ES6 methods that have been removed from the object, and add "function" if possible
-        if string.0 is '['
+        if /^(?:async\s*)?(?:\*\s*)?\[/.test string
           // In general, the method name could be an arbitrary JS expression. This is not currently handled.
           throw new Error "cannot serialize method with computed name"
-        unless /^(?:async\s+)?(?:function(?!\p{ID_Continue})|\(|(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*\s*=>)/u.test string
+        unless /^(?:async\s+)?(?:(function|class)(?!\p{ID_Continue})|\(|(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*\s*=>)/u.test string
           // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
           return string.replace /^(async\s+)?/u, (_, maybeAsync = '') => maybeAsync + 'function '
         string

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -148,6 +148,10 @@ describe "serialize", ->
     func: any := (x: ???) => x
     func.a = 1
     assert.throws (=> serialize func), /cannot serialize function with properties/
+
+    func2: any := (@: object) -> @
+    func2.prototype.a = 1
+    assert.throws (=> serialize func2), /cannot serialize function with modified prototype/
   it "native functions", =>
     assert.throws (=> serialize parseInt), /cannot serialize native function/
   it "circular", =>

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -165,6 +165,8 @@ describe "serialize", ->
     assert.equal serialize({ functionF() { } }.functionF), "function functionF() { }"
     assert.equal serialize({ async bar() { } }.bar), "async function bar() { }"
     assert.throws (=> serialize { [Math.sqrt 5]() {} }), /cannot serialize method with computed name/
+    assert.throws (=> serialize { *[Math.PI]() {} }), /cannot serialize method with computed name/
+    assert.throws (=> serialize { async [Number.EPSILON]() {} }), /cannot serialize method with computed name/
   it "null-prototype objects", =>
     obj := Object.create null,
       foo: value: 1, writable: true, enumerable: true, configurable: true
@@ -178,3 +180,20 @@ describe "serialize", ->
     assert.equal serialize(new BigInt64Array [1n, 2n, 3n]), "new BigInt64Array([1n,2n,3n])"
     assert.equal serialize(Buffer.from [1, 2, 3]), "Buffer.from([1,2,3])"
     assert.equal serialize(new Uint8ClampedArray [-1, 0, 2, 256]), "new Uint8ClampedArray([0,0,2,255])"
+  it "classes", =>
+    class C
+      toString()
+        'C'
+    assert.equal
+      serialize C
+      """
+      class C {
+                  toString() {
+                      return 'C';
+                  }
+              }
+      """
+    class D < C
+    assert.equal serialize(D), 'class D extends C {\n        }'
+  it "generator functions", =>
+    assert.equal serialize(:Iterator<number, void> -> yield 5), "function* () { yield 5; }"

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -168,6 +168,7 @@ describe "serialize", ->
   it "ES6 methods", =>
     assert.equal serialize({ functionF() { } }.functionF), "function functionF() { }"
     assert.equal serialize({ async bar() { } }.bar), "async function bar() { }"
+    assert.equal serialize({ *x() { }, async *y() { } }), '{"x":function *x() { },"y":async function *y() { }}'
     assert.throws (=> serialize { [Math.sqrt 5]() {} }), /cannot serialize method with computed name/
     assert.throws (=> serialize { *[Math.PI]() {} }), /cannot serialize method with computed name/
     assert.throws (=> serialize { async [Number.EPSILON]() {} }), /cannot serialize method with computed name/


### PR DESCRIPTION
Fixes #1189 

Technically, this doesn't detect the case where a class's prototype is modified after initialization, i.e:

```civet
C := comptime do
  class C {}
  C.prototype.toString = -> 'C'
  C
```

but I'm not 100% sure this is possible in the general case. In any case, the current behavior of creating `function class C {}` is definitely wrong.