### PR TITLE
Allow EmptyStatement in ClassBody

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1062,6 +1062,7 @@ ClassElement
       type: "ClassStaticBlock",
       children: $0,
     }
+  EmptyStatement
 
 ClassElementDefinition
   ( MethodDefinition / FieldDefinition )

--- a/test/class.civet
+++ b/test/class.civet
@@ -10,6 +10,29 @@ describe "class", ->
   """
 
   testCase """
+    empty statement
+    ---
+    class X
+      ;
+    ---
+    class X {
+      ;
+    }
+  """
+
+  testCase """
+    braced empty statement
+    ---
+    class X {
+      ;
+    }
+    ---
+    class X {
+      ;
+    }
+  """
+
+  testCase """
     member function
     ---
     class X {


### PR DESCRIPTION
Fixes #1223

This was actually [in the spec](https://262.ecma-international.org/#prod-ClassElement), just hard to see the ";" at the end.