### PR TITLE
More comptime

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -110,6 +110,7 @@ build({
   alias:
     'node:module': './source/browser.civet'
     'node:path': './source/browser.civet'
+    'node:vm': './source/browser.civet'
   external: ['node:fs']
   plugins: [
     resolveExtensions

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -107,7 +107,10 @@ build({
   sourcemap
   platform: 'browser'
   outfile: 'dist/browser.js'
-  external: ['node:fs', 'node:module', 'node:path']
+  alias:
+    'node:module': './source/browser.civet'
+    'node:path': './source/browser.civet'
+  external: ['node:fs']
   plugins: [
     resolveExtensions
     heraPlugin module: true

--- a/integration/example/simple.json
+++ b/integration/example/simple.json
@@ -1,1 +1,1 @@
-{"hello": "world"}
+{"hello": ["world"]}

--- a/source/browser.civet
+++ b/source/browser.civet
@@ -1,0 +1,13 @@
+// Shimmed node:path and node:module for browser build
+
+// node:path
+export function dirname(path: string): string
+  path.replace /[^]*\//, ''
+export function resolve(path: string): string
+  path
+
+// node:module
+export function createRequire(path: string): (id: string) => unknown
+  (id: string) =>
+    throw new ReferenceError
+      "Civet comptime does not support 'require' on this platform"

--- a/source/browser.civet
+++ b/source/browser.civet
@@ -11,3 +11,9 @@ export function createRequire(path: string): (id: string) => unknown
   (id: string) =>
     throw new ReferenceError
       "Civet comptime does not support 'require' on this platform"
+
+export default {
+  dirname
+  resolve
+  createRequire
+}

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -181,7 +181,7 @@ function readFiles(filenames: string[]): AsyncGenerator<ReadFile>
         if process.stdin.isTTY
           // In interactive stdin, `readline` lets user end the file via ^D.
           lines: string[] := []
-          rl := import('readline') |> await |> .createInterface process.stdin, process.stdout
+          rl := import('node:readline') |> await |> .createInterface process.stdin, process.stdout
           rl.on 'line', (buffer: string) => lines.push buffer + '\n'
           content = await new Promise (resolve, reject) =>
             rl.on 'SIGINT', =>
@@ -202,14 +202,14 @@ declare global
   var v8debug: unknown
 
 export function repl(options: Options)
-  vm := await import 'vm'
+  vm := await import 'node:vm'
   // Node 21.7.0+ supports dynamic import() in vm calls via this constant:
   importModuleDynamically .= vm.constants?.USE_MAIN_CONTEXT_DEFAULT_LOADER
   unless importModuleDynamically
     // For older Node, we need to provide our own dynamic import function,
     // which requires `--experimental-vm-modules`.  Check if we did it already:
     if vm.SourceTextModule?
-      { pathToFileURL } := await import 'url'
+      { pathToFileURL } := await import 'node:url'
       importModuleDynamically = (specifier: string) =>
         if /^\.\.?[/\\]/.test specifier
           import pathToFileURL path.join process.cwd(), specifier
@@ -218,7 +218,7 @@ export function repl(options: Options)
     else
       // If not, run this script with `--experimental-vm-modules`.
       execArgv := [ '--experimental-vm-modules' ]
-      { register } := await import 'module'
+      { register } := await import 'node:module'
       /* This doesn't work; --loader seems to force ESM mode which breaks CLI.
       unless register
         // On Node <20.6.0, we need to use `--loader` for the ESM loader.
@@ -226,7 +226,7 @@ export function repl(options: Options)
       */
       if process.env.NODE_OPTIONS
         execArgv.push process.env.NODE_OPTIONS
-      { fork } := await import 'child_process'
+      { fork } := await import 'node:child_process'
       fork __filename, process.argv[2..], {
         execArgv
         stdio: 'inherit'
@@ -241,7 +241,7 @@ export function repl(options: Options)
       else 'execute'
   } code.`
   global.quit = global.exit = => process.exit 0
-  nodeRepl := await import 'repl'
+  nodeRepl := await import 'node:repl'
   r := nodeRepl.start
     prompt:
       switch
@@ -478,9 +478,9 @@ export function cli
             console.error `Could not write ${filename} for Civet ESM mode:`
             console.error e
             process.exit 1
-        { fork } := await import 'child_process'
+        { fork } := await import 'node:child_process'
 
-        { register } := await import 'module'
+        { register } := await import 'node:module'
         let execArgv
         if register
           // On Node 20.6.0+, module.register does the work for us;

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -3,6 +3,7 @@
 // These get replaced by shims from browser.civet on the browser
 { resolve, dirname } from "node:path"
 { createRequire } from "node:module"
+vm from "node:vm"
 
 import type {
   ComptimeExpression
@@ -24,10 +25,7 @@ function processComptime(statements: StatementTuple[]): void | Promise<void>
   // by looking at initialConfig instead of config
   return unless getInitialConfig()?.comptime
 
-  promises := runComptime statements, :void =>
-    globalThis.__filename = resolve getFilename() ?? ""
-    globalThis.__dirname = dirname globalThis.__filename
-    globalThis.require = createRequire globalThis.__filename
+  promises := runComptime statements
   if getSync()
     return
   else
@@ -36,7 +34,7 @@ function processComptime(statements: StatementTuple[]): void | Promise<void>
       ;
 
 // Launch comptime evaluations, and return promises to await (in async mode)
-function runComptime(statements: StatementTuple[], prepareEval: => void): unknown[]
+function runComptime(statements: StatementTuple[]): unknown[]
   sync := getSync()
   gatherRecursive statements,
     (node): node is (ComptimeStatement | ComptimeExpression) =>
@@ -52,16 +50,42 @@ function runComptime(statements: StatementTuple[], prepareEval: => void): unknow
 
     // Convert the comptime block into JS code
     options: Options := js: true
-    js := generate prune(content), options
+    js .= generate prune(content), options
+    js = `"use strict";${js}`
     // If there are any errors, leave the comptime subtree alone
     // (so there's still an error).
     return if options.errors?
 
     // Run the JS code at compile time (now)
-    let output: unknown
+    let output: unknown, context: object
     try
-      prepareEval()
-      output = eval?.(`"use strict";${js}`)
+      context = vm.createContext?() ?? globalThis
+      filename := context.__filename = resolve getFilename() ?? ""
+      context.__dirname = dirname filename
+      context.require = createRequire filename
+      if vm.runInContext?
+        // Copy serializable globals over to vm context
+        for global of [
+          "RegExp", "Date", "Set", "Map", "URL"
+          "Int8Array", "Uint8Array", "Int16Array", "Uint16Array", "Int32Array"
+          "Uint32Array", "Float32Array", "Float64Array", "Uint8ClampedArray"
+          "BigInt64Array", "BigUint64Array", "Buffer"
+        ]
+          context[global] = globalThis[global]
+        // Exception: Array and Object literals will use different prototypes.
+        // Use isArray to detect all Array types.
+        // But require() will use Object from the main context.
+        context.Object2 = Object
+        output = vm.runInContext js, context, {
+          filename
+          importModuleDynamically:
+            vm.constants?.USE_MAIN_CONTEXT_DEFAULT_LOADER
+        }
+      else
+        // Indirect eval call (via ?.) causes evaluation in global scope,
+        // instead of the scope of this function.
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval
+        output = eval?.(js)
     catch e
       exp.children = [
         type: "Error"
@@ -75,7 +99,14 @@ function runComptime(statements: StatementTuple[], prepareEval: => void): unknow
       finish := =>
         let string
         try
-          string = serialize output
+          if vm.runInContext?
+            // Run serializer within context, so Object is the correct object
+            context.output = output
+            string = vm.runInContext
+              `${serialize(serialize)}serialize(output)`
+              context
+          else
+            string = serialize output
         catch e
           exp.children = [
             type: "Error"
@@ -187,9 +218,7 @@ function serialize(value: ???): string
                 for [key, value] of val as Map<???, ???>
                   `[${recurse key},${recurse value}]`
               ).join(",") + "])"
-            when Array::
-              `[${(val as ???[]).map(recurse).join ","}]`
-            when Object::
+            when Object::, globalThis.Object2?::
               // The string representing the object's own enumerable, writable properties
               objStr .= '{'
               // The string representing other property descriptors, if applicable, not including the outermost braces
@@ -227,12 +256,15 @@ function serialize(value: ???): string
             when BigInt64Array::, BigUint64Array::
               `new ${val.constructor.name}([${Array.from(val as ArrayLike<bigint>, `${&}n`).join ','}])`
             // Spelled differently for browsers, where `Buffer` doesn't exist
-            when globalThis.Buffer?.prototype
+            when globalThis.Buffer?::
               `Buffer.from([${(val as Buffer).join ','}])`
             else
-              // One day we may handle other classes like so:
-              // str += `__proto__:${val.constructor.name}`
-              throw new TypeError `cannot serialize object with prototype ${Object.getPrototypeOf val}`
+              if Array.isArray val
+                `[${(val as ???[]).map(recurse).join ","}]`
+              else
+                // One day we may handle other classes like so:
+                // str += `__proto__:${val.constructor.name}`
+                throw new TypeError `cannot serialize object with prototype ${val.constructor?.name ?? Object.getPrototypeOf val}`
         stack.delete val
         str
       else

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -1,5 +1,9 @@
 "civet coffeePrototype"
 
+// These get replaced by shims from browser.civet on the browser
+{ resolve, dirname } from "node:path"
+{ createRequire } from "node:module"
+
 import type {
   ComptimeExpression
   ComptimeStatement
@@ -20,31 +24,19 @@ function processComptime(statements: StatementTuple[]): void | Promise<void>
   // by looking at initialConfig instead of config
   return unless getInitialConfig()?.comptime
 
+  promises := runComptime statements, :void =>
+    globalThis.__filename = resolve getFilename() ?? ""
+    globalThis.__dirname = dirname globalThis.__filename
+    globalThis.require = createRequire globalThis.__filename
   if getSync()
-    runComptime statements, =>
-      // @ts-ignore weird require type
-      global.require = => throw new ReferenceError
-        "Civet comptime does not support 'require' in synchronous compilation mode"
     return
   else
-    prepareEval .= =>
-      // for e.g. browser environment
-      // @ts-ignore weird require type
-      global.require = => throw new ReferenceError
-        "Civet comptime does not support 'require' on this platform"
-    (async do
-      try
-        path from "node:path"
-        { createRequire } from "node:module"
-        prepareEval = =>
-          global.__filename = path.resolve getFilename() ?? ""
-          global.__dirname = path.dirname global.__filename
-          global.require = createRequire global.__filename
-    ).then :Promise<void> =>
-      await.all runComptime statements, prepareEval
+    async do
+      await.all promises
+      ;
 
 // Launch comptime evaluations, and return promises to await (in async mode)
-function runComptime(statements: StatementTuple[], prepareEval: =>): unknown[]
+function runComptime(statements: StatementTuple[], prepareEval: => void): unknown[]
   sync := getSync()
   gatherRecursive statements,
     (node): node is (ComptimeStatement | ComptimeExpression) =>

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -58,8 +58,16 @@ function runComptime(statements: StatementTuple[], prepareEval: => void): unknow
     return if options.errors?
 
     // Run the JS code at compile time (now)
-    prepareEval()
-    output .= eval?.(`"use strict";${js}`) as unknown
+    let output: unknown
+    try
+      prepareEval()
+      output = eval?.(`"use strict";${js}`)
+    catch e
+      exp.children = [
+        type: "Error"
+        message: `comptime block failed to execute: ${e}\n${js}`
+      ]
+      return
 
     // Await result (in async mode only) and serialize output
     let promise: unknown

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -28,10 +28,10 @@ describe "comptime", ->
 
   """, options
 
-  it "statement has side effect", =>
-    global.outside = 0
-    await compile "comptime global.outside = 7", options
-    assert.equal global.outside, 7
+  it "statement has no side effect", =>
+    globalThis.outside = 0
+    await compile "comptime globalThis.outside = 7", options
+    assert.equal globalThis.outside, 0
 
   testCase """
     one-line expression
@@ -60,11 +60,27 @@ describe "comptime", ->
   """, options
 
   testCase """
+    array
+    ---
+    json = comptime [1, 2, 3]
+    ---
+    json = [1,2,3]
+  """, options
+
+  testCase """
+    object
+    ---
+    json = comptime hello: "world"
+    ---
+    json = {"hello":"world"}
+  """, options
+
+  testCase """
     require
     ---
     json = comptime require("./integration/example/simple.json")
     ---
-    json = {"hello":"world"}
+    json = {"hello":["world"]}
   """, options
 
   testCase """
@@ -72,7 +88,7 @@ describe "comptime", ->
     ---
     json = comptime require("./integration/example/simple.json")
     ---
-    json = {"hello":"world"}
+    json = {"hello":["world"]}
   """, syncOptions
 
   testCase """
@@ -88,7 +104,7 @@ describe "comptime", ->
     ---
     x = comptime Promise.resolve 1+2
     ---
-    ParseErrors: comptime result [object Promise] not serializable: TypeError: cannot serialize object with prototype [object Promise]
+    ParseErrors: comptime result [object Promise] not serializable: TypeError: cannot serialize object with prototype Promise
   """, syncOptions
 
   testCase """

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -8,6 +8,7 @@ declare global
 
 describe "comptime", ->
   options := parseOptions: comptime: true
+  syncOptions := {...options, sync: true}
 
   testCase """
     statement with indented block
@@ -66,13 +67,13 @@ describe "comptime", ->
     json = {"hello":"world"}
   """, options
 
-  throws """
+  testCase """
     require in sync mode
     ---
     json = comptime require("./integration/example/simple.json")
     ---
-    ReferenceError: Civet comptime does not support 'require' in synchronous compilation mode
-  """, {...options, sync: true}
+    json = {"hello":"world"}
+  """, syncOptions
 
   testCase """
     async
@@ -81,6 +82,14 @@ describe "comptime", ->
     ---
     x = 3
   """, options
+
+  throws """
+    async in sync mode
+    ---
+    x = comptime Promise.resolve 1+2
+    ---
+    ParseErrors: comptime result [object Promise] not serializable: TypeError: cannot serialize object with prototype [object Promise]
+  """, syncOptions
 
   testCase """
     await


### PR DESCRIPTION
* Use a new shim approach for browser build, enabling Node `import`s to be at top level
  * `comptime require` no longer needs Civet to be in async mode! Async mode is just necessary for promises made by the user, so this is more natural.
* Run comptime using `vm` in Node, just like `repl` (used by CLI). Still use `eval` on browser.
  * This isolates global variables.
  * Currently a bit painful to serialize... I might be missing something simpler here, but at least it seems to be working.
* Improve comptime errors and imports a bit
* comptime

Switching to `vm` actually makes dynamic `import` work too, on Node 21.7+. But it generates a warning, so I haven't added a test. Here's a demo:

```sh
$ civet -c --comptime                  (node-shim ?$)
Civet 0.7.5 REPL.  Enter a blank line to transpile code.
🐈> x = comptime
...   import { readFile } from 'fs/promises'
...   JSON.parse(await readFile 'package.json').version
...
(node:33596) ExperimentalWarning: vm.USE_MAIN_CONTEXT_DEFAULT_LOADER is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
x = "0.7.5"
🐈>
```