### PR TITLE
comptime else blocks, else refactor

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1635,6 +1635,22 @@ and in the
 using the `comptime: true` option.
 If not enabled, `comptime` blocks will execute at runtime.
 
+<Playground>
+// comptime is disabled here
+value := comptime 1+2+3
+</Playground>
+
+Async `comptime` blocks executed at runtime are not `await`ed (to avoid forcing
+`async`), so they return a `Promise`, unlike when they're run at compile time.
+In cases like this, you can provide a fallback for when `comptime` is disabled:
+
+<Playground>
+html := comptime
+  fetch 'https://civet.dev' |> await |> .text()
+else // fallback for disabled comptime
+  '<html></html>'
+</Playground>
+
 ## Classes
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4025,12 +4025,7 @@ IfStatement
     }
 
 ElseClause
-  Nested Else BlockOrEmpty:block -> {
-    type: "ElseClause",
-    children: $0,
-    block,
-  }
-  _? Else BlockOrEmpty:block -> {
+  ( Nested / _? ) Else BlockOrEmpty:block -> {
     type: "ElseClause",
     children: $0,
     block,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4137,12 +4137,17 @@ DoStatement
     }
 
 ComptimeStatement
-  Comptime NoPostfixBracedOrEmptyBlock:block ->
+  Comptime NoPostfixBracedOrEmptyBlock:t ElseClause?:e ->
+    // Wrap the else block if present and comptime is off
+    let block = !initialConfig.comptime && e?.block || t
     block = insertTrimmingSpace(block, "")
     return {
       type: "ComptimeStatement",
       children: [block],
       block,
+      // In case we want access to the original blocks:
+      then: t,
+      else: e,
     }
 
 # https://262.ecma-international.org/#prod-WhileStatement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4025,8 +4025,16 @@ IfStatement
     }
 
 ElseClause
-  Nested Else BlockOrEmpty
-  _? Else BlockOrEmpty
+  Nested Else BlockOrEmpty:block -> {
+    type: "ElseClause",
+    children: $0,
+    block,
+  }
+  _? Else BlockOrEmpty:block -> {
+    type: "ElseClause",
+    children: $0,
+    block,
+  }
 
 IfClause
   If Condition:condition ->

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -293,7 +293,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
 
   switch s.type
     when "IfStatement"
-      { else: e} := s
+      { else: e } := s
       block := blockWithPrefix(condition.expression.blockPrefix, s.then)
 
       if block.bare and e and not block.semicolon

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -285,12 +285,12 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
 
       // else block
       if exp.else
-        assignResults(exp.else[2], collect)
+        assignResults(exp.else.block, collect)
       else // Add else block pushing undefined if no else block
         exp.children.push([" else {", collect("undefined"), "}"])
       return
     case "PatternMatchingStatement":
-      assignResults(exp.children[0][0], collect)
+      assignResults(exp.children[0], collect)
       return
     case "SwitchStatement":
       // insert a results.push in each case block
@@ -390,8 +390,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
       // if block
       insertReturn(exp.then)
       // else block
-      // PatternMatchingStatement generates else blocks of []
-      if (exp.else and exp.else.length !== 0) insertReturn(exp.else[2])
+      if (exp.else) insertReturn(exp.else.block)
       // Add explicit return after if block if no else block
       else exp.children.push ["", {
         type: "ReturnStatement"
@@ -401,7 +400,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
       }]
       return
     case "PatternMatchingStatement":
-      insertReturn(exp.children[0][0])
+      insertReturn(exp.children[0])
       return
     case "SwitchStatement":
       insertSwitchReturns(exp)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -252,12 +252,12 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
     expressionizedBlock
   ]
   if e
-    e2 := expressionizeBlock(e[2])
+    e2 := expressionizeBlock(e.block)
     unless e2
       return wrapIIFE([["", statement]])
 
-    // Replace 'else' in e[1] with ':'. (e[0] is space before 'else')
-    children.push e[0], ":", e2, ...e[3..]
+    // Replace 'else' in e.children[1] with ':'. (e.children[0] is space before 'else')
+    children.push e.children[0], ":", e2, ...e.children[3..]
   else
     children.push ":void 0"
   children.push closeParen
@@ -1531,6 +1531,7 @@ export {
   processProgramAsync
   processUnaryExpression
   quoteString
+  replaceNode
   reorderBindingRestProperty
   replaceNodes
   skipImplicitArguments

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -1,23 +1,31 @@
 import type {
   ASTNode
   ASTRef
+  BlockStatement
+  Condition
+  ElseClause
   ParenthesizedExpression
   ParseRule
+  PatternClause
   PatternExpression
   StatementTuple
   SwitchStatement
 } from ./types.civet
 
 import {
+  replaceNode
+} from ./lib.civet
+
+import {
   gatherRecursiveAll
 } from ./traversal.civet
 
 import {
-  addParentPointers
   flatJoin
   isExit
-  isWhitespaceOrEmpty
   makeLeftHandSideExpression
+  makeNode
+  updateParentPointers
 } from ./util.civet
 
 import {
@@ -64,14 +72,14 @@ function processPatternTest(lhs: ASTNode, patterns: PatternExpression[]): ASTNod
     ]
   }
 
-function processPatternMatching(statements: ASTNode): void {
+function processPatternMatching(statements: ASTNode): void
   gatherRecursiveAll(statements, .type is "SwitchStatement")
-    .forEach((s: SwitchStatement) => {
+    .forEach (s: SwitchStatement) =>
       { caseBlock } := s
       { clauses } := caseBlock
 
       // Remove inserted `break;` in `when` clauses that don't need them
-      for c of clauses
+      for each c of clauses
         if c.type is "WhenClause" and c.break
           if isExit c.block
             c.children.splice c.children.indexOf(c.break), 1
@@ -81,13 +89,13 @@ function processPatternMatching(statements: ASTNode): void {
       isPattern .= false
       if clauses.some .type is "PatternClause"
         isPattern = true
-        clauses.forEach (c) =>
+        for each c of clauses
           // else/default clause is ok
           unless c.type is "PatternClause" or c.type is "DefaultClause"
             errors = true
             c.children.push
-              type: "Error",
-              message: "Can't mix pattern matching and non-pattern matching clauses",
+              type: "Error"
+              message: "Can't mix pattern matching and non-pattern matching clauses"
 
       return if errors or !isPattern
 
@@ -97,27 +105,30 @@ function processPatternMatching(statements: ASTNode): void {
         condition = condition.expression as ParenthesizedExpression
 
       { ref, hoistDec, refAssignmentComma } .= maybeRefAssignment condition, "m"
-      let prev = [],
-        root = prev
+      root: ASTNode[] := []
+      prev .= root
+      let e?: ElseClause
 
       l := clauses.length
-      clauses.forEach((c, i) => {
-        if (c.type is "DefaultClause") {
-          prev.push(c.block)
-          return
-        }
+      for each c, i of clauses
+        if c.type is "DefaultClause"
+          if e?
+            replaceNode e.block, c.block, e
+          else
+            prev.push c.block
+          break
 
-        { patterns, block } .= c
+        { patterns, block } .= c as PatternClause
         pattern .= patterns[0]
 
         // TODO: multiple binding patterns
 
-        conditionExpression := patterns
+        conditionExpression: ASTNode[] := patterns
         .map getPatternConditions ., ref
         .map flatJoin ., " && "
         |> flatJoin ., " || "
 
-        condition := {
+        condition: Condition := makeNode {
           type: "ParenthesizedExpression"
           children: ["(", ...refAssignmentComma, conditionExpression, ")"]
           expression: conditionExpression
@@ -126,29 +137,37 @@ function processPatternMatching(statements: ASTNode): void {
         braceBlock block
         block = blockWithPrefix getPatternBlockPrefix(pattern, ref), block
 
-        next := []
-
         // Insert else if there are more branches
-        if (i < l - 1) next.push("\n", "else ")
+        if i < l - 1
+          expressions: StatementTuple[] := []
+          block := makeNode {
+            type: "BlockStatement"
+            expressions
+            children: [expressions]
+            bare: true
+          } satisfies BlockStatement
+          e = makeNode {
+            type: "ElseClause"
+            block
+            children: ["\n", "else ", block]
+          } satisfies ElseClause
+        else
+          e = undefined
 
-        prev.push ["", {
+        prev.push ["", makeNode {
           type: "IfStatement"
-          children: ["if", condition, block, next]
+          children: ["if", condition, block, e]
           then: block
-          else: next
+          else: e
           hoistDec
         }]
         hoistDec = undefined
         refAssignmentComma = []
-        prev = next
-      })
+        prev = e.block.expressions if e?
 
       s.type = "PatternMatchingStatement"
-      s.children = [root]
-      // Update parent pointers
-      addParentPointers(s, s.parent)
-    })
-}
+      s.children = root
+      updateParentPointers s
 
 function getPatternConditions(
   pattern: PatternExpression,

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -64,6 +64,7 @@ export type OtherNode =
   | AccessStart
   | Call
   | CommentNode
+  | ElseClause
   | Index
   | Initializer
   | ParametersNode
@@ -208,7 +209,14 @@ export type IfStatement
   parent?: Parent
   condition: Condition
   then: BlockStatement
-  else: [ ASTNode, ElseToken, BlockStatement ]?
+  else: ElseClause?
+
+export type ElseClause
+  type: "ElseClause"
+  children: [ Whitespace | ASTString, ElseToken, BlockStatement ]
+  block: BlockStatement
+
+export type ElseToken = "else " | { $loc: Loc, token: "else" }
 
 export type IfExpression
   type: "IfExpression"
@@ -279,7 +287,7 @@ export type SwitchStatement
 
 export type CaseBlock
   type: "CaseBlock"
-  clauses: (PatternClause | CaseClause | WhenClause)[]
+  clauses: (PatternClause | CaseClause | WhenClause | DefaultClause)[]
   children: Children
 
 export type PatternClause
@@ -301,14 +309,17 @@ export type WhenClause
   break: ASTNode
   block: BlockStatement
 
+export type DefaultClause
+  type: "DefaultClause"
+  children: Children
+  block: BlockStatement
+
 export type LabeledStatement
   type: "LabeledStatement"
   label: ASTNode
   statement: ASTNodeBase
   children: Children
   parent?: Parent
-
-export type ElseToken = { $loc: Loc, token: "else" }
 
 export type AccessStart
   type: "AccessStart"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -175,7 +175,7 @@ function isExit(node: ASTNode): boolean
     when "IfStatement"
       (and)
         isExit node.then
-        isExit node.else?.-1
+        isExit node.else?.block
     when "BlockStatement"
       // [1] extracts statement from [indent, statement, delim]
       isExit node.expressions.-1?[1]

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -131,7 +131,43 @@ describe "comptime", ->
     console.log(["foo"])
   """, options
 
+  testCase """
+    else
+    ---
+    x = comptime 1+2 else 0
+    ---
+    x = 3
+  """, options
+
+  testCase """
+    else two lines
+    ---
+    x = comptime 1+2
+    else 0
+    ---
+    x = 3
+  """, options
+
+  testCase """
+    else blocks
+    ---
+    x = comptime
+      1+2
+    else
+      0
+    ---
+    x = 3
+  """, options
+
   describe "disabled", ->
+    testCase """
+      else
+      ---
+      x = comptime 1+2 else 0
+      ---
+      x = (()=>{ return 0})()
+    """
+
     testCase """
       empty
       ---


### PR DESCRIPTION
Most of the work here is refactoring `ElseClause` into its own AST object node, instead of the previous use of a tuple. I think this is worth doing; a little less magic working when working with these clauses. Also added missing `BlockStatement`s when generating these in pattern matching. Also cleaned up that pattern matching code a bit, which took a while.

Added feature: `comptime` blocks can specify an `else` block to specify a different thing to do when `comptime` mode is off. This can be useful for typing, especially `Promise` vs. non-`Promise`. It can also help with things like linting when `comptime` is off: you get to specify the effective code that should be linted.