### PR TITLE
Self-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         file: coverage/lcov.info
 
-  build:
+  self-test:
     name: Self-Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,6 @@ jobs:
     - name: Install and Test
       run: |
         yarn
-        yarn build
         yarn test:self
 
   build-docs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: Build and Test
     runs-on: ubuntu-latest
     steps:
 
@@ -38,6 +38,25 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         file: coverage/lcov.info
+
+  build:
+    name: Self-Test
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        cache: yarn
+        node-version: 20
+
+    - name: Install and Test
+      run: |
+        yarn
+        yarn build
+        yarn test:self
 
   build-docs:
     name: Build Docs

--- a/.mocharc-self.json
+++ b/.mocharc-self.json
@@ -1,0 +1,16 @@
+// Self-test: run Civet tests using the current built version of Civet
+{
+  "extension": [
+    "civet",
+    "coffee"
+  ],
+  "loader": [
+    "@danielx/hera/esm",
+    "./dist/esm.mjs"
+  ],
+  "reporter": "dot",
+  "recursive": true,
+  "spec": [
+    "test"
+  ]
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,15 @@
+{
+  "extension": [
+    "civet",
+    "coffee"
+  ],
+  "loader": [
+    "@danielx/hera/esm",
+    "./node_modules/@danielx/civet/dist/esm.mjs"
+  ],
+  "reporter": "dot",
+  "recursive": true,
+  "spec": [
+    "test"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "docs:preview": "yarn build && vitepress preview civet.dev",
     "prepublishOnly": "yarn build && yarn test",
     "test": "bash ./build/test.sh",
-    "test:self": "mocha --config .mocharc-self.json"
+    "test:self": "yarn build && mocha --config .mocharc-self.json"
   },
   "author": "Daniel X. Moore",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "docs:build": "yarn build && vitepress build civet.dev",
     "docs:preview": "yarn build && vitepress preview civet.dev",
     "prepublishOnly": "yarn build && yarn test",
-    "test": "bash ./build/test.sh"
+    "test": "bash ./build/test.sh",
+    "test:self": "mocha --config .mocharc-self.json"
   },
   "author": "Daniel X. Moore",
   "license": "MIT",
@@ -120,21 +121,6 @@
     "exclude": [
       "source/parser/types.civet",
       "source/bun-civet.civet"
-    ]
-  },
-  "mocha": {
-    "extension": [
-      "civet",
-      "coffee"
-    ],
-    "loader": [
-      "@danielx/hera/esm",
-      "./node_modules/@danielx/civet/dist/esm.mjs"
-    ],
-    "reporter": "dot",
-    "recursive": true,
-    "spec": [
-      "test"
     ]
   }
 }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -497,7 +497,7 @@ IsLike
 
 # Whitespace followed by RHS
 WRHS
-  PushIndent ( Nested _? RHS )?:wrhs PopIndent ->
+  PushIndent ( ( Nested _? ) RHS )?:wrhs PopIndent ->
     if (!wrhs) return $skip
     return wrhs
   ( ( EOS __ ) / _ ) RHS

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1222,6 +1222,17 @@ describe "custom identifier infix operators", ->
     """
 
     testCase """
+      indented form
+      ---
+      bare and
+        expressions is like []
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      bare &&
+        (Array.isArray(expressions) && len(expressions, 0))
+    """
+
+    testCase """
       is not like
       ---
       x is not like {type: "Ref"}


### PR DESCRIPTION
Implementing https://github.com/DanielXMoore/Civet/pull/1263#issuecomment-2127573885 :

> I wonder about adding another test mode that runs yarn test but where it uses the current code to build itself (after building itself with the current release). Essentially yarn build + yarn test using the current build instead of NPM. I wouldn't run this all the time, probably, but it would be especially good for CI testing to avoid surprises like this in the future. Civet is of course the largest example of Civet code, so it's a good real-world test.

I came across this again in https://effectivetypescript.com/2024/04/16/inferring-a-type-predicate/ (text and video), which calls this TypeScript's "self-check", so I've adopted the "self-test" terminology here.
* `yarn test:self` is a variation on `yarn test` that runs Mocha with the current built version, after running `yarn build`. (Open to better naming convention. Building first seems important here.)
* CI includes a parallel job to run this self-test. So wait time should be the same, just using more minutes.

While implementing this, I found a bug where a line of `source/parser/util.civet` wouldn't parse. So even more evidence that this is an important test to have! I fixed that bug too.