### PR TITLE
Add LSP warning about using dev Civet

### DIFF
--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -488,8 +488,12 @@ function TSService(projectURL = "./") {
   // Use Civet from the project if present
   let Civet = BundledCivetModule
   let CivetConfig = BundledCivetConfigModule
+  const civetPath = "@danielx/civet"
   try {
-    const civetPath = "@danielx/civet"
+    projectRequire(`${civetPath}/lsp/package.json`)
+    console.info("USING DEVELOPMENT VERSION OF CIVET -- BE SURE TO yarn build")
+  } catch (e) {}
+  try {
     Civet = projectRequire(civetPath)
     CivetConfig = projectRequire(`${civetPath}/config`)
     const CivetVersion = projectRequire(`${civetPath}/package.json`).version


### PR DESCRIPTION
This warning might help a future me when it seems like my local Civet isn't running. 🙂 

Also double checked that the LSP should work with the new async API (as well as the old API, as `await` never hurts).

If you like this, could you merge it and release the VSCode extension? Then (and only then) we can do a Civet release.