### PR TITLE
Fix handling of empty arrays and objects in patterns

### DIFF
--- a/source/generate.civet
+++ b/source/generate.civet
@@ -69,18 +69,16 @@ export default gen
 // Useful for debugging so I don't need to step though tons of empty nodes
 // Also remove parent pointers so we can JSON.stringify the tree
 export function prune(node: any): any
-  if node is null or node is undefined
-    return
+  return unless node?
 
-  if node.length is 0
+  if node <? "string" and node.length is 0
     return
   if node.parent?
     delete node.parent
 
   if Array.isArray(node)
-    a := node.map (n) ->
-      prune(n)
-    .filter !!&
+    a := node.map prune
+    .filter &
 
     if a.length > 1
       return a

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -329,16 +329,8 @@ function elideMatchersFromPropertyBindings(properties) {
         const [ws] = children
 
         switch (value and value.type) {
-          when "ArrayBindingPattern"
-            bindings .= nonMatcherBindings(value)
-            bindings = undefined unless bindings.length
-            return {
-              ...p,
-              children: [ws, name, bindings && ": ", bindings, p.delim],
-            }
-          when "ObjectBindingPattern"
-            bindings .= nonMatcherBindings(value)
-            bindings = undefined unless bindings.properties.length
+          when "ArrayBindingPattern", "ObjectBindingPattern"
+            bindings := nonMatcherBindings(value)
             return {
               ...p,
               children: [ws, name, bindings && ": ", bindings, p.delim],

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -786,7 +786,7 @@ describe "switch", ->
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
       if(typeof x === 'object' && x != null && 'children' in x && Array.isArray(x.children) && len(x.children, 0)) {
-          const {children} = x;
+          const {children: []} = x;
           console.log("empty")}
     """
 
@@ -798,7 +798,7 @@ describe "switch", ->
           console.log "empty"
       ---
       if(typeof x === 'object' && x != null && 'props' in x && typeof x.props === 'object' && x.props != null) {
-          const {props} = x;
+          const {props: {}} = x;
           console.log("empty")}
     """
 


### PR DESCRIPTION
Fix the issue mentioned here: https://github.com/DanielXMoore/Civet/pull/1200#discussion_r1583864309

This turned out to be tricky to figure out, as it had to do with the generator!  ArrayBindingPattern nodes have a `length` field which was zero in this case. We could instead remove `length` fields from AST node objects, but it seems like a useful field name (I'd rather have it *defined* for ObjectBindingPattern too so that code could be more symmetric), and maybe used a fair amount around array patterns, so changing the generator seemed better.  Note that empty arrays are still also removed, using the code down below.