### PR TITLE
Fix preprocessing of declaration conditions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4666,6 +4666,7 @@ DeclarationCondition
     return {
       type: "DeclarationCondition",
       declaration,
+      children: [declaration],
     }
 
 ExpressionWithIndentedApplicationForbidden

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1054,24 +1054,28 @@ function processStatementExpressions(statements: StatementTuple[]): void
 function processNegativeIndexAccess(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (n) => n.type is "NegativeIndex")
     .forEach (exp) =>
-      { parent } := exp
-      index := parent.children.indexOf(exp)
+      { children } := exp.parent
+
+      let start = 0
+      start++ while start < children# and isWhitespaceOrEmpty children[start]
+      index := children.indexOf(exp)
+
       let ref, subexp
-      if index is 1
-        child := parent.children[0]
+      if index is start+1  // first access
+        child := children[start]
         ref = maybeRef(child)
         if ref !== child
-          subexp = parent.children.splice 0, 1
-      else if index > 1
+          subexp = children.splice start, 1
+      else if index > start+1
         ref = makeRef()
-        subexp = parent.children.splice 0, index
+        subexp = children.splice start, index
       else
         throw new Error("Invalid parse tree for negative index access")
 
       if subexp
         { hoistDec, refAssignment } := makeRefAssignment ref, subexp
         exp.hoistDec = hoistDec
-        parent.children.unshift makeLeftHandSideExpression refAssignment
+        children.splice start, 0, makeLeftHandSideExpression refAssignment
 
       exp.len.children = [
         ref,

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -24,7 +24,6 @@ import type {
   IterationStatement
   MemberExpression
   MethodDefinition
-  ParseRule
   Placeholder
   StatementExpression
   StatementTuple
@@ -129,7 +128,6 @@ import {
 
 import {
   getConfig
-  getInitialConfig
   getState
   getSync
 } from ../parser.hera

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -1,7 +1,6 @@
 import type {
   AmpersandBlockBody
   ArrowFunction
-  ASTRef
   ASTLeaf
   ASTNode
   ASTNodeBase

--- a/test/if.civet
+++ b/test/if.civet
@@ -1052,7 +1052,7 @@ describe "if", ->
       if last := x.-1
         console.log last
       ---
-      let ref;let ref1;if ((ref1 =(ref =  x)[ref.length-1])) {const last = ref1;
+      let ref;if ((ref = x[x.length-1])) {const last = ref;
         console.log(last)
       }
     """

--- a/test/if.civet
+++ b/test/if.civet
@@ -1045,3 +1045,25 @@ describe "if", ->
         console.log(x)
       }
     """
+
+    testCase """
+      negative access
+      ---
+      if last := x.-1
+        console.log last
+      ---
+      let ref;let ref1;if ((ref1 =(ref =  x)[ref.length-1])) {const last = ref1;
+        console.log(last)
+      }
+    """
+
+    testCase """
+      &
+      ---
+      if f := &.x
+        console.log f
+      ---
+      let ref;if ((ref = $ => $.x)) {const f = ref;
+        console.log(f)
+      }
+    """


### PR DESCRIPTION
Fixes #1224. We didn't have `children` in the intermediate AST node, so all earlier steps of processing were skipping the contents.

Also noticed and fixed an issue with excess `ref`s in negative index access when there was prepended whitespace. (See first commit for the ugliness that resulted.)
