### PR TITLE
Fix ASI by handling tokens

### DIFF
--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -7,8 +7,9 @@ import type {
 } from ./types.civet
 
 import {
-  updateParentPointers
+  isToken
   startsWith
+  updateParentPointers
 } from ./util.civet
 
 import {
@@ -198,6 +199,7 @@ function needsPrecedingSemicolon(exp: ASTNode)
       return needsPrecedingSemicolon child
     return false
   
+  exp = exp.token if isToken exp
   if exp <? "string"
     return /^\s*[\(\[\`\+\-\/]/.test exp
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -646,6 +646,7 @@ export {
   isExit
   isFunction
   isStatement
+  isToken
   isWhitespaceOrEmpty
   literalValue
   makeAmpersandFunction

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -27,9 +27,9 @@ describe "assignment", ->
     b--
     --b
     ---
-    a++
+    a++;
     ++a
-    b--
+    b--;
     --b
   """
 
@@ -39,7 +39,7 @@ describe "assignment", ->
     a⧺
     ⧺a
     ---
-    a++
+    a++;
     ++a
   """
 
@@ -49,7 +49,7 @@ describe "assignment", ->
     a—
     —a
     ---
-    a--
+    a--;
     --a
   """
 

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -54,6 +54,18 @@ describe "binary operations", ->
   """
 
   testCase """
+    additive
+    ---
+    a
+    - b
+    -c
+    ---
+    a
+    - b;
+    -c
+  """
+
+  testCase """
     relational
     ---
     a < b

--- a/test/comment.civet
+++ b/test/comment.civet
@@ -122,7 +122,7 @@ describe "comment", ->
     loop
       /*inside*/ break
     ---
-    /*first*/ break
+    /*first*/ break;
     /*second*/ break
     while(true) {
       /*inside*/ break


### PR DESCRIPTION
In particular fixes the reported issue with https://civet.dev/comparison#automatic-semicolon-insertion

## Before:

![image](https://github.com/DanielXMoore/Civet/assets/2218736/6c26c0de-7612-41da-a1f2-0cd0ea791373)

## After:

![image](https://github.com/DanielXMoore/Civet/assets/2218736/c6399796-5ff5-4c88-a59c-e587c5adb902)
