### PR TITLE
support for 'unique symbol' type in TS

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7366,8 +7366,8 @@ TypeLiteral
     return $0
   "void" NonIdContinue ->
     return { type: "VoidType", $loc, token: $1 }
-  "unique symbol" NonIdContinue ->
-    return { type: "UniqueSymbolType", $loc, token: $1 }
+  "unique" _ "symbol" NonIdContinue ->
+    return { type: "UniqueSymbolType", children: $0 }
   "[]" ->
     return { $loc, token: "[]" }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7366,6 +7366,8 @@ TypeLiteral
     return $0
   "void" NonIdContinue ->
     return { type: "VoidType", $loc, token: $1 }
+  "unique symbol" NonIdContinue ->
+    return { type: "UniqueSymbolType", $loc, token: $1 }
   "[]" ->
     return { $loc, token: "[]" }
 

--- a/test/types/unique-symbol.civet
+++ b/test/types/unique-symbol.civet
@@ -1,0 +1,10 @@
+{testCase} from ../helper.civet
+
+describe "[TS] unique symbol", ->
+  testCase """
+    basic
+    ---
+    x: unique symbol := new Symbol()
+    ---
+    const x: unique symbol = new Symbol()
+  """


### PR DESCRIPTION
Fixes:

```civet
const callbacks: unique symbol = Symbol("eventCallbacks")
```

Where it fails to detect that `unique symbol` is a type.

https://civet.dev/playground?code=Y29uc3QgY2FsbGJhY2tzOiB1bmlxdWUgc3ltYm9sID0gU3ltYm9sKCJldmVudENhbGxiYWNrcyIp