### PR TITLE
throws can specify exception; ParseErrors type; bug fixes

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -8,6 +8,16 @@ type { BlockStatement } from "./types.hera"
 
 import StateCache from "./state-cache.civet"
 
+export class ParseErrors extends Error
+  name = 'ParseErrors'
+  filename: string
+  line: number
+  column: number
+  offset: number
+  @(message: string, @filename: string, @line: number, @column: number, @offset: number)
+    super message
+    @message = message
+
 // Need to no-cache any rule that directly modifies parser state
 // indentation stack, jsx stack, etc.
 
@@ -145,10 +155,10 @@ export function compile<const T extends CompilerOptions>(src: string, options?: 
       return ast
 
     function checkErrors
-      if options.errors?.length
+      if options!.errors?.length
         // TODO: Better error display
         //@ts-ignore
-        throw new Error `Parse errors: ${options.errors.map(.message).join("\n")} `
+        throw new ParseErrors options.errors.map(.message).join("\n")
 
     if options.sourceMap or options.inlineMap
       sm := SourceMap(src)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3641,6 +3641,7 @@ _BinaryOp
   Identifier:id ->
     if (!state.operators.has(id.name)) return $skip
     return {
+      token: id.name,
       call: id,
       special: true,
       ...state.operators.get(id.name),
@@ -3648,6 +3649,7 @@ _BinaryOp
   OmittedNegation __ Identifier:id ->
     if (!state.operators.has(id.name)) return $skip
     return {
+      token: id.name,
       call: id,
       special: true,
       negated: true,

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -371,10 +371,19 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
       prefix = prefix.concat(glob.dot)
 
       for part of glob.object.properties
+        if part.type is "Error"
+          parts.push part
+          continue
         if part.type is "MethodDefinition"
-          throw new Error("Glob pattern cannot have method definition")
+          parts.push
+            type: "Error"
+            message: "Glob pattern cannot have method definition"
+          continue
         if part.value and !["CallExpression", "MemberExpression", "Identifier"].includes(part.value.type)
-          throw new Error(`Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`)
+          parts.push
+            type: "Error"
+            message: `Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`
+          continue
 
         suppressPrefix .= false
         name .= part.name
@@ -517,7 +526,10 @@ function lastAccessInCallExpression(exp)
   return exp if exp.type is "Identifier"
   let children, i
   do
+    // Leaf node occurs e.g. for import.meta
+    return unless exp.children?
     { children } = exp
+    console.log exp unless children?
     i = children.length - 1
     while (i >= 0 and (
       children[i].type is "Call" ||

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -112,6 +112,7 @@ export type CommentNode =
   parent?: Parent
 
 export type BinaryOp = (string &
+  name?: never
   special?: never
   relational?: never
   assoc?: never

--- a/test/array.civet
+++ b/test/array.civet
@@ -203,6 +203,8 @@ describe "array", ->
     empty spread
     ---
     y = [...]
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -131,6 +131,8 @@ describe "assignment", ->
     object destructuring with multiple rest properties
     ---
     {a, b, ...c, ...d} = e
+    ---
+    ParseErrors: Multiple rest properties in object pattern
   """
 
   testCase """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -984,6 +984,8 @@ describe "custom identifier infix operators", ->
       ---
       operator foo non
       a foo b foo c
+      ---
+      ParseErrors: non-associative operator foo used at same precedence level without parenthesization
     """
 
     throws """
@@ -991,6 +993,8 @@ describe "custom identifier infix operators", ->
       ---
       operator foo non same (+)
       a foo b + c
+      ---
+      ParseErrors: non-associative operator foo used at same precedence level without parenthesization
     """
 
     testCase """
@@ -1018,6 +1022,8 @@ describe "custom identifier infix operators", ->
       ---
       operator foo arguments same (+)
       a + b foo c
+      ---
+      ParseErrors: arguments operator foo used at same precedence level as + to the left
     """
 
     throws """
@@ -1025,6 +1031,8 @@ describe "custom identifier infix operators", ->
       ---
       operator foo arguments same (+)
       a foo b + c
+      ---
+      ParseErrors: arguments operator foo used at same precedence level as + to the right
     """
 
     testCase """

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -66,11 +66,12 @@ describe "comptime", ->
     json = {"hello":"world"}
   """, options
 
-  // Civet comptime does not support 'require' in synchronous compilation mode
   throws """
     require in sync mode
     ---
     json = comptime require("./integration/example/simple.json")
+    ---
+    ReferenceError: Civet comptime does not support 'require' in synchronous compilation mode
   """, {...options, sync: true}
 
   testCase """

--- a/test/conditional.civet
+++ b/test/conditional.civet
@@ -21,4 +21,6 @@ describe "conditional", ->
     needs space before ?
     ---
     x? y : z
+    ---
+    ParseError
   """

--- a/test/export.civet
+++ b/test/export.civet
@@ -94,6 +94,8 @@ describe "export", ->
       export default multi const
       ---
       export default const x = 5, y = 10
+      ---
+      ParseErrors: export default with 2 variable declaration (should be 1)
     """
 
   testCase """
@@ -138,6 +140,8 @@ describe "export", ->
     unbraced named with trailing comma
     ---
     export a,
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -210,6 +210,8 @@ describe "for", ->
     infinite range without for
     ---
     [1..]
+    ---
+    ParseErrors: Infinite range [x..] is only valid in for loops
   """
 
   testCase """
@@ -403,6 +405,8 @@ describe "for", ->
       ---
       foreach item of getArray()
         console.log item
+      ---
+      ParseError
     """
 
     testCase """

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -502,6 +502,8 @@ describe "function application", ->
     x of then
     ---
     x then
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -319,18 +319,24 @@ describe "&. function block shorthand", ->
     not.prop
     ---
     x.map not.prop
+    ---
+    ParseError
   """
 
   throws """
     typeof.prop
     ---
     x.map typeof.prop
+    ---
+    ParseError
   """
 
   throws """
     delete.prop
     ---
     x.map delete.prop
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -243,12 +243,16 @@ describe "function", ->
       yield forbidden within thick arrow
       ---
       => yield 5
+      ---
+      ParseErrors: Can't use yield inside of => arrow function
     """
 
     throws """
       yield forbidden within thick arrow, inlineMap
       ---
       => yield 5
+      ---
+      ParseErrors: Can't use yield inside of => arrow function
     """, inlineMap: true
 
     testCase """
@@ -477,6 +481,8 @@ describe "function", ->
     ---
     (x) ->
       import * from 'x'
+    ---
+    ParseError
   """
 
   testCase """
@@ -667,6 +673,8 @@ describe "function", ->
     ---
     (a, ...b, ...c) ->
       c
+    ---
+    ParseErrors: Only one rest parameter is allowed
   """
 
   testCase """

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -79,8 +79,24 @@ testCase.skip = (text: string, compilerOpts?: CompilerOptionsWithWrapper) -> tes
 testCase.js = (text: string) ->
   testCase text, js: true
 
+/**
+ * Pass a string with the following format:
+ * ```
+ * description
+ * ---
+ * source
+ * ---
+ * error
+ * ```
+ * The source will be compiled and checked that it throws an error.
+ * The description will be used as the test description.
+ * The error part is optional, and can specify:
+ *  - just the name of the error (e.g. ParseError)
+ *  - the stringified error (of the form `type: message`),
+ *    sans the Expected/Found part of ParseErrors
+ */
 throws := (text: string, compilerOpts?: CompilerOptions, opt?: "only" | "skip") ->
-  let [desc, src] = text.split("\n---\n")
+  [desc, src, error] := text.split /\n---(?:\n|$)/
   throw new Error "Missing code block" unless src
 
   fn := opt ? it[opt] : it
@@ -91,15 +107,40 @@ throws := (text: string, compilerOpts?: CompilerOptions, opt?: "only" | "skip") 
       result = await compile src, compilerOpts
     catch caught
       e = caught
-    assert.throws => e && throw e, (undefined as any), """
+    // First confirm throw
+    assert.throws
+      => e && throw e
+      undefined as any
+      """
 
-      --- Source   ---
-      #{src}
+        --- Source   ---
+        #{src}
 
-      --- Got      ---
-      #{result!}
+        --- Got      ---
+        #{result!}
 
-    """
+        """
+    // Then check against desired error message
+    if error
+      {name} := e! as {name: string}
+      let s
+      if error.includes ':' // name: message
+        s = e!.toString()
+        if (e! as {name: string}).name is 'ParseError'
+          s = s.replace /\nExpected:[^]*$/, ''
+      else // just name
+        s = name
+      assert.equal s, error, """
+        --- Source         ---
+        #{src}
+
+        --- Expected Error ---
+        #{error}
+
+        --- Got Error      ---
+        #{e!.toString()}
+
+      """
 
 throws.only = (text: string, compilerOpts?: CompilerOptions) -> throws text, compilerOpts, "only"
 throws.skip = (text: string, compilerOpts?: CompilerOptions) -> throws text, compilerOpts, "skip"

--- a/test/if.civet
+++ b/test/if.civet
@@ -150,6 +150,8 @@ describe "if", ->
           a
     else
       c
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/import.civet
+++ b/test/import.civet
@@ -345,6 +345,8 @@ describe "import", ->
       dynamic import declaration expression with type
       ---
       fs := import { type File } from fs
+      ---
+      ParseErrors: cannot use `type` in dynamic import
     """
 
     testCase """

--- a/test/indent.civet
+++ b/test/indent.civet
@@ -145,4 +145,6 @@ describe "indent", ->
         return true
     \telse
     \t\treturn false
+    ---
+    ParseError
   """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -71,6 +71,8 @@ describe "braced JSX attributes", ->
     if expressions
     ---
     <Component c=if cond then 1 else 2 />
+    ---
+    ParseError
   """
 
   testCase """
@@ -141,6 +143,8 @@ describe "braced JSX attributes", ->
     binary expressions with spaces
     ---
     <Component sum=1 + 2 />
+    ---
+    ParseError
   """
 
   testCase """
@@ -470,6 +474,8 @@ describe "JSX class shorthand", ->
     requires space between attribute and class shorthand
     ---
     <div +x.y>
+    ---
+    ParseError
   """
 
 describe "JSX LiveScript-like toggles", ->

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -113,6 +113,8 @@ describe "Indentation-based JSX", ->
       <div>
     console.log 'unreachable'
       </div>
+    ---
+    ParseError
   """
 
   testCase """
@@ -562,6 +564,8 @@ describe "Unbraced function children in JSX", ->
     doesn't work on same line as text
     ---
     <For each={items}> Hello (item) => <li>{item}
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -105,6 +105,8 @@ describe "JSX", ->
     throws with mismatched tags
     ---
     <h1>{text}</h2>
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/numbers.civet
+++ b/test/numbers.civet
@@ -85,6 +85,8 @@ describe "numbers", ->
     throws when double dotting
     ---
     1..toString()
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -251,24 +251,32 @@ describe "object", ->
     doesn't allow bare assignments inside
     ---
     {x=y}
+    ---
+    ParseError
   """
 
   throws """
     doesn't allow update assignments inside
     ---
     {x+=y}
+    ---
+    ParseError
   """
 
   throws """
     doesn't allow update assignments inside
     ---
     {x-=y}
+    ---
+    ParseError
   """
 
   throws """
     doesn't allow comparisons inside
     ---
     {x<=y}
+    ---
+    ParseError
   """
 
   testCase """
@@ -1164,12 +1172,16 @@ describe "object", ->
       no new properties
       ---
       {new.target}
+      ---
+      ParseError
     """
 
     throws """
       no meta properties
       ---
       {import.meta}
+      ---
+      ParseError
     """
 
   describe "object globs", ->
@@ -1306,28 +1318,38 @@ describe "object", ->
       no initializer
       ---
       obj.{a, b=5}
+      ---
+      ParseError
     """
 
     throws """
       no + flags
       ---
       obj.{+x}
+      ---
+      ParseErrors: Glob pattern must have call or member expression value, found "true"
     """
     throws """
       no - flags
       ---
       obj.{-x}
+      ---
+      ParseErrors: Glob pattern must have call or member expression value, found "false"
     """
     throws """
       no ! flags
       ---
       obj.{!x}
+      ---
+      ParseErrors: Glob pattern must have call or member expression value, found "false"
     """
 
     throws """
       no general expressions
       ---
       obj.{x: a+b}
+      ---
+      ParseErrors: Glob pattern must have call or member expression value, found [[{"$loc":{"pos":7,"length":1},"token":" "}],{"type":"Identifier","name":"a","names":["a"],"children":[{"$loc":{"pos":8,"length":1},"token":"a"}]},[],{"$loc":{"pos":9,"length":1},"token":"+"},[],{"type":"Identifier","name":"b","names":["b"],"children":[{"$loc":{"pos":10,"length":1},"token":"b"}]}]
     """
 
     testCase """

--- a/test/partial-placeholder.civet
+++ b/test/partial-placeholder.civet
@@ -114,36 +114,48 @@ describe "partial placeholder", ->
       as call
       ---
       . a
+      ---
+      ParseErrors: Partial placeholder . outside of call expression
     """
 
     throws """
       object
       ---
       a: .
+      ---
+      ParseErrors: Partial placeholder . outside of call expression
     """
 
     throws """
       object key
       ---
       .: a
+      ---
+      ParseErrors: Partial placeholder . outside of call expression
     """
 
     throws """
       array
       ---
       [ . ]
+      ---
+      ParseErrors: Partial placeholder . outside of call expression
     """
 
     throws """
       unary op
       ---
       !.
+      ---
+      ParseErrors: Partial placeholder . outside of call expression
     """
 
     throws """
       binary op
       ---
       . + 1
+      ---
+      ParseErrors: Partial placeholder . outside of call expression
     """
 
   describe "pipeline", ->

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -237,6 +237,8 @@ describe "pipe", ->
     pipe after return is error
     ---
     a |> b |> return |> c
+    ---
+    ParseErrors: Can't continue a pipeline after returning
   """
 
   testCase """
@@ -522,6 +524,8 @@ describe "pipe", ->
       can't assign to function calls
       ---
       f() |>= foo
+      ---
+      ParseErrors: Can't assign to Call
     """
 
     testCase """
@@ -563,12 +567,18 @@ describe "pipe", ->
       pipe then assign
       ---
       a |> b |>= c
+      ---
+      ParseErrors: Can't use |>= in the middle of a pipeline
     """
 
     throws """
       multiple assigns
       ---
       a |>= b |>= c |>= d |>= e
+      ---
+      ParseErrors: Can't use |>= in the middle of a pipeline
+      Can't use |>= in the middle of a pipeline
+      Can't use |>= in the middle of a pipeline
     """
 
   testCase """

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -473,10 +473,14 @@ describe "property access", ->
       needs space
       ---
       mario'sname
+      ---
+      ParseError
     """
 
     throws """
       invalid start to template string
       ---
       mario's s'
+      ---
+      ParseError
     """

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -71,6 +71,8 @@ describe "regexp", ->
     throws when regexp is actually unclosed comment
     ---
     /*/
+    ---
+    ParseError
   """
 
   describe "don't parse as implicit function arguments", ->

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -499,6 +499,8 @@ describe "switch", ->
         ;
       else
         ;
+    ---
+    ParseErrors: Can't mix pattern matching and non-pattern matching clauses
   """
 
   testCase """

--- a/test/top-level.civet
+++ b/test/top-level.civet
@@ -28,4 +28,6 @@ describe "top-level", ->
     ---
       x = 5
     y = 10
+    ---
+    ParseError
   """

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -48,6 +48,8 @@ describe "[TS] class", ->
     ---
     class UserAccount
       name?!: string
+    ---
+    ParseError
   """
 
   testCase """
@@ -320,12 +322,16 @@ describe "[TS] class", ->
       not extends
       ---
       class A not extends B
+      ---
+      ParseError
     """
 
     throws """
       !<
       ---
       class A !< B
+      ---
+      ParseError
     """
 
   testCase """

--- a/test/types/enum.civet
+++ b/test/types/enum.civet
@@ -68,6 +68,8 @@ describe "[TS] enum", ->
     enum Direction
       Up, Down
         Left, Right
+    ---
+    ParseError
   """
 
   testCase.js """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -132,6 +132,8 @@ describe "[TS] function", ->
     abstract requires new
     ---
     let type: abstract () => T
+    ---
+    ParseError
   """
 
   testCase """
@@ -196,6 +198,8 @@ describe "[TS] function", ->
     ---
     assert = (value: unknown)?: asserts value ->
       throw new Error "falsey" unless value
+    ---
+    ParseErrors: Can't use optional ?: syntax with asserts type
   """
 
   testCase """
@@ -451,4 +455,6 @@ describe "[TS] function", ->
       double this type
       ---
       function (this: T, @: T) {}
+      ---
+      ParseErrors: Only one typed this parameter is allowed
     """

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -44,7 +44,7 @@ describe "[TS] let declaration", ->
     ---
     let ref?!
     ---
-    let ref?!
+    ParseError
   """
 
   testCase """

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -310,6 +310,8 @@ describe "[TS] type declaration", ->
     typeof does not accept binary expressions
     ---
     type Data = typeof 'hello' + 'world'
+    ---
+    ParseError
   """
 
   testCase """
@@ -660,6 +662,8 @@ describe "[TS] type declaration", ->
     type OptionsFlags<Type> = {
       -readonly [Property in keyof Type]-: boolean
     }
+    ---
+    ParseError
   """
 
   throws """
@@ -668,6 +672,8 @@ describe "[TS] type declaration", ->
     type OptionsFlags<Type> = {
       -[Property in keyof Type]-?: boolean
     }
+    ---
+    ParseError
   """
 
   testCase """

--- a/test/types/using.civet
+++ b/test/types/using.civet
@@ -42,4 +42,6 @@ describe "using", ->
     ---
     using x = getResource()
     x.doSomething()
+    ---
+    ParseErrors: `using` is not currently transpiled in JS mode.
   """, js: true


### PR DESCRIPTION
* As discussed in #1214, `throws` can now take a third string separated by `---`. It can specify either:
  * Just the error `name`
  * `name: message`, but skipping the verbose part of `ParseError`s
* Add new `ParseErrors` class to represent errors generated from `"Error"` nodes
* Fix a few errors that were crashing instead of generating `ParseError(s)`. This was actually a useful exercise!