### PR TITLE
Invalid command-line argument handling

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -158,7 +158,7 @@ export function parseArgs(args: string[]): ParsedArgs
           filenames.push arg
     i++
 
-  process.exit errors if errors
+  process.exit Math.min 255, errors if errors
   {filenames, scriptArgs, options}
 
 type ReadFile = (

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -94,6 +94,7 @@ export function parseArgs(args: string[]): ParsedArgs
   filenames: string[] := []
   scriptArgs: string[] .= []
   i .= 0
+  errors .= 0
   function endOfArgs(j: number): void
     i = args.length  // trigger end of loop
     return if j >= args.length  // no more args
@@ -149,13 +150,15 @@ export function parseArgs(args: string[]): ParsedArgs
         endOfArgs ++i  // remaining arguments are filename and/or arguments
       else
         if arg.startsWith('-') and arg is not '-'
-          throw new Error `Invalid command-line argument ${arg}`
-        if options.run
+          console.error `Invalid command-line argument: ${arg}`
+          errors++
+        else if options.run
           endOfArgs i  // remaining arguments are arguments to the script
         else
           filenames.push arg
     i++
 
+  process.exit errors if errors
   {filenames, scriptArgs, options}
 
 type ReadFile = (


### PR DESCRIPTION
Fixes #1255

![image](https://github.com/DanielXMoore/Civet/assets/2218736/a4bc2907-bb3d-4794-bff8-41d11ce5ef0a)

The `(3)` shows the return code.