### PR TITLE
Replacing some instances of __ with stricter whitespace checking

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -213,7 +213,7 @@ NonPipelineExtendedExpression
 NonAssignmentExtendedExpression
   # Check for nested expressionized statements first
   NestedNonAssignmentExtendedExpression
-  __ ExpressionizedStatementWithTrailingCallExpressions ->
+  _? ExpressionizedStatementWithTrailingCallExpressions ->
     return prepend($1, $2)
 
 NestedNonAssignmentExtendedExpression
@@ -621,13 +621,13 @@ AssignmentExpression
   # NOTE: Try to match a single line assignment expression before matching newline then assignment expression
   SingleLineAssignmentExpression
   # TODO: Ideally this wouldn't be needed.
-  __ AssignmentExpressionTail
+  ( EOS _? ) AssignmentExpressionTail
   # NonPipelineAssignmentExpression
 
 NonPipelineAssignmentExpression
   # NOTE: Try to match a single line assignment expression before matching newline then assignment expression
   NonPipelineSingleLineAssignmentExpression
-  __ NonPipelineAssignmentExpressionTail
+  ( EOS _? ) NonPipelineAssignmentExpressionTail
 
 SingleLineAssignmentExpression
   _?:ws AssignmentExpressionTail:tail ->

--- a/test/if.civet
+++ b/test/if.civet
@@ -539,7 +539,8 @@ describe "if", ->
       else
         "b"
       ---
-      let ref;if (y) {
+      let ref;
+      if (y) {
         ref = "a"
       }
       else {


### PR DESCRIPTION
I was experimenting with #918 by trying to reduce recursion opportunities by avoiding rules that consume zero tokens. It didn't solve the issue but I think it's a good direction.