### PR TITLE
Fix empty then clause in if expressions

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -234,10 +234,12 @@ function expressionizeBlock(blockOrExpression: ASTNode)
       else
         results.push [ws, wrapped, ","]
 
-    if results.length > 1
-      return makeLeftHandSideExpression results
-
-    return results
+    if results# > 1
+      makeLeftHandSideExpression results
+    else if results#
+      results
+    else
+      ["void 0"]
   else
     blockOrExpression
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -676,6 +676,52 @@ describe "if", ->
     """
 
     testCase """
+      parenthesized expression
+      ---
+      x = (if y
+        "a"
+      else
+        "b"
+      )
+      ---
+      x = ((y?
+        "a"
+      :
+        "b")
+      )
+    """
+
+    testCase """
+      parenthesized expression with empty then block
+      ---
+      x = (if y
+      else
+        "b"
+      )
+      ---
+      x = ((y?void 0
+      :
+        "b")
+      )
+    """
+
+    testCase """
+      parenthesized expression with then and else on one line
+      ---
+      x = (if y then "a" else "b")
+      ---
+      x = ((y? "a" : "b"))
+    """
+
+    testCase """
+      parenthesized expression with empty then and else on one line
+      ---
+      x = (if y then else "b")
+      ---
+      x = ((y?void 0 : "b"))
+    """
+
+    testCase """
       postfix inside parenthesized expression
       ---
       x = (a if y)


### PR DESCRIPTION
Empty then blocks in `if` expressions currently produce invalid JS.  [Example](https://civet.dev/playground?code=eCA9IChpZiB5CmVsc2UgNSk%3D):

```js
x = (if y
else 5)
↓↓↓
x = ((y?
: 5))
```

This PR adds a missing `void 0`.