### PR TITLE
Use register to avoid experimental loaders deprecation warning

### DIFF
--- a/.mocharc-self.json
+++ b/.mocharc-self.json
@@ -4,9 +4,9 @@
     "civet",
     "coffee"
   ],
-  "loader": [
-    "@danielx/hera/esm",
-    "./dist/esm.mjs"
+  "require": [
+    "@danielx/hera/register",
+    "./register.js"
   ],
   "reporter": "dot",
   "recursive": true,

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,9 +3,9 @@
     "civet",
     "coffee"
   ],
-  "loader": [
-    "@danielx/hera/esm",
-    "./node_modules/@danielx/civet/dist/esm.mjs"
+  "require": [
+    "@danielx/hera/register",
+    "./node_modules/@danielx/civet/register"
   ],
   "reporter": "dot",
   "recursive": true,

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@danielx/civet": "0.7.16",
-    "@danielx/hera": "^0.8.14",
+    "@danielx/hera": "^0.8.15",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@danielx/civet": "0.7.16",
-    "@danielx/hera": "^0.8.15",
+    "@danielx/hera": "^0.8.16",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^9.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,7 +100,7 @@
   ],
   "include": [
     "source",
-    "test",
+    "test/**/*.civet",
     "types",
   ],
   "ts-node": {


### PR DESCRIPTION
Depends up updated Hera: https://github.com/DanielXMoore/Hera/pull/19