### PR TITLE
Upgrade TypeScript

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -106,7 +106,7 @@
     "nyc": "^15.1.0",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.6.0",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "vscode-languageclient": "^8.0.2",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.7"

--- a/lsp/yarn.lock
+++ b/lsp/yarn.lock
@@ -2412,10 +2412,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
+  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "license": "MIT",
   "dependencies": {
     "@cspotcode/source-map-support": "^0.8.1",
-    "@typescript/vfs": "^1.5.0",
+    "@typescript/vfs": "^1.5.3",
     "unplugin": "^1.6.0"
   },
   "devDependencies": {
@@ -90,7 +90,7 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
     "tsup": "^7.2.0",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "vite": "^4.4.12",
     "vitepress": "^1.0.0-alpha.35",
     "vscode-languageserver": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -547,6 +547,13 @@
   dependencies:
     debug "^4.1.1"
 
+"@typescript/vfs@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.5.3.tgz#b3e9e580cbdf282d6581543dcf3b2c0e44ebf9fb"
+  integrity sha512-OSZ/o3wwD5VPZVdGGsXWk7sRGRtwrGnqA4zwmb33FTs7Wxmad0QTkQCbaNyqWA8hL09TCwAthdp8yjFA5G1lvw==
+  dependencies:
+    debug "^4.1.1"
+
 "@vue/compiler-core@3.3.4":
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.4.tgz#7fbf591c1c19e1acd28ffd284526e98b4f581128"
@@ -1869,10 +1876,10 @@ tsup@^7.2.0:
     sucrase "^3.20.3"
     tree-kill "^1.2.2"
 
-typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
+  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
TypeScript 5.5 should save us from having to give explicit types for type predicates, so it's a worthy improvement to the LSP in particular.

I did a simple test (counting errors from `civet --typecheck source/**/*.civet`) and it went down from 863 to 836. Not a huge decrease but a good sign!

Side note: A bunch of these ~800 errors aren't "real" (don't show up in the LSP); it seems that `civet --typecheck` isn't getting the type declarations from Node, so probably failing to load `tsconfig.json` somehow. Once resolved, we might make this a CI process to help count the number of errors and watch it go down, as in the mission of #1283.