### PR TITLE
Fix `&&` chain precedence with bitwise `&`/`|`/`^`

### DIFF
--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -1,6 +1,7 @@
 import type {
   ASTNode
   BinaryOp
+  ChainOp
   Existence
 } from ./types.civet
 
@@ -23,6 +24,8 @@ precedenceOrder := [
   ['|']
   ['^']
   ['&']
+  // NOTE: Extra in-between level for &&ing together relational chains
+  ['chain']
   // NOTE: Equality and inequality merged because of relational chaining
   ['==', '!=', '===', '!==',
    '<', '<=', '>', '>=', 'in', 'instanceof']
@@ -40,6 +43,7 @@ for each ops, prec of precedenceOrder
     precedenceMap.set op, prec
 
 precedenceStep := 1/64
+precedenceAnd := precedenceMap.get("&&")!
 precedenceRelational := precedenceMap.get("==")!
 precedenceCustomDefault := precedenceMap.get("custom")!
 
@@ -136,7 +140,6 @@ function processBinaryOpExpression($0)
         else
           b = recurse b
 
-        // typeof shorthand: x instanceof "String" -> typeof x === "string"
         if op.token is "instanceof"
           // Ensure space around `instanceof`
           if wsOp.length is 0
@@ -144,6 +147,7 @@ function processBinaryOpExpression($0)
           if wsB.length is 0
             wsB = " "
 
+          // typeof shorthand: x instanceof "string" -> typeof x === "string"
           if b is like {
             type: "Literal"
             children: [ {type: "StringLiteral"}, ... ]
@@ -161,6 +165,18 @@ function processBinaryOpExpression($0)
         let children
         if op.type is "PatternTest"
           children = [processPatternTest a, b]
+        else if op.type is "ChainOp"
+          children = [a, wsOp, "&&", wsB, b]
+          // Parenthesize chain if it is surrounded by operator with precedence
+          // in between && (where this will end up being) and relational
+          // (which the chain should simulate).
+          if (start-2 >= 0 and
+              getPrecedence(expandedOps[start-2]) >= precedenceAnd and
+              expandedOps[start-2].token is not '&&') or
+             (end+2 < expandedOps.length and
+              getPrecedence(expandedOps[end+2]) >= precedenceAnd and
+              expandedOps[end+2].token is not '&&')
+            children = ["(", ...children, ")"]
         else if op.call
           wsOp = insertTrimmingSpace(wsOp, "")
 
@@ -230,6 +246,15 @@ function isExistence(exp: ASTNode): Existence?
 function isRelationalOp(op: BinaryOp)
   op.relational or getPrecedence(op) is precedenceRelational
 
+// chainOp is a special BinaryOp that is implemented by JavaScript's &&,
+// but has precedence 'chain' just below relational operators, so in some
+// situations needs to be wrapped in parentheses to simulate that precedence.
+chainOp: ChainOp :=
+  type: 'ChainOp'
+  special: true
+  prec: precedenceMap.get('chain')!
+  assoc: 'right'
+
 /**
 * first is an expression
 * binops is an array of [__, op, __, exp] tuples
@@ -264,7 +289,7 @@ function expandChainedComparisons([first, binops]: [ASTNode, [ASTNode, BinaryOp,
       for each index, k of chains
         if k > 0
           // NOTE: Inserting ws tokens to keep even operator spacing in the resulting array
-          results.push " ", "&&", " "
+          results.push " ", chainOp, " "
 
         binop := binops[index]
         exp := binop[3] = expandExistence binop[3]
@@ -287,7 +312,7 @@ function expandChainedComparisons([first, binops]: [ASTNode, [ASTNode, BinaryOp,
   function expandExistence(exp: ASTNode): ASTNode
     // Expand existence operator like x?
     if existence := isExistence(exp)
-      results.push existence, " ", "&&", " "
+      results.push existence, " ", chainOp, " "
       existence.expression
     else
       exp

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -138,8 +138,13 @@ export type BinaryOp = (string &
   asConst?: boolean
 ) | (PatternTest &
   token?: never
+  relational?: never
   assoc?: never
   asConst?: never
+) | (ChainOp &
+  token?: never
+  relational?: never
+  assoc?: never
 )
 
 export type PatternTest
@@ -149,6 +154,11 @@ export type PatternTest
   special: true
   negated: boolean
   hoistDec?: unknown
+
+export type ChainOp
+  type: "ChainOp"
+  special: true
+  prec: number
 
 export type AssignmentExpression
   type: "AssignmentExpression"

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -149,6 +149,18 @@ describe "binary operations", ->
   """
 
   testCase """
+    relational chaining with middle precedence op
+    ---
+    z | a < b < c
+    a < b < c & x
+    z ^ a < b < c ^ x
+    ---
+    z | (a < b && b < c);
+    (a < b && b < c) & x
+    z ^ (a < b && b < c) ^ x
+  """
+
+  testCase """
     snug <
     ---
     x<y


### PR DESCRIPTION
As reported by Steffan on Discord, the `&&`s emitted to chain together relational ops have a lower precedence than those relational ops, which caused problems when surrounding them with ops that have precedence in between `&&` and relational (namely, `&`, `|`, `^`, and any custom `operator`s set to have those precedence).

I'm not sure this is the cleanest solution. (Initially I thought we could do something when expanding chains, when we already have the `&&` chain assembled — but parens are hard to add in there while maintaining the correct pattern of `[data, ws, op, ws, data, ws, op, ws, ...]`.) This PR adds a custom operator type and ties into the existing precedence logic, which at least seemed simple to implement.