### PR TITLE
Fix duplicate property merging for props not actually bound

### DIFF
--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -424,6 +424,11 @@ function aggregateDuplicateBindings(bindings) {
   for p of props
     { name, value } := p
 
+    // We do not bind a property that gets matched against
+    // an array or object pattern
+    if value?.type is like "ArrayBindingPattern", "ObjectBindingPattern"
+      continue
+
     // This is to handle aliased props, non-aliased props, and binding identifiers in arrays
     const key = value?.name or name?.name or name
     if propsGroupedByName.has key

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1354,6 +1354,29 @@ describe "switch", ->
           x}
     """
 
+    // #1230
+    testCase """
+      duplicate nested object bindings
+      ---
+      switch m
+        { foo: { foo } }
+          foo
+      ---
+      if(typeof m === 'object' && m != null && 'foo' in m && typeof m.foo === 'object' && m.foo != null && 'foo' in m.foo) {const { foo: { foo } } = m;
+          foo}
+    """
+
+    testCase """
+      duplicate identifier in array in object bindings
+      ---
+      switch m
+        { foo: [ foo, ... ] }
+          foo
+      ---
+      if(typeof m === 'object' && m != null && 'foo' in m && Array.isArray(m.foo) && m.foo.length >= 1) {const { foo: [ foo, ...ref ] } = m;
+          foo}
+    """
+
     testCase """
       reserved word keys
       ---


### PR DESCRIPTION
Fixes #1230

I think these are all the cases where things aren't actually bound, but let me know if you think of something else. We currently don't seem to have a computation anywhere of the names that are bound to.