### PR TITLE
Avoid implicit return when block guarantees exit

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -274,6 +274,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       wrapIterationReturningResults(exp, outer, collect)
       return
     case "BlockStatement":
+      return if node.expressions.some isExit
       assignResults(exp.expressions[exp.expressions.length - 1], collect)
       return
     case "IfStatement":
@@ -315,7 +316,8 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
   switch node.type
     case "BlockStatement":
       if node.expressions.length
-        const last = node.expressions[node.expressions.length - 1]
+        return if node.expressions.some ([, exp]) => isExit exp
+        last := node.expressions[node.expressions.length - 1]
         insertReturn(last)
       else
         // NOTE: Kind of hacky but I'm too much of a coward to make `->` add an implicit return

--- a/test/function.civet
+++ b/test/function.civet
@@ -1584,15 +1584,33 @@ describe "function", ->
       add implicit return even if an explicit return is present
       ---
       (x) ->
-        return x
+        return x if c
         a
         b
       ---
       (function(x) {
-        return x
+        if (c) { return x }
         a
         return b
       })
+    """
+
+    testCase """
+      return before hoisted function
+      ---
+      function find(x)
+        return recurse x
+        function recurse(y)
+          return unless y?
+          y.forEach recurse
+      ---
+      function find(x) {
+        return recurse(x)
+        function recurse(y) {
+          if (!(y != null)) { return }
+          return y.forEach(recurse)
+        }
+      }
     """
 
     testCase """


### PR DESCRIPTION
Motivation: Avoiding the following:

https://github.com/DanielXMoore/Civet/blob/bf76cb6e0a624c97a84f3180507aec12a84e5832/source/parser/op.civet#L289

This function has a `return` up top, then defines some hoisted functions. Without this semicolon, the last function gets a `return` before it. Hence the semicolon to avoid this.

All this seems ugly. Instead we can turn off implicit return if there is a guaranteed return or other exit earlier in the same block. We already have `isExit` to detect this, so this amounts to a one-line check.