### PR TITLE
"is like" pattern matching operator

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -66,6 +66,9 @@ if [, dir, base] := /^(.*\/)?([^/]*)$/.exec file
   console.log dir, base
 </Playground>
 
+Note that array lengths must match exactly because this is a form of
+[pattern matching](#pattern-matching).
+
 <Playground>
 if {x, y} := getLocation()
   console.log `At ${x}, ${y}`
@@ -1197,7 +1200,7 @@ switch x
 
 <Playground>
 switch x
-  [{type: "text", content: /\s+/}, ...rest]
+  [{type: "text", content: /^\s+$/}, ...rest]
     console.log "leading whitespace"
   [{type: "text", content}, ...rest]
     console.log "leading text:", content
@@ -1285,6 +1288,22 @@ function directionVector(dir: Direction)
       [0, -1]
     ^Direction.Up
       [0, +1]
+</Playground>
+
+If you just want to match a value against a single pattern, you can use a
+[declaration in a condition](#declarations-in-conditions-and-loops):
+
+<Playground>
+if [{type, content}, ...rest] := x
+  console.log "leading content", content
+</Playground>
+
+If you just want to check *whether* a value matches a single pattern,
+you can use the `is like` operator:
+
+<Playground>
+if x is like [{type, content: /^\s+$/}, ...]
+  console.log "leading whitespace"
 </Playground>
 
 ## Loops

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -40,6 +40,7 @@ import {
   makeLeftHandSideExpression,
   makeRef,
   maybeRef,
+  maybeRefAssignment,
   modifyString,
   negateCondition,
   prepend,
@@ -3108,17 +3109,8 @@ PropertyDefinition
     const { expression, type } = last
     if (type === "Index") {
       // TODO: If `last` is a suitable string literal, could use it for `name`.
-      ref = maybeRef(expression)
-      if (ref !== expression) {
-        hoistDec = {
-          type: "Declaration",
-          children: ["let ", ref],
-        }
-        refAssignment = {
-          type: "Assignment",
-          children: [ref, " = ", expression],
-        }
-
+      ({ ref, hoistDec, refAssignment } = maybeRefAssignment(expression))
+      if (refAssignment) {
         name = {
           type: "ComputedPropertyName",
           children: [last.children[0], "(", refAssignment, ",", ref, ")", ...last.children.slice(-2)],

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4444,21 +4444,23 @@ CaseClause
     return {
       type: "PatternClause",
       children: $0,
-      block,
       patterns,
+      block,
     }
-  Case CaseExpressionList IgnoreColon ( ThenClause / BareBlock ) -> {
+  Case CaseExpressionList:cases IgnoreColon ( ThenClause / BareBlock ):block -> {
     type: "CaseClause",
-    children: $0
+    children: $0,
+    cases,
+    block,
   }
   # NOTE: Added "when" from CoffeeScript. `when` always inserts `break;`.
   When CaseExpressionList:cases IgnoreColon InsertOpenBrace ( ThenClause / BareBlock ):block InsertBreak:b InsertNewline InsertIndent InsertCloseBrace ->
     return {
       type: "WhenClause",
+      children: $0,
       cases,
       block,
       break: b,
-      children: $0,
     }
   # NOTE: Merged in default clause
   Default ImpliedColon ( ThenClause / BareBlock):block ->
@@ -4477,10 +4479,10 @@ CaseClause
     }
 
 PatternExpressionList
-  ConditionFragment:first ( _? Comma ( Nested / _ )? ConditionFragment )*:rest ->
+  PatternExpression:first ( _? Comma ( Nested / _ )? PatternExpression )*:rest ->
     return [first, ...rest.map(([, , , p]) => p)]
 
-ConditionFragment
+PatternExpression
   BindingPattern
   ForbidIndentedApplication ( SingleLineBinaryOpRHS+ )?:pattern RestoreIndentedApplication ->
     if (!pattern) return $skip

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -437,10 +437,15 @@ NonPipelineArgumentPart
 
 BinaryOpExpression
   UnaryExpression BinaryOpRHS* ->
-    if ($2.length) return processBinaryOpExpression($0)
-    return $1
+    return processBinaryOpExpression($0)
 
 BinaryOpRHS
+  ( _ / IndentedFurther / Nested ) Is _? Like _? PatternExpressionList:patterns ->
+    return {
+      type: "PatternTest",
+      children: [patterns],
+      patterns,
+    }
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
     // Insert empty whitespace placeholder to maintan structure
@@ -5840,6 +5845,10 @@ Is
 LetOrConstOrVar
   LetOrConst
   Var
+
+Like
+  "like" NonIdContinue ->
+    return { $loc, token: $1 }
 
 Loop
   # NOTE: loop becomes while

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -437,15 +437,22 @@ NonPipelineArgumentPart
 
 BinaryOpExpression
   UnaryExpression BinaryOpRHS* ->
+    if (!$2.length) return $1
     return processBinaryOpExpression($0)
 
 BinaryOpRHS
-  ( _ / IndentedFurther / Nested ) Is _? Like _? PatternExpressionList:patterns ->
-    return {
-      type: "PatternTest",
-      children: [patterns],
-      patterns,
-    }
+  ( _? / IndentedFurther / Nested ):ws1 ( Is _? ( Not _? )? Like ):op _?:ws2 PatternExpressionList:patterns ->
+    return [
+      ws1,
+      {
+        type: "PatternTest",
+        children: op,
+        special: true,
+        negated: !!op[2],
+      },
+      ws2,
+      patterns
+    ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
     // Insert empty whitespace placeholder to maintan structure

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -14,6 +14,7 @@ import {
 
 import {
   findAncestor
+  findChildIndex
   gatherRecursiveAll
   gatherRecursive
 } from ./traversal.civet
@@ -146,10 +147,10 @@ function getIndent(statement: StatementTuple) {
 function hoistRefDecs(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (s) => s.hoistDec)
     .forEach (node) =>
-      let { hoistDec } = node
+      { hoistDec } := node
       node.hoistDec = null
 
-      const { ancestor, child } = findAncestor node, (ancestor) =>
+      { ancestor, child } := findAncestor node, (ancestor) =>
         ancestor.type is "BlockStatement" and (!ancestor.bare or ancestor.root)
 
       if ancestor
@@ -162,9 +163,7 @@ function hoistRefDecs(statements: StatementTuple[]): void
 function insertHoistDec(block: BlockStatement, node: ASTNode | StatementTuple, dec: ASTNode): void
   // NOTE: This is more accurately 'statements'
   { expressions } := block
-  index := expressions.findIndex (exp) =>
-    exp is node or (Array.isArray(exp) and exp[1] is node)
-
+  index := findChildIndex expressions, node
   if index < 0
     throw new Error("Couldn't find expression in block for hoistable declaration.")
 
@@ -173,7 +172,7 @@ function insertHoistDec(block: BlockStatement, node: ASTNode | StatementTuple, d
   expressions.splice index, 0, statement
 
   // hoistDec wasn't previously a child, so now needs parent pointers
-  addParentPointers dec, block
+  updateParentPointers dec, block
 
 function processBlocks(statements: StatementTuple[]): void
   insertSemicolon(statements)

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -32,9 +32,12 @@ import {
   addParentPointers
   convertOptionalType
   makeNode
-  makeRef
   updateParentPointers
 } from ./util.civet
+
+import {
+  makeRef
+} from ./ref.civet
 
 import {
   assignResults

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -256,8 +256,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   { ref, pattern } := expression
 
   if pattern
-    conditions .= []
-    getPatternConditions(pattern, ref, conditions)
+    conditions .= getPatternConditions(pattern, ref)
 
     conditions = conditions.filter (c) =>
       !(c.length is 3 and c[0] is "typeof " and c[1] is ref and c[2] is " === 'object'") and

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -7,11 +7,14 @@ import type {
 } from ./types.civet
 
 import {
-  makeRef
-  maybeRef
   insertTrimmingSpace
   literalValue
 } from ./util.civet
+
+import {
+  makeRef
+  maybeRef
+} from ./ref.civet
 
 // Construct for loop from RangeLiteral
 function forRange(

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -35,11 +35,14 @@ import {
   isExit
   isFunction
   isWhitespaceOrEmpty
-  makeRef
   updateParentPointers
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
+
+import {
+  makeRef
+} from ./ref.civet
 
 function isVoidType(t?: TypeNode): boolean
   return t?.type is "LiteralType" and t.t.type is "VoidType"

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -1,7 +1,7 @@
 // Helper functions added to preamble of output code
 
 type { ASTNode, ASTRef, StatementTuple } from './types.civet'
-{ makeRef } from './util.civet'
+{ makeRef } from './ref.civet'
 { state } from "../parser.hera"
 declare var state: {
   prelude: StatementTuple[]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -70,7 +70,9 @@ import {
 
 import {
   makeRef
+  makeRefAssignment
   maybeRef
+  maybeRefAssignment
   needsRef
 } from ./ref.civet
 
@@ -358,21 +360,13 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
     if (glob?.type is "PropertyGlob") {
       let prefix = children.slice(0, i)
       const parts = []
-      let hoistDec, refAssignment
+      let hoistDec, refAssignment, refAssignmentComma
       // add ref to ensure object base evaluated only once
-      if (prefix.length > 1) {
-        const ref = makeRef()
-        hoistDec = {
-          type: "Declaration",
-          children: ["let ", ref],
-          names: [],
-        }
-        refAssignment = [{
-          type: "AssignmentExpression",
-          children: [ref, " = ", prefix],
-        }, ","]
+      if prefix.length > 1
+        ref := makeRef()
+        { hoistDec, refAssignment } = makeRefAssignment ref, prefix
+        refAssignmentComma = refAssignment ? [refAssignment, ","] : []
         prefix = [ref]
-      }
       prefix = prefix.concat(glob.dot)
 
       for part of glob.object.properties
@@ -433,7 +427,7 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
       if refAssignment
         object = {
           type: "ParenthesizedExpression"
-          children: ["(", ...refAssignment, object, ")"]
+          children: ["(", ...refAssignmentComma, object, ")"]
           expression: object
         }
       if (i is children.length - 1) return object
@@ -1068,14 +1062,9 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
         throw new Error("Invalid parse tree for negative index access")
 
       if subexp
-        exp.hoistDec = {
-          type: "Declaration",
-          children: ["let ", ref],
-          names: [],
-        }
-        parent.children.unshift makeLeftHandSideExpression
-          type: "AssignmentExpression"
-          children: [ref, " = ", subexp]
+        { hoistDec, refAssignment } := makeRefAssignment ref, subexp
+        exp.hoistDec = hoistDec
+        parent.children.unshift makeLeftHandSideExpression refAssignment
 
       exp.len.children = [
         ref,
@@ -1512,6 +1501,7 @@ export {
   makeLeftHandSideExpression
   makeRef
   maybeRef
+  maybeRefAssignment
   modifyString
   negateCondition
   precedenceStep

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -44,6 +44,7 @@ import {
   addParentPointers
   assert
   deepCopy
+  flatJoin
   getTrimmingSpace
   hasAwait
   hasImportDeclaration
@@ -952,11 +953,7 @@ function unchainOptionalMemberExpression(exp: MemberExpression | CallExpression,
     j++
 
   if l := conditions.length
-    cs := conditions.map (c, i) =>
-      if i is l - 1
-        c
-      else
-        [c, " && "]
+    cs := flatJoin conditions, " && "
 
     {
       ...exp

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -60,16 +60,19 @@ import {
   makeAmpersandFunction
   makeLeftHandSideExpression
   makeNode
-  makeRef
-  maybeRef
   maybeWrap
   maybeUnwrap
-  needsRef
   parenthesizeType
   prepend
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
+
+import {
+  makeRef
+  maybeRef
+  needsRef
+} from ./ref.civet
 
 import {
   blockWithPrefix

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -361,12 +361,11 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
     if (glob?.type is "PropertyGlob") {
       let prefix = children.slice(0, i)
       const parts = []
-      let hoistDec, refAssignment, refAssignmentComma
+      let hoistDec, refAssignmentComma
       // add ref to ensure object base evaluated only once
       if prefix.length > 1
         ref := makeRef()
-        { hoistDec, refAssignment } = makeRefAssignment ref, prefix
-        refAssignmentComma = refAssignment ? [refAssignment, ","] : []
+        { hoistDec, refAssignmentComma } = makeRefAssignment ref, prefix
         prefix = [ref]
       prefix = prefix.concat(glob.dot)
 
@@ -425,7 +424,7 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
         properties: parts
         hoistDec
       }
-      if refAssignment
+      if refAssignmentComma
         object = {
           type: "ParenthesizedExpression"
           children: ["(", ...refAssignmentComma, object, ")"]

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -3,6 +3,7 @@ import type {
   ASTNode
   BinaryOp
   Existence
+  PatternTest
 } from ./types.civet
 
 import {
@@ -49,6 +50,8 @@ function getPrecedence(op: BinaryOp): number
   if typeof op === "string"
     precedenceMap.get(op) ??
     throw new Error `Unknown operator: ${op}`
+  else if op.type is "PatternTest"
+    precedenceRelational
   else if typeof op.prec === "number"
     op.prec
   else
@@ -56,15 +59,6 @@ function getPrecedence(op: BinaryOp): number
     if op.relational then precedenceRelational else precedenceCustomDefault
 
 function processBinaryOpExpression($0)
-  [first, ops] .= $0
-  return first unless ops#
-  if ops.-1.type is "PatternTest"
-    let patternTest
-    [...ops, patternTest] = ops
-    return processPatternTest
-      processBinaryOpExpression [first, ops]
-      patternTest.patterns
-
   return recurse expandChainedComparisons($0)
 
   // Expanded ops is [a, __, op1, __, b, __, op2, __, c, __, op3, __, d], etc.
@@ -158,7 +152,9 @@ function processBinaryOpExpression($0)
           b = makeAsConst b
 
         let children
-        if op.call
+        if op.type is "PatternTest"
+          children = [processPatternTest a, b]
+        else if op.call
           wsOp = insertTrimmingSpace(wsOp, "")
 
           if op.reversed
@@ -228,8 +224,8 @@ function isRelationalOp(op: BinaryOp)
   op.relational or getPrecedence(op) is precedenceRelational
 
 /**
-* binops is an array of [__, op, __, exp] tuples
 * first is an expression
+* binops is an array of [__, op, __, exp] tuples
 */
 function expandChainedComparisons([first, binops]: [ASTNode, [ASTNode, BinaryOp, ASTNode, ASTNode][]])
   return [first] unless binops.length

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -10,6 +10,10 @@ import {
   makeLeftHandSideExpression
 } from ./util.civet
 
+import {
+  processPatternTest
+} from ./pattern-matching.civet
+
 // Binary operator precedence, from low to high
 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence#table
 // NOTE: Added ^^ between || and &&, just like ^ is between | and &
@@ -52,6 +56,15 @@ function getPrecedence(op: BinaryOp): number
     if op.relational then precedenceRelational else precedenceCustomDefault
 
 function processBinaryOpExpression($0)
+  [first, ops] .= $0
+  return first unless ops#
+  if ops.-1.type is "PatternTest"
+    let patternTest
+    [...ops, patternTest] = ops
+    return processPatternTest
+      processBinaryOpExpression [first, ops]
+      patternTest.patterns
+
   return recurse expandChainedComparisons($0)
 
   // Expanded ops is [a, __, op1, __, b, __, op2, __, c, __, op3, __, d], etc.

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -3,6 +3,7 @@ import type {
   ASTRef
   ParenthesizedExpression
   ParseRule
+  PatternExpression
   SwitchStatement
 } from ./types.civet
 
@@ -99,13 +100,9 @@ function processPatternMatching(statements: ASTNode): void {
 
         // TODO: multiple binding patterns
 
-        const alternativeConditions = patterns.map((pattern, i) => {
-          const conditions = []
-          getPatternConditions(pattern, ref, conditions)
-          return conditions
-        })
-
-        const conditionExpression = alternativeConditions.map((conditions, i) => {
+        const conditionExpression = patterns
+        .map getPatternConditions(., ref)
+        .map((conditions, i) => {
           const conditionArray = conditions.map((c, i) => {
             if (i is 0) return c
             return [" && ", ...c]
@@ -177,17 +174,17 @@ function processPatternMatching(statements: ASTNode): void {
 }
 
 function getPatternConditions(
-  pattern,
-  ref,
-  conditions,
-): void {
-  if (pattern.rest) return // No conditions for rest elements
+  pattern: PatternExpression,
+  ref: ASTNode,
+  conditions: ASTNode[] = [],
+): ASTNode[] {
+  if (pattern.rest) return conditions // No conditions for rest elements
 
   switch (pattern.type) {
     case "ArrayBindingPattern": {
       const { elements, length } = pattern,
         hasRest = elements.some((e) => e.rest),
-        l = (length - hasRest).toString(),
+        l = (length - +hasRest).toString(),
         lengthCheck = hasRest
         ? [ref, ".length >= ", l]
         : [getHelperRef("len"), "(", ref, ", ", l, ")"]
@@ -296,6 +293,7 @@ function getPatternConditions(
     default:
       break
   }
+  return conditions
 }
 
 function elideMatchersFromArrayBindings(elements) {

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -18,7 +18,7 @@ import {
 
 import {
   makeRef
-  maybeRef
+  maybeRefAssignment
 } from ./ref.civet
 
 import {
@@ -74,18 +74,8 @@ function processPatternMatching(statements: ASTNode): void {
         // Unwrap parenthesized expression
         condition = condition.expression as ParenthesizedExpression
 
-      let hoistDec, refAssignment = [], ref = maybeRef(condition, "m");
-      if (ref !== condition) {
-        hoistDec = {
-          type: "Declaration",
-          children: ["let ", ref],
-          names: [],
-        }
-        refAssignment = [{
-          type: "AssignmentExpression",
-          children: [ref, " = ", condition],
-        }, ","]
-      }
+      { ref, hoistDec, refAssignment } .= maybeRefAssignment condition, "m"
+      refAssignmentComma .= refAssignment ? [refAssignment, ","] : []
       let prev = [],
         root = prev
 
@@ -117,7 +107,7 @@ function processPatternMatching(statements: ASTNode): void {
 
         const condition = {
           type: "ParenthesizedExpression",
-          children: ["(", ...refAssignment, conditionExpression, ")"],
+          children: ["(", ...refAssignmentComma, conditionExpression, ")"],
           expression: conditionExpression,
         }
 
@@ -165,7 +155,7 @@ function processPatternMatching(statements: ASTNode): void {
           hoistDec
         }]
         hoistDec = undefined
-        refAssignment = []
+        refAssignment = refAssignmentComma = []
         prev = next
       })
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -15,6 +15,7 @@ import {
   addParentPointers
   flatJoin
   isExit
+  makeLeftHandSideExpression
 } from ./util.civet
 
 import {
@@ -42,6 +43,23 @@ import {
   ReservedWord
 } from ../parser.hera
 declare var ReservedWord: ParseRule
+
+function processPatternTest(lhs: ASTNode, patterns: PatternExpression[]): ASTNode
+  { ref, hoistDec, refAssignmentComma } := maybeRefAssignment lhs, "m"
+
+  conditionExpression := patterns
+  .map getPatternConditions ., ref
+  .map flatJoin ., " && "
+  |> flatJoin ., " || "
+
+  makeLeftHandSideExpression {
+    type: "PatternTest"
+    hoistDec
+    children: [
+      ...refAssignmentComma
+      conditionExpression
+    ]
+  }
 
 function processPatternMatching(statements: ASTNode): void {
   gatherRecursiveAll(statements, .type is "SwitchStatement")
@@ -448,4 +466,5 @@ function aliasBinding(p, ref: ASTRef): void
 export {
   getPatternConditions
   processPatternMatching
+  processPatternTest
 }

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -13,6 +13,7 @@ import {
 
 import {
   addParentPointers
+  flatJoin
   isExit
 } from ./util.civet
 
@@ -93,17 +94,10 @@ function processPatternMatching(statements: ASTNode): void {
 
         // TODO: multiple binding patterns
 
-        const conditionExpression = patterns
-        .map getPatternConditions(., ref)
-        .map((conditions, i) => {
-          const conditionArray = conditions.map((c, i) => {
-            if (i is 0) return c
-            return [" && ", ...c]
-          })
-
-          if (i is 0) return conditionArray
-          return [" || ", ...conditionArray]
-        })
+        conditionExpression := patterns
+        .map getPatternConditions ., ref
+        .map flatJoin ., " && "
+        |> flatJoin ., " || "
 
         const condition = {
           type: "ParenthesizedExpression",

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -14,9 +14,12 @@ import {
 import {
   addParentPointers
   isExit
+} from ./util.civet
+
+import {
   makeRef
   maybeRef
-} from ./util.civet
+} from ./ref.civet
 
 import {
   braceBlock

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -75,8 +75,7 @@ function processPatternMatching(statements: ASTNode): void {
         // Unwrap parenthesized expression
         condition = condition.expression as ParenthesizedExpression
 
-      { ref, hoistDec, refAssignment } .= maybeRefAssignment condition, "m"
-      refAssignmentComma .= refAssignment ? [refAssignment, ","] : []
+      { ref, hoistDec, refAssignmentComma } .= maybeRefAssignment condition, "m"
       let prev = [],
         root = prev
 
@@ -149,7 +148,7 @@ function processPatternMatching(statements: ASTNode): void {
           hoistDec
         }]
         hoistDec = undefined
-        refAssignment = refAssignmentComma = []
+        refAssignmentComma = []
         prev = next
       })
 

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -7,12 +7,14 @@ type {
   clone
   makeLeftHandSideExpression
   makeNode
-  makeRef
-  needsRef
   removeHoistDecs
   skipIfOnlyWS
   updateParentPointers
 } from ./util.civet
+{
+  makeRef
+  needsRef
+} from ./ref.civet
 
 { processUnaryExpression } from ./unary.civet
 

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -1,12 +1,14 @@
 import type {
+  ASTNode
   ASTNodeObject
+  DeclarationStatement
 } from "./types.civet"
 
 function makeRef(base = "ref", id = base): ASTRef
   return {
-    type: "Ref",
-    base,
-    id,
+    type: "Ref"
+    base
+    id
   }
 
 /**
@@ -27,8 +29,34 @@ function maybeRef(exp: ASTNode, base: string = "ref"): ASTNode
   if (!needsRef(exp)) return exp
   return makeRef(base)
 
+function makeRefAssignment(ref: ASTNode, exp: ASTNode): {
+  hoistDec: DeclarationStatement
+  refAssignment: ASTNode
+}
+  hoistDec:
+    type: "Declaration"
+    children: ["let ", ref]
+    names: []
+  refAssignment:
+    type: "AssignmentExpression"
+    children: [ref, " = ", exp]
+
+function maybeRefAssignment(exp: ASTNode, base: string = "ref"): {
+  ref: ASTNode
+  hoistDec: DeclarationStatement?
+  refAssignment: ASTNode
+}
+  let hoistDec, refAssignment
+  ref := maybeRef exp, base
+  unless ref is exp
+    { hoistDec, refAssignment } = makeRefAssignment ref, exp
+
+  return { ref, hoistDec, refAssignment }
+
 export {
   makeRef
+  makeRefAssignment
   maybeRef
+  maybeRefAssignment
   needsRef
 }

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -32,26 +32,36 @@ function maybeRef(exp: ASTNode, base: string = "ref"): ASTNode
 function makeRefAssignment(ref: ASTNode, exp: ASTNode): {
   hoistDec: DeclarationStatement
   refAssignment: ASTNode
+  refAssignmentComma: ASTNode[]
 }
-  hoistDec:
-    type: "Declaration"
-    children: ["let ", ref]
-    names: []
-  refAssignment:
+  refAssignment :=
     type: "AssignmentExpression"
     children: [ref, " = ", exp]
+  {
+    hoistDec:
+      type: "Declaration"
+      children: ["let ", ref]
+      names: []
+    refAssignment
+    refAssignmentComma:
+      if refAssignment
+        [refAssignment, ","]
+      else
+        []
+  }
 
 function maybeRefAssignment(exp: ASTNode, base: string = "ref"): {
   ref: ASTNode
-  hoistDec: DeclarationStatement?
-  refAssignment: ASTNode
+  hoistDec?: DeclarationStatement?
+  refAssignment?: ASTNode
+  refAssignmentComma: ASTNode[]
 }
   let hoistDec, refAssignment
   ref := maybeRef exp, base
-  unless ref is exp
-    { hoistDec, refAssignment } = makeRefAssignment ref, exp
-
-  return { ref, hoistDec, refAssignment }
+  if ref is exp
+    { ref, refAssignmentComma: [] }
+  else
+    { ref, ...makeRefAssignment ref, exp }
 
 export {
   makeRef

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -1,8 +1,12 @@
 import type {
   ASTNode
-  ASTNodeObject
+  ASTRef
   DeclarationStatement
 } from "./types.civet"
+
+import {
+  isWhitespaceOrEmpty
+} from "./util.civet"
 
 function makeRef(base = "ref", id = base): ASTRef
   return {
@@ -15,7 +19,17 @@ function makeRef(base = "ref", id = base): ASTRef
  * Returns a new ref if the expression needs a ref (not a simple value).
  * Otherwise returns undefined.
  */
-function needsRef(expression: ASTNodeObject, base = "ref")
+function needsRef(expression: ASTNode, base = "ref"): ASTRef | undefined
+  return unless expression? <? "object"
+  if Array.isArray expression
+    nonempty := [0...expression.length]
+    .filter (i) => not isWhitespaceOrEmpty expression[i]
+    if nonempty# is 1
+      if ref := needsRef expression[nonempty[0]], base
+        return ref
+      return
+    else
+      return makeRef base
   switch (expression.type) {
     case "Ref":
     case "Identifier":
@@ -26,8 +40,7 @@ function needsRef(expression: ASTNodeObject, base = "ref")
 
 // Transform into a ref if needed
 function maybeRef(exp: ASTNode, base: string = "ref"): ASTNode
-  if (!needsRef(exp)) return exp
-  return makeRef(base)
+  needsRef(exp, base) or exp
 
 function makeRefAssignment(ref: ASTNode, exp: ASTNode): {
   hoistDec: DeclarationStatement

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -1,0 +1,34 @@
+import type {
+  ASTNodeObject
+} from "./types.civet"
+
+function makeRef(base = "ref", id = base): ASTRef
+  return {
+    type: "Ref",
+    base,
+    id,
+  }
+
+/**
+ * Returns a new ref if the expression needs a ref (not a simple value).
+ * Otherwise returns undefined.
+ */
+function needsRef(expression: ASTNodeObject, base = "ref")
+  switch (expression.type) {
+    case "Ref":
+    case "Identifier":
+    case "Literal":
+      return
+  }
+  return makeRef(base)
+
+// Transform into a ref if needed
+function maybeRef(exp: ASTNode, base: string = "ref"): ASTNode
+  if (!needsRef(exp)) return exp
+  return makeRef(base)
+
+export {
+  makeRef
+  maybeRef
+  needsRef
+}

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -266,13 +266,26 @@ export type SwitchStatement
 
 export type CaseBlock
   type: "CaseBlock"
-  clauses: CaseClause[]
+  clauses: (PatternClause | CaseClause | WhenClause)[]
   children: Children
 
-export type CaseClause
-  type: unknown
+export type PatternClause
+  type: "PatternClause"
   children: Children
-  break?: ASTNode
+  patterns: PatternExpression[]
+  block: BlockStatement
+
+export type CaseClause
+  type: "CaseClause"
+  children: Children
+  cases: ASTNode[]
+  block: BlockStatement
+
+export type WhenClause
+  type: "WhenClause"
+  children: Children
+  cases: ASTNode[]
+  break: ASTNode
   block: BlockStatement
 
 export type LabeledStatement
@@ -408,11 +421,32 @@ export type TryStatement
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 
-export type BindingPattern = ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral
+export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral
+
+export type PatternExpression = BindingPattern | ConditionFragment
+
+export type BindingRestElement =
+  type: "BindingRestElement"
+  children: Children
+  parent?: Parent
+  name: string
+  names: string[]
+  rest: true
+
+export type ConditionFragment =
+  type: "ConditionFragment"
+  children: Children
+  parent?: Parent
 
 export type RegularExpressionLiteral = ASTLeaf & type: "RegularExpressionLiteral"
 
-export type ArrayBindingPattern = ASTNodeBase
+export type ArrayBindingPattern =
+  type: "ArrayBindingPattern"
+  children: Children
+  parent?: Parent
+  elements: BindingPattern[]
+  length: number
+  names: string[]
 
 export type Placeholder =
   type: "Placeholder"
@@ -430,9 +464,9 @@ export type BindingPatternContent = unknown[]
 
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",
-  children: [Whitespace, ASTLeaf, BindingPatternContent, WSNode, ASTLeaf],
-  names: string[],
-  properties: BindingPatternContent,
+  children: [Whitespace, ASTLeaf, BindingPatternContent, WSNode, ASTLeaf]
+  names: string[]
+  properties: BindingPatternContent
 
 export type FunctionExpression =
   type: "FunctionExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -127,7 +127,19 @@ export type BinaryOp = (string &
   reversed?: boolean
   negated?: boolean
   asConst?: boolean
+) | (PatternTest &
+  token?: never
+  assoc?: never
+  asConst?: never
 )
+
+export type PatternTest
+  type: "PatternTest"
+  children: Children
+  parent?: Parent
+  special: true
+  negated: boolean
+  hoistDec?: unknown
 
 export type AssignmentExpression
   type: "AssignmentExpression"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -27,8 +27,8 @@ import {
 } from ./traversal.civet
 
 import {
-  insertReturn
-} from ./function.civet
+  makeRef
+} from ./ref.civet
 
 assert := {
   equal(a: unknown, b: unknown, msg: string): void
@@ -491,31 +491,6 @@ function makeNode<T extends ASTNodeObject>(node: T): T
   updateParentPointers node
   node
 
-function makeRef(base = "ref", id = base): ASTRef
-  return {
-    type: "Ref",
-    base,
-    id,
-  }
-
-/**
- * Returns a new ref if the expression needs a ref (not a simple value).
- * Otherwise returns undefined.
- */
-function needsRef(expression, base = "ref")
-  switch (expression.type) {
-    case "Ref":
-    case "Identifier":
-    case "Literal":
-      return
-  }
-  return makeRef(base)
-
-// Transform into a ref if needed
-function maybeRef(exp: ASTNode, base: string = "ref"): ASTNode
-  if (!needsRef(exp)) return exp
-  return makeRef(base)
-
 /**
  * Used to ignore the result of __ if it is only whitespace
  * Useful to preserve spacing around comments
@@ -674,11 +649,8 @@ export {
   makeAmpersandFunction
   makeLeftHandSideExpression
   makeNode
-  makeRef
-  maybeRef
   maybeWrap
   maybeUnwrap
-  needsRef
   parenthesizeType
   prepend
   removeHoistDecs

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -625,12 +625,20 @@ function wrapWithReturn(expression?: ASTNode): ASTNode
     parent: expression?.parent,
   }
 
+function flatJoin<T, S>(array: T[][], separator: S): (T | S)[]
+  result := []
+  for each items, i of array
+    result.push separator if i
+    result.push ...items
+  result
+
 export {
   addParentPointers
   assert
   clone
   convertOptionalType
   deepCopy
+  flatJoin
   getTrimmingSpace
   hasAwait
   hasImportDeclaration

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -162,11 +162,12 @@ function isStatement(node: ASTNode): node is StatementNode
 function isWhitespaceOrEmpty(node): boolean {
   if (!node) return true
   if (node.type is "Ref") return false
-  if (node.token) return node.token.match(/^\s*$/)
+  if (node.token) return /^\s*$/.test(node.token)
   if (node.children) node = node.children
   if (!node.length) return true
-  if (typeof node is "string") return node.match(/^\s*$/)
+  if (typeof node is "string") return /^\s*$/.test(node)
   if (Array.isArray(node)) return node.every(isWhitespaceOrEmpty)
+  return false
 }
 
 /**

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1098,3 +1098,19 @@ describe "custom identifier infix operators", ->
       ---
       let m;(m = x + y+z,typeof m === 'string' && /abc/.test(m) || typeof m === 'string' && /def/.test(m))
     """
+
+    testCase """
+      conditional in left-hand side
+      ---
+      x < y is like /abc/
+      ---
+      x < y && (typeof y === 'string' && /abc/.test(y))
+    """
+
+    testCase """
+      conditionals in left-hand side
+      ---
+      x < y < z? is like /abc/
+      ---
+      x < y && z != null && y < z && (typeof z === 'string' && /abc/.test(z))
+    """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1090,3 +1090,11 @@ describe "custom identifier infix operators", ->
       ---
       let m;const isRef = (m = f(),typeof m === 'object' && m != null && 'type' in m && m.type === "Ref")
     """
+
+    testCase """
+      binary ops in left-hand side
+      ---
+      x + y+z is like /abc/, /def/
+      ---
+      let m;(m = x + y+z,typeof m === 'string' && /abc/.test(m) || typeof m === 'string' && /def/.test(m))
+    """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1046,3 +1046,47 @@ describe "custom identifier infix operators", ->
 
       right(right(a, b), c)
     """
+
+  describe "is like pattern matching test", ->
+    testCase """
+      basic
+      ---
+      x is like [1, x, 3]
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      ;(Array.isArray(x) && len(x, 3) && x[0] === 1 && x[2] === 3)
+    """
+
+    testCase """
+      multiple patterns
+      ---
+      x is like [1, x, 3], []
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      ;(Array.isArray(x) && len(x, 3) && x[0] === 1 && x[2] === 3 || Array.isArray(x) && len(x, 0))
+    """
+
+    testCase """
+      ref
+      ---
+      f() is like [1, x, 3]
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      let m;(m = f(),Array.isArray(m) && len(m, 3) && m[0] === 1 && m[2] === 3)
+    """
+
+    testCase """
+      assigned
+      ---
+      isRef := node is like {type: "Ref"}
+      ---
+      const isRef = (typeof node === 'object' && node != null && 'type' in node && node.type === "Ref")
+    """
+
+    testCase """
+      assigned with ref
+      ---
+      isRef := f() is like {type: "Ref"}
+      ---
+      let m;const isRef = (m = f(),typeof m === 'object' && m != null && 'type' in m && m.type === "Ref")
+    """


### PR DESCRIPTION
Fixes #391

Most of this PR is code cleanup:
* `getPatternConditions` no longer requires a third `conditions` argument; it starts as an empty array that gets returned
* This lets the condition combination code get simplified a lot (also thanks to the recent `.` feature)
* New `source/parser/ref.civet` to house ref helpers
* New `makeRefAssignment` to ease creation of `hoistDec` and `refAssignment`
* New `maybeRefAssignment` = `maybeRef` + `makeRefAssignment`
* New `flatJoin` to ease combining expressions with ` && ` or ` || `
* More types (but still incomplete)