### PR TITLE
Binary op fixes

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -469,7 +469,7 @@ BinaryOpExpression
     return processBinaryOpExpression($0)
 
 BinaryOpRHS
-  ( _? / IndentedFurther / Nested ):ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
+  NotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
     return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
@@ -487,7 +487,7 @@ BinaryOpRHS
   !NewlineBinaryOpAllowed SingleLineBinaryOpRHS -> $2
 
 IsLike
-  Is _? ( Not _? )?:not Like ->
+  Is _? ( OmittedNegation _? )?:not Like ->
     return {
       type: "PatternTest",
       children: $0,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -473,7 +473,7 @@ BinaryOpRHS
     return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
-    // Insert empty whitespace placeholder to maintan structure
+    // Insert empty whitespace placeholder to maintain structure
     return [[], op, [], rhs]
   # Spaced binary ops a + b
   # a
@@ -497,15 +497,15 @@ IsLike
 
 # Whitespace followed by RHS
 WRHS
-  PushIndent ( Nested RHS )?:wrhs PopIndent ->
+  PushIndent ( Nested _? RHS )?:wrhs PopIndent ->
     if (!wrhs) return $skip
     return wrhs
-  ( _ / ( EOS __ )) RHS
+  ( ( EOS __ ) / _ ) RHS
 
 SingleLineBinaryOpRHS
   # NOTE: It's named single line but that's only for the operator, the RHS can be after a newline
   # This is to maintain compatibility with CoffeeScript conditions
-  _?:ws1 BinaryOp:op ( _ / ( EOS __ ) ):ws2 RHS:rhs ->
+  _?:ws1 BinaryOp:op ( ( EOS __ ) / _ ):ws2 RHS:rhs ->
     return [ws1 || [], op, ws2, rhs]
 
 RHS

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3642,7 +3642,7 @@ IdentifierBinaryOp
     return $skip
 
 BinaryOp
-  /(?=\p{ID_Start}|[_$^«»⋙≤≥∈∋∉∌≣≡≢≠=‖⁇&|*\/!?%<>⧺+-])/ _BinaryOp:op -> op
+  /(?=\p{ID_Start}|[_$^«»⋙≤≥∈∋∉∌≣≡≢≠=⩶⩵‖⁇&|*\/!?%<>⧺+-])/ _BinaryOp:op -> op
 
 _BinaryOp
   BinaryOpSymbol ->

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -517,6 +517,16 @@ describe "binary operations", ->
   """
 
   testCase """
+    space before newline
+    ---
+    a ||\u0020
+    b
+    ---
+    a ||\u0020
+    b
+  """
+
+  testCase """
     weird spacing
     ---
     a

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -669,6 +669,14 @@ describe "binary operations", ->
     a <= b && b >= c && c != d && d !== e && e == f && f === g
   """
 
+  testCase """
+    long Unicode relations
+    ---
+    a ⩵ b ⩶ c
+    ---
+    a == b && b === c
+  """
+
 describe "custom identifier infix operators", ->
   testCase """
     bless

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1222,6 +1222,14 @@ describe "custom identifier infix operators", ->
     """
 
     testCase """
+      is !like
+      ---
+      x is !like {type: "Ref"}
+      ---
+      !(typeof x === 'object' && x != null && 'type' in x && x.type === "Ref")
+    """
+
+    testCase """
       section
       ---
       (is like {type: "Ref"})


### PR DESCRIPTION
A few binary op fixes:
* Handle trailing spaces before newlines (fixes #1281)
* `is !like` to match other `!` shorthand for `not`
* Fix support for `⩵` and `⩶` (Unicode double and triple equals). These were supported to work, but weren't in the lookahead.