### PR TITLE
CLI -e/--eval for running/compiling a string

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -37,6 +37,7 @@ export interface Options extends CompileOptions
   outputDir?: string
   outputExt?: string
   outputPath?: path.ParsedPath
+  eval?: string
   config?: string | boolean | undefined
   ast?: boolean | "raw"
   repl?: boolean
@@ -91,6 +92,8 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
         options.compile = true
       when '-o', '--output'
         options.output = args[++i]
+      when '-e', '--eval'
+        options.eval = args[++i]
       when '--config'
         options.config = args[++i]
       when '--no-config'
@@ -138,7 +141,7 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
 
   options.typescript = true if options.typecheck or options.emitDeclaration
 
-  unless filenames.length or options.typescript
+  unless filenames.length or options.typescript or options.eval
     if isTTY
       options.repl = true
     else
@@ -185,7 +188,13 @@ type ReadFile = (
   error?: unknown
 ) & ((content: string) | (error: unknown))
 
-function readFiles(filenames: string[]): AsyncGenerator<ReadFile>
+function readFiles(filenames: string[], evalString?: string): AsyncGenerator<ReadFile>
+  if evalString?
+    yield
+      filename: '<eval>'
+      content: evalString + '\n'
+      stdin: true
+
   for each let filename of filenames
     stdin := filename is '-'
     try
@@ -416,6 +425,7 @@ Options:
   --version        Show the version number
   -o / --output XX Specify output directory and/or extension, or filename
   -c / --compile   Compile input files to TypeScript (or JavaScript)
+  -e / --eval XX   Evaluate specified code (or compile it with -c)
   --config XX      Specify a config file (default scans for a config.civet, civet.json, civetconfig.civet or civetconfig.json file, optionally in a .config directory, or starting with a .)
   --civet XX       Specify civet compiler flag, as in "civet XX" prologue
   --comptime       Enable execution of code during compilation via comptime
@@ -471,7 +481,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
   return repl args, options if options.repl
 
   errors .= 0
-  for await {filename, error, content, stdin} of readFiles filenames
+  for await {filename, error, content, stdin} of readFiles filenames, options.eval
     if error
       console.error `${filename} failed to load:`
       console.error error

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -6,16 +6,25 @@ function argsParse(args: string | string[], parsed: ParsedArgs): Promise<void>
   args = args.split /\s+/ if args <? 'string'
   assert.deepStrictEqual await parseArgs(args, true), parsed
 
-function argsOptions(args: string | string[], required: Options): Promise<void>
+type OptionsOrUndefined = {
+  [P in keyof Options]: Options[P] | undefined
+}
+
+function argsOptions(args: string | string[], required: OptionsOrUndefined): Promise<void>
   args = args.split /\s+/ if args <? 'string'
   parsed := await parseArgs args, true
-  for key of [ 'filenames', 'scriptArgs' ]
+  for key of [ 'filenames', 'scriptArgs' ] as const
     assert.deepStrictEqual parsed[key], [], key
   if 'parseOptions' in required
-    required.parseOptions.rewriteCivetImports ??= '.civet.jsx'
+    required.parseOptions?.rewriteCivetImports ??= '.civet.jsx'
   { options } := parsed
-  for key, value in required
-    assert.deepStrictEqual options[key], value, `options.${key}`
+  for key in required
+    key
+  for key in required
+    assert.deepStrictEqual
+      options[key as keyof Options]
+      required[key as keyof Options]
+      `options.${key}`
 
 describe 'CLI parseArgs', ->
   for version of [ '-v', '-version', '--version' ]
@@ -210,3 +219,16 @@ describe 'CLI parseArgs', ->
         outputExt: '.js'
         outputPath: undefined
         parseOptions: rewriteCivetImports: '.js'
+
+  it `parses -e`, =>
+    argsOptions '-e console.log("hello")',
+      eval: 'console.log("hello")'
+      run: true
+      repl: undefined
+
+  it `parses -c -e`, =>
+    argsOptions '-c -e console.log("hello")',
+      eval: 'console.log("hello")'
+      compile: true
+      run: false
+      repl: undefined


### PR DESCRIPTION
Fixes #1333

Demo:

![image](https://github.com/user-attachments/assets/4144f3b7-7e23-4973-acf7-948d66932966)

`-e` doesn't work with `--typecheck`; we'd need to extend the unplugin interface to support strings instead of files.

If you specify multiple `-e` flags, currently just the last `-e` gets executed. This is how Node behaves. Oddly, Coffee executes the first one. We could easily run all of them with an `options.evals` array instead of a single string...

Also haven't implemented `-p` (print last expression) from Node.