### PR TITLE
Comptime function properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
       "coffee"
     ],
     "loader": [
-      "ts-node/esm",
       "@danielx/hera/esm",
       "./node_modules/@danielx/civet/dist/esm.mjs"
     ],

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -60,15 +60,13 @@ function serialize(value: ???): string
         `${val}n`
       <? "function"
         // Some functions can actually be serialized
-        hasNoProps := (and)
-          Object.getOwnPropertyNames(val).every & is in ["length", "name", "arguments", "caller", "prototype"]
-          Object.getOwnPropertySymbols(val)# is 0
-        unless hasNoProps
-          throw new TypeError "cannot serialize function with properties"
-        string := Function::toString.call val
+        string .= Function::toString.call val
         if /\{\s+\[native code]\s+\}$/.test string
           // builtin, or returned from Function::bind
           throw new TypeError "cannot serialize native function"
+        if /^class[\s{]/u.test string
+          // Skip other checks; properties on the function are `static` things in the class
+          return string
         // Check for ES6 methods that have been removed from the object, and add "function" if possible
         if /^(?:async\s*)?(?:\*\s*)?\[/.test string
           // In general, the method name could be an arbitrary JS expression. This is not currently handled.
@@ -81,13 +79,25 @@ function serialize(value: ???): string
             Object.getOwnPropertyNames(val::)# <= 1 // constructor
             Object.getOwnPropertySymbols(val::)# is 0
             val::constructor is in [val, undefined]
-        isClass := /^class[\s{]/u.test string
         isGenerator := /^(?:async\s*)?(?:function\s*)?\*/u.test string
-        if protoHasProps and not (isClass or isGenerator)
+        if protoHasProps and not isGenerator
           throw new TypeError "cannot serialize function with modified prototype"
         unless /^(?:async\s+)?(?:(function|class)(?!\p{ID_Continue})|\(|(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*\s*=>)/u.test string
           // Slightly more annoying than just `'function ' + string`: need to insert it before `async`
-          return string.replace /^(async\s+)?/u, (_, maybeAsync = '') => maybeAsync + 'function '
+          string |>= .replace /^(async\s+)?/u, (_, maybeAsync = '') => maybeAsync + 'function '
+
+        // Properties that a function may have inherently even if they aren't explicitly assigned
+        defaultProps := ["length", "name", "arguments", "caller", "prototype"]
+
+        hasProps := not (and)
+          Object.getOwnPropertyNames(val).every & is in defaultProps
+          Object.getOwnPropertySymbols(val)# is 0
+        if hasProps
+          props := Object.getOwnPropertyDescriptors val
+          for prop of defaultProps
+            delete props[prop]
+          return `Object.defineProperties(${string},${recurse props})`
+
         string
       <? "symbol"
         if key? := Symbol.keyFor val
@@ -128,7 +138,7 @@ function serialize(value: ???): string
                   `${JSON.stringify key}:${recurse value}`
               ).join(",") + "}"
             when null
-              `Object.create(null,${serialize Object.getOwnPropertyDescriptors val})`
+              `Object.create(null,${recurse Object.getOwnPropertyDescriptors val})`
             when Int8Array::, Uint8Array::, Int16Array::, Uint16Array::, Int32Array::, Uint32Array::, Float32Array::, Float64Array::, Uint8ClampedArray::
               // There's no "TypedArray" interface in TS
               `new ${val.constructor.name}([${(val as any).join ','}])`

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -67,6 +67,11 @@ function serialize(value: ???): string
         if /^class[\s{]/u.test string
           // Skip other checks; properties on the function are `static` things in the class
           return string
+
+        if stack.has val
+          throw new Error "circular reference detected"
+        stack.add val
+
         // Check for ES6 methods that have been removed from the object, and add "function" if possible
         if /^(?:async\s*)?(?:\*\s*)?\[/.test string
           // In general, the method name could be an arbitrary JS expression. This is not currently handled.
@@ -96,8 +101,9 @@ function serialize(value: ???): string
           props := Object.getOwnPropertyDescriptors val
           for prop of defaultProps
             delete props[prop]
-          return `Object.defineProperties(${string},${recurse props})`
+          string = `Object.defineProperties(${string},${recurse props})`
 
+        stack.delete val
         string
       <? "symbol"
         if key? := Symbol.keyFor val

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -147,7 +147,9 @@ describe "serialize", ->
   it "functions with properties", =>
     func: any := (x: ???) => x
     func.a = 1
-    assert.throws (=> serialize func), /cannot serialize function with properties/
+    assert.equal
+      serialize func
+      'Object.defineProperties((x) => x,{"a":{"value":1,"writable":true,"enumerable":true,"configurable":true}})'
 
     func2: any := (@: object) -> @
     func2.prototype.a = 1
@@ -199,6 +201,8 @@ describe "serialize", ->
               }
       """
     class D < C
-    assert.equal serialize(D), 'class D extends C {\n        }'
+      @tag = 'D'
+    // TODO: Why does this fail?
+    // assert.equal serialize(D), "class D extends C {\n          static tag = 'D'\n        }"
   it "generator functions", =>
     assert.equal serialize(:Iterator<number, void> -> yield 5), "function* () { yield 5; }"

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -163,6 +163,9 @@ describe "serialize", ->
     array: any := []
     array.push array
     assert.throws (=> serialize array), /circular reference detected/
+    func: any := &
+    func.func = func
+    assert.throws (=> serialize func), /circular reference detected/
   it "aliasing", =>
     inner: never[] := []
     outer := [inner, inner]

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -143,7 +143,7 @@ describe "serialize", ->
     // @ts-ignore Adding a type annotation adds parens to the output, so it's intentionally not typed
     assert.match serialize(&), /^\$(\d*) => \$\1$/
   it "regular functions", =>
-    assert.equal serialize((x: ???) -> x), "function (x) { return x; }"
+    assert.equal serialize((x: ???) -> x), "function(x) { return x }"
   it "functions with properties", =>
     func: any := (x: ???) => x
     func.a = 1
@@ -195,14 +195,13 @@ describe "serialize", ->
       serialize C
       """
       class C {
-                  toString() {
-                      return 'C';
-                  }
-              }
+            toString() {
+              return 'C'
+            }
+          }
       """
     class D < C
       @tag = 'D'
-    // TODO: Why does this fail?
-    // assert.equal serialize(D), "class D extends C {\n          static tag = 'D'\n        }"
+    assert.equal serialize(D), "class D extends C {\n      static tag = 'D'\n    }"
   it "generator functions", =>
-    assert.equal serialize(:Iterator<number, void> -> yield 5), "function* () { yield 5; }"
+    assert.equal serialize(:Iterator<number, void> -> yield 5), "function*() { yield 5 }"


### PR DESCRIPTION
Serialize function properties for `comptime` using `Object.defineProperties`. We could afford to do this for properties that aren't `{ +configurable, +writable, +enumerable }` on `Object`s too, but that isn't covered in this PR. This PR also fixes a couple things with circular reference detection, now that functions can be circular.