### PR TITLE
Sourcemap fix, show diagnostics with nonfatal parse errors

### DIFF
--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -560,7 +560,7 @@ async function updateDiagnosticsForDoc(document: TextDocument) {
           end,
         },
         message,
-        source: 'ts'
+        source: 'civet'
       }
     }).filter(x => !!x))
   }

--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -534,8 +534,7 @@ async function updateDiagnosticsForDoc(document: TextDocument) {
     console.log("no meta for ", sourcePath)
     return
   }
-  const { sourcemapLines, transpiledDoc, parseErrors } = meta
-  if (!transpiledDoc) return
+  const { sourcemapLines, transpiledDoc, parseErrors, fatal } = meta
 
   const transpiledPath = documentToSourcePath(transpiledDoc)
   const diagnostics: Diagnostic[] = [];
@@ -564,7 +563,8 @@ async function updateDiagnosticsForDoc(document: TextDocument) {
         source: 'ts'
       }
     }).filter(x => !!x))
-  } else {
+  }
+  if (!fatal) {
     [
       ...logTiming("service.getSyntacticDiagnostics", service.getSyntacticDiagnostics)(transpiledPath),
       ...logTiming("service.getSemanticDiagnostics", service.getSemanticDiagnostics)(transpiledPath),

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -10,9 +10,8 @@ export locationTable = (input: string) ->
   lines := []
   line .= 0
   pos .= 0
-  let result
 
-  while result = linesRe.exec(input)
+  while result := linesRe.exec(input)
     pos += result[0].length
     lines[line++] = pos
 
@@ -36,7 +35,7 @@ export SourceMap = (sourceString: string) ->
   sm :=
     lines: [[]] as SourceMapEntries
     line: 0
-    column: 0
+    colOffset: 0 // relative to previous entry
     srcLine: 0
     srcColumn: 0
     srcOffset: 0
@@ -46,12 +45,14 @@ export SourceMap = (sourceString: string) ->
 
   return
     data: sm
+    source: ->
+      sourceString
     renderMappings: ->
       lastSourceLine .= 0
       lastSourceColumn .= 0
 
-      sm.lines.map (line) ->
-        line.map (entry) ->
+      sm.lines.map (line) =>
+        line.map (entry) =>
           if entry.length is 4
             [colDelta, sourceFileIndex, srcLine, srcCol] .= entry
             lineDelta := srcLine - lastSourceLine
@@ -77,8 +78,7 @@ export SourceMap = (sourceString: string) ->
     updateSourceMap: (outputStr: string, inputPos?: number, colOffset=0) ->
       outLines := outputStr.split(EOL)
 
-      let srcLine: number,
-        srcCol: number
+      let srcLine: number, srcCol: number
 
       if inputPos?
         [srcLine, srcCol] = lookupLineColumn(srcTable, inputPos)
@@ -87,16 +87,16 @@ export SourceMap = (sourceString: string) ->
         sm.srcColumn = srcCol
         sm.srcOffset = inputPos + outputStr#
 
-      outLines.forEach (line, i) ->
+      for each line, i of outLines
         if i > 0
           sm.line++
           sm.srcLine++
-          sm.column = 0
+          sm.colOffset = 0
           sm.lines[sm.line] = []
           sm.srcColumn = srcCol = colOffset
 
-        l := sm.column
-        sm.column += line.length
+        l := sm.colOffset
+        sm.colOffset = line.length
         sm.srcColumn += line.length
 
         if inputPos?
@@ -134,8 +134,8 @@ remap := (codeWithSourceMap: string, upstreamMap: {data: {lines: SourceMapEntrie
   return remappedCodeWithSourceMap
 
 composeLines := (upstreamMapping: SourceMapEntries, lines: SourceMapEntries): SourceMapEntries ->
-  lines.map (line) ->
-    line.map (entry) ->
+  lines.map (line) =>
+    line.map (entry) =>
       if entry.length is 1
         return entry
 
@@ -145,7 +145,7 @@ composeLines := (upstreamMapping: SourceMapEntries, lines: SourceMapEntries): So
       if !srcPos
         return [entry[0]]
 
-      [ upstreamLine, upstreamCol] := srcPos
+      [ upstreamLine, upstreamCol ] := srcPos
 
       if entry.length is 4
         return [colDelta, sourceFileIndex, upstreamLine, upstreamCol]
@@ -158,11 +158,11 @@ parseWithLines := (base64encodedJSONstr: string) ->
   sourceLine .= 0
   sourceColumn .= 0
 
-  lines := json.mappings.split(";").map (line) ->
+  lines := json.mappings.split(";").map (line) =>
     if line.length is 0
       return []
 
-    line.split(",").map (entry) ->
+    line.split(",").map (entry) =>
       result := decodeVLQ entry
 
       switch result.length
@@ -190,8 +190,7 @@ prettySourceExcerpt := (source: string, location: {line: number, column: number}
 
   // print the source code above and below the error location with line numbers and underline from location to length
   for i of [lineNum - 2 .. lineNum + 2]
-    if i < 0 or i >= lines.length
-      continue
+    continue unless 0 <= i < lines.length
 
     line := lines[i]
     lineNumStr .= (i + 1).toString()
@@ -241,7 +240,7 @@ export base64Encode = (src: string) ->
 vlqTable := new Uint8Array(128)
 vlqChars := 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 
-;(->
+do
   i .= 0
   l .= vlqTable.length
   while i < l
@@ -252,7 +251,6 @@ vlqChars := 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
   while i < l
     vlqTable[vlqChars.charCodeAt(i)] = i
     i++
-)();
 
 /* c8 ignore start */
 decodeError := (message: string) ->
@@ -265,7 +263,7 @@ decodeVLQ := (mapping: string) ->
   result .= []
 
   // Scan over the input
-  while (i < l)
+  while i < l
     shift .= 0
     vlq .= 0
     v .= 0
@@ -319,15 +317,15 @@ remapPosition := (position: [number, number], sourcemapLines: SourceMapEntries) 
   lastMapping .= undefined
   lastMappingPosition .= 0
 
-  while (i < l)
+  while i < l
     mapping := textLine[i]
     p += mapping[0]
 
-    if (mapping.length is 4)
+    if mapping.length is 4
       lastMapping = mapping
       lastMappingPosition = p
 
-    if (p >= character)
+    if p >= character
       break
 
     i++
@@ -335,7 +333,7 @@ remapPosition := (position: [number, number], sourcemapLines: SourceMapEntries) 
   if character - lastMappingPosition != 0
     return undefined
 
-  if (lastMapping)
+  if lastMapping
     [lastMapping[2], lastMapping[3]]
 
   else

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -50,4 +50,4 @@ describe "integration", ->
     it `should sourcemap correctly, ${mode} mode`, ->
       {err, stderr} := await execCmdError `bash -c "(cd integration/example && ../../dist/civet --no-config error-${mode}.civet)"`
       assert.match err.message, /Command failed/
-      assert.match stderr, ///error-#{mode}.civet:6:6///
+      assert.match stderr, ///error-#{mode}.civet:6:7///


### PR DESCRIPTION
It turns out #1262 introduced a bug in sourcemaps, which caused the VSCode plugin to crash because of negative column numbers. 😦 The key fix in this PR is removing the `+` here:

```diff
-        sm.column += line.length
+        sm.colOffset = line.length
```

Fixing this restores correct behavior. This is fairly urgent because the VSCode plugin is currently broken.

I also added a feature to the LSP / VSCode plugin: if there are nonfatal errors (via `Error` nodes), so there's still a transpiled document, we still get TypeScript diagnostics. Example:

![image](https://github.com/DanielXMoore/Civet/assets/2218736/d15f1df6-9186-4a42-8866-d9f453f7debf)

