### PR TITLE
Generous matching of --version, --help

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -11,11 +11,11 @@ let unplugin:
 export function version: string
   require("../package.json").version
 
-if process.argv.includes "--version"
+if process.argv.some (is like "--version", "-version", "-v")
   console.log version()
   process.exit(0)
 
-if process.argv.includes "--help"
+if process.argv.some (is like "--help", "-help", "-h")
   process.stderr.write """
            ▄▄· ▪   ▌ ▐·▄▄▄ .▄▄▄▄▄
           ▐█ ▌▪██ ▪█·█▌▀▄.▀·•██       _._     _,-'""`-._


### PR DESCRIPTION
Fixes #1254 (without yet addressing #1258).

Potentially controversial: Ties up `-h` and `-v`. I could instead just add `-help` and `-version`. Some languages such as Python and Rust use `-V` for version, so we could instead opt for that.