### PR TITLE
Add `%/`/`÷` integer division, fix `%%` precedence

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -62,6 +62,7 @@ For now, we have the following related options:
 | [`coffeeBooleans`](reference#coffeescript-booleans) | `yes`, `no`, `on`, `off` |
 | [`coffeeClasses`](reference#coffeescript-classes) | CoffeeScript-style `class` methods via `->` functions |
 | [`coffeeComment`](reference#coffeescript-comments) | `# single line comments` |
+| [`coffeeDiv`](reference#coffeescript-comments) | `x // y` integer division |
 | [`coffeeDo`](reference#coffeescript-do) | `do ->`; disables [ES6 `do...while` loops](reference#do-while-until-loop) and [Civet `do` blocks](reference#do-blocks) |
 | [`coffeeEq`](reference#coffeescript-operators) | `==` → `===`, `!=` → `!==` |
 | [`coffeeForLoops`](reference#coffeescript-for-loops) | `for in`/`of`/`from` loops behave like they do in CoffeeScript (like Civet's `for each of`/`in`/`of` respectively) |

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -596,16 +596,35 @@ a !^= b
 a xnor= b
 </Playground>
 
-### Modulo Operator
+### Integer Division and Modulo Operator
+
+`%/` or `÷` is integer division (like `//` in some languages).
+
+<Playground>
+let a = -3
+let b = 5
+let frac = a / b // -0.6
+let div = a %/ b // -1
+console.log frac, div
+</Playground>
 
 `%` can return negative values, while `%%` is always between 0 and the divisor.
 
 <Playground>
 let a = -3
 let b = 5
-let rem = a % b
-let mod = a %% b
+let rem = a % b // -3
+let mod = a %% b // 2
 console.log rem, mod
+</Playground>
+
+Together, these operators implement the
+[division theorem](https://proofwiki.org/wiki/Division_Theorem):
+
+<Playground>
+let a = -3
+let b = 5
+console.assert a === (a %/ b) * b + a %% b
 </Playground>
 
 ### `Object.is`

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2390,6 +2390,11 @@ not x == y
 </Playground>
 
 <Playground>
+"civet coffeeDiv"
+x // y
+</Playground>
+
+<Playground>
 "civet coffeeBinaryExistential"
 x ? y
 </Playground>

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -93,6 +93,8 @@ Things Changed from CoffeeScript
   `a is not in b` → `b.indexOf(a) < 0` instead of `a in b` and `a not in b`;
   `a in b` remains `a in b` as in JS, and `a not in b` → `!(a in b)`
   (unless you specify `"civet coffeeCompat"` or `"civet coffeeOf"`)
+- `//` is a one-line comment; use `%/` for integer division
+  (or specify `"civet coffeeCompat"` or `"civet coffeeDiv"`)
 - `x?.y` now compiles to `x?.y` rather than the `if typeof x !== 'undefined' && x !== null` if check
 - Existential `x?` → `(x != null)` no longer checks for undeclared variables.
 - `x?()` → `x?.()` instead of `if (typeof x === 'function') { x() }`

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3670,7 +3670,7 @@ IdentifierBinaryOp
     return $skip
 
 BinaryOp
-  /(?=\p{ID_Start}|[_$^«»⋙≤≥∈∋∉∌≣≡≢≠=⩶⩵‖⁇&|*\/!?%<>⧺+-])/ _BinaryOp:op -> op
+  /(?=\p{ID_Start}|[_$^«»⋙≤≥∈∋∉∌≣≡≢≠=⩶⩵‖⁇&|*\/!?%÷<>⧺+-])/ _BinaryOp:op -> op
 
 _BinaryOp
   BinaryOpSymbol ->
@@ -3699,12 +3699,17 @@ BinaryOpSymbol
   "**"
   "*"
   "/"
+  "%/" / "÷" ->
+    return {
+      call: getHelperRef("div"),
+      special: true,
+    }
   "%%" ->
     return {
       call: getHelperRef("modulo"),
       special: true,
     }
-  # NOTE: %% must be above %
+  # NOTE: %/ and %% must be above %
   "%"
   "++" / "⧺" ->
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3698,8 +3698,7 @@ _BinaryOp
 BinaryOpSymbol
   "**"
   "*"
-  "/"
-  "%/" / "÷" ->
+  "%/" / "÷" / ( CoffeeDivEnabled "//" ) ->
     return {
       call: getHelperRef("div"),
       special: true,
@@ -3712,6 +3711,8 @@ BinaryOpSymbol
       prec: '%',
     }
   # NOTE: %/ and %% must be above %
+  # NOTE: // must be above /
+  "/"
   "%"
   "++" / "⧺" ->
     return {
@@ -7630,6 +7631,11 @@ CoffeeCommentEnabled
     if(config.coffeeComment) return
     return $skip
 
+CoffeeDivEnabled
+  "" ->
+    if(config.coffeeDiv) return
+    return $skip
+
 CoffeeDoEnabled
   "" ->
     if(config.coffeeDo) return
@@ -7709,6 +7715,7 @@ Reset
       coffeeBooleans: false,
       coffeeClasses: false,
       coffeeComment: false,
+      coffeeDiv: false,
       coffeeDo: false,
       coffeeEq: false,
       coffeeForLoops: false,
@@ -7748,6 +7755,7 @@ Reset
           "coffeeBooleans",
           "coffeeClasses",
           "coffeeComment",
+          "coffeeDiv",
           "coffeeDo",
           "coffeeEq",
           "coffeeForLoops",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3703,11 +3703,13 @@ BinaryOpSymbol
     return {
       call: getHelperRef("div"),
       special: true,
+      prec: '/',
     }
   "%%" ->
     return {
       call: getHelperRef("modulo"),
       special: true,
+      prec: '%',
     }
   # NOTE: %/ and %% must be above %
   "%"

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -64,6 +64,13 @@ declareHelper := {
       }
       "\n"
     ]]
+  div(divRef): void
+    state.prelude.push ["", [ // [indent, statement]
+      preludeVar
+      divRef
+      ts ": (a: number, b: number) => number"
+      " = (a, b) => Math.floor(a / b);\n"
+    ]]
   modulo(moduloRef): void
     state.prelude.push ["", [ // [indent, statement]
       preludeVar

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -44,6 +44,15 @@ describe "binary operations", ->
   """
 
   testCase """
+    positive modulo precedence
+    ---
+    x + a %% b
+    ---
+    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    x + modulo(a, b)
+  """
+
+  testCase """
     floor divide
     ---
     a %/ b
@@ -52,6 +61,15 @@ describe "binary operations", ->
     var div: (a: number, b: number) => number = (a, b) => Math.floor(a / b);
     div(a, b)
     div(a, b)
+  """
+
+  testCase """
+    floor divide precedence
+    ---
+    x + a %/ b
+    ---
+    var div: (a: number, b: number) => number = (a, b) => Math.floor(a / b);
+    x + div(a, b)
   """
 
   testCase """

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -44,6 +44,17 @@ describe "binary operations", ->
   """
 
   testCase """
+    floor divide
+    ---
+    a %/ b
+    a ÷ b
+    ---
+    var div: (a: number, b: number) => number = (a, b) => Math.floor(a / b);
+    div(a, b)
+    div(a, b)
+  """
+
+  testCase """
     additive
     ---
     a + b

--- a/test/compat/coffee-div.civet
+++ b/test/compat/coffee-div.civet
@@ -1,0 +1,12 @@
+{testCase} from ../helper.civet
+
+describe "coffeeDiv", ->
+  testCase """
+    //
+    ---
+    "civet coffee-compat"
+    a // b
+    ---
+    var div: (a: number, b: number) => number = (a, b) => Math.floor(a / b);
+    div(a, b)
+  """

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -8,6 +8,7 @@ declare module "@danielx/civet" {
     coffeeClasses: boolean
     coffeeComment: boolean
     coffeeCompat: boolean
+    coffeeDiv: boolean
     coffeeDo: boolean
     coffeeEq: boolean
     coffeeForLoops: boolean


### PR DESCRIPTION
Civet has `%%` (nice modulo) from CoffeeScript, but lacked `//` (integer division) from CoffeeScript/Python/etc. because it conflicts with JavaScript comments.

In Discord we came up with `%/` and `÷` for integer division, because:
* `%/` is parallel to `%%` (both are like adding a `%` prefix)
* `%/` doesn't mess up regexes (a previous proposal of `/%` would prevent the regular expression `/% /`)
* `%/` is different from Nim's different operator `/%` (unsigned division).
* `%/` looks somewhat similar to Unicode `÷` (which is how Julia represents integer division, and seems nice).
* Only downside is that `%/` is maybe hard to remember... but often used with `%%` so it will probably look reasonable.

I also added CoffeeScript `//` via `coffeeDiv` compatibility flag. This might break code that uses a blanket `coffeeCompat`, if it also used JS `//` comments. But arguably this was a bug, and now we're more CoffeeScript-compatible. Anyone running into this issue can use `coffeeCompat -coffeeDiv`.