### PR TITLE
Fix pipe mode in CLI

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -81,6 +81,7 @@ interface Options extends CompileOptions
   repl?: boolean
   typecheck?: boolean
   emitDeclaration?: boolean
+  typescript?: boolean
 
 interface ParsedArgs
   filenames: string[]
@@ -94,7 +95,7 @@ export function parseArgs(args: string[]): ParsedArgs
     options.compile
     options.typecheck
     options.emitDeclaration
-  filenames: string[] := []
+  filenames: string[] .= []
   scriptArgs: string[] .= []
   i .= 0
   errors .= 0
@@ -160,6 +161,17 @@ export function parseArgs(args: string[]): ParsedArgs
         else
           filenames.push arg
     i++
+
+  options.typescript = Boolean options.typecheck or options.emitDeclaration
+
+  unless filenames.length or options.typescript
+    if process.stdin.isTTY
+      options.repl = true
+    else
+      // When piped, default to old behavior of transpiling stdin to stdout
+      options.compile = true
+      options.run = false
+      filenames = ['-']
 
   process.exit Math.min 255, errors if errors
   options.run = isRun()
@@ -378,17 +390,7 @@ export function cli
       ...options
     }
 
-  typescript := options.typecheck or options.emitDeclaration
-
-  unless filenames.length or typescript
-    if process.stdin.isTTY
-      options.repl = true
-    else
-      // When piped, default to old behavior of transpiling stdin to stdout
-      options.compile = true
-      filenames = ['-']
-
-  if typescript
+  if options.typescript
     unpluginOptions := {
       ...options
       ts: if options.js then 'civet' else 'preserve'


### PR DESCRIPTION
Fix `civet < foo.civet > bar.tsx` accidentally turning on `js: true` and `inlineSourceMaps: true`

Introduced in #1304, as reported by @STRd6 on Discord

