### PR TITLE
Use `is like` in some cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "unplugin": "^1.6.0"
   },
   "devDependencies": {
-    "@danielx/civet": "0.7.1",
+    "@danielx/civet": "0.7.4",
     "@danielx/hera": "^0.8.13",
     "@prettier/sync": "^0.3.0",
     "@types/assert": "^1.5.6",

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -498,20 +498,16 @@ function processParams(f): void
 
   if (!prefix.length) return
   // In constructor definition, insert prefix after first super() call
-  if (isConstructor) {
-    const superCalls = gatherNodes expressions, (exp) =>
-      exp.type is "CallExpression" and exp.children[0]?.token is "super"
-    if (superCalls.length) {
-      const {child} = findAncestor(superCalls[0],
-        (ancestor) => ancestor is block)
-      const index = findChildIndex(expressions, child)
-      if (index < 0) {
+  if isConstructor
+    superCalls := gatherNodes expressions,
+      (is like {type: "CallExpression", children: [ {token: "super"}, ... ]})
+    if superCalls#
+      {child} := findAncestor superCalls[0], (is block)
+      index := findChildIndex expressions, child
+      if index < 0
         throw new Error("Could not find super call within top-level expressions")
-      }
       expressions.splice(index + 1, 0, ...prefix)
       return
-    }
-  }
   expressions.unshift(...prefix)
 
 function processFunctions(statements, config): void

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,6 +1,7 @@
 import type {
   ASTNode
   ASTNodeBase
+  CallExpression
   FunctionNode
   IterationExpression
   IterationFamily
@@ -26,6 +27,7 @@ import {
   gatherNodes
   gatherRecursiveAll
   gatherRecursiveWithinFunction
+  type Predicate
 } from ./traversal.civet
 
 import {
@@ -500,7 +502,7 @@ function processParams(f): void
   // In constructor definition, insert prefix after first super() call
   if isConstructor
     superCalls := gatherNodes expressions,
-      (is like {type: "CallExpression", children: [ {token: "super"}, ... ]})
+      (is like {type: "CallExpression", children: [ {token: "super"}, ... ]}) as Predicate<CallExpression>
     if superCalls#
       {child} := findAncestor superCalls[0], (is block)
       index := findChildIndex expressions, child

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -326,7 +326,7 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
 
   // Parenthesized operator like (+), immediately called, expands to
   // use of the operator. This is useful for e.g. shortcutting (&&).
-  if children[0]?.parenthesizedOp?.token and children[1]?.type is "Call"
+  if children is like [ {parenthesizedOp: {token}}, {type: "Call"}, ... ]
     op := children[0].parenthesizedOp
     call .= children[1]
     args := [...call.args] // shallow copy

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -139,8 +139,10 @@ function processBinaryOpExpression($0)
           b = recurse b
 
         // typeof shorthand: x instanceof "String" -> typeof x === "string"
-        if op.token === "instanceof" and b.type === "Literal" and
-           b.children is like [ {type: "StringLiteral"}, ... ]
+        if op.token === "instanceof" and b is like {
+          type: "Literal"
+          children: [ {type: "StringLiteral"}, ... ]
+        }
           a = ["typeof ", makeLeftHandSideExpression(a)]
           if op.negated
             op = { ...op, token: "!==", negated: false }

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -140,7 +140,7 @@ function processBinaryOpExpression($0)
 
         // typeof shorthand: x instanceof "String" -> typeof x === "string"
         if op.token === "instanceof" and b.type === "Literal" and
-           b.children?.[0]?.type === "StringLiteral"
+           b.children is like [ {type: "StringLiteral"}, ... ]
           a = ["typeof ", makeLeftHandSideExpression(a)]
           if op.negated
             op = { ...op, token: "!==", negated: false }

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -115,10 +115,7 @@ function isEmptyBareBlock(node: ASTNode): boolean
   if (node?.type !== "BlockStatement") return false
   { bare, expressions } := node
   return bare and
-    //expressions is like [], [, {type: "EmptyStatement"}]
-    (expressions.length is 0 ||
-      (expressions.length is 1 &&
-        expressions[0][1]?.type is "EmptyStatement"))
+    expressions is like [], [ [, {type: "EmptyStatement"}, ...] ]
 
 function isFunction(node: ASTNode & { type: unknown, async?: boolean }): boolean
   { type } := node

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,10 +150,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.1.tgz#b12f5268cb9f4336fa342ae551e18b3989900c6c"
-  integrity sha512-CpgSIsvP8ZboPFVVXmClCFFg6ar2ohwL7wJW6KdfAcwCrdKM41P0XuQ2Bt2L0CO+Q0ewG9F+fcgIJ3WMdWxgYQ==
+"@danielx/civet@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.4.tgz#4099d7102496d73d4cb53b0038a1075dfacc1b3a"
+  integrity sha512-joetlGCHcaGU0emS5MTHiWlYxjNXLQulz0PYj0LQYwVShxafY93makfsQ7w7/EKTj1cGuLZgPeMTBQNOEcKJ0Q==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
     "@typescript/vfs" "^1.5.0"


### PR DESCRIPTION
I think these show some nice examples of `is like`.

On the other hand, I currently can't get VSCode to parse these files with these changes (because it's refusing to use updated Civet in `node_modules`), so can't get TS feedback, so we might want to fix that first...