### PR TITLE
Revamp automatic async and generator, operator support

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -709,17 +709,7 @@ YieldExpression
 ArrowFunction
   ThinArrowFunction
   ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:suffix FatArrow:arrow FatArrowBody:expOrBlock ->
-    if (hasAwait(expOrBlock) && !async) {
-      async = "async "
-    }
-
-    let error
-    if (hasYield(expOrBlock)) {
-      error = {
-        type: "Error",
-        message: "Can't use yield inside of => arrow function",
-      }
-    }
+    if (!async) async = []
 
     return {
       type: "ArrowFunction",
@@ -731,10 +721,9 @@ ArrowFunction
       },
       parameters,
       returnType: suffix,
-      ts: false,
       async,
       block: expOrBlock,
-      children: [async, parameters, suffix, arrow, error, expOrBlock ],
+      children: [async, parameters, suffix, arrow, expOrBlock ],
     }
 
 FatArrow
@@ -2090,7 +2079,6 @@ FunctionSignature
       name: id?.name,
       parameters,
       returnType: suffix,
-      ts: false,
       async,
       generator,
       modifier: {
@@ -2116,16 +2104,6 @@ FunctionExpression
         signature,
         ts: true,
       }
-    }
-
-    if (hasAwait(block) && !signature.async.length) {
-      signature.async.push("async ")
-      signature.modifier.async = true
-    }
-
-    if (hasYield(block) && !signature.generator.length) {
-      signature.generator.push("*")
-      signature.modifier.generator = true
     }
 
     // Attach the block
@@ -2264,7 +2242,9 @@ OperatorDeclaration
 # NOTE: Like FunctionSignature, but no async or star or @,
 # and parameters are required (to be useful).
 OperatorSignature
-  Operator:op ( _ Function )?:func _:w1 Identifier:id OperatorBehavior?:behavior _?:w2 NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async _ )?:async Operator:op ( _ Function )?:func ( _? Star )?:generator _:w1 Identifier:id OperatorBehavior?:behavior _?:w2 NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
+    if (!async) async = []
+    if (!generator) generator = []
     // Add "function" (if not already one) to replace "operator"
     if (!func) {
       func = { $loc: op.$loc, token: "function" }
@@ -2274,12 +2254,17 @@ OperatorSignature
     return {
       type: "FunctionSignature",
       id,
-      modifier: {},
+      name: id.name,
       parameters,
       returnType: suffix,
-      ts: false,
+      async,
+      generator,
+      modifier: {
+        async: !!async.length,
+        generator: !!generator.length,
+      },
       block: null,
-      children: [ func, w1, id, w2, parameters, suffix ],
+      children: [ async, func, generator, w1, id, w2, parameters, suffix ],
       behavior,
     }
 
@@ -2311,29 +2296,24 @@ OperatorAssociativity
 
 ThinArrowFunction
   ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:suffix _? Arrow:arrow NoCommaBracedOrEmptyBlock:block ->
-    if (hasAwait(block) && !async) {
-      async = "async "
-    }
-
-    let generator
-    if (hasYield(block)) {
-      generator = "*"
-    }
+    if (!async) async = []
+    const generator = []
 
     return {
       type: "FunctionExpression",
       id: undefined,
       parameters,
       returnType: suffix,
-      ts: false,
       async,
       generator,
       block,
       signature: {
         name: undefined,
+        async,
+        generator,
         modifier: {
-          async: !!async,
-          generator: !!generator,
+          async: !!async.length,
+          generator: !!generator.length,
         },
         returnType: suffix,
       },

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -35,12 +35,17 @@ import {
 import {
   assert
   convertOptionalType
+  hasAwait
+  hasYield
+  inplacePrepend
   insertTrimmingSpace
   isEmptyBareBlock
   isExit
   isFunction
+  isStatement
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
+  makeNode
   updateParentPointers
   wrapIIFE
   wrapWithReturn
@@ -69,25 +74,23 @@ function isAsyncGeneratorVoidType(t?: TypeIdentifierNode): boolean
 
 // Add implicit block unless followed by a method/function of the same name,
 // or block is within an ExportDeclaration.
-function implicitFunctionBlock(f): void {
+function implicitFunctionBlock(f): void
   if (f.abstract or f.block or f.signature?.optional) return
 
-  const { name, parent } = f
+  { name, parent } := f
   if (parent?.type is "ExportDeclaration") return
-  const expressions = parent?.expressions ?? parent?.elements
-  const currentIndex = expressions?.findIndex(([, def]) => def is f)
-  const following = currentIndex >= 0 and expressions[currentIndex + 1]?.[1]
+  expressions := parent?.expressions ?? parent?.elements
+  currentIndex := expressions?.findIndex(([, def]) => def is f)
+  following := currentIndex >= 0 and expressions[currentIndex + 1]?.[1]
 
-  if (f.type is following?.type and name and name is following.name) {
+  if f.type is following?.type and name and name is following.name
     f.ts = true
-  } else {
-    const block = makeEmptyBlock()
+  else
+    block := makeEmptyBlock()
     block.parent = f
     f.block = block
     f.children.push(block)
     f.ts = false
-  }
-}
 
 function processReturn(f: FunctionNode, implicitReturns: boolean): void
   { returnType } .= f.signature
@@ -522,10 +525,32 @@ function processParams(f): void
       return
   expressions.unshift(...prefix)
 
+function processSignature(f: FunctionNode): void
+  {block, signature} := f
+
+  if hasAwait(block) and not f.async?#
+    f.async.push "async "
+    signature.modifier.async = true
+
+  if hasYield(block) and not f.generator?#
+    if f.type is "ArrowFunction"
+      gatherRecursiveWithinFunction block, .type is "YieldExpression"
+      .forEach (y) =>
+        i := y.children.findIndex .type is "Yield"
+        // i+1 because after "yield" we have a consistent location in sourcemap
+        y.children.splice i+1, 0,
+          type: "Error"
+          message: "Can't use yield inside of => arrow function"
+    else
+      f.generator.push "*"
+      signature.modifier.generator = true
+
 function processFunctions(statements, config): void
   gatherRecursiveAll(statements, ({ type }) => type is "FunctionExpression" or type is "ArrowFunction")
   .forEach (f) =>
-    if (f.type is "FunctionExpression") implicitFunctionBlock(f)
+    if f.type is "FunctionExpression"
+      implicitFunctionBlock(f)
+    processSignature(f)
     processParams(f)
     processReturn(f, config.implicitReturns)
 
@@ -626,10 +651,59 @@ function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
     }
   ]
 
+function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
+  {ref, typeSuffix, body} .= rhs
+  unless ref?
+    ref = makeRef "$"
+    inplacePrepend ref, body
+  if body?.type is "ObjectExpression"
+    body = makeLeftHandSideExpression body
+
+  parameters := makeNode {
+    type: "Parameters"
+    children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref]
+    names: []
+  } as ParametersNode
+  expressions := [[' ', body]] satisfies StatementTuple[]
+  block := makeNode {
+    type: "BlockStatement"
+    bare: true
+    expressions
+    children: [expressions]
+    implicitlyReturned: true
+  } as BlockStatement
+
+  async := []
+  children := [ async, parameters, " =>", block ]
+
+  fn := makeNode {
+    type: "ArrowFunction"
+    async
+    signature:
+      modifier: {
+        async: !!async
+      }
+    children
+    ref
+    block
+    parameters
+    ampersandBlock: true
+    body
+  } as ArrowFunction
+
+  if isStatement body
+    braceBlock block
+    // Prevent unrolling braced block
+    fn.ampersandBlock = false
+    delete fn.body
+
+  fn
+
 export {
   assignResults
   expressionizeIteration
   insertReturn
+  makeAmpersandFunction
   processCoffeeDo
   processFunctions
   processReturn

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -62,7 +62,6 @@ import {
   isFunction
   isWhitespaceOrEmpty
   literalValue
-  makeAmpersandFunction
   makeLeftHandSideExpression
   makeNode
   maybeWrap
@@ -102,9 +101,10 @@ import {
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf } from ./for.civet
 import {
+  expressionizeIteration
+  makeAmpersandFunction
   processCoffeeDo
   processFunctions
-  expressionizeIteration
   skipImplicitArguments
 } from ./function.civet
 import { processPatternMatching } from ./pattern-matching.civet

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -528,6 +528,8 @@ export type FunctionExpression =
   children: Children
   parent?: Parent
   name: string
+  async: ASTNode[]
+  generator: ASTNode[]
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
@@ -556,6 +558,8 @@ export type MethodDefinition =
   children: Children
   parent?: Parent
   name: string
+  async: ASTNode[]
+  generator: ASTNode[]
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
@@ -565,6 +569,7 @@ export type ArrowFunction =
   children: Children
   parent?: Parent
   name: string
+  async: ASTNode[]
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -330,13 +330,13 @@ function startsWith(target: ASTNode, value: RegExp)
  * Skips over nested functions, which have their own async behavior.
  */
 function hasAwait(exp)
-  gatherRecursiveWithinFunction(exp, ({ type }) => type is "Await").length > 0
+  gatherRecursiveWithinFunction(exp, .type is "Await").length > 0
 
 function hasYield(exp)
-  gatherRecursiveWithinFunction(exp, ({ type }) => type is "Yield").length > 0
+  gatherRecursiveWithinFunction(exp, .type is "Yield").length > 0
 
 function hasImportDeclaration(exp)
-  gatherRecursiveWithinFunction(exp, ({ type }) => type is "ImportDeclaration").length > 0
+  gatherRecursiveWithinFunction(exp, .type is "ImportDeclaration").length > 0
 
 /**
 * Copy an AST node deeply, including children.
@@ -378,55 +378,6 @@ function removeHoistDecs(node: ASTNode): void
   if node.children
     for child of node.children
       removeHoistDecs(child)
-
-function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
-  {ref, typeSuffix, body} .= rhs
-  unless ref?
-    ref = makeRef "$"
-    inplacePrepend ref, body
-  if body?.type is "ObjectExpression"
-    body = makeLeftHandSideExpression body
-
-  parameters := makeNode {
-    type: "Parameters"
-    children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref]
-    names: []
-  } as ParametersNode
-  expressions := [[' ', body]] satisfies StatementTuple[]
-  block := makeNode {
-    type: "BlockStatement"
-    bare: true
-    expressions
-    children: [expressions]
-    implicitlyReturned: true
-  } as BlockStatement
-
-  children := [ parameters, " =>", block ]
-  async := hasAwait(body)
-  if async
-    children.unshift("async ")
-
-  fn := makeNode {
-    type: "ArrowFunction"
-    signature:
-      modifier: {
-        async
-      }
-    children
-    ref
-    block
-    parameters
-    ampersandBlock: true
-    body
-  } as ArrowFunction
-
-  if isStatement body
-    braceBlock block
-    // Prevent unrolling braced block
-    fn.ampersandBlock = false
-    delete fn.body
-
-  fn
 
 skipParens := new Set [
   "AmpersandRef"
@@ -561,22 +512,21 @@ function parenthesizeType(type: ASTNodeBase)
 function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean): ASTNode
   let prefix
 
-  let async
+  async := []
   if asyncFlag
-    async = "async "
+    async.push "async "
   else if hasAwait expressions
-    async = "async "
+    async.push "async "
     prefix =
       type: "Await"
       children: ["await "]
 
   block := makeNode {
-    type: "BlockStatement",
-    expressions,
-    children: ["{", expressions, "}"],
-    bare: false,
-    root: false,
-    parent: undefined,
+    type: "BlockStatement"
+    expressions
+    children: ["{", expressions, "}"]
+    bare: false
+    root: false
   }
 
   parameters :=
@@ -586,11 +536,11 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean): ASTNode
 
   signature :=
     modifier:
-      async: !!async
+      async: !!async.length
     returnType: undefined
 
   fn := makeNode {
-    type: "ArrowFunction",
+    type: "ArrowFunction"
     signature
     parameters
     returnType: undefined
@@ -649,7 +599,6 @@ export {
   isToken
   isWhitespaceOrEmpty
   literalValue
-  makeAmpersandFunction
   makeLeftHandSideExpression
   makeNode
   maybeWrap

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -795,6 +795,74 @@ describe "custom identifier infix operators", ->
   """
 
   testCase """
+    implicit operator generator
+    ---
+    operator seq(a, b)
+      yield a
+      yield b
+      return
+    a seq b
+    ---
+    function* seq(a, b) {
+      yield a
+      yield b
+      return
+    }
+    seq(a, b)
+  """
+
+  testCase """
+    explicit operator generator
+    ---
+    operator* seq(a, b)
+      yield a
+      yield b
+      return
+    a seq b
+    ---
+    function* seq(a, b) {
+      yield a
+      yield b
+      return
+    }
+    seq(a, b)
+  """
+
+  testCase """
+    implicit async operator
+    ---
+    operator seq(a, b)
+      await a
+      await b
+      return
+    a seq b
+    ---
+    async function seq(a, b) {
+      await a
+      await b
+      return
+    }
+    seq(a, b)
+  """
+
+  testCase """
+    explicit async operator
+    ---
+    async operator seq(a, b)
+      await a
+      await b
+      return
+    a seq b
+    ---
+    async function seq(a, b) {
+      await a
+      await b
+      return
+    }
+    seq(a, b)
+  """
+
+  testCase """
     let operator
     ---
     operator let min = Math.min, max = Math.max

--- a/test/function.civet
+++ b/test/function.civet
@@ -244,7 +244,7 @@ describe "function", ->
       ---
       => yield 5
       ---
-      ParseErrors: unknown:1:3 Can't use yield inside of => arrow function
+      ParseErrors: unknown:1:9 Can't use yield inside of => arrow function
     """
 
     throws """
@@ -252,8 +252,19 @@ describe "function", ->
       ---
       => yield 5
       ---
-      ParseErrors: unknown:1:3 Can't use yield inside of => arrow function
+      ParseErrors: unknown:1:9 Can't use yield inside of => arrow function
     """, inlineMap: true
+
+    throws """
+      multiple forbidden yield
+      ---
+      =>
+        yield 1
+        yield 2
+      ---
+      ParseErrors: unknown:2:8 Can't use yield inside of => arrow function
+      unknown:3:8 Can't use yield inside of => arrow function
+    """
 
     testCase """
       thick arrow


### PR DESCRIPTION
* `async`/`*` now added in a postprocessing stage
* More code sharing
* Errors in `=>` now appear at `await` statements
* Fix support in `operator` (fixes #1248)
* Allow explicit `async` and `*` in `operator` definition (also #1248)