### PR TITLE
(is like ...) section, document "is not like"

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1001,6 +1001,13 @@ new Promise (resolve =)
 callback := (sum +=)
 </Playground>
 
+You can also make sections from
+the [pattern matching operator `is like`](#pattern-matching):
+
+<Playground>
+array.filter (is like {type, children})
+</Playground>
+
 ### Functions as Infix Operators
 
 You can "bless" an existing function to behave as an infix operator
@@ -1299,7 +1306,7 @@ if [{type, content}, ...rest] := x
 </Playground>
 
 If you just want to check *whether* a value matches a single pattern,
-you can use the `is like` operator:
+you can use the `is like` or `is not like` operator:
 
 <Playground>
 if x is like [{type, content: /^\s+$/}, ...]
@@ -1310,6 +1317,7 @@ In particular, this gives a nice shorthand for `RegExp.prototype.test`:
 
 <Playground>
 isInt := x is like /^[+-]?\d+$/
+exists := x? is not like /^\s*$/
 </Playground>
 
 ## Loops

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -441,18 +441,8 @@ BinaryOpExpression
     return processBinaryOpExpression($0)
 
 BinaryOpRHS
-  ( _? / IndentedFurther / Nested ):ws1 ( Is _? ( Not _? )? Like ):op _?:ws2 PatternExpressionList:patterns ->
-    return [
-      ws1,
-      {
-        type: "PatternTest",
-        children: op,
-        special: true,
-        negated: !!op[2],
-      },
-      ws2,
-      patterns
-    ]
+  ( _? / IndentedFurther / Nested ):ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
+    return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
     // Insert empty whitespace placeholder to maintan structure
@@ -467,6 +457,15 @@ BinaryOpRHS
     // NOTE: Flatten NotDedentedBinaryOp into whitespace and operator
     return [...op, ...rhs]
   !NewlineBinaryOpAllowed SingleLineBinaryOpRHS -> $2
+
+IsLike
+  Is _? ( Not _? )?:not Like ->
+    return {
+      type: "PatternTest",
+      children: $0,
+      special: true,
+      negated: !!not,
+    }
 
 # Whitespace followed by RHS
 WRHS
@@ -2156,6 +2155,19 @@ FunctionExpression
         assigned: lhs[0][1],
         expression: refB,
       },
+    })
+    return {
+      type: "ParenthesizedExpression",
+      children: [ open, fn, close ],
+      expression: fn,
+    }
+  OpenParen:open __:ws1 IsLike:op __:ws2 PatternExpressionList:rhs CloseParen:close ->
+    const refA = makeRef("a")
+    const fn = makeAmpersandFunction({
+      ref: refA,
+      body: processBinaryOpExpression([refA, [
+        [ws1, op, ws2, rhs] // BinaryOpRHS
+      ]])
     })
     return {
       type: "ParenthesizedExpression",

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1114,3 +1114,19 @@ describe "custom identifier infix operators", ->
       ---
       x < y && z != null && y < z && (typeof z === 'string' && /abc/.test(z))
     """
+
+    testCase """
+      is not like
+      ---
+      x is not like {type: "Ref"}
+      ---
+      !(typeof x === 'object' && x != null && 'type' in x && x.type === "Ref")
+    """
+
+    testCase """
+      section
+      ---
+      (is like {type: "Ref"})
+      ---
+      (a => (typeof a === 'object' && a != null && 'type' in a && a.type === "Ref"))
+    """


### PR DESCRIPTION
Add support for `(is like ...)` sections. It's a special binary operator so this needs to be explicit. [I don't think `(... is like)` or `(is like)` sections can make sense, because the right-hand side needs to be parsed as a pattern.]

I forgot that I previously added `is not like`, this PR documents and tests  that as well.