### PR TITLE
Avoid expressionizing statements in fat arrow functions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -748,7 +748,8 @@ TrailingPipe
 # https://262.ecma-international.org/#prod-ConciseBody
 FatArrowBody
   # If same-line single expression, avoid wrapping in braces
-  !EOS NonPipelinePostfixedExpression:exp !TrailingDeclaration !TrailingPipe !SemicolonDelimiter ->
+  # NOTE: Skip expressionized statements, so they get braced instead
+  !EOS !( _? ExpressionizedStatement ) NonPipelinePostfixedExpression:exp !TrailingDeclaration !TrailingPipe !SemicolonDelimiter ->
     // Ensure object literal is wrapped in parens
     if (exp.type === "ObjectExpression") {
       exp = makeLeftHandSideExpression(exp)

--- a/test/function.civet
+++ b/test/function.civet
@@ -507,6 +507,14 @@ describe "function", ->
   """
 
   testCase """
+    fat arrow with expressionizable statement body
+    ---
+    => throw new Error
+    ---
+    () => { throw new Error }
+  """
+
+  testCase """
     fat arrow nested body with same line closing parenthesis
     ---
     g( =>
@@ -1716,7 +1724,7 @@ describe "function", ->
       ---
       (x) => if x then a else b
       ---
-      (x) => (x? a : b)
+      (x) => { if (x) return a; else return b }
     """
 
     testCase """


### PR DESCRIPTION
Fixes #1123

The change in the if/else is debatable, but this change is definitely good for expressionizing that wraps in IIFEs.