### PR TITLE
More CLI/typechecking fixes

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -111,17 +111,17 @@ In the root directory of your project, or in a `.config` subdirectory,
 you can add one of the following files:
 
 * `🐈.json`
-* `🐈.civet`
 * `civetconfig.json`
-* `civetconfig.civet`
 * `civet.config.json`
-* `civet.config.civet`
 * `package.json` with a `"civetConfig"` property
-* [`package.yaml`](https://github.com/pnpm/pnpm/issues/1100) with a `"civetConfig"`
-property (and [yaml](https://eemeli.org/yaml) `install`ed as optional
-[`peerDependencies`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies))
+* Any of the above with `.yaml` or `.yml` extension
+  * Requires [yaml](https://eemeli.org/yaml) to be `install`ed as optional
+  [`peerDependencies`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies)
+  * In particular, supports [`package.yaml`](https://github.com/pnpm/pnpm/issues/1100) with a `"civetConfig"` property
+* Any of the above with a `.civet` or `.js` extension,
+  with code that `export default`s an object equivalent to a JSON file.
 
-A JSON file should consist of an object with a `"parseOptions"` property,
+The JSON data should consist of an object with a `"parseOptions"` property,
 which should be an object specifying one of more directives in the natural way.
 For example, the [directive](#local-configuration-via-directives)
 `"civet objectIs -implicit-returns tab=2"` is equivalent to:

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -175,11 +175,11 @@ module to look for and parse config files:
 ```js
 import { findInDir, findConfig, loadConfig } from "@danielx/civet/config"
 // Look for standard name for config file in specified directory
-const path1 = findInDir(process.cwd())
+const path1 = await findInDir(process.cwd())
 // Look for standard name for config file in specified directory or ancestors
-const path2 = findConfig(process.cwd())
+const path2 = await findConfig(process.cwd())
 // Load config file from specified path
-const config = loadConfig(path)
+const config = await loadConfig(path)
 // Pass config to compile
 const code = await compile(civetCode, config)
 ```

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -157,12 +157,17 @@ You can ask Civet to run TypeScript to check for type errors in your Civet code
 (the analog of `tsc`):
 
 ```sh
-civet --typecheck src/**/*.civet
+civet --typecheck
 ```
 
-Be sure to specify all the files you want to check.
 This command returns an error code if there are any type errors,
 so you can use it in an NPM script and in CI.
+
+Alternatively, you can typecheck just specific files:
+
+```sh
+civet --typecheck new.civet
+```
 
 You can typecheck and generate JavaScript/TypeScript files at the same time.
 This could be a good NPM `build` script, for example.
@@ -177,6 +182,7 @@ You can also use TypeScript to generate `.d.ts` declaration files
 (if there are no type errors):
 
 ```sh
+civet --emit-declaration
 civet --emit-declaration src/**/*.civet
 ```
 

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -114,6 +114,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
   let rootDir = process.cwd();
   let esbuildOptions: BuildOptions;
   let configErrors: Diagnostic[] | undefined;
+  let configFileNames: string[]
 
   const tsPromise =
     transformTS || options.ts === 'tsc'
@@ -193,6 +194,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           process.cwd()
         );
         configErrors = configContents.errors;
+        configFileNames = configContents.fileNames;
 
         compilerOptions = {
           ...configContents.options,
@@ -209,7 +211,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         fsMap = new Map();
       }
     },
-    async buildEnd() {
+    async buildEnd(useConfigFileNames = false) {
       if (transformTS) {
         const ts = await tsPromise!;
 
@@ -287,7 +289,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         host.compilerHost.getDirectories = system.getDirectories;
 
         const program = ts.createProgram({
-          rootNames: [...fsMap.keys()],
+          rootNames: useConfigFileNames ? configFileNames : [...fsMap.keys()],
           options: compilerOptions,
           host: host.compilerHost,
         });

--- a/integration/unplugin/src/index.ts
+++ b/integration/unplugin/src/index.ts
@@ -251,6 +251,11 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           compilerOptions,
           ts
         );
+
+        // createVirtualCompilerHost doesn't preserve getDirectories
+        // from the system, so add it here.
+        host.compilerHost.getDirectories = system.getDirectories;
+
         const program = ts.createProgram({
           rootNames: [...fsMap.keys()],
           options: compilerOptions,

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -5,7 +5,7 @@
 {rawPlugin} from ./unplugin
 let unplugin:
   buildStart: () => Promise<void>
-  buildEnd: (this: {emitFile: (data: {source: string, fileName: string, type: string}) => void}) => Promise<void>
+  buildEnd: (this: {emitFile: (data: {source: string, fileName: string, type: string}) => void}, useConfigFileNames?: boolean) => Promise<void>
   load: (this: {addWatchFile: (filename: string) => void}, filename: string) => Promise<{code: string, map: unknown}>
 
 export function version: string
@@ -378,7 +378,9 @@ export function cli
       ...options
     }
 
-  unless filenames.length
+  typescript := options.typecheck or options.emitDeclaration
+
+  unless filenames.length or typescript
     if process.stdin.isTTY
       options.repl = true
     else
@@ -386,7 +388,7 @@ export function cli
       options.compile = true
       filenames = ['-']
 
-  if options.typecheck or options.emitDeclaration
+  if typescript
     unpluginOptions := {
       ...options
       ts: if options.js then 'civet' else 'preserve'
@@ -560,7 +562,7 @@ export function cli
       await unplugin.buildEnd.call {
         emitFile({source, fileName})
           fs.writeFile fileName, source
-      }
+      }, not filenames.length
     catch error
       if match := (error as Error).message.match /Aborting build because of (\d+) TypeScript diagnostic/
         process.exitCode = Math.min 255, errors + +match[1]

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -89,8 +89,11 @@ interface ParsedArgs
 
 export function parseArgs(args: string[]): ParsedArgs
   options: Options := {}
-  Object.defineProperty options, 'run',
-    get: (this: Options) -> not (@ast or @compile or @typecheck or @emitDeclaration)
+  isRun := => not (or)
+    options.ast
+    options.compile
+    options.typecheck
+    options.emitDeclaration
   filenames: string[] := []
   scriptArgs: string[] .= []
   i .= 0
@@ -152,13 +155,14 @@ export function parseArgs(args: string[]): ParsedArgs
         if arg.startsWith('-') and arg is not '-'
           console.error `Invalid command-line argument: ${arg}`
           errors++
-        else if options.run
+        else if (options.run = isRun())
           endOfArgs i  // remaining arguments are arguments to the script
         else
           filenames.push arg
     i++
 
   process.exit Math.min 255, errors if errors
+  options.run = isRun()
   {filenames, scriptArgs, options}
 
 type ReadFile = (

--- a/source/config.civet
+++ b/source/config.civet
@@ -46,24 +46,31 @@ export function findConfig(startDir: string): Promise<string | undefined>
 
   return
 
-export function loadConfig(path: string): Promise<CompileOptions>
-  config := await fs.readFile path, "utf8"
+export function loadConfig(pathname: string): Promise<CompileOptions>
+  config := await fs.readFile pathname, "utf8"
 
   let data: CompileOptions = {}
-  if path.endsWith ".json"
+  if pathname.endsWith ".json"
+    let json: CompileOptions | { civetConfig: CompileOptions }
     try
-      json := JSON.parse config
-      data = json.civetConfig ?? json // allow civetConfig in package.json
+      json = JSON.parse config
     catch e
-      throw new Error `Error parsing JSON config file ${path}: ${e}`
+      throw new Error `Error parsing JSON config file ${pathname}: ${e}`
+    // Allow civetConfig in package.json, but ignore rest of package.json
+    if 'civetConfig' in json
+      data = json.civetConfig
+    else if path.basename(pathname).startsWith 'package'
+      return {}
+    else
+      data = json
 
-  else if /\.ya?ml$/.test path
+  else if /\.ya?ml$/.test pathname
     try
       { default: YAML } := await import "yaml"
       yaml := YAML.parse config
       data = yaml.civetConfig ?? yaml
     catch e
-      throw new Error `Error parsing YAML config file ${path}: ${e}`
+      throw new Error `Error parsing YAML config file ${pathname}: ${e}`
   else
     let js
     try
@@ -71,13 +78,13 @@ export function loadConfig(path: string): Promise<CompileOptions>
         js: true
         sync: true  // doesn't seem worth making loadConfig API async
     catch e
-      throw new Error `Error compiling Civet config file ${path}: ${e}`
+      throw new Error `Error compiling Civet config file ${pathname}: ${e}`
 
     try
       exports := await import `data:text/javascript,${ encodeURIComponent js }`
       data = exports?.default
     catch e
-      throw new Error `Error running Civet config file ${path}: ${e}`
+      throw new Error `Error running Civet config file ${pathname}: ${e}`
 
   unless data? <? "object" and not Array.isArray data
     throw new Error `Civet config file must export an object, not ${Array.isArray(data) ? 'array' : data? ? typeof data : 'null'}`

--- a/source/config.civet
+++ b/source/config.civet
@@ -6,29 +6,37 @@ fs from fs/promises
 // we should import them directly here, instead of looking at an old release.
 type { CompileOptions } from "@danielx/civet"
 
-configFileNames := new Set [
-  "🐈.json"
-  "🐈.civet"
-  "civetconfig.json"
-  "civetconfig.civet"
-  "civet.config.json"
-  "civet.config.civet"
-  "package.json"
-  "package.yaml"
+configNames := [
+  "🐈"
+  "civetconfig"
+  "civet.config"
+  "package"
 ]
+configExtensions := [
+  ".civet"
+  ".js"
+  ".yaml"
+  ".yml"
+  ".json"
+]
+configDir := ".config"
 
 export function findInDir(dirPath: string): Promise<string | undefined>
-  for entryName of await fs.readdir dirPath
-    entryPath := path.join dirPath, entryName
+  entries := new Set await fs.readdir dirPath
+  pathFor := (name: string) => path.join dirPath, name
 
-    if entryName is ".config" and try fs.stat entryPath |> await |> .isDirectory()
-      // scan for ./civet.json as well as ./.config/civet.json
-      found := await findInDir entryPath
-      return found if found
+  // Check for config file in .config directory
+  if entries.has(configDir) and try fs.stat pathFor configDir |> await |> .isDirectory()
+    found := await findInDir pathFor configDir
+    return found if found
 
-    name := entryName.replace(/^\./, "") // allow both .civetconfig.civet and civetconfig.civet
-    if configFileNames.has(name) and try fs.stat entryPath |> await |> .isFile()
-      return entryPath
+  // Check for config files in order
+  for each configName of configNames
+    for each extension of configExtensions
+      // Allow both .civetconfig.civet and civetconfig.civet
+      for each entry of ["." + configName + extension, configName + extension]
+        if entries.has(entry) and try fs.stat pathFor entry |> await |> .isFile()
+          return pathFor entry
 
   return
 
@@ -71,14 +79,17 @@ export function loadConfig(pathname: string): Promise<CompileOptions>
       data = yaml.civetConfig ?? yaml
     catch e
       throw new Error `Error parsing YAML config file ${pathname}: ${e}`
-  else
+
+  else  // code
     let js
-    try
-      js = compile config,
-        js: true
-        sync: true  // doesn't seem worth making loadConfig API async
-    catch e
-      throw new Error `Error compiling Civet config file ${pathname}: ${e}`
+    if pathname.endsWith ".civet"
+      try
+        js = await compile config,
+          js: true
+      catch e
+        throw new Error `Error compiling Civet config file ${pathname}: ${e}`
+    else
+      js = config
 
     try
       exports := await import `data:text/javascript,${ encodeURIComponent js }`


### PR DESCRIPTION
CLI config files:
* Avoid using `package.json` as config file when it doesn't have `civetConfig` key.
* Enforce config filename checks to occur in our desired priority order, instead of being filesystem-specific. So e.g. `civetconfig.json` takes priority over `package.json`.
* Allow `civetconfig.js` (and all other config files can use `.js` — even `package.js` though this isn't documented)
* Allow `civetconfig.yaml` (and all other config files can use `.yaml`/`.yml` — previously was just `package.yaml`/`package.yml`)
* Fix `options.run` getting clobbered when any config file got read (which was particularly bad with `package.json`). Fixes #1303

Typechecking:
* Types in `node_modules/@types` are now automatically read, via a workaround until https://github.com/microsoft/TypeScript-Website/pull/3165
* `includes`/`excludes`/`files` now supported, including `.civet` extensions
* If you don't specify `includes`/`excludes`/`files`, TypeScript's default behavior of finding all files in the project directory will now include `.civet` files. No more `TS18003: No inputs were found in config file 'tsconfig.json'.` as reported in https://github.com/DanielXMoore/Civet/pull/1302#issuecomment-2204849270
* `civet --typecheck` and `civet --emitDeclaration` without any filename arguments now typechecks/emits declarations all files specified by `include`/`exclude`/`files`, just like `tsc`

