### PR TITLE
Add class with A, B mixin notation

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -13,6 +13,7 @@ import {
   blockWithPrefix,
   convertNamedImportsToObject,
   convertObjectToJSXAttributes,
+  convertWithClause,
   dedentBlockString,
   dedentBlockSubstitutions,
   deepCopy,
@@ -57,6 +58,7 @@ import {
   reorderBindingRestProperty,
   replaceNodes,
   skipImplicitArguments,
+  trimFirstSpace,
   typeOfJSX,
 } from "./parser/lib.civet"
 
@@ -936,11 +938,29 @@ ClassBinding
 
 # https://262.ecma-international.org/#prod-ClassHeritage
 ClassHeritage
-  ExtendsClause ImplementsClause?
-  ImplementsClause
+  ExtendsClause:extendsClause WithClause?:withClause ImplementsClause?:implementsClause ->
+    if (withClause) {
+      extendsClause = convertWithClause(withClause, extendsClause)
+    }
+    return [ extendsClause, implementsClause ]
+
+  WithClause?:withClause ImplementsClause?:implementsClause ->
+    if (withClause) return [ convertWithClause(withClause), implementsClause ]
+    if (implementsClause) return implementsClause
+    return $skip
 
 ExtendsClause
   ExtendsToken __ ExtendsTarget
+
+# with for mixin shorthand
+# class A extends B with C, D -> class A extends D(C(B))
+WithClause
+  __ With __:ws ExtendsTarget:t ( "," __ ExtendsTarget )*:rest ->
+    return {
+      type: "WithClause",
+      children: $0,
+      targets: [[ws, t], ...rest.map(([_comma, ws, target]) => [ws, target])],
+    }
 
 ExtendsToken
   # NOTE: Added "<" extends shorthand
@@ -6106,6 +6126,10 @@ When
 
 While
   "while" NonIdContinue ->
+    return { $loc, token: $1 }
+
+With
+  "with" NonIdContinue ->
     return { $loc, token: $1 }
 
 Yield

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -6,6 +6,7 @@ import type {
   Binding
   BlockStatement
   DeclarationStatement
+  ExpressionNode
   IfStatement
   Initializer
   IterationStatement
@@ -13,6 +14,7 @@ import type {
   StatementTuple
   SwitchStatement
   TypeSuffix
+  WithClause
   WSNode
 } from ./types.civet
 
@@ -37,7 +39,9 @@ import {
 import {
   convertOptionalType
   isExit
+  makeLeftHandSideExpression
   makeNode
+  trimFirstSpace
   updateParentPointers
 } from ./util.civet
 
@@ -507,7 +511,41 @@ function dynamizeImportDeclarationExpression($0)
     ]
   }
 
+function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSNode, ExpressionNode])
+  let extendsToken, extendsTarget, ws: WSNode
+  if extendsClause
+    [ extendsToken, ws, extendsTarget ] = extendsClause
+  else
+    extendsToken =
+      type: "Extends"
+      children: [" extends"]
+    ws = ""
+    extendsTarget = "Object"
+
+  wrapped := withClause.targets.reduce (extendsTarget, [wsNext, withTarget]) =>
+    args := [ extendsTarget ]
+    exp := {
+      type: "CallExpression",
+      children: [
+        makeLeftHandSideExpression(withTarget),
+        {
+          type: "Call",
+          args,
+          children: ["(", trimFirstSpace(ws), args, ")"],
+        },
+      ],
+    } as ExpressionNode
+
+    ws = wsNext
+
+    return exp
+  , extendsTarget
+
+  // Ensure at least one space after extends token
+  return [ extendsToken, insertTrimmingSpace(ws, " "), wrapped ]
+
 export {
+  convertWithClause
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -68,6 +68,7 @@ import {
   maybeUnwrap
   parenthesizeType
   prepend
+  trimFirstSpace
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
@@ -90,6 +91,7 @@ import {
 } from ./block.civet
 
 import {
+  convertWithClause
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
@@ -1536,6 +1538,7 @@ export {
   blockWithPrefix
   convertNamedImportsToObject
   convertObjectToJSXAttributes
+  convertWithClause
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
@@ -1587,6 +1590,7 @@ export {
   reorderBindingRestProperty
   replaceNodes
   skipImplicitArguments
+  trimFirstSpace
   typeOfJSX
   wrapIIFE
 }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -675,3 +675,8 @@ export type VoidType = ASTLeaf & type: "VoidType"
 export type TypeLiteralNode = ASTLeaf | VoidType
 
 export type ThisAssignments = [string, ASTRef][]
+
+export type WithClause =
+  type: "WithClause"
+  children: Children
+  targets: [WSNode, ExpressionNode][]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -229,8 +229,17 @@ function insertTrimmingSpace(target: ASTNode, c: string): ASTNode
       ...target
       token: target.token.replace(/^ ?/, c)
     }
+  else if target <? "string"
+    target.replace(/^ ?/, c)
   else
     target
+
+/**
+ * Trims the first single space from the spacing array or node's children if present
+ * maintains $loc for source maps
+ */
+function trimFirstSpace(target: ASTNode): ASTNode
+  insertTrimmingSpace target, ""
 
 function inplaceInsertTrimmingSpace(target: ASTNode, c: string): void
   return target unless target?
@@ -610,6 +619,7 @@ export {
   removeParentPointers
   skipIfOnlyWS
   startsWith
+  trimFirstSpace
   updateParentPointers
   wrapIIFE
   wrapWithReturn

--- a/test/class.civet
+++ b/test/class.civet
@@ -1341,3 +1341,26 @@ describe "class", ->
         }
       }
     """
+
+  describe "mixin 'with' notation", ->
+    testCase """
+      with notation
+      ---
+      class A extends /*B*/ B with /*C*/C, /*D*/ D, /*E*/ E
+        x = 3
+      ---
+      class A extends /*E*/ E(/*D*/ D(/*C*/C(/*B*/ B))) {
+        x = 3
+      }
+    """
+
+    testCase """
+      without extends
+      ---
+      class A with B,C
+        x = 3
+      ---
+      class A extends C(B(Object)) {
+        x = 3
+      }
+    """


### PR DESCRIPTION
Added the usage half of mixins.

```
      class A with B,C
        x = 3
      ---
      class A extends C(B(Object)) {
        x = 3
      }
```