### PR TITLE
Comptime URLs

### DIFF
--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -127,6 +127,8 @@ function serialize(value: ???): string
                 for own key, value in val as {[key: string]: ???}
                   `${JSON.stringify key}:${recurse value}`
               ).join(",") + "}"
+            when URL::
+              `new URL(${JSON.stringify (val as URL).href})`
             when null
               `Object.create(null,${serialize Object.getOwnPropertyDescriptors val})`
             when Int8Array::, Uint8Array::, Int16Array::, Uint16Array::, Int32Array::, Uint32Array::, Float32Array::, Float64Array::, Uint8ClampedArray::

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -202,3 +202,5 @@ describe "serialize", ->
     assert.equal serialize(D), 'class D extends C {\n        }'
   it "generator functions", =>
     assert.equal serialize(:Iterator<number, void> -> yield 5), "function* () { yield 5; }"
+  it "URLs", =>
+    assert.equal serialize(new URL "https://google.com/"), 'new URL("https://google.com/")'


### PR DESCRIPTION
Even though it's not technically part of JS itself, `URL` is a global class in both browsers and Node.