### PR TITLE
Fix extension for CLI's `--typecheck`

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,4 +1,4 @@
-{ compile, generate, parse, lib, isCompileError, SourceMap } from ./main.civet
+{ compile, generate, parse, lib, isCompileError, SourceMap, type ParseError, type ParseErrors } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
 // unplugin ends up getting installed in the same dist directory
@@ -64,13 +64,13 @@ if process.argv.some (is like "--help", "-help", "-h")
 
 encoding .= "utf8" as BufferEncoding
 
-fs from "fs/promises"
-type { Stats } from fs
-path from "path"
+fs from node:fs/promises
+type { Stats } from node:fs
+path from node:path
 
 // TODO: Once the types are exported within the Civet source code,
 // we should import them directly here, instead of looking at an old release.
-type { CompileOptions } from "@danielx/civet"
+type { CompileOptions } from @danielx/civet
 
 interface Options extends CompileOptions
   run?: boolean
@@ -271,15 +271,15 @@ export function repl(options: Options)
       else if input in ['quit\n', 'exit\n', 'quit()\n', 'exit()\n']
         process.exit 0
       else if input.endsWith '\n\n'  // finished input with blank line
-        function showError(error)
+        function showError(error: ???)
           console.error "Error while parsing Civet code:"
           if isCompileError error
             // Unwrap ParseErrors to first error
             if (error as ParseErrors).errors?
               error = (error as ParseErrors).errors[0]
             console.log """
-              #{input.split('\n')[0...error.line].join '\n'}
-              #{' '.repeat error.column - 1}^ #{error.header}
+              #{input.split('\n')[0...(error as ParseError).line].join '\n'}
+              #{' '.repeat (error as ParseError).column - 1}^ #{(error as ParseError).header}
             """
           else
             console.error error
@@ -388,7 +388,8 @@ export function cli
       ts: if options.js then 'civet' else 'preserve'
       outputExtension: '.tsx'
     }
-    (unpluginOptions.parseOptions ??= {}).rewriteCivetImports = '.civet.tsx'
+    // TypeScript wants .civet.tsx files imported as .civet.jsx
+    (unpluginOptions.parseOptions ??= {}).rewriteCivetImports = '.civet.jsx'
     unplugin = rawPlugin unpluginOptions, framework: 'civet-cli'
     await unplugin.buildStart()
 


### PR DESCRIPTION
In trying to get Civet to typecheck itself, I noticed that `import`ing a `.civet` file didn't resolve because of the dreaded "import `.js` to get a `.ts` file" issue.

Also add a bit of typing to CLI itself.

This PR reduces the number of self-check type errors from 722 to 635, most of which seem "real".

(These numbers are assuming https://github.com/microsoft/TypeScript-Website/pull/3165 gets merged; until then, the numbers are higher because Node isn't successfully imported. Though we work around that issue by adding `types: ['node']` to `tsconfig.json`.)