### PR TITLE
Cleanup Bun loader code

### DIFF
--- a/integration/example/test.civet
+++ b/integration/example/test.civet
@@ -1,3 +1,7 @@
 // For example, this file can be run in Bun via `bun run test.civet`
 // (thanks to `bunfig.toml` in this directory).
-console.log 'hello from civet'
+
+function greet(src: string)
+  console.log `Hello from ${src}!`
+
+greet 'Civet'

--- a/source/bun-civet.civet
+++ b/source/bun-civet.civet
@@ -9,20 +9,25 @@ After that, you can use .civet files with the Bun cli, like:
 $ bun file.civet
 ###
 
-import { plugin } from 'bun'
+import { plugin, file } from 'bun'
+//import { plugin, file, Transpiler } from 'bun'
 
-await plugin
+await plugin {
   name: 'Civet loader'
-  setup: (builder) ->
+  setup(builder)
     { compile } := await import('./main.mjs')
-    { readFile } := await import('node:fs/promises')
+    //transpiler := new Transpiler loader: 'tsx'
 
-    builder.onLoad filter: /\.civet$/, ({path}) ->
-      source := await readFile path, 'utf8'
+    builder.onLoad filter: /\.civet$/, ({path}) =>
+      source := file path |> .text() |> await
       // Compiling and running at the same time, so enable comptime
       // to ensure any async promises get resolved
-      contents := await compile source, comptime: true
+      contents .= await compile source, comptime: true
+      // Transpile directly as workaround to loader spec below not working
+      //contents = await transpiler.transform contents
 
-      return
-        contents: contents
+      return {
+        contents
         loader: 'tsx'
+      }
+}


### PR DESCRIPTION
This was an attempt at #1286, but the Transpiler doesn't actually seem to work as desired (need to manually specify `tsconfig`, and even then, it doesn't seem to add the implicit `import`, and the result behaves weird if the module has no `import`/`export`). But the cleanup was a moderate improvement, so I'm submitting that:

* Modify example to include TypeScript type notation, for testing
* Use Bun's file interface instead of Node compatibility layer
* Use braced object notation for cleaner methods
* Commented out code for manual transpilation of JSX (doesn't work yet)