### PR TITLE
eslint: comptime for version, assert instead of with

### DIFF
--- a/integration/eslint/esbuild.civet
+++ b/integration/eslint/esbuild.civet
@@ -1,5 +1,5 @@
 esbuild from "esbuild"
-civetPlugin from "@danielx/civet/esbuild-plugin"
+civetPlugin from "@danielx/civet/esbuild"
 
 watch := process.argv.includes '--watch'
 build :=
@@ -33,6 +33,10 @@ for format of ["esm", "cjs"]
     outdir: 'dist'
     outExtension: { ".js": if format == "esm" then ".js" else ".cjs" }
     plugins: [
-      civetPlugin({ emitDeclaration: true })
+      civetPlugin {
+        comptime: true
+        //emitDeclaration: true
+        ts: "civet"
+      }
     ]
   }).catch -> process.exit 1

--- a/integration/eslint/package.json
+++ b/integration/eslint/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.3",
   "description": "ESLint plugin for Civet code",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=18.0.0"
   },
   "exports": {
     ".": {
@@ -46,7 +46,7 @@
     "typescript-eslint": ">=7.0.0"
   },
   "devDependencies": {
-    "@danielx/civet": "^0.7.3",
+    "@danielx/civet": "^0.7.5",
     "@eslint/js": "^9.1.1",
     "@types/eslint": "^8.56.10",
     "eslint": "^9.1.1",

--- a/integration/eslint/source/index.civet
+++ b/integration/eslint/source/index.civet
@@ -1,6 +1,5 @@
 Civet, { type CompileOptions } from '@danielx/civet'
-civetMeta from '@danielx/civet/package.json' with type: 'json'
-pluginMeta from '../package.json' with type: 'json'
+civetMeta from '@danielx/civet/package.json' assert type: 'json'
 { remapPosition } from '@danielx/civet/ts-diagnostic'
 type { ESLint, Linter } from 'eslint'
 js from "@eslint/js"
@@ -52,7 +51,7 @@ export function civet(options: Options = {js: true}): ESLint.Plugin
   plugin := {
     meta:
       name: "civet"
-      version: pluginMeta.version
+      version: comptime require('../package.json').version
     processors:
       civet: {
         meta:

--- a/integration/eslint/yarn.lock
+++ b/integration/eslint/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.3.tgz#30ccf240996173ce687b36635d1f2563ee4336e0"
-  integrity sha512-KNUTQSIFf3hPIQ/MF59Ec1Fb39t4quBhhUFS5FjcnCYWpyWL6ry91O33WT2+6IjhDfC3wm3hMoIHzoZMjzsi0g==
+"@danielx/civet@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.5.tgz#3635d7ec9644ddb3aa9baa6f72c311c71d25c124"
+  integrity sha512-myPZBvXi25MGCOh01HbphBZn/a8UPA/C5uCAknIxbKffgyV7XlH7F306j9GHkwP6XPhGaPbnMocdEDUUdBHHEw==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
     "@typescript/vfs" "^1.5.0"
@@ -1121,7 +1121,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-typescript-eslint@^7.8.0:
+typescript-eslint@>=7.0.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-7.8.0.tgz#d2a73d4caac35d4d9825bfdfac06a9bf2ba175e4"
   integrity sha512-sheFG+/D8N/L7gC3WT0Q8sB97Nm573Yfr+vZFzl/4nBdYcmviBPtwGSX9TJ7wpVg28ocerKVOt+k2eGmHzcgVA==


### PR DESCRIPTION
* Use `comptime` to inline package version
* Use `assert` instead of `with` for greater Node compatibility (at least until `assert` gets deprecated, but hasn't happened yet)
* Switch to unplugin. I'd like to do `emitDeclaration` too, but there are a lot of type errors right now. (Also not getting Civet's types to load correctly... maybe a bug, to be investigated.)