### PR TITLE
Allow `civetConfig` in `package.`[`json`|`yaml`]

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -117,6 +117,9 @@ you can add one of the following files:
 * `civet.config.json`
 * `civet.config.civet`
 * `package.json` with a `"civetConfig"` property
+* [`package.yaml`](https://github.com/pnpm/pnpm/issues/1100) with a `"civetConfig"`
+property (and [yaml](https://eemeli.org/yaml) `install`ed as optional
+[`peerDependencies`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies))
 
 A JSON file should consist of an object with a `"parseOptions"` property,
 which should be an object specifying one of more directives in the natural way.

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -116,6 +116,7 @@ you can add one of the following files:
 * `civetconfig.civet`
 * `civet.config.json`
 * `civet.config.civet`
+* `package.json` with a `"civetConfig"` property
 
 A JSON file should consist of an object with a `"parseOptions"` property,
 which should be an object specifying one of more directives in the natural way.

--- a/package.json
+++ b/package.json
@@ -98,7 +98,13 @@
     "vue": "^3.2.45"
   },
   "peerDependencies": {
-    "typescript": "^4.5 || ^5.0"
+    "typescript": "^4.5 || ^5.0",
+    "yaml": "^2.4.5"
+  },
+  "peerDependenciesMeta": {
+    "yaml": {
+      "optional": true
+    }
   },
   "c8": {
     "all": true,

--- a/source/config.civet
+++ b/source/config.civet
@@ -14,6 +14,7 @@ configFileNames := new Set [
   "civet.config.json"
   "civet.config.civet"
   "package.json"
+  "package.yaml"
 ]
 
 export function findInDir(dirPath: string): Promise<string | undefined>
@@ -55,6 +56,14 @@ export function loadConfig(path: string): Promise<CompileOptions>
       data = json.civetConfig ?? json // allow civetConfig in package.json
     catch e
       throw new Error `Error parsing JSON config file ${path}: ${e}`
+
+  else if /\.ya?ml$/.test path
+    try
+      { default: YAML } := await import "yaml"
+      yaml := YAML.parse config
+      data = yaml.civetConfig ?? yaml
+    catch e
+      throw new Error `Error parsing YAML config file ${path}: ${e}`
   else
     let js
     try

--- a/source/config.civet
+++ b/source/config.civet
@@ -13,6 +13,7 @@ configFileNames := new Set [
   "civetconfig.civet"
   "civet.config.json"
   "civet.config.civet"
+  "package.json"
 ]
 
 export function findInDir(dirPath: string): Promise<string | undefined>
@@ -50,7 +51,8 @@ export function loadConfig(path: string): Promise<CompileOptions>
   let data: CompileOptions = {}
   if path.endsWith ".json"
     try
-      data = JSON.parse config
+      json := JSON.parse config
+      data = json.civetConfig ?? json // allow civetConfig in package.json
     catch e
       throw new Error `Error parsing JSON config file ${path}: ${e}`
   else


### PR DESCRIPTION
Allow reading config from `civetConfig` property in `package.json`.

Includes support for `pnpm` [`package.yaml`](https://github.com/pnpm/pnpm/issues/1100), and maybe a starting point for the implementation of support for different config file formats, as @STRd6 mentioned in https://github.com/DanielXMoore/Civet/issues/647#issuecomment-1693542267.

> Allow for parsing different config file extensions based on what modules exist in the local user project

Related to #1239.