### PR TITLE
Fix argument parsing

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -409,23 +409,28 @@ ArgumentList
 # NOTE: ArgumentList variant that forbids top-level pipeline operators
 NonPipelineArgumentList
   # Check for same line arguments then nested arguments
-  NonPipelineArgumentPart ( CommaDelimiter !EOS _? NonPipelineArgumentPart )* ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
+  !EOS NonPipelineArgumentPart ( CommaDelimiter !EOS _? NonPipelineArgumentPart )* ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
     return [
-      $1,
-      ...$2.flatMap(([comma, eos, ws, arg]) => [comma, prepend(ws, arg)]),
-      ...$3.flatMap(([comma, args]) =>
+      $2,
+      ...$3.flatMap(([comma, eos, ws, arg]) => [comma, prepend(ws, arg)]),
+      ...$4.flatMap(([comma, args]) =>
         Array.isArray(args) ? [comma, ...args] : [comma, args]
-      )
+      ),
     ]
   # NOTE: Added nested arguments on separate new lines
-  NestedImplicitObjectLiteral ->
-    return [ insertTrimmingSpace($1, '') ]
+  NestedImplicitObjectLiteral ( CommaDelimiter ( NestedImplicitObjectLiteral / NestedArgumentList ) )* ->
+    return [
+      insertTrimmingSpace($1, ''),
+      ...$2.flatMap(([comma, args]) =>
+        Array.isArray(args) ? [comma, ...args] : [comma, args]
+      ),
+    ]
   NestedArgumentList
   # NOTE: Eliminated left recursion
-  _? NonPipelineArgumentPart ( CommaDelimiter _? NonPipelineArgumentPart )* ->
+  NonPipelineArgumentPart ( CommaDelimiter _? NonPipelineArgumentPart )* ->
     return [
-      prepend($1, $2),
-      ...$3.flatMap(([comma, ws, arg]) => [comma, prepend(ws, arg)]),
+      $1,
+      ...$2.flatMap(([comma, ws, arg]) => [comma, prepend(ws, arg)]),
     ]
 
 NestedArgumentList

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -358,7 +358,7 @@ describe "function application", ->
     ,
       handleUncaughtExceptions: false
     ---
-    sourceMapSupport( {
+    sourceMapSupport({
       environment: 'node',
     }
     , {

--- a/test/object.civet
+++ b/test/object.civet
@@ -327,6 +327,24 @@ describe "object", ->
     }
   """
 
+  testCase do
+    big := (
+      for i in [1..100]
+        `  x${i}: x${i}`
+    ).join '\n'
+    """
+      huge nested object
+      ---
+      defaultColors :=
+      BIG
+      ---
+      const defaultColors = {
+      BIGCOMMA
+      }
+    """
+    .replace /BIGCOMMA/, big.replace /$/mg, ','
+    .replace /BIG/, big
+
   testCase """
     mix of top-level and inline
     ---


### PR DESCRIPTION
Fixes #918 by preventing accidental double matching of different cases of arguments.

This does not fix one missing `PushIndent` mentioned in https://github.com/DanielXMoore/Civet/issues/918#issuecomment-2189107922, which I'll probably leave for another PR: We don't consider indented expressions that are normal expressions, only those that are expressionized statements. So `x =\n  if ...` is considered an indented expression, but `x =\n  y` isn't. I think this is broken. For example, `a =\n  x\n  y` probably shouldn't [parse as a function call](https://civet.dev/playground?code=YSA9CiAgeAogIHk%3D).
