### PR TITLE
Fix source-map-support import with new NodeJS register

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,6 @@ to set up your environment to get productive right away and have a Good Time℠.
 Code coverage with [c8](https://github.com/bcoe/c8) "just works" thanks to their source map
 integration and Civet's source maps.
 
-Currently Civet's ESM loader depends on [ts-node](https://www.npmjs.com/package/ts-node)
-
 #### c8 + Mocha
 
 `package.json`
@@ -260,13 +258,13 @@ Currently Civet's ESM loader depends on [ts-node](https://www.npmjs.com/package/
       "civet"
     ],
     "loader": [
-      "ts-node/esm",
       "@danielx/civet/esm"
     ],
     ...
   ...
 ```
 
+<!--
 `ts-node` must be configured with `transpileOnly` (it can't resolve alternative extensions). Also I think `module` needs to be at least `ES2020` for the Civet ESM loader to work.
 
 `tsconfig.json`
@@ -279,6 +277,7 @@ Currently Civet's ESM loader depends on [ts-node](https://www.npmjs.com/package/
     }
   }
 ```
+-->
 
 If you don't care for code coverage you can skip c8 (but it is so easy why not keep it?).
 

--- a/integration/example/error-cjs.civet
+++ b/integration/example/error-cjs.civet
@@ -1,0 +1,6 @@
+"civet"
+"civet"
+"civet"
+"civet"
+"civet"
+throw new Error "intentional"

--- a/integration/example/error-esm.civet
+++ b/integration/example/error-esm.civet
@@ -1,0 +1,7 @@
+"civet"
+"civet"
+"civet"
+"civet"
+"civet"
+throw new Error "intentional"
+export irrelevant = 1

--- a/register.js
+++ b/register.js
@@ -43,6 +43,8 @@ if (require.extensions) {
   };
 }
 
+const outputCache = new Map
+
 function retrieveFile(path) {
   if (!path.endsWith('.civet')) return
 
@@ -54,12 +56,15 @@ function retrieveFile(path) {
     } catch (e) {}
   }
 
-  return compile(fs.readFileSync(path, 'utf8'), {
-    filename: path,
-    js: true,
-    inlineMap: true,
-    sync: true,
-  });
+  if (!outputCache.has(path)) {
+    outputCache.set(path, compile(fs.readFileSync(path, 'utf8'), {
+      filename: path,
+      js: true,
+      inlineMap: true,
+      sync: true,
+    }));
+  }
+  return outputCache.get(path)
 }
 
 try {

--- a/register.js
+++ b/register.js
@@ -23,28 +23,51 @@ try {
   const { pathToFileURL } = require('node:url');
 
   register('./dist/esm.mjs', pathToFileURL(__filename));
-} catch (e) {}
+} catch (e) {
+  // older Node lacking module register
+}
 
-// CJS registration
+const fs = require("fs");
+const { compile } = require("./");
+
+// Old-style CJS registration
 if (require.extensions) {
-  const fs = require("fs");
-  const { compile } = require("./");
-
   require.extensions[".civet"] = function (module, filename) {
     const js = compile(fs.readFileSync(filename, 'utf8'), {
       filename,
       js: true,
       inlineMap: true,
+      sync: true,
     });
     module._compile(js, filename);
   };
+}
 
-  try {
-    require('@cspotcode/source-map-support').install({
-      environment: 'node',
-      hookRequire: true  // support inline source maps
-    })
-  } catch (e) {
-    // ignore missing dependency
+function retrieveFile(path) {
+  if (!path.endsWith('.civet')) return
+
+  // If it's a file URL, convert to local path
+  // I could not find a way to handle non-URLs except to swallow an error
+  if (path.startsWith('file:')) {
+    try {
+      path = require('url').fileURLToPath(path)
+    } catch (e) {}
   }
+
+  return compile(fs.readFileSync(path, 'utf8'), {
+    filename: path,
+    js: true,
+    inlineMap: true,
+    sync: true,
+  });
+}
+
+try {
+  require('@cspotcode/source-map-support').install({
+    environment: 'node',
+    hookRequire: true,
+    retrieveFile,
+  })
+} catch (e) {
+  // ignore missing dependency
 }

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -26,46 +26,11 @@ node --loader ts-node/esm --loader @danielx/civet/esm source.civet
 { readFileSync } from fs
 { pathToFileURL, fileURLToPath } from url
 
-sourceMapSupport from @cspotcode/source-map-support
-
 Civet from ./main.civet
 { compile, SourceMap } := Civet
 
 baseURL := pathToFileURL(process.cwd() + '/').href
 extensionsRegex := /\.civet$/
-
-let registered = false
-outputCache: Map<string, string> := new Map
-
-directorySeparator := '/'
-backslashRegExp := /\\/g
-/**
- * Replace backslashes with forward slashes.
- */
-function normalizeSlashes(value: string): string {
-  return value.replace(backslashRegExp, directorySeparator);
-}
-
-ensureRegister := ->
-  return if registered
-
-  installation := {
-    environment: 'node' as const
-    retrieveFile(pathOrUrl: string)
-      let path = pathOrUrl
-      // If it's a file URL, convert to local path
-      // I could not find a way to handle non-URLs except to swallow an error
-      if path.startsWith('file:')
-        try
-          path = fileURLToPath(path)
-      path = normalizeSlashes(path)
-
-      return outputCache.get(path)
-  }
-
-  sourceMapSupport.install installation
-
-  registered = true
 
 export function resolve(specifier: string, context: any, next: any)
   { parentURL = baseURL } := context
@@ -99,9 +64,6 @@ export async function load(url: string, context: any, next: any)
       // NOTE: Setting the source in the context makes it available when ts-node uses defaultLoad
       source: tsSource
 
-    // NOTE: we must install our source map support after ts-node does to take priority
-    ensureRegister()
-
     // Remove .tsx extension for final URL
     result.responseURL = (result.responseURL ?? transpiledUrl)
     .replace /.tsx$/, ''
@@ -109,8 +71,6 @@ export async function load(url: string, context: any, next: any)
     // parse source map from downstream (ts-node) result
     // compose with civet source map
     result.source = SourceMap.remap(result.source, sourceMap, url, result.responseURL)
-    // NOTE: This path needs to match what ts-node uses so we can override the source map
-    outputCache.set(normalizeSlashes(path), result.source)
 
     return result
 

--- a/test/infra/esm.civet
+++ b/test/infra/esm.civet
@@ -12,7 +12,7 @@ describe "esm", ->
     resolve("somefile.civet", {}, next)
     resolve("somefile.js", {}, next)
 
-  it "should load", ->
+  it "should load with ts-node", ->
     // This sets up a hacky loader next vaguely like the one in node's esm loading
     next := (url: string, context: unknown) ->
       // This simulates Node.js loading the modified source returned from the previous context

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -12,13 +12,21 @@ assert from assert
 compile := (src: string) ->
   return Function gen (parse src), {}
 
-execCmd := (cmd: string) ->
-  new Promise (resolve, reject) ->
-    exec cmd, (err, stdout, _stderr) ->
+function execCmd(cmd: string): Promise<string>
+  new Promise (resolve, reject) =>
+    exec cmd, (err, stdout, _stderr) =>
       if err
         reject err
       else
         resolve stdout
+
+function execCmdError(cmd: string): Promise<{err: Error, stderr: string}>
+  new Promise (resolve, reject) =>
+    exec cmd, (err, _stdout, stderr) =>
+      if err
+        resolve {err, stderr}
+      else
+        reject "expected error"
 
 describe "integration", ->
   // TODO: CoffeeScript single line comments
@@ -37,3 +45,9 @@ describe "integration", ->
     data := JSON.parse(fs.readFileSync("integration/example/dist/main.js.map", "utf8"))
 
     assert.equal data.sources[0], "main.civet"
+
+  for mode of ["cjs", "esm"]
+    it `should sourcemap correctly, ${mode} mode`, ->
+      {err, stderr} := await execCmdError `bash -c "(cd integration/example && ../../dist/civet --no-config error-${mode}.civet)"`
+      assert.match err.message, /Command failed/
+      assert.match stderr, ///error-#{mode}.civet:6:6///


### PR DESCRIPTION
Our rewrite in ESM support to NodeJS's new `module` `register` function (#1128) messed up `@cspotcode/source-map-support`. It seems that the `register`ed module (`esm.civet`) runs in a separate Worker or other context, so it doesn't enable sourcemap support in the main thread. We had a second call to source-map-support for CJS, but it was broken because it didn't specify `retrieveFile`.

A result of this is we can't (easily) use a cache to share the compiled source code between the build for loading and the build for sourcemapping. I think this is fine, as we only need to recompile when dealing with an exception, which is presumably exceptional. But I kept a cache in the sourcemapping side, in case the user uses exceptions for a lot of logic or something.

Also fixed a bug in CJS `require.extensions` mode (which still seems important for `node -r @danielx/civet/register`) that didn't use `sync` mode.

Also removed some claims that this ESM/CJS functionality needs `ts-node`. This hasn't been true for a while: we compile in `js: true` mode.