### PR TITLE
Typecheck fixes

### DIFF
--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -113,6 +113,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
   let compilerOptions: any, compilerOptionsWithSourceMap: any;
   let rootDir = process.cwd();
   let esbuildOptions: BuildOptions;
+  let configErrors: Diagnostic[] | undefined;
 
   const tsPromise =
     transformTS || options.ts === 'tsc'
@@ -170,6 +171,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           ts.sys,
           process.cwd()
         );
+        configErrors = configContents.errors;
 
         compilerOptions = {
           ...configContents.options,
@@ -254,8 +256,11 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
             };
           });
 
+        if (configErrors?.length) {
+          diagnostics.unshift(...configErrors);
+        }
+
         if (diagnostics.length > 0) {
-          // TODO: Map diagnostics to original file via sourcemap
           console.error(
             ts.formatDiagnosticsWithColorAndContext(
               diagnostics,

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -178,7 +178,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         };
         // We use .tsx extensions when type checking, so need to enable
         // JSX mode even if the user doesn't request/use it.
-        compilerOptions.jsx ??= "preserve";
+        compilerOptions.jsx ??= ts.JsxEmit.Preserve;
         compilerOptionsWithSourceMap = {
           ...compilerOptions,
           sourceMap: true,


### PR DESCRIPTION
3 fixes for `civet --typecheck`, and `typecheck: true` in the unplugin:

1. Fix default JSX setting for TypeString engine. Not sure if this was always broken, or the lines got re-ordered, but we need to give a default value via an enum instead of a string here.
2. Include errors/warnings from `tsconfig.json` parsing. I noticed that errors such as `No inputs were found in config file 'tsconfig.json'.` were lying around in the parsed config output when debugging. Now we emit them along with (before) all the other errors, to better match `tsc` behavior.
3. Mangle [`imports` field](https://nodejs.org/api/packages.html#subpath-imports) in `package.json` for TypeScript. As reported by @danielbayley on Discord, it's reasonable to expect something like `"#types": "./src/types.civet"` to work, and it does when running code via the Civet CLI for example, but TypeScript needs it to read `"#types": "./src/types.civet.tsx"` so that it understands the extension. Now we modify the `package.json` as TypeScript reads it. (There might be other fields that need to similarly mogrified, such as `exports`, but I'm not certain whether it's necessary...)