### PR TITLE
Optional dot in `?.` and `!.` property access: `x?y` and `x!y`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -502,7 +502,7 @@ obj.key ?= "civet"
 ### Optional Chaining
 
 <Playground>
-obj?.prop
+obj?prop
 obj?[key]
 fun?(arg)
 </Playground>
@@ -510,10 +510,10 @@ fun?(arg)
 ### Optional Chain Assignment
 
 <Playground>
-obj?.prop = value
+obj?prop = value
 obj?[key] = value
 fun?(arg).prop = value
-fun?(arg)?.prop?[key] = value
+fun?(arg)?prop?[key] = value
 </Playground>
 
 ### Existence Checking
@@ -2050,6 +2050,8 @@ type Age = Person::age
 ### Assertions
 
 <Playground>
+data!
+data!prop
 elt as HTMLInputElement
 elt as! HTMLInputElement
 </Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -905,7 +905,8 @@ Placeholder
     }
   # .x -> &.x
   # NOTE: !NumericLiteral is so we don't match on `.1` etc.
-  &AccessStart &PropertyAccess !NumericLiteral ->
+  # NOTE: ExplicitAccessStart so ?.x and !.x work, but not !x (negation)
+  &ExplicitAccessStart &PropertyAccess !NumericLiteral ->
     return {
       type: "Placeholder",
       subtype: "&",
@@ -1479,6 +1480,21 @@ SliceParameters
     }
 
 AccessStart
+  PropertyAccessModifier?:modifier Dot:dot !Dot ->
+    return {
+      type: "AccessStart",
+      children: modifier ? [modifier, dot] : [dot],
+      optional: modifier?.token === "?",
+    }
+  # NOTE: ?x -> ?.x, !x -> !.x shorthand
+  PropertyAccessModifier:modifier InsertDot:dot !Dot ->
+    return {
+      type: "AccessStart",
+      children: [modifier, dot],
+      optional: modifier.token === "?",
+    }
+
+ExplicitAccessStart
   PropertyAccessModifier?:modifier Dot:dot !Dot ->
     return {
       type: "AccessStart",

--- a/test/at.civet
+++ b/test/at.civet
@@ -18,6 +18,14 @@ describe "@ -> this", ->
   """
 
   testCase """
+    @?id
+    ---
+    @?id
+    ---
+    this?.id
+  """
+
+  testCase """
     @[]
     ---
     @[x]

--- a/test/call-expression.civet
+++ b/test/call-expression.civet
@@ -1,4 +1,4 @@
-{ testCase, throws } from ./helper.civet
+{ testCase } from ./helper.civet
 
 describe "call-expression", ->
   testCase """

--- a/test/class.civet
+++ b/test/class.civet
@@ -637,7 +637,7 @@ describe "class", ->
   """
 
   testCase """
-    constuctor '@' shortand
+    constructor '@' shortand
     ---
     class A
       @()

--- a/test/optional-chain.civet
+++ b/test/optional-chain.civet
@@ -14,6 +14,14 @@ describe "optional chain", ->
   """
 
   testCase """
+    member shorthand
+    ---
+    a?b
+    ---
+    a?.b
+  """
+
+  testCase """
     array shorthand
     ---
     a?[b]

--- a/test/types/non-null-assertion.civet
+++ b/test/types/non-null-assertion.civet
@@ -10,6 +10,14 @@ describe "[TS] non null assertion", ->
   """
 
   testCase """
+    ! accessor shorthand
+    ---
+    a!x = b!y
+    ---
+    a!.x = b!.y
+  """
+
+  testCase """
     index accessor
     ---
     a![x] = y


### PR DESCRIPTION
As proposed in #1327 thread, and Discord, and as in Coco.

Fixes #1327 in particular.