### PR TITLE
Declaration inside unless/until adds declaration after block

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -91,6 +91,18 @@ while number? := next()
   sum += number
 </Playground>
 
+The negated forms `unless` and `until` expose the declaration *after* the block
+instead of inside it.
+(Inside the block, it would be guaranteed falsey or null.)
+This is useful for guard checks:
+
+<Playground>
+unless item? := getItem() then return
+unless {x, y} := item.getCoords()
+  throw new Error "Item missing coordinates"
+console.log `(${x}, ${y})`
+</Playground>
+
 ## Objects
 
 ### Unbraced Literals

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -91,9 +91,19 @@ while number? := next()
   sum += number
 </Playground>
 
-The negated forms `unless` and `until` expose the declaration *after* the block
-instead of inside it.
-(Inside the block, it would be guaranteed falsey or null.)
+The negated form `until` exposes the declaration *after* the block
+instead of inside it:
+
+<Playground>
+until {status: "OK", data} := attempt()
+console.log data
+</Playground>
+
+The negated form of `if`, `unless`,
+always exposes the declaration to an `else` block (if present).
+It also exposes the declaration to after the `unless` block
+*provided* the "then" block contains a guaranteed "exit" statement
+such as `return` or `throw`.
 This is useful for guard checks:
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3939,7 +3939,6 @@ _PostfixStatement
   ForClause
   IfClause
   LoopClause
-  UnlessClause
   WhileClause
 
 # https://262.ecma-international.org/#prod-Statement
@@ -4016,11 +4015,12 @@ LabelledItem
 IfStatement
   # NOTE: Added paren-less condition
   # NOTE: Block isn't Statement so we can handle implied braces by nesting
-  ( IfClause / UnlessClause ):clause BlockOrEmpty:block ElseClause?:e ->
+  IfClause:clause BlockOrEmpty:block ElseClause?:e ->
     return {
       type: "IfStatement",
       children: [...clause.children, block, e],
       condition: clause.condition,
+      negated: clause.negated,
       then: block,
       else: e,
     }
@@ -4033,28 +4033,17 @@ ElseClause
   }
 
 IfClause
-  If Condition:condition ->
-    return {
-      type: "IfStatement",
-      children: $0,
-      condition,
+  ( If / Unless ):kind _?:ws Condition:condition ->
+    if (kind.negated) {
+      kind = { ...kind, token: "if" }
+      condition = negateCondition(condition)
     }
 
-UnlessClause
-  Unless:kind Condition:condition ->
-    // Rewrite unless to if
-    kind = { ...kind, token: "if" }
-
-    // Move leading space to after if
-    kind.token += getTrimmingSpace(condition)
-    condition = insertTrimmingSpace(condition, '')
-
-    condition = negateCondition(condition)
-
     return {
       type: "IfStatement",
-      children: [kind, condition],
+      children: [ kind, ws, condition ],
       condition,
+      negated: kind.negated,
     }
 
 # https://262.ecma-international.org/#prod-IterationStatement
@@ -4158,7 +4147,7 @@ WhileStatement
 
 WhileClause
   ( While / Until ):kind _?:ws Condition:condition ->
-    if (kind.token === "until") {
+    if (kind.negated) {
       kind = { ...kind, token: "while" }
       condition = negateCondition(condition)
     }
@@ -4166,8 +4155,9 @@ WhileClause
     return {
       type: "IterationStatement",
       subtype: kind.token,
-      children: [kind, ws, condition],
+      children: [ kind, ws, condition ],
       condition,
+      negated: kind.negated,
     }
 
 # https://262.ecma-international.org/#prod-ForStatement
@@ -6080,7 +6070,7 @@ Unless
 
 Until
   "until" NonIdContinue ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, negated: true }
 
 Using
   "using" NonIdContinue ->

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -18,18 +18,20 @@ import type {
 
 import {
   blockWithPrefix
+  braceBlock
   makeEmptyBlock
   replaceBlockExpression
 } from ./block.civet
 
 import {
+  findAncestor
+  findChildIndex
   gatherRecursiveAll
 } from ./traversal.civet
 
 import {
   getPatternBlockPrefix
   getPatternConditions
-  nonMatcherBindings
 } from ./pattern-matching.civet
 
 import {
@@ -264,10 +266,13 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   { condition } := s
   return unless condition?.expression
   { expression } .= condition
+
   // Support for negated conditions built by unless/until
-  switch expression
-    {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]}
-      expression = expression2
+  negated .= false
+  if {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]} := expression
+    expression = expression2
+    negated = true
+
   processDeclarationCondition expression, condition.expression, s
 
   { ref, pattern } := expression
@@ -290,6 +295,24 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
       conditions.forEach (c) =>
         condition.children.push " && ", c
       condition.children.push ")"
+
+  if negated and condition.expression.blockPrefix
+    { ancestor, child } := findAncestor s,
+      (a): a is BlockStatement => a.type is "BlockStatement"
+    unless ancestor?
+      throw new Error "Couldn't find block for postfix declaration"
+    index := findChildIndex ancestor.expressions, child
+    if index < 0
+      throw new Error "Couldn't find where in block to put postfix declaration"
+    ancestor.expressions.splice index + 1, 0, ...condition.expression.blockPrefix
+    updateParentPointers ancestor
+    braceBlock ancestor
+    switch s.type
+      when "IfStatement"
+        block := s.else?.block ?? s.then
+        if block.bare and not block.semicolon
+          block.children.push block.semicolon = ";"
+    return
 
   switch s.type
     when "IfStatement"

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -5,11 +5,11 @@ import type {
   ASTRef
   Binding
   BlockStatement
-  Children
   DeclarationStatement
   IfStatement
   Initializer
   IterationStatement
+  ParenthesizedExpression
   StatementTuple
   SwitchStatement
   TypeSuffix
@@ -36,6 +36,7 @@ import {
 
 import {
   convertOptionalType
+  isExit
   makeNode
   updateParentPointers
 } from ./util.civet
@@ -289,12 +290,27 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
           true
 
     if conditions#
-      condition.children.unshift "("
-      conditions.forEach (c) =>
-        condition.children.push " && ", c
-      condition.children.push ")"
+      if s.negated
+        unless condition.expression is like {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression'}]}
+          console.log condition.expression
+          throw new Error "Unsupported negated condition"
+        { children } := condition.expression.children[1] as ParenthesizedExpression
+        close := children.pop()
+        conditions.forEach (c) =>
+          children.push " && ", c
+        children.push close
+      else
+        condition.children.unshift "("
+        conditions.forEach (c) =>
+          condition.children.push " && ", c
+        condition.children.push ")"
 
-  if s.negated and condition.expression.blockPrefix
+  // Move declaration to after the statement for until loops,
+  // and for unless conditions with a guaranteed exit in the then clause.
+  { blockPrefix } := condition.expression
+  if s.negated and blockPrefix and
+     (s.type is "IfStatement" and isExit(s.then) or
+      s.type is "IterationStatement")
     { ancestor, child } := findAncestor s,
       (a): a is BlockStatement => a.type is "BlockStatement"
     unless ancestor?
@@ -302,12 +318,21 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
     index := findChildIndex ancestor.expressions, child
     if index < 0
       throw new Error "Couldn't find where in block to put postfix declaration"
-    ancestor.expressions.splice index + 1, 0, ...condition.expression.blockPrefix
+    ancestor.expressions.splice index + 1, 0, ...blockPrefix
     updateParentPointers ancestor
     braceBlock ancestor
     switch s.type
       when "IfStatement"
-        block := s.else?.block ?? s.then
+        // If there's an else clause, and then clause has an exit,
+        // move else clause to after the declaration (so it also has access).
+        if elseBlock := s.else?.block
+          if elseBlock.bare and not elseBlock.semicolon
+            elseBlock.children.push elseBlock.semicolon = ";"
+          ancestor.expressions.splice index + 1 + blockPrefix#, 0, ['', elseBlock]
+          s.children = s.children.filter (is not s.else)
+          s.else = undefined
+        // Ensure semicolon after if before added declaration
+        block := s.then
         if block.bare and not block.semicolon
           block.children.push block.semicolon = ";"
     return
@@ -315,32 +340,31 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   switch s.type
     when "IfStatement"
       { else: e } := s
-      block := blockWithPrefix(condition.expression.blockPrefix, s.then)
 
-      if block.bare and e and not block.semicolon
-        block.children.push block.semicolon = ";"
-
-      // Replace then block with prefixed block
-      s.children = s.children.map (c) =>
-        if c is s.then
-          block
-        else
-          c
-      s.then = block
-
-      // Update parent pointers since declaration conditions have expanded
-      updateParentPointers(block, s)
+      // Prefix then or else block depending on negation
+      if s.negated
+        if e?
+          block := blockWithPrefix blockPrefix, e.block
+          e.children = e.children.map & is e.block ? block : &
+          e.block = block
+          updateParentPointers e
+      else
+        block := blockWithPrefix blockPrefix, s.then
+        if block.bare and e and not block.semicolon
+          block.children.push block.semicolon = ";"
+        s.children = s.children.map & is s.then ? block : &
+        s.then = block
+        updateParentPointers s
 
     when "IterationStatement"
+      return unless blockPrefix
       { children, block } := s
-      newBlock := blockWithPrefix(condition.expression.blockPrefix, block)
-      s.children = children.map (c) => c?.type is "BlockStatement" ? newBlock : c
-
-      // Update parent pointers since declaration conditions have expanded
-      updateParentPointers(newBlock, s)
+      newBlock := blockWithPrefix blockPrefix, block
+      s.children = children.map & is block ? newBlock : &
+      updateParentPointers s
 
     when "SwitchStatement"
-      { blockPrefix, ref, statementDeclaration } := condition.expression as! { blockPrefix: StatementTuple[], ref: ASTRef, statementDeclaration: boolean}
+      { ref, statementDeclaration } := condition.expression as! { ref: ASTRef, statementDeclaration: boolean}
       return unless blockPrefix
 
       newCondition :=

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -268,10 +268,8 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   { expression } .= condition
 
   // Support for negated conditions built by unless/until
-  negated .= false
   if {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]} := expression
     expression = expression2
-    negated = true
 
   processDeclarationCondition expression, condition.expression, s
 
@@ -296,7 +294,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
         condition.children.push " && ", c
       condition.children.push ")"
 
-  if negated and condition.expression.blockPrefix
+  if s.negated and condition.expression.blockPrefix
     { ancestor, child } := findAncestor s,
       (a): a is BlockStatement => a.type is "BlockStatement"
     unless ancestor?

--- a/source/parser/traversal.civet
+++ b/source/parser/traversal.civet
@@ -1,6 +1,7 @@
 import type {
   ASTNode
   ASTNodeObject
+  ASTNodeParent
   Children
 } from ./types.civet
 import { isFunction } from ./util.civet
@@ -38,13 +39,18 @@ function findChildIndex(parent: ASTNodeObject | Children, child: ASTNode)
  * Also returns the `child` that we came from (possibly `node`), in an
  * `{ancestor, child}` object.  If none are found, `ancestor` will be null.
  */
+function findAncestor<T extends ASTNodeParent>(
+  node: ASTNodeObject,
+  predicate: (parent: ASTNodeParent, child: ASTNodeObject) => parent is T,
+  stopPredicate?: (parent: ASTNodeParent, child: ASTNodeObject) => boolean
+): { ancestor: T?, child: ASTNodeObject }
 function findAncestor(
   node: ASTNodeObject,
-  predicate: (parent: NonNullable<ASTNode>, child: ASTNode) => boolean,
-  stopPredicate?: (parent: NonNullable<ASTNode>, child: ASTNode) => boolean
-): { ancestor: ASTNodeObject | undefined, child: ASTNodeObject }
+  predicate: (parent: ASTNodeParent, child: ASTNodeObject) => boolean,
+  stopPredicate?: (parent: ASTNodeParent, child: ASTNodeObject) => boolean
+): { ancestor: ASTNodeObject?, child: ASTNodeObject }
   { parent } .= node
-  while parent and !stopPredicate?(parent, node)
+  while parent and not stopPredicate?(parent, node)
     if predicate(parent, node)
       return { ancestor: parent, child: node }
     node = parent

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -214,6 +214,7 @@ export type IfStatement
 export type ElseClause
   type: "ElseClause"
   children: [ Whitespace | ASTString, ElseToken, BlockStatement ]
+  parent?: Parent
   block: BlockStatement
 
 export type ElseToken = "else " | { $loc: Loc, token: "else" }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -243,6 +243,7 @@ export type IterationStatement
   parent?: Parent
   condition: Condition
   block: BlockStatement
+  negated: boolean?
 
 export type BreakStatement
   type: "BreakStatement"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -208,6 +208,7 @@ export type IfStatement
   children: Children
   parent?: Parent
   condition: Condition
+  negated: boolean?
   then: BlockStatement
   else: ElseClause?
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -177,7 +177,7 @@ function isExit(node: ASTNode): boolean
         isExit node.else?.block
     when "BlockStatement"
       // [1] extracts statement from [indent, statement, delim]
-      isExit node.expressions.-1?[1]
+      node.expressions.some (s) => isExit s[1]
     // Infinite loops
     when "IterationStatement"
       (and)
@@ -185,7 +185,7 @@ function isExit(node: ASTNode): boolean
         node.condition.expression?.type is "Literal"
         node.condition.expression?.raw is "true"
         gatherRecursiveWithinFunction(node.block,
-          ({type}) => type is "BreakStatement").length is 0
+          .type is "BreakStatement").length is 0
         // TODO: Distinguish between break of this loop vs. break of inner loops
     else
       false

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -113,7 +113,7 @@ describe "example code", ->
     ---
     var val, indentRegex;
     let ref;
-      if(!this.fromSourceString) {
+      if (!this.fromSourceString) {
         ref = val
       }
       else if (heredoc) {

--- a/test/function.civet
+++ b/test/function.civet
@@ -1836,7 +1836,7 @@ describe "function", ->
           a
       ---
       (function(x) {
-        if(!x) {
+        if (!x) {
           return a
         };return
       })
@@ -2123,7 +2123,7 @@ describe "function", ->
       function f(arg) {
         let ret;
         ret = 'default'
-        if(!arg) { return ret }
+        if (!arg) { return ret }
         ret = arg
         return ret
       }

--- a/test/if.civet
+++ b/test/if.civet
@@ -309,7 +309,7 @@ describe "if", ->
     unless x
       return y
     ---
-    if(!x) {
+    if (!x) {
       return y
     }
   """
@@ -320,7 +320,7 @@ describe "if", ->
     unless x + z
       return y
     ---
-    if(!(x + z)) {
+    if (!(x + z)) {
       return y
     }
   """
@@ -333,7 +333,7 @@ describe "if", ->
     else
       return z
     ---
-    if(!x) {
+    if (!x) {
       return y
     }
     else {
@@ -387,7 +387,7 @@ describe "if", ->
     ---
     return true unless x
     ---
-    if(!x) { return true }
+    if (!x) { return true }
   """
 
   testCase """
@@ -667,7 +667,7 @@ describe "if", ->
       else
         "b"
       ---
-      let ref;if(!y) {
+      let ref;if (!y) {
         ref = "a"
       }
       else {
@@ -942,9 +942,9 @@ describe "if", ->
         console.log "falsey"
       console.log x
       ---
-      let ref;if(!(ref = getBool())) {
+      let ref;if (!(ref = getBool())) {
         console.log("falsey")
-      }const  x = ref;
+      }const x = ref;
       console.log(x)
     """
 
@@ -954,7 +954,7 @@ describe "if", ->
       unless x := getBool() then return
       console.log "truthy", x
       ---
-      let ref;if(!(ref = getBool())) return;const  x = ref;
+      let ref;if (!(ref = getBool())) return;const x = ref;
       console.log("truthy", x)
     """
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -939,12 +939,60 @@ describe "if", ->
       declaration with unless
       ---
       unless x := getBool()
+        return
+      else
+        isNull := x == null
+        console.log isNull
+      console.log x
+      ---
+      let ref;if (!(ref = getBool())) {
+        return
+      }const x = ref; {
+        const isNull = x == null
+        console.log(isNull)
+      }
+      console.log(x)
+    """
+
+    testCase """
+      declaration with unless, no else
+      ---
+      unless x := getBool()
+        return
+      console.log x
+      ---
+      let ref;if (!(ref = getBool())) {
+        return
+      }const x = ref;
+      console.log(x)
+    """
+
+    testCase """
+      declaration with unless, no exit
+      ---
+      unless x := getBool()
+        console.log 'falsey'
+      else
+        console.log x
+      ---
+      let ref;if (!(ref = getBool())) {
+        console.log('falsey')
+      }
+      else {const x = ref;
+        console.log(x)
+      }
+    """
+
+    testCase """
+      declaration with unless, no exit or else
+      ---
+      unless x := getBool()
         console.log "falsey"
       console.log x
       ---
       let ref;if (!(ref = getBool())) {
         console.log("falsey")
-      }const x = ref;
+      }
       console.log(x)
     """
 
@@ -956,6 +1004,19 @@ describe "if", ->
       ---
       let ref;if (!(ref = getBool())) return;const x = ref;
       console.log("truthy", x)
+    """
+
+    testCase """
+      pattern-matching declaration with unless
+      ---
+      unless {x, y} := getPoint()
+        throw new Error "invalid point"
+      console.log x, y
+      ---
+      let ref;if (!(ref = getPoint() && typeof ref === 'object' && 'x' in ref && 'y' in ref)) {
+        throw new Error("invalid point")
+      }const {x, y} = ref;
+      console.log(x, y)
     """
 
     testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -939,11 +939,23 @@ describe "if", ->
       declaration with unless
       ---
       unless x := getBool()
-        console.log "falsey", x
+        console.log "falsey"
+      console.log x
       ---
-      let ref;if(!(ref = getBool())) {const  x = ref;
-        console.log("falsey", x)
-      }
+      let ref;if(!(ref = getBool())) {
+        console.log("falsey")
+      }const  x = ref;
+      console.log(x)
+    """
+
+    testCase """
+      one-line declaration with unless
+      ---
+      unless x := getBool() then return
+      console.log "truthy", x
+      ---
+      let ref;if(!(ref = getBool())) return;const  x = ref;
+      console.log("truthy", x)
     """
 
     testCase """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -332,7 +332,7 @@ describe "switch", ->
         throw e
         break
         continue
-        console.log('maybe');break;
+        console.log('maybe')
       }
       case 6: {
         if (cond) {

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -189,7 +189,7 @@ describe "[TS] function", ->
       throw new Error "falsey" unless value
     ---
     assert = function(value: unknown): asserts value {
-      if(!value) { throw new Error("falsey") };return
+      if (!value) { throw new Error("falsey") };return
     }
   """
 
@@ -209,7 +209,7 @@ describe "[TS] function", ->
       throw new Error "not string" unless value <? "string"
     ---
     assertString = function(value: unknown): asserts value is string {
-      if(!(typeof value === "string")) { throw new Error("not string") };return
+      if (!(typeof value === "string")) { throw new Error("not string") };return
     }
   """
 

--- a/test/while.civet
+++ b/test/while.civet
@@ -180,11 +180,13 @@ describe "while", ->
       until
       ---
       until item := next()
-        console.log "falsey", item
+        console.log "falsey"
+      console.log "truthy", item
       ---
-      let ref;while (!(ref = next())) {const item = ref;
-        console.log("falsey", item)
-      }
+      let ref;while (!(ref = next())) {
+        console.log("falsey")
+      }const item = ref;
+      console.log("truthy", item)
     """
 
     testCase """


### PR DESCRIPTION
So I implemented the idea that declarations of `unless` and `until` go after the block instead of inside:

```js
unless x := f()
  return
console.log x
↓↓↓
let ref
if ((ref = f()) {
  return
}
const x = ref
console.log(x)
```

However, I'm no longer sure this is a good idea. For example, what if we have an `else` block?

```js
unless x := f()
  return
else
  // should x be bound here?
// should x be bound here?
```

I'm pretty sure `x` should be bound inside the `else`, and for symmetry with the other situations, I think also afterward? So my temptation would be to put the declaration of `x` above the `unless` instead of after it, so that it's accessible everywhere. It doesn't seem particularly bad to expose it to the "then" clause — this is actually more symmetric with `if` — what's important is that it's exposed in the "else clause and outside block, because it can be useful there.  Whereas `if` keeps the protection of the binding to the "then" clause, because that's the only place it is helpful. What do you think?

Fixes #1215, fixes #756