### PR TITLE
Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,60 +219,18 @@ could be a valid property `1.e10` → `1..e10`. The workaround is to add a trail
   console.log "hi"
   ```
 
-Comparison to CoffeeScript
----
+### Comparison to CoffeeScript
 
 Take a look at this [detailed Civet // CoffeeScript comparision](./notes/Comparison-to-CoffeeScript.md)
 
-ECMAScript Compatibility
----
+### Directives
 
-You can specify `"civet"` prologue directives to increase
-compatibility with ECMAScript/TypeScript:
+Civet is not just one language; it can be configured in a variety of ways
+via directives to add or remove language features, or improve behavior
+in certain environments.
+See [config documentation](https://civet.dev/config).
 
-| Configuration       | What it enables |
-|---------------------|---------------------------------------|
-| -implicit-returns   | turn off implicit return of last value in functions |
-
-Put them at the top of your file:
-
-```
-"civet -implicit-returns"
-```
-
-Your can separate multiple options with spaces.
-
-Deno Compatibility
----
-
-TypeScript only allows importing `.ts` files as `.js`. Deno follows ESM and requires importing files with the correct extension.
-
-Civet automatically rewrites imports to work around [this issue](https://github.com/microsoft/TypeScript/issues/42151) in TS.
-
-When Civet detects it is running in Deno rewriting imports is turned off. If for some reason Civet fails to detect running in Deno
-you can turn off rewriting imports manually with these configuration options:
-
-| Configuration         | What it enables |
-|-----------------------|------------------------------------------|
-| -rewrite-ts-imports   | disable rewriting .ts -> .js in imports  |
-| deno                  | currently just disables rewriting imports but could add more deno specific options in the future |
-
-Other Options
----
-
-The `"civet"` prologue directive can also specify the following options:
-
-| Configuration       | What it enables |
-|---------------------|---------------------------------------|
-| rewrite-civet-imports=.ext | Rewrite `import "file.civet"` to `import "file.ext"` |
-| tab=NNN             | treat tab like NNN spaces (default=1) |
-
-For example, `"civet tab=2"` or `"civet tab=4"` lets you mix tabs and spaces
-in a file and be treated like they'd render in VSCode with `editor.tabSize`
-set accordingly.
-
-Using Civet in your Node.js Environment
----
+### Using Civet in your Node.js Environment
 
 You have now been convinced that Civet is right for your current/next project. Here is how
 to set up your environment to get productive right away and have a Good Time℠.

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -35,8 +35,9 @@ and following ESM, require importing files with the correct extension.
 
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
-| [`autoVar`](reference#autovar) | automatically declare undeclared variables with `var` |
+| [`autoConst`](reference#autoconst) | automatically declare undeclared variables with `const` |
 | [`autoLet`](reference#autolet) | automatically declare undeclared variables with `let` |
+| [`autoVar`](reference#autovar) | automatically declare undeclared variables with `var` |
 | [`defaultElement=tag`](reference#implicit-element) | specify default JSX tag: `<.foo>` → `<tag class="foo">` |
 | [`objectIs`](reference#object-is) | implement the `is` operator via `Object.is` |
 
@@ -77,8 +78,10 @@ Running in a particular environment?  Try one of these options:
 
 | Configuration         | What it enables |
 |-----------------------|------------------------------------------|
+| `client`              | Code may run on client (default unless you specify `server`, currently just for [Solid](reference#solidjs)) |
 | `deno`                | `-rewrite-ts-imports` |
 | `react`               | Use `className` instead of `class` in [JSX class shorthand](reference#class) |
+| `server`              | Code may run on server (currently just for [Solid](reference#solidjs)) |
 | [`solid`](reference#solidjs) | Automatic type casting of JSX |
 ## Local Configuration via Directives
 

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -4,4 +4,191 @@ title: Config
 
 # {{ $frontmatter.title }}
 
-For now, see the [README on GitHub](https://github.com/DanielXMoore/Civet#readme).
+Civet offers many configuration options
+to adjust the language to your liking.
+We start with the various options,
+and then show the various ways that they can be specified.
+
+[[toc]]
+
+## General Options
+
+| Configuration         | What it enables |
+|-----------------------|------------------------------------------|
+| `tab=`*N*             | treat tab like *N* spaces (default=1) |
+
+## Import Options
+
+TypeScript only allows importing `.ts` files as `.js`;
+see [this issue](https://github.com/microsoft/TypeScript/issues/42151).
+As a workaround,
+Civet automatically rewrites imports to `.ts` into imports to `.js`.
+Some environments, such as Deno, allow importing `.ts` directly,
+and following ESM, require importing files with the correct extension.
+
+| Configuration         | What it enables |
+|-----------------------|------------------------------------------|
+| `rewrite-civet-imports=.ext` | Rewrite `import "file.civet"` to `import "file.ext"` |
+| `-rewrite-ts-imports` | disable rewriting `.ts` → `.js` in imports to avoid [this issue](https://github.com/microsoft/TypeScript/issues/42151) (useful in environments supporting direct imports of `.ts`) |
+
+## Language Options
+
+| Configuration       | What it enables |
+|---------------------|---------------------------------------|
+| [`autoVar`](reference#autovar) | automatically declare undeclared variables with `var` |
+| [`autoLet`](reference#autolet) | automatically declare undeclared variables with `let` |
+| [`defaultElement=tag`](reference#implicit-element) | specify default JSX tag: `<.foo>` → `<tag class="foo">` |
+| [`objectIs`](reference#object-is) | implement the `is` operator via `Object.is` |
+
+## ECMAScript Compatibility
+
+Eventually, we plan a `jsCompat` compatibility flag to modify Civet to be
+closer to pure ECMAScript, removing the
+[few places where Civet is not a superset of ECMAScript](comparison).
+For now, we have the following related options:
+
+| Configuration       | What it enables |
+|---------------------|---------------------------------------|
+| `-implicit-returns` | turn off implicit return of last value in functions |
+
+## CoffeeScript Compatibility
+
+| Configuration       | What it enables |
+|---------------------|---------------------------------------|
+| [`coffeeCompat`](reference#coffeescript-compatibility) | enable all of the following CoffeeScript compatibility flags |
+| [`autoVar`](reference#autovar) | automatically declare undeclared variables with `var` |
+| [`coffeeBinaryExistential`](reference#coffeescript-operators) | `x ? y` → `x ?? y` |
+| [`coffeeBooleans`](reference#coffeescript-booleans) | `yes`, `no`, `on`, `off` |
+| [`coffeeClasses`](reference#coffeescript-classes) | CoffeeScript-style `class` methods via `->` functions |
+| [`coffeeComment`](reference#coffeescript-comments) | `# single line comments` |
+| [`coffeeDo`](reference#coffeescript-do) | `do ->`; disables [ES6 `do...while` loops](reference#do-while-until-loop) and [Civet `do` blocks](reference#do-blocks) |
+| [`coffeeEq`](reference#coffeescript-operators) | `==` → `===`, `!=` → `!==` |
+| [`coffeeForLoops`](reference#coffeescript-for-loops) | `for in`/`of`/`from` loops behave like they do in CoffeeScript (like Civet's `for each of`/`in`/`of` respectively) |
+| [`coffeeInterpolation`](reference#double-quoted-strings) | `"a string with #{myVar}"` |
+| [`coffeeIsnt`](reference#coffeescript-operators) | `isnt` → `!==` |
+| [`coffeeLineContinuation`](reference#coffeescript-line-continuations) | `\` at end of line continues to next line |
+| [`coffeeNot`](reference#coffeescript-operators) | `not` → `!`, disabling Civet extensions like [`is not`](reference#humanized-operators) |
+| [`coffeeOf`](reference#coffeescript-operators) | `a of b` → `a in b`, `a not of b` → `!(a in b)`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
+| [`coffeePrototype`](reference#coffeescript-operators) | `x::` -> `x.prototype`, `x::y` -> `x.prototype.y` |
+
+## Environment Options
+
+Running in a particular environment?  Try one of these options:
+
+| Configuration         | What it enables |
+|-----------------------|------------------------------------------|
+| `deno`                | `-rewrite-ts-imports` |
+| `react`               | Use `className` instead of `class` in [JSX class shorthand](reference#class) |
+| [`solid`](reference#solidjs) | Automatic type casting of JSX |
+## Local Configuration via Directives
+
+At the top of any Civet file (possibly after a `#!` line, comments,
+triple slash directives, and other string directives such as `"use strict"`),
+you can specify one or more configurations with a `"civet"` directive.
+For example:
+
+```js
+"civet objectIs -implicit-returns tab=2"
+```
+
+This directive specifies that:
+* [The `is` operator should be implemented via `Object.is`](reference#object-is)
+* [Implicit returns](reference#implicit-returns) are disabled
+* Tab characters should be treated like 2 spaces
+
+In general, a word like `objectIs` or `object-is` enables a feature;
+a negated word like <span style="display:inline-block">`-implicitReturns`</span>
+or `-implicit-returns` disables a feature;
+and an assignment like `tab=2` specifies a value for a feature (in rare cases).
+You can use `camelCase` or `kebab-case` as you prefer.
+
+## Global Configuration via Config Files
+
+In the root directory of your project, or in a `.config` subdirectory,
+you can add one of the following files:
+
+* `🐈.json`
+* `🐈.civet`
+* `civetconfig.json`
+* `civetconfig.civet`
+* `civet.config.json`
+* `civet.config.civet`
+
+A JSON file should consist of an object with a `"parseOptions"` property,
+which should be an object specifying one of more directives in the natural way.
+For example, the [directive](#local-configuration-via-directives)
+`"civet objectIs -implicit-returns tab=2"` is equivalent to:
+
+```js
+{
+  "parseOptions": {
+    "objectIs": true,
+    "implicitReturns": false,
+    "tab": 2
+  }
+}
+```
+
+## Global Configuration within Build Tools
+
+The [unplugin](https://github.com/DanielXMoore/Civet/blob/main/integration/unplugin)
+offers [options](https://github.com/DanielXMoore/Civet/tree/main/integration/unplugin#options)
+to specify global config directives (overriding even config files) and
+to specify or disable a config file.  For example:
+
+```js
+civetPlugin({
+  parseOptions: {
+    objectIs: true,
+    implicitReturns: false,
+    tab: 2,
+  },
+})
+```
+
+## Configuration via API
+
+The Civet compilation API (`compile`) offers a similar `parseOptions`
+for specifying config directives:
+
+```js
+import {compile} from "@danielx/civet"
+const code = await compile(civetCode, {
+  parseOptions: {
+    objectIs: true,
+    implicitReturns: false,
+    tab: 2,
+  },
+})
+```
+
+`compile` does not look at config files.  Instead, you can use the `config`
+module to look for and parse config files:
+
+```js
+import { findInDir, findConfig, loadConfig } from "@danielx/civet/config"
+// Look for standard name for config file in specified directory
+const path1 = findInDir(process.cwd())
+// Look for standard name for config file in specified directory or ancestors
+const path2 = findConfig(process.cwd())
+// Load config file from specified path
+const config = loadConfig(path)
+// Pass config to compile
+const code = await compile(civetCode, config)
+```
+
+## Configuration via CLI
+
+By default, the Civet CLI searches all ancestor directories of the current
+directory for a [configuration file](#global-configuration-via-config-files)
+with a standard name.
+It also options to specify config directives and to override config files:
+
+```sh
+# Specify a directive
+civet --civet "objectIs -implicit-returns tab=2" ...
+# Specify a config file
+civet --config custom-config.civet ...
+# Disable config files
+civet --no-config ...
+```

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -200,7 +200,10 @@ esbuild.build({
       // outputExtension: '.tsx',        // appended to .civet in output
       // ts: 'civet',                    // TS -> JS transpilation mode
       // typecheck: false,               // check types via tsc
-      // comptime: false,                // evaluate comptime blocks
+      // config: null,                   // Civet config filename; null to skip
+      // parseOptions: {                 // directives to apply globally
+      //   comptime: false,              // evaluate comptime blocks
+      // },
     })
   ]
 }).catch(() => process.exit(1))

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -54,6 +54,16 @@ for item of iterable
   sos += square
 </Playground>
 
+### `autoConst`
+
+<Playground>
+"civet autoConst"
+let sos = 0
+for item of iterable
+  square = item * item
+  sos += square
+</Playground>
+
 ### Declarations in Conditions and Loops
 
 <Playground>
@@ -2290,6 +2300,14 @@ return
 
 <Playground>
 "civet solid"
+link := <a href="https://civet.dev/">Civet
+</Playground>
+
+You can specify whether the code will run on the client (default)
+and/or the server:
+
+<Playground>
+"civet solid client server"
 link := <a href="https://civet.dev/">Civet
 </Playground>
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2161,6 +2161,13 @@ and [jsx spec issues](https://github.com/facebook/jsx/issues)
 <div .button.{size()}>
 </Playground>
 
+Specify the `"civet react"` directive to use the `className` attribute instead:
+
+<Playground>
+"civet react"
+<div .foo>Civet
+</Playground>
+
 ### Implicit Element
 
 <Playground>
@@ -2306,6 +2313,18 @@ for own key, value of object
   console.log key, value
 for item from iterable
   console.log item
+</Playground>
+
+### CoffeeScript Do Blocks
+
+This option disables [Civet `do` blocks](#do-blocks)
+and [`do...while` loops](#do-while-until-loop).
+
+<Playground>
+"civet coffeeDo"
+do foo
+do ->
+  await fetch url
 </Playground>
 
 ### Double-Quoted Strings

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -119,7 +119,10 @@ interface PluginOptions {
     Note that some bundlers require additional plugins to handle TS.
     For example, for Webpack, you would need to install `ts-loader` and add it to your webpack config.
     Unfortunately, Rollup's TypeScript plugin is incompatible with this plugin, so you need to set `ts` to another option.
-- `comptime`: Whether to evaluate
-  [`comptime` blocks](https://civet.dev/reference#comptime-blocks)
-  at compile time.  Default: `false`.
+- `parseOptions`: Options object to pass to the Civet parser,
+  like adding `"civet"` directives to all files.  Default: `{}`.
+  - `comptime`: Whether to evaluate
+    [`comptime` blocks](https://civet.dev/reference#comptime-blocks)
+    at compile time.  Default: `false`.
+  - See [reference](https://civet.dev/reference) for more.
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/README.md
+++ b/integration/unplugin/README.md
@@ -119,10 +119,15 @@ interface PluginOptions {
     Note that some bundlers require additional plugins to handle TS.
     For example, for Webpack, you would need to install `ts-loader` and add it to your webpack config.
     Unfortunately, Rollup's TypeScript plugin is incompatible with this plugin, so you need to set `ts` to another option.
+- `config`: Civet config filename to load, or `null` to avoid looking for the
+  default config filenames in the project root directory.
+  See [Civet config](https://civet.dev/config).
 - `parseOptions`: Options object to pass to the Civet parser,
   like adding `"civet"` directives to all files.  Default: `{}`.
+  These options override any options specified in a
+  [config file](https://civet.dev/config).
+  Notably, unlike config files, you can specify the following option:
   - `comptime`: Whether to evaluate
     [`comptime` blocks](https://civet.dev/reference#comptime-blocks)
     at compile time.  Default: `false`.
-  - See [reference](https://civet.dev/reference) for more.
 - `transformOutput(code, id)`: Adds a custom transformer over jsx/tsx code produced by `civet.compile`. It gets passed the jsx/tsx source (`code`) and filename (`id`), and should return valid jsx/tsx code.

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -39,6 +39,8 @@ export type PluginOptions = {
   js?: boolean;
   /** @deprecated Use "emitDeclaration" instead */
   dts?: boolean;
+  /** config filename, or null to not look for default config file */
+  config?: string | null | undefined;
   parseOptions?: ParseOptions;
 };
 
@@ -131,8 +133,10 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
       if (transformTS || options.ts === 'tsc') {
         const ts = await tsPromise!;
 
-        const civetConfigPath = await findInDir(process.cwd())
-        if (civetConfigPath != null) {
+        const civetConfigPath = 'config' in options
+          ? options.config
+          : await findInDir(process.cwd())
+        if (civetConfigPath) {
           compileOptions = await loadConfig(civetConfigPath)
         }
         // Merge parseOptions, with plugin options taking priority

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -154,16 +154,19 @@ Civet provides a compatibility prologue directive that aims to be 97+% compatibl
 | Configuration       | What it enables |
 |---------------------|---------------------------------------------------------------------|
 | autoVar             | declare implicit vars based on assignment to undeclared identifiers |
+| coffeeBinaryExistential | `x ? y` → `x ?? y` |
 | coffeeBooleans      | `yes`, `no`, `on`, `off` |
+| coffeeClasses       | CoffeeScript-style `class` methods via `->` functions |
 | coffeeComment       | `# single line comments` |
 | coffeeDo            | `do ->`, disables ES6 do/while |
 | coffeeEq            | `==` → `===`, `!=` → `!==` |
 | coffeeForLoops      | for in, of, from loops behave like they do in CoffeeScript |
 | coffeeInterpolation | `"a string with #{myVar}"` |
 | coffeeIsnt          | `isnt` → `!==` |
+| coffeeLineContinuation | `\` at end of line continues to next line |
 | coffeeNot           | `not` → `!`, disabling Civet extensions like `is not` |
 | coffeeOf            | `a of b` → `a in b`, `a not of b` → `!(a in b)`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
-| coffeePrototype     | enables `x::` -> `x.prototype` and `x::y` -> `x.prototype.y` shorthand.
+| coffeePrototype     | `x::` -> `x.prototype`, `x::y` -> `x.prototype.y` |
 
 You can use these with `"civet coffeeCompat"` to opt in to all or use them bit by bit with `"civet coffeeComment coffeeEq coffeeInterpolation"`.
 Another possibility is to slowly remove them to provide a way to migrate files a little at a time `"civet coffeeCompat -coffeeBooleans -coffeeComment -coffeeEq"`.

--- a/source/config.civet
+++ b/source/config.civet
@@ -13,11 +13,11 @@ configFileNames := new Set [
   "civetconfig.civet"
 ]
 
-function findInDir(dirPath: string): Promise<string | undefined>
+export function findInDir(dirPath: string): Promise<string | undefined>
   for entryName of await fs.readdir dirPath
     entryPath := path.join dirPath, entryName
 
-    if entryName is ".config" and try fs.stat entryPath |> await |> .isDir()
+    if entryName is ".config" and try fs.stat entryPath |> await |> .isDirectory()
       // scan for ./civet.json as well as ./.config/civet.json
       found := await findInDir entryPath
       return found if found

--- a/source/config.civet
+++ b/source/config.civet
@@ -11,6 +11,8 @@ configFileNames := new Set [
   "🐈.civet"
   "civetconfig.json"
   "civetconfig.civet"
+  "civet.config.json"
+  "civet.config.civet"
 ]
 
 export function findInDir(dirPath: string): Promise<string | undefined>

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -113,6 +113,7 @@ declare module "@danielx/civet/esbuild-plugin" {
 
 declare module "@danielx/civet/config" {
   const Config: {
+    findInDir(dirPath: string): Promise<string | undefined>
     findConfig: (path: string) => Promise<string | null>
     loadConfig: (
       path: string

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -112,12 +112,14 @@ declare module "@danielx/civet/esbuild-plugin" {
 }
 
 declare module "@danielx/civet/config" {
-  const Config: {
-    findInDir(dirPath: string): Promise<string | undefined>
-    findConfig: (path: string) => Promise<string | null>
-    loadConfig: (
-      path: string
-    ) => Promise<import("@danielx/civet").CompileOptions>
+  export function findInDir(dirPath: string): Promise<string | undefined>
+  export function findConfig(path: string): Promise<string | null>
+  export function loadConfig(
+    path: string
+  ): Promise<import("@danielx/civet").CompileOptions>
+  export default {
+    findInDir: typeof findInDir,
+    findConfig: typeof findConfig,
+    loadConfig: typeof loadConfig,
   }
-  export default Config
 }


### PR DESCRIPTION
This is a major step toward #1239. The documentation in particular was an effort. 🙂

* https://civet.dev/config docs page is finally interesting. It both lists all options (moving some material from `README`) and shows how to specify config files.
* unplugin upgrades
  * `parseOptions` option to override options
  * BREAKING CHANGE: `comptime` is no longer at the top level, but within `parseOptions`, for consistency with rest of Civet. (I could add a top-level `comptime` for backward compatibility, but it's a pretty new option so I can't imagine there's much use yet.)
  * By default, search for config files in root directory
  * `config: "filename"` or `config: null` override
* Bug fix when looking for `.config` directory
* Support `civet.config.json` and `civet.config.civet` as requested in Discord (by analogy to e.g. `eslint.config.js`)

There's more config file support to add, as listed in #1239. But these can be another PR.