### PR TITLE
Ampersand fixes

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -902,7 +902,7 @@ Placeholder
     }
 
 AmpersandTypeSuffix
-  &( _? QuestionMark? _? Colon ) TypeSuffix -> $2
+  &( QuestionMark? Colon ) TypeSuffix -> $2
 
 # https://262.ecma-international.org/#prod-ClassDeclaration
 ClassDeclaration

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -878,14 +878,15 @@ ParenthesizedExpression
 
 Placeholder
   # Partial function application: f(., x) -> $ => f($, x)
-  Dot:dot !/(?:\p{ID_Continue}|[\u200C\u200D$.])/ ->
+  Dot:dot !/(?:\p{ID_Continue}|[\u200C\u200D$.])/ PlaceholderTypeSuffix?:typeSuffix ->
     return {
       type: "Placeholder",
       subtype: ".",
+      typeSuffix,
       children: [ dot ],
     }
   # Ruby/Crystal style block shorthand: &+1 -> $ => $+1
-  Ampersand:amp ![&=] AmpersandTypeSuffix?:typeSuffix ->
+  Ampersand:amp ![&=] PlaceholderTypeSuffix?:typeSuffix ->
     return {
       type: "Placeholder",
       subtype: "&",
@@ -901,7 +902,7 @@ Placeholder
       children: [ { token: "&" } ],
     }
 
-AmpersandTypeSuffix
+PlaceholderTypeSuffix
   &( QuestionMark? Colon ) TypeSuffix -> $2
 
 # https://262.ecma-international.org/#prod-ClassDeclaration
@@ -3269,15 +3270,6 @@ ComputedPropertyName
       type: "ComputedPropertyName",
       expression,
       children: [ $1, expression, $4 ],
-      implicit: true,
-    }
-  # `.: value` is shorthand for `[.]: value`
-  # (while `&: T` is a type annotation)
-  &"." InsertOpenBracket:open Placeholder:expression InsertCloseBracket:close ->
-    return {
-      type: "ComputedPropertyName",
-      expression,
-      children: [ open, expression, close ],
       implicit: true,
     }
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1273,7 +1273,9 @@ function processPlaceholders(statements: StatementTuple[]): void
           // Declaration
           type is "Initializer"
           // Right-hand side of assignment
-          type is "AssignmentExpression" and ancestor.expression is child
+          type is "AssignmentExpression" and
+            findChildIndex(ancestor, child) is
+            ancestor.children.indexOf ancestor.expression
           type is "ReturnStatement"
           type is "YieldExpression"
       switch ancestor?.type

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1268,7 +1268,11 @@ function processPlaceholders(statements: StatementTuple[]): void
         {type} := ancestor
         (or)
           type is "Call"
-          type is "BlockStatement"
+          // Block, except for 1-liners inside if/else
+          type is "BlockStatement" and not (
+            ancestor.expressions.length is 1 and
+            ancestor.parent is like {type: "IfStatement"}, {type: "ElseClause", parent: {type: "IfStatement"}}
+          )
           type is "PipelineExpression"
           // Declaration
           type is "Initializer"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1243,6 +1243,7 @@ function populateRefs(statements: ASTNode): void {
 
 function processPlaceholders(statements: StatementTuple[]): void
   placeholderMap := new Map<ASTNodeObject, (Placeholder)[]>()
+  liftedIfs := new Set<IfStatement>()
 
   gatherRecursiveAll statements, .type is "Placeholder"
   .forEach (_exp) =>
@@ -1266,13 +1267,14 @@ function processPlaceholders(statements: StatementTuple[]): void
       let child
       { ancestor, child } = findAncestor exp, (ancestor, child) =>
         {type} := ancestor
+        if type is "IfStatement"
+          liftedIfs.add ancestor
         (or)
           type is "Call"
-          // Block, except for 1-liners inside if/else
-          type is "BlockStatement" and not (
-            ancestor.expressions.length is 1 and
-            ancestor.parent is like {type: "IfStatement"}, {type: "ElseClause", parent: {type: "IfStatement"}}
-          )
+          // Block, except for if/else blocks when condition already lifted
+          type is "BlockStatement" and
+            not (ancestor.parent is like {type: "IfStatement"} and liftedIfs.has ancestor.parent as IfStatement) and
+            not (ancestor.parent is like {type: "ElseClause", parent: {type: "IfStatement"}} and liftedIfs.has ancestor.parent!.parent as IfStatement)
           type is "PipelineExpression"
           // Declaration
           type is "Initializer"

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -448,6 +448,37 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    big if/else expression
+    ---
+    arr.map
+      if &.x
+        &.foo
+      else if &.y
+        &.bar
+      else
+        &.baz
+    ---
+    arr.map($ =>\u0020
+      (()=>{if ($.x) {
+        return $.foo
+      }
+      else if ($.y) {
+        return $.bar
+      }
+      else {
+        return $.baz
+      }})(),)
+  """
+
+  testCase """
+    if expression without & in condition
+    ---
+    roundUp := if even then & else &+1
+    ---
+    let ref;if (even) ref = $ => $; else ref = $1 => $1+1;const roundUp =ref
+  """
+
+  testCase """
     if statement
     ---
     =>

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -414,6 +414,16 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    ternary expression
+    ---
+    a := & ? & : 0
+    b := & ? &+1 : -&
+    ---
+    const a = $ => $ ? $ : 0
+    const b = $1 => $1 ? $1+1 : -$1
+  """
+
+  testCase """
     if expression
     ---
     check := if & then x else y

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -443,6 +443,14 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    it works with assignment and binary operators
+    ---
+    x = & + 1
+    ---
+    x = $ => $ + 1
+  """
+
+  testCase """
     it works with const assignment
     ---
     const x = &.foo

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -422,6 +422,22 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    if expression with & in then
+    ---
+    check := if & then &+1 else y
+    ---
+    const check = $ => ($? ($+1) : y)
+  """
+
+  testCase """
+    if expression with & in else
+    ---
+    check := if & then x else &
+    ---
+    const check = $ => ($? x : $)
+  """
+
+  testCase """
     if statement
     ---
     =>

--- a/test/partial-placeholder.civet
+++ b/test/partial-placeholder.civet
@@ -44,8 +44,8 @@ describe "partial placeholder", ->
   testCase """
     object key
     ---
-    f .: a
-    f {.: a}
+    f [.]: a
+    f {[.]: a}
     ---
     $ => f({[$]: a});
     $1 => f({[$1]: a})
@@ -167,4 +167,13 @@ describe "partial placeholder", ->
       ---
       f(a, b, last);
       [x].concat(array)
+    """
+
+  describe "typed .", ->
+    testCase """
+      simple
+      ---
+      add .: number, 5
+      ---
+      ($: number) => add($, 5)
     """


### PR DESCRIPTION
Fixes #1231 

* `&` with binary operators in assignments (e.g. `x = &+1`) previously didn't stop at the assignment
* `&` in if/else previously stopped because the then and else clauses are wrapped in blocks; now we continue up if the clause is a one-liner
* `&` in ternary: `cond ? & : 0` previously treated `: 0` as typing. Now we require no space before `: Type` to disambiguate from ternary
* `.: x` was previously treated as `[.]: x`. While this is cool, it prevented typing of `.` placeholders. I've gone ahead and made `.` consistent with `&`: it can now be typed via `: Type`.

I'm a little worried about if/else. I'm sure how to feel about this example:

```js
=>
  if cond
    &+1
  else
    &+2
// ↓↓↓ (currently)
() => {
  if (cond) {
    return $ => $ + 1;
  } else {
    return $1 => $1 + 2;
  }
};
// OR (this PR)
() => {
  return $ => { if (cond) {
    return $+1
  }
  else {
    return $+2
  }}
}
```

If you can think of a better rule for if/else, please let me know. (We could require there to be no indentation, i.e. `bare`, but that feels a bit limiting; see https://github.com/DanielXMoore/Civet/issues/1231#issuecomment-2098783437 )