### PR TITLE
Prevent BinaryOp function shorthand from shadowing arrow functions.

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2147,7 +2147,7 @@ FunctionExpression
     }
 
   # BinaryOp function shorthand
-  OpenParen:open BinaryOp:op CloseParen:close ->
+  !ArrowFunction OpenParen:open BinaryOp:op CloseParen:close ->
     // (foo) doesn't need an arrow wrapper; just foo suffices
     if (op.special && op.call && !op.negated) return op.call
 

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -986,6 +986,21 @@ describe "custom identifier infix operators", ->
     a || foo(b, c) && d
   """
 
+  testCase """
+    shadowed in arguments
+    ---
+    operator foo (a, b)
+      a
+
+    (foo) => arr[foo]
+    ---
+    function foo (a, b) {
+      return a
+    };
+
+    (foo) => arr[foo]
+  """
+
   describe "custom precedence", ->
     testCase """
       same as symbol


### PR DESCRIPTION
Fix #1249