### PR TITLE
Upgrade Playground to modern Prettier

### DIFF
--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -1,5 +1,6 @@
-importScripts('https://cdn.jsdelivr.net/npm/prettier@2.8.1/standalone.js');
-importScripts('https://cdn.jsdelivr.net/npm/prettier@2.8.1/parser-typescript.js');
+importScripts('https://cdn.jsdelivr.net/npm/prettier@3.2.5/standalone.js');
+importScripts('https://cdn.jsdelivr.net/npm/prettier@3.2.5/plugins/estree.js');
+importScripts('https://cdn.jsdelivr.net/npm/prettier@3.2.5/plugins/typescript.js');
 importScripts('https://cdn.jsdelivr.net/npm/shiki@0.14.7');
 importScripts('/__civet.js');
 
@@ -93,7 +94,7 @@ onmessage = async (e) => {
 
   if (prettierOutput) {
     try {
-      tsCode = prettier.format(tsCode, {
+      tsCode = await prettier.format(tsCode, {
         parser: 'typescript',
         plugins: prettierPlugins,
         printWidth: 50,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@danielx/civet": "0.7.4",
     "@danielx/hera": "^0.8.13",
-    "@prettier/sync": "^0.3.0",
+    "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^9.1.1",
     "@types/node": "^20.12.2",
@@ -84,7 +84,7 @@
     "esbuild": "0.20.0",
     "marked": "^4.2.4",
     "mocha": "^10.0.0",
-    "prettier": "^3.1.1",
+    "prettier": "^3.2.5",
     "terser": "^5.16.1",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,10 +486,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@prettier/sync@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@prettier/sync/-/sync-0.3.0.tgz#91f2cfc23490a21586d1cf89c6f72157c000ca1e"
-  integrity sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==
+"@prettier/sync@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@prettier/sync/-/sync-0.5.2.tgz#f8401e45b667e8d6207015fd03619ea2c2e3e680"
+  integrity sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==
+  dependencies:
+    make-synchronized "^0.2.8"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -1352,6 +1354,11 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+make-synchronized@^0.2.8:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/make-synchronized/-/make-synchronized-0.2.9.tgz#edcbe2d8e7aeac8e0f41a0bb25b05cc7a7e2e8e4"
+  integrity sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==
+
 mark.js@8.11.1:
   version "8.11.1"
   resolved "https://registry.yarnpkg.com/mark.js/-/mark.js-8.11.1.tgz#180f1f9ebef8b0e638e4166ad52db879beb2ffc5"
@@ -1562,10 +1569,10 @@ preact@^10.0.0:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.17.1.tgz#0a1b3c658c019e759326b9648c62912cf5c2dde1"
   integrity sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==
 
-prettier@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.1.tgz#6ba9f23165d690b6cbdaa88cb0807278f7019848"
-  integrity sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==
+prettier@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
+  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
 
 punycode@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
I did this originally to fix some of the Prettier bugs we've been seeing. It didn't end up helping, but will be useful in the future to upgrade the Playground worker to the new Prettier 3 async interface.