### PR TITLE
Fix #1250 - source mapping for AtThis identifier

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1161,7 +1161,13 @@ ThisLiteral
       children: [at, {
         type: "PropertyAccess",
         name: id,
-        children: [".", id],
+        children: [".", {
+          $loc: {
+            pos: $loc.pos + 1,
+            length: $loc.length - 1,
+          },
+          token: id
+        }],
       }],
       thisShorthand: true,
     }


### PR DESCRIPTION
Before:
![image](https://github.com/DanielXMoore/Civet/assets/18894/6358a116-4cac-4ea3-bc54-711d13a2def6)

After:
![image](https://github.com/DanielXMoore/Civet/assets/18894/e0217c8f-b8cf-44b0-ab7d-128ed696080b)
