### PR TITLE
Jest integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ The modern way to write TypeScript.
 - [Civet VSCode Extension](https://marketplace.visualstudio.com/items?itemName=DanielX.civet)
 - [Discord Server](https://discord.gg/xkrW9GebBc)
 - Plugins for
-  [Vite, esbuild, Astro, Rollup, Webpack, Rspack](source/unplugin)
+  [Vite, esbuild, Astro, Rollup, Webpack, Rspack](source/unplugin),
   <!--
   [esbuild](source/esbuild-plugin.civet),
   [Vite](https://github.com/edemaine/vite-plugin-civet),
   -->
   [ESM/CJS loader](source/esm.civet),
   [Babel](source/babel-plugin.mjs),
+  [Jest](https://github.com/DanielXMoore/Civet/blob/main/integration/jest),
   [Gulp](integration/gulp),
   [Bun](source/bun-civet.civet)
 - Starter templates for [Solid](https://github.com/orenelbaum/solid-civet-template) and [Solid Start](https://github.com/orenelbaum/solid-start-civet-template)

--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -15,6 +15,7 @@ title: Integrations
   - [Older Vite plugin](https://github.com/edemaine/vite-plugin-civet) (no longer recommended)
 - [ESM/CJS loader](https://github.com/DanielXMoore/Civet/blob/main/register.js) for `import`/`require` to support `.civet` files
 - [Babel plugin](https://github.com/DanielXMoore/Civet/blob/main/source/babel-plugin.mjs)
+- [Jest plugin](https://github.com/DanielXMoore/Civet/blob/main/integration/jest)
 - [Gulp plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/gulp)
 - [Bun plugin](https://github.com/DanielXMoore/Civet/blob/main/source/bun-civet.civet)
 - [Civetman](https://github.com/zihan-ch/civetman) automatically compiles `.civet` files, making it easy to integrate with arbitrary build chains (see also [vite-plugin-civetman](https://github.com/krist7599555/vite-plugin-civetman))

--- a/integration/jest/.gitignore
+++ b/integration/jest/.gitignore
@@ -1,0 +1,1 @@
+index.js

--- a/integration/jest/README.md
+++ b/integration/jest/README.md
@@ -1,0 +1,64 @@
+# civet-jest
+
+`civet-jest` is a [Jest transformer](https://jestjs.io/docs/code-transformation)
+for automatically transpiling [Civet](https://civet.dev/) code into JavaScript
+when testing via [Jest](https://jestjs.io/).
+
+It does not yet support chaining with
+[babel-jest](https://github.com/jestjs/jest/tree/main/packages/babel-jest),
+so JSX is not supported.
+
+## Usage
+
+### Installation
+
+1. Install Civet if you haven't already: `npm install -D @danielx/civet`
+2. Install this plugin: `npm install -D civet-jest`
+
+### Configuration
+
+Edit your `jest.config.*` file to define the transform and allow the `.civet`
+file extension.  Here is an complete example `jest.config.mjs`:
+
+```js
+import {defaults} from 'jest-config'
+
+export default {
+  extensionsToTreatAsEsm: [ '.civet' ],
+  moduleFileExtensions: [ ...defaults.moduleFileExtensions, 'civet' ],
+  testMatch: [ '<rootDir>/test/**/*.civet' ],
+  transform: {
+    '\\.civet': 'civet-jest',
+  },
+  verbose: true,
+}
+```
+
+This directory has a similar [`jest.config.mjs`](jest.config.mjs)
+that enables local testing via `yarn test`.
+
+### package.json script
+
+In CommonJS mode, you should be able to just use:
+
+```json
+{
+  "scripts": {
+    "test": "jest"
+  }
+}
+```
+
+In [ESM mode](https://jestjs.io/docs/ecmascript-modules),
+you need something like this:
+
+```json
+{
+  "scripts": {
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+  }
+}
+```
+
+This directory has a similar [`package.json`](package.json)
+that enables local testing via `yarn test`.

--- a/integration/jest/index.civet
+++ b/integration/jest/index.civet
@@ -1,0 +1,30 @@
+createCacheKeyFunction := require('@jest/create-cache-key-function').default;
+{ compile } := require '@danielx/civet'
+
+module.exports = {
+
+  // sync compilation API (when `require`ing .civet files)
+  process(sourceText: string, filename: string)
+    { code, sourceMap } := compile sourceText, {
+      filename
+      js: true
+      sync: true
+      sourceMap: true
+    }
+    { code, map: sourceMap.json() }
+
+  // async compilation API (when `import`ing .civet files)
+  async processAsync(sourceText: string, filename: string)
+    { code, sourceMap } := await compile sourceText, {
+      filename
+      js: true
+      sourceMap: true
+    }
+    { code, map: sourceMap.json() }
+
+  getCacheKey: createCacheKeyFunction [
+    __filename
+    require.resolve '@danielx/civet'
+  ]
+
+}

--- a/integration/jest/jest.config.mjs
+++ b/integration/jest/jest.config.mjs
@@ -1,0 +1,16 @@
+// NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" npx jest
+
+import {defaults} from 'jest-config'
+
+export default {
+  extensionsToTreatAsEsm: [ '.civet' ],
+  moduleFileExtensions: [ ...defaults.moduleFileExtensions, 'civet' ],
+  testMatch: [ '<rootDir>/test/**/*.civet' ],
+  transform: {
+    // You should use the transform like this:
+    //'\\.civet': 'civet-jest',
+    // For local testing, we use the following:
+    '\\.civet': './', // 'civet-jest',
+  },
+  verbose: true,
+}

--- a/integration/jest/package.json
+++ b/integration/jest/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "civet-jest",
+  "version": "0.0.0",
+  "description": "Test Civet files with Jest",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "prepare": "civet --js -c index.civet -o index.js",
+    "test": "yarn prepare && cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+  },
+  "homepage": "https://github.com/DanielXMoore/Civet#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DanielXMoore/Civet.git"
+  },
+  "keywords": [
+    "jest",
+    "civet"
+  ],
+  "author": "Civet Team",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/DanielXMoore/Civet/issues"
+  },
+  "peerDependencies": {
+    "@danielx/civet": ">=0.7.0"
+  },
+  "devDependencies": {
+    "@danielx/civet": "0.7.17",
+    "cross-env": "7.0.3",
+    "jest": "29.7.0"
+  },
+  "dependencies": {
+    "@jest/create-cache-key-function": "29.7.0"
+  }
+}

--- a/integration/jest/test/example.civet
+++ b/integration/jest/test/example.civet
@@ -1,0 +1,8 @@
+assert from assert
+
+describe 'tests', =>
+  it 'equal', =>
+    assert.equal 1+1, 2
+  it 'not equal', =>
+    assert.throws =>
+      assert.equal 1+1, 3


### PR DESCRIPTION
New `civet-jest` NPM package that makes it easy to run `.civet` tests and code with Jest.

I tested that the caching setup detects changing versions of the Civet compiler.