### PR TITLE
Detect Error nodes in inlineMap mode

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -136,10 +136,17 @@ export compile := (src: string, options?: CompilerOptions) ->
   if options.ast
     return ast
 
+  function checkErrors
+    if options!.errors?.length
+      // TODO: Better error display
+      //@ts-ignore
+      throw new Error `Parse errors: ${options.errors.map(.message).join("\n")} `
+
   if options.sourceMap or options.inlineMap
     sm := SourceMap(src)
     options.updateSourceMap = sm.updateSourceMap
     code := generate ast, options
+    checkErrors()
 
     if options.inlineMap
       //@ts-ignore
@@ -151,12 +158,7 @@ export compile := (src: string, options?: CompilerOptions) ->
       }
 
   result := generate ast, options
-
-  if options.errors?.length
-    // TODO: Better error display
-    //@ts-ignore
-    throw new Error `Parse errors: ${options.errors.map(.message).join("\n")} `
-
+  checkErrors()
   return result
 
 type CacheKey = [string, number, number, string]

--- a/test/function.civet
+++ b/test/function.civet
@@ -239,6 +239,18 @@ describe "function", ->
       })
     """
 
+    throws """
+      yield forbidden within thick arrow
+      ---
+      => yield 5
+    """
+
+    throws """
+      yield forbidden within thick arrow, inlineMap
+      ---
+      => yield 5
+    """, inlineMap: true
+
     testCase """
       thick arrow
       ---


### PR DESCRIPTION
Fixes #1206

I verified that the second added test fails without this change. Not totally sure this is the right place for the `inlineMap` test, but `yield` in fat arrow is something we didn't already check for that generates an Error node, so it works.