### PR TITLE
Pattern matching fixes

### DIFF
--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -7,7 +7,6 @@ import type {
 } from ./types.civet
 
 import {
-  addParentPointers
   updateParentPointers
   startsWith
 } from ./util.civet
@@ -31,7 +30,7 @@ import {
  */
 function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: BlockStatement)
   if prefixStatements and prefixStatements.length
-    const indent = getIndent(block.expressions[0])
+    indent := getIndent(block.expressions[0])
     // Match prefix statements to block indent level
     if indent
       //@ts-ignore
@@ -40,7 +39,7 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
 
     const expressions = [...prefixStatements, ...block.expressions]
     // blockPrefix wasn't previously a child, so now needs parent pointers
-    addParentPointers prefixStatements, block
+    updateParentPointers prefixStatements, block
 
     block = {
       ...block,
@@ -55,7 +54,7 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
   return block
 
 // Add braces if block lacks them
-function braceBlock(block: BlockStatement)
+function braceBlock(block: BlockStatement): void
   if block.bare
     if block.children is block.expressions
       block.children = [block.expressions]

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -1,6 +1,7 @@
 import type {
   ASTLeaf
   ASTNode
+  ASTNodeParent
   ASTRef
   Binding
   Children
@@ -26,10 +27,10 @@ import {
 
 import {
   getPatternConditions
+  nonMatcherBindings
 } from ./pattern-matching.civet
 
 import {
-  addParentPointers
   convertOptionalType
   makeNode
   updateParentPointers
@@ -179,7 +180,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: {c
 
   return ref
 
-function processDeclarationCondition(condition, rootCondition, parent: { children: Children }): void
+function processDeclarationCondition(condition, rootCondition, parent: ASTNodeParent): void
   return unless condition.type is "DeclarationCondition"
 
   { decl, bindings } := condition.declaration as DeclarationStatement
@@ -188,7 +189,7 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
   { pattern, suffix, initializer, splices, thisAssignments } .= binding
   nullCheck := suffix?.optional and not suffix.t and not suffix.nonnull
 
-  let ref = prependStatementExpressionBlock(initializer!, parent)
+  ref .= prependStatementExpressionBlock(initializer!, parent)
 
   if ref
     Object.assign condition, {
@@ -228,13 +229,12 @@ function processDeclarationCondition(condition, rootCondition, parent: { childre
     }
 
   // condition wasn't previously a child, so now needs parent pointers
-  addParentPointers condition, parent
+  updateParentPointers condition, parent
 
-  Object.assign rootCondition,
-    blockPrefix: [
-      ["", [ decl, pattern, suffix, " = ", ref, ...splices ], ";"],
-      ...thisAssignments
-    ]
+  rootCondition.blockPrefix = [
+    ["", [ decl, nonMatcherBindings(pattern), suffix, " = ", ref, ...splices ], ";"],
+    ...thisAssignments
+  ]
 
 function processDeclarationConditions(node: ASTNode): void
   gatherRecursiveAll node, (n) =>
@@ -259,15 +259,21 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   { ref, pattern } := expression
 
   if pattern
-    conditions .= getPatternConditions(pattern, ref)
+    conditions := getPatternConditions(pattern, ref)
+    .filter (c) =>
+      switch c
+        // We already check whether the ref is truthy, so it's non-null
+        [^ref, " != null"]
+          false
+        // Keep top-level object checks to be consistent with pattern matching
+        // (e.g. exclude {length} := s from matching a string)
+        //["typeof ", ^ref, " === 'object'"]
+        else
+          true
 
-    conditions = conditions.filter (c) =>
-      !(c.length is 3 and c[0] is "typeof " and c[1] is ref and c[2] is " === 'object'") and
-      !(c.length is 2 and c[0] is ref and c[1] is " != null")
-
-    if conditions.length
+    if conditions#
       condition.children.unshift "("
-      conditions.forEach (c) ->
+      conditions.forEach (c) =>
         condition.children.push " && ", c
       condition.children.push ")"
 

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -39,6 +39,7 @@ import {
 
 import {
   makeRef
+  maybeRef
 } from ./ref.civet
 
 import {
@@ -190,7 +191,14 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
   { pattern, suffix, initializer } .= binding
   nullCheck := suffix?.optional and not suffix.t and not suffix.nonnull
 
-  ref .= prependStatementExpressionBlock(initializer!, parent)
+  unless initializer?
+    condition.children = [
+      type: "Error"
+      message: "Missing initializer in declaration condition"
+    ]
+    return
+
+  ref: ASTNode .= prependStatementExpressionBlock(initializer!, parent)
 
   if ref
     Object.assign condition, {
@@ -201,16 +209,22 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
       statementDeclaration: true
     }
   else
-    ref = makeRef()
-    grandparent := condition.parent?.parent
-    children :=
+    { expression } := initializer
+    ref = maybeRef expression
+    simple := ref is expression
+    let children
+    if simple
+      ref = insertTrimmingSpace ref, ""
+      children = [ref]
+    else
+      children = [ref, initializer]
       // Wrap declaration that is a plain assignment (no pattern-matching) and the immediate grandchild of an `if` or `while`
       // to satisfy eslint's no-cond-assign rule
       // More complex conditions (triggered by pattern matching or `until`/`unless`) don't need double parens
+      grandparent := condition.parent?.parent
       if pattern.type is "Identifier" and (grandparent?.type is "IfStatement" or grandparent?.type is "IterationStatement") and not nullCheck
-        ["(", ref, initializer, ")"]
-      else
-        [ref, initializer]
+        children.unshift "("
+        children.push ")"
 
     // `x? := ...` as a condition means `x := ..., x?`
     if nullCheck
@@ -221,7 +235,7 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
     Object.assign condition, {
       type: "AssignmentExpression"
       children
-      hoistDec:
+      hoistDec: unless simple
         type: "Declaration"
         children: ["let ", ref, suffix]
         names: []

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -26,6 +26,7 @@ import {
 } from ./traversal.civet
 
 import {
+  getPatternBlockPrefix
   getPatternConditions
   nonMatcherBindings
 } from ./pattern-matching.civet
@@ -186,7 +187,7 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
   { decl, bindings } := condition.declaration as DeclarationStatement
   // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
   binding := bindings[0]
-  { pattern, suffix, initializer, splices, thisAssignments } .= binding
+  { pattern, suffix, initializer } .= binding
   nullCheck := suffix?.optional and not suffix.t and not suffix.nonnull
 
   ref .= prependStatementExpressionBlock(initializer!, parent)
@@ -231,10 +232,7 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
   // condition wasn't previously a child, so now needs parent pointers
   updateParentPointers condition, parent
 
-  rootCondition.blockPrefix = [
-    ["", [ decl, nonMatcherBindings(pattern), suffix, " = ", ref, ...splices ], ";"],
-    ...thisAssignments
-  ]
+  rootCondition.blockPrefix = getPatternBlockPrefix(pattern, ref, decl, suffix)
 
 function processDeclarationConditions(node: ASTNode): void
   gatherRecursiveAll node, (n) =>

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -15,6 +15,7 @@ import {
   addParentPointers
   flatJoin
   isExit
+  isWhitespaceOrEmpty
   makeLeftHandSideExpression
 } from ./util.civet
 
@@ -107,7 +108,7 @@ function processPatternMatching(statements: ASTNode): void {
         let { patterns, block } = c
         let pattern = patterns[0]
 
-        const indent = block.expressions?.[0]?.[0] or ""
+        indent := block.expressions?.[0]?.[0] or ""
 
         // TODO: multiple binding patterns
 
@@ -116,15 +117,15 @@ function processPatternMatching(statements: ASTNode): void {
         .map flatJoin ., " && "
         |> flatJoin ., " || "
 
-        const condition = {
-          type: "ParenthesizedExpression",
-          children: ["(", ...refAssignmentComma, conditionExpression, ")"],
-          expression: conditionExpression,
+        condition := {
+          type: "ParenthesizedExpression"
+          children: ["(", ...refAssignmentComma, conditionExpression, ")"]
+          expression: conditionExpression
         }
 
-        const prefix = []
+        prefix := []
 
-        switch (pattern.type) {
+        switch pattern.type
           case "ArrayBindingPattern":
             if (pattern.length is 0) break
           case "ObjectBindingPattern": {
@@ -132,25 +133,25 @@ function processPatternMatching(statements: ASTNode): void {
             if (pattern.properties?.length is 0) break
 
             // Gather bindings
-            let [splices, thisAssignments] = gatherBindingCode(pattern)
-            const patternBindings = nonMatcherBindings(pattern)
+            [splices, thisAssignments] .= gatherBindingCode(pattern)
+            patternBindings := nonMatcherBindings(pattern)
 
-            splices = splices.map((s) => [", ", nonMatcherBindings(s)])
-            thisAssignments = thisAssignments.map((a) => [indent, a, ";"])
+            splices = splices.map (s) => [", ", nonMatcherBindings(s)]
+            thisAssignments = thisAssignments.map [indent, &, ";"]
 
-            const duplicateDeclarations = aggregateDuplicateBindings([patternBindings, splices])
+            duplicateDeclarations := aggregateDuplicateBindings([patternBindings, splices])
 
-            prefix.push([indent, "const ", patternBindings, " = ", ref, splices, ";"])
-            prefix.push(...thisAssignments)
-            prefix.push(...duplicateDeclarations.map((d) => [indent, d, ";"]))
+            prefix.push
+              [indent, "const ", patternBindings, " = ", ref, ...splices, ";"]
+              ...thisAssignments
+              ...duplicateDeclarations.map [indent, &, ";"]
 
             break
           }
-        }
 
-        block.expressions.unshift(...prefix)
+        block.expressions.unshift ...prefix
 
-        const next = []
+        next := []
 
         // Add braces if necessary
         braceBlock(block)
@@ -353,21 +354,18 @@ function elideMatchersFromPropertyBindings(properties) {
   })
 }
 
-function nonMatcherBindings(pattern) {
-  switch (pattern.type) {
-    case "ArrayBindingPattern": {
-      const elements = elideMatchersFromArrayBindings(pattern.elements)
-      const children = ["[", elements, "]"]
-      return {
-        ...pattern,
-        children,
-        elements,
+function nonMatcherBindings(pattern)
+  switch pattern.type
+    when "ArrayBindingPattern"
+      elements := elideMatchersFromArrayBindings(pattern.elements)
+      {
+        ...pattern
+        elements
+        children: pattern.children.map & is pattern.elements ? elements : &
       }
-    }
-    case "PostRestBindingElements": {
+    when "PostRestBindingElements"
       const els = elideMatchersFromArrayBindings(pattern.children[1])
-
-      return {
+      {
         ...pattern,
         children: [
           pattern.children[0],
@@ -375,14 +373,15 @@ function nonMatcherBindings(pattern) {
           ...pattern.children.slice(2),
         ],
       }
-    }
-    case "ObjectBindingPattern":
-      return ["{", elideMatchersFromPropertyBindings(pattern.properties), "}"]
-
-    default:
-      return pattern
-  }
-}
+    when "ObjectBindingPattern"
+      properties := elideMatchersFromPropertyBindings(pattern.properties)
+      {
+        ...pattern
+        properties
+        children: pattern.children.map & is pattern.properties ? properties : &
+      }
+    else
+      pattern
 
 function aggregateDuplicateBindings(bindings) {
   props := gatherRecursiveAll bindings, .type is "BindingProperty"
@@ -465,6 +464,7 @@ function aliasBinding(p, ref: ASTRef): void
 
 export {
   getPatternConditions
+  nonMatcherBindings
   processPatternMatching
   processPatternTest
 }

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -4,6 +4,7 @@ import type {
   ParenthesizedExpression
   ParseRule
   PatternExpression
+  StatementTuple
   SwitchStatement
 } from ./types.civet
 
@@ -25,6 +26,7 @@ import {
 } from ./ref.civet
 
 import {
+  blockWithPrefix
   braceBlock
 } from ./block.civet
 
@@ -105,10 +107,8 @@ function processPatternMatching(statements: ASTNode): void {
           return
         }
 
-        let { patterns, block } = c
-        let pattern = patterns[0]
-
-        indent := block.expressions?.[0]?.[0] or ""
+        { patterns, block } .= c
+        pattern .= patterns[0]
 
         // TODO: multiple binding patterns
 
@@ -123,38 +123,10 @@ function processPatternMatching(statements: ASTNode): void {
           expression: conditionExpression
         }
 
-        prefix := []
-
-        switch pattern.type
-          case "ArrayBindingPattern":
-            if (pattern.length is 0) break
-          case "ObjectBindingPattern": {
-            // NOTE: Array matching pattern falls through so we use the null check
-            if (pattern.properties?.length is 0) break
-
-            // Gather bindings
-            [splices, thisAssignments] .= gatherBindingCode(pattern)
-            patternBindings := nonMatcherBindings(pattern)
-
-            splices = splices.map (s) => [", ", nonMatcherBindings(s)]
-            thisAssignments = thisAssignments.map [indent, &, ";"]
-
-            duplicateDeclarations := aggregateDuplicateBindings([patternBindings, splices])
-
-            prefix.push
-              [indent, "const ", patternBindings, " = ", ref, ...splices, ";"]
-              ...thisAssignments
-              ...duplicateDeclarations.map [indent, &, ";"]
-
-            break
-          }
-
-        block.expressions.unshift ...prefix
+        braceBlock block
+        block = blockWithPrefix getPatternBlockPrefix(pattern, ref), block
 
         next := []
-
-        // Add braces if necessary
-        braceBlock(block)
 
         // Insert else if there are more branches
         if (i < l - 1) next.push("\n", "else ")
@@ -300,6 +272,35 @@ function getPatternConditions(
   }
   return conditions
 }
+
+function getPatternBlockPrefix(
+  pattern: PatternExpression
+  ref: ASTNode
+  decl: ASTNode = "const "
+  suffix?: ASTNode
+): StatementTuple[]?
+  switch pattern.type
+    when "ArrayBindingPattern"
+      return unless pattern.length
+    when "ObjectBindingPattern"
+      return unless pattern.properties.length
+    when "Literal", "RegularExpressionLiteral", "PinPattern", "ConditionFragment"
+      return
+
+  // Gather bindings
+  [splices, thisAssignments] .= gatherBindingCode(pattern)
+  patternBindings := nonMatcherBindings(pattern)
+
+  splices = splices.map (s) => [", ", nonMatcherBindings(s)]
+  thisAssignments = thisAssignments.map ['', &, ";"]
+
+  duplicateDeclarations := aggregateDuplicateBindings([patternBindings, splices])
+
+  [
+    ['', [decl, patternBindings, suffix, " = ", ref, ...splices], ";"]
+    ...thisAssignments
+    ...duplicateDeclarations.map ['', &, ";"]
+  ]
 
 function elideMatchersFromArrayBindings(elements) {
   return elements.map((el) => {
@@ -464,6 +465,7 @@ function aliasBinding(p, ref: ASTRef): void
 
 export {
   getPatternConditions
+  getPatternBlockPrefix
   nonMatcherBindings
   processPatternMatching
   processPatternTest

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -329,13 +329,21 @@ function elideMatchersFromPropertyBindings(properties) {
         const [ws] = children
 
         switch (value and value.type) {
-          case "ArrayBindingPattern":
-          case "ObjectBindingPattern":
+          when "ArrayBindingPattern"
+            bindings .= nonMatcherBindings(value)
+            bindings = undefined unless bindings.length
             return {
               ...p,
-              children: [ws, name, ": ", nonMatcherBindings(value), p.delim],
+              children: [ws, name, bindings && ": ", bindings, p.delim],
             }
-          case "Identifier":
+          when "ObjectBindingPattern"
+            bindings .= nonMatcherBindings(value)
+            bindings = undefined unless bindings.properties.length
+            return {
+              ...p,
+              children: [ws, name, bindings && ": ", bindings, p.delim],
+            }
+          when "Identifier"
             return p
           case "Literal":
           case "RegularExpressionLiteral":

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -433,7 +433,7 @@ export type TryStatement
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 
-export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral | RegularExpressionLiteral
+export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral
 
 export type PatternExpression = BindingPattern | ConditionFragment
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -433,7 +433,7 @@ export type TryStatement
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 
-export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral
+export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral | RegularExpressionLiteral
 
 export type PatternExpression = BindingPattern | ConditionFragment
 
@@ -467,7 +467,10 @@ export type Placeholder =
   parent?: Parent
   typeSuffix?: TypeSuffix?
 
-export type PinPattern = ASTNodeBase
+export type PinPattern =
+  type: "PinPattern"
+  children: Children
+  expression: ExpressionNode
 
 // _?, __
 export type Whitespace = (ASTLeaf | ASTString)[]?

--- a/test/if.civet
+++ b/test/if.civet
@@ -360,7 +360,7 @@ describe "if", ->
     ---
     x if { x } := y
     ---
-    let ref;if ((ref = y) && typeof ref === 'object' && 'x' in ref) { const { x } = ref;x }
+    if ((y) && typeof y === 'object' && 'x' in y) { const { x } = y;x }
   """
 
   testCase """
@@ -821,8 +821,8 @@ describe "if", ->
       else
         console.log "not upper case"
       ---
-      let ref;if ((ref = node) && typeof ref === 'object' && 'type' in ref && ref.type === "Identifier" && 'name' in ref && typeof ref.name === 'string' && /^[A-Z]*$/.test(ref.name)) {
-        const {type, name} = ref;
+      if ((node) && typeof node === 'object' && 'type' in node && node.type === "Identifier" && 'name' in node && typeof node.name === 'string' && /^[A-Z]*$/.test(node.name)) {
+        const {type, name} = node;
         console.log("upper case", name)
       }
       else {
@@ -881,13 +881,13 @@ describe "if", ->
     """
 
     testCase """
-      if declaration with @
+      if declaration with @ and let
       ---
       if @foo .= bar
         console.log @foo
       ---
-      let ref;if (ref = bar) {
-        let foo = ref;
+      if (bar) {
+        let foo = bar;
         this.foo = foo;
         console.log(this.foo)
       }
@@ -940,12 +940,12 @@ describe "if", ->
       else if y := 1
         "bye"
       ---
-      let ref;let ref1;if ((ref = 0)) {
-        const x = ref;
+      if (0) {
+        const x = 0;
         "hi"
       }
-      else if ((ref1 = 1)) {
-        const y = ref1;
+      else if (1) {
+        const y = 1;
         "bye"
       }
     """
@@ -993,8 +993,8 @@ describe "if", ->
       if {x, ^y} := obj
         console.log x
       ---
-      let ref;if ((ref = obj) && typeof ref === 'object' && 'x' in ref && 'y' in ref && ref.y === y) {
-        const {x, y} = ref;
+      if ((obj) && typeof obj === 'object' && 'x' in obj && 'y' in obj && obj.y === y) {
+        const {x, y} = obj;
         console.log(x)
       }
     """
@@ -1006,8 +1006,8 @@ describe "if", ->
         console.log type
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
-      let ref;if ((ref = array) && Array.isArray(ref) && len(ref, 2) && typeof ref[0] === 'object' && ref[0] != null && 'type' in ref[0] && ref[0].type === "text" && typeof ref[1] === 'object' && ref[1] != null && 'type' in ref[1] && ref[1].type === "image") {
-        const [{type: type1}, {type: type2}] = ref;
+      if ((array) && Array.isArray(array) && len(array, 2) && typeof array[0] === 'object' && array[0] != null && 'type' in array[0] && array[0].type === "text" && typeof array[1] === 'object' && array[1] != null && 'type' in array[1] && array[1].type === "image") {
+        const [{type: type1}, {type: type2}] = array;
         const type = [type1, type2];
         console.log(type)
       }

--- a/test/if.civet
+++ b/test/if.civet
@@ -981,7 +981,7 @@ describe "if", ->
         console.log @a, b
       ---
       let ref;if ((ref = regex.exec(string)) && Array.isArray(ref) && ref.length >= 1) {
-        const [...a] = ref,[b] = a.splice(-1);
+        const [...a] = ref, [b] = a.splice(-1);
         this.a = a;
         console.log(this.a, b)
       }
@@ -996,6 +996,20 @@ describe "if", ->
       let ref;if ((ref = obj) && typeof ref === 'object' && 'x' in ref && 'y' in ref && ref.y === y) {
         const {x, y} = ref;
         console.log(x)
+      }
+    """
+
+    testCase """
+      duplicate bindings
+      ---
+      if [{type: "text"}, {type: "image"}] := array
+        console.log type
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      let ref;if ((ref = array) && Array.isArray(ref) && len(ref, 2) && typeof ref[0] === 'object' && ref[0] != null && 'type' in ref[0] && ref[0].type === "text" && typeof ref[1] === 'object' && ref[1] != null && 'type' in ref[1] && ref[1].type === "image") {
+        const [{type: type1}, {type: type2}] = ref;
+        const type = [type1, type2];
+        console.log(type)
       }
     """
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -360,7 +360,7 @@ describe "if", ->
     ---
     x if { x } := y
     ---
-    let ref;if ((ref = y) && 'x' in ref) { const { x } = ref;x }
+    let ref;if ((ref = y) && typeof ref === 'object' && 'x' in ref) { const { x } = ref;x }
   """
 
   testCase """
@@ -814,6 +814,23 @@ describe "if", ->
     """
 
     testCase """
+      if declaration with values
+      ---
+      if {type: "Identifier", name: /^[A-Z]*$/} := node
+        console.log "upper case", name
+      else
+        console.log "not upper case"
+      ---
+      let ref;if ((ref = node) && typeof ref === 'object' && 'type' in ref && ref.type === "Identifier" && 'name' in ref && typeof ref.name === 'string' && /^[A-Z]*$/.test(ref.name)) {
+        const {type, name} = ref;
+        console.log("upper case", name)
+      }
+      else {
+        console.log("not upper case")
+      }
+    """
+
+    testCase """
       if declaration with type
       ---
       if m: Match := s.match(re)
@@ -860,6 +877,19 @@ describe "if", ->
       let ref;if ((ref/*left*/=/*right*/s.match(re)) && Array.isArray(ref) && len(ref, 2)) {
         const [_, s] = ref;
         s
+      }
+    """
+
+    testCase """
+      if declaration with @
+      ---
+      if @foo .= bar
+        console.log @foo
+      ---
+      let ref;if (ref = bar) {
+        let foo = ref;
+        this.foo = foo;
+        console.log(this.foo)
       }
     """
 
@@ -963,7 +993,7 @@ describe "if", ->
       if {x, ^y} := obj
         console.log x
       ---
-      let ref;if ((ref = obj) && 'x' in ref && 'y' in ref && ref.y === y) {
+      let ref;if ((ref = obj) && typeof ref === 'object' && 'x' in ref && 'y' in ref && ref.y === y) {
         const {x, y} = ref;
         console.log(x)
       }
@@ -989,7 +1019,7 @@ describe "if", ->
       else
         b
       ---
-      let ref;let ref1;if ((ref1 = f()) && 'y' in ref1) {
+      let ref;let ref1;if ((ref1 = f()) && typeof ref1 === 'object' && 'y' in ref1) {
         const {y} = ref1;
         ref = a
       }

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -778,6 +778,30 @@ describe "switch", ->
     """
 
     testCase """
+      empty array in object
+      ---
+      switch x
+        {children: []}
+          console.log "empty"
+      ---
+      if(typeof x === 'object' && x != null && 'children' in x && Array.isArray(x.children) && len(x.children, 0)) {
+          const {children} = x;
+          console.log("empty")}
+    """
+
+    testCase """
+      empty object in object
+      ---
+      switch x
+        {props: {}}
+          console.log "empty"
+      ---
+      if(typeof x === 'object' && x != null && 'props' in x && typeof x.props === 'object' && x.props != null) {
+          const {props} = x;
+          console.log("empty")}
+    """
+
+    testCase """
       array with empty object
       ---
       switch x

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -760,7 +760,8 @@ describe "switch", ->
       if(Array.isArray(x) && len(x, 3) && x[2] === 4) {
           const [
           a,
-          b,] = x;
+          b,
+        ] = x;
           console.log(a, b)}
     """
 

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -784,6 +784,7 @@ describe "switch", ->
         {children: []}
           console.log "empty"
       ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
       if(typeof x === 'object' && x != null && 'children' in x && Array.isArray(x.children) && len(x.children, 0)) {
           const {children} = x;
           console.log("empty")}

--- a/test/while.civet
+++ b/test/while.civet
@@ -150,7 +150,7 @@ describe "while", ->
       while {x, y} := next()
         x++
       ---
-      let ref;while ((ref = next()) && 'x' in ref && 'y' in ref) {
+      let ref;while ((ref = next()) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {
         const {x, y} = ref;
         x++
       }
@@ -174,7 +174,7 @@ describe "while", ->
       while {x, y}? := next()
         x++
       ---
-      let ref;while (((ref= next()) != null) && 'x' in ref && 'y' in ref) {
+      let ref;while (((ref= next()) != null) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {
         const {x, y} = ref;
         x++
       }
@@ -200,7 +200,7 @@ describe "while", ->
         x++
       ---
       x = 0
-      let ref;while ((ref = next()) && 'x' in ref && 'y' in ref) {
+      let ref;while ((ref = next()) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {
         const {x, y} = ref;
         x++
       }
@@ -215,7 +215,7 @@ describe "while", ->
         ;
       ---
       f = function() {
-        let ref;while ((ref = next()) && 'x' in ref && 'y' in ref) {
+        let ref;while ((ref = next()) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {
           const {x, y} = ref;
           x++
         }
@@ -234,7 +234,7 @@ describe "while", ->
       ---
       f = function() {
         a
-        let ref;while ((ref = next()) && 'x' in ref && 'y' in ref) {
+        let ref;while ((ref = next()) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {
           const {x, y} = ref;
           x++
         }


### PR DESCRIPTION
Generally share more code between pattern matching and declaration conditions to fix the following:

* Fix declaration conditions with literals (fix #1147)
* Fix duplicate bindings in declaration conditions
* Bonus: Avoid refs in simple declaration conditions
* Added: Fix empty arrays in object pattern matching (fix #1201)