### PR TITLE
Fix complex negative property access

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1099,8 +1099,8 @@ function processStatementExpressions(statements: StatementTuple[]): void
 
 function processNegativeIndexAccess(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (n) => n.type is "NegativeIndex")
-    .forEach (exp) =>
-      { children } := exp.parent
+    .forEach (exp): void =>
+      { children } := exp.parent!
 
       let start = 0
       start++ while start < children# and isWhitespaceOrEmpty children[start]
@@ -1114,7 +1114,7 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
           subexp = children.splice start, 1
       else if index > start+1
         ref = makeRef()
-        subexp = children.splice start, index
+        subexp = children.splice start, index - start
       else
         throw new Error("Invalid parse tree for negative index access")
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -458,6 +458,7 @@ export type TryStatement
 export type CatchClause
   type: "CatchClause"
   children: [ Whitespace | ASTString, CatchToken, BlockStatement ]
+  parent?: Parent
   block: BlockStatement
 
 export type CatchToken = "catch(e) " | { $loc: Loc, token: "finally" }
@@ -465,6 +466,7 @@ export type CatchToken = "catch(e) " | { $loc: Loc, token: "finally" }
 export type FinallyClause
   type: "FinallyClause"
   children: [ Whitespace | ASTString, FinallyToken, BlockStatement ]
+  parent?: Parent
   block: BlockStatement
 
 export type FinallyToken = "finally " | { $loc: Loc, token: "finally" }

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -316,6 +316,14 @@ describe "property access", ->
       x[x.length-1] = 2
     """
 
+    testCase """
+      negative with declaration and ref
+      ---
+      lastChild := node.children.-1
+      ---
+      let ref;const lastChild = (ref = node.children)[ref.length-1]
+    """
+
   describe "bind shorthand", ->
     testCase """
       @.


### PR DESCRIPTION
## Input:
```js
lastChild := node.children.-1
```
## Output without this PR:
```js
let ref;const lastChild = (ref = node.children[ref.length-1])
```
## Output with this PR:
```js
let ref;const lastChild = (ref = node.children)[ref.length-1]
```

## Context

Civet doesn't work if built with current Civet because this line is compiling incorrectly:

https://github.com/DanielXMoore/Civet/blob/41ba011b4a506af1c0a08b22a838a46e9f637fd2/source/parser/binding.civet#L140

Hopefully this will allow us to upgrade Civet and fix the CLI according to #1261.