### PR TITLE
Fix if types

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,5 +122,6 @@
       "source/parser/types.civet",
       "source/bun-civet.civet"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6882,6 +6882,9 @@ InterfaceBlock
   __ OpenBrace NestedInterfaceProperties __ CloseBrace
   __ OpenBrace ( __ InterfaceProperty )* __ CloseBrace
   # NOTE: Added indentation based implied braces
+  NestedInterfaceBlock
+
+NestedInterfaceBlock
   InsertOpenBrace NestedInterfaceProperties InsertNewline InsertIndent InsertCloseBrace
 
 NestedInterfaceProperties
@@ -7082,7 +7085,7 @@ TypeSuffix
 MaybeNestedType
   # NOTE: Let InterfaceBlock take first crack at an indented block
   # But don't prevent parsing a braced type with unary suffix like {}[]
-  !(__ OpenBrace) InterfaceBlock -> $2
+  NestedInterfaceBlock
   PushIndent ( Nested Type )? PopIndent ->
     if (!$2) return $skip
     return $2
@@ -7302,7 +7305,8 @@ TypeElse
 TypeBlock
   Then Type -> $2
   !EOS Type -> $2
-  PushIndent (Nested Type)? PopIndent ->
+  NestedInterfaceBlock
+  PushIndent ( Nested Type )? PopIndent ->
     if (!$2) return $skip
     return $2
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7278,8 +7278,8 @@ NestedType
 TypeConditional
   _? /(?=if|unless)/ TypeIfThenElse ->
     return [$1, expressionizeTypeIf($3)]
-  TypeCondition NotDedented QuestionMark Type __ Colon Type ->
-    if ($1.negated) return [ $1, $2, $3, $7, $5, $6, $4 ]
+  TypeCondition NotDedented QuestionMark __ Type __ Colon __ Type ->
+    if ($1.negated) return [ $1, $2, $3, $4, $9, $6, $7, $8, $5 ]
     return $0
   TypeBinary
 

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -330,6 +330,16 @@ describe "[TS] type declaration", ->
     type Example1 = Dog extends Animal<infer U> ? U : string
   """
 
+  testCase """
+    conditional with newline after colon
+    ---
+    type Example1 = Dog extends Animal ? number :
+                    Dog extends Plant ? string : unknown
+    ---
+    type Example1 = Dog extends Animal ? number :
+                    Dog extends Plant ? string : unknown
+  """
+
   describe "extends shorthand", ->
     testCase """
       conditional

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -506,6 +506,25 @@ describe "[TS] type declaration", ->
     """
 
     testCase """
+      multi-line with interface block
+      ---
+      type Output =
+        if T extends { sourceMap: true }
+          code: string
+          sourceMap: SourceMap
+        else
+          string
+      ---
+      type Output =
+        (T extends { sourceMap: true }? {
+          code: string
+          sourceMap: SourceMap
+        }
+        :
+          string)
+    """
+
+    testCase """
       else matching
       ---
       type Example1 =


### PR DESCRIPTION
Fixes #1181:

* Allow arbitrary spaces around colon in type ternary
* Support nested interface block in if/else types

The big example from #1181 now works correctly:

```js
export function compile<T extends CompileOptions>(src: string, options?: T): Promise<
  if T extends { ast: true }
    CivetAST
  else
    if T extends { sourceMap: true }
      code: string
      sourceMap: SourceMap
    else
      string
>
---
export function compile<T extends CompileOptions>(src: string, options?: T): Promise<
  (T extends { ast: true }?
    CivetAST
  :
    (T extends { sourceMap: true }? {
      code: string
      sourceMap: SourceMap
    }
    :
      string))
>
```