### PR TITLE
changelog generation: fetch PRs mostly in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 This changelog is generated automatically by [`build/changelog.civet`](build/changelog.civet).
 
-## Unreleased
-* Automatic changelog creation [#1350]
-
 ## 0.7.22
 * add babel cjs [#1351]
+* Automatic changelog creation [#1350]
 
 ## 0.7.21
 * Fix `..` slice operator precedence [#1332]
@@ -1091,3 +1089,4 @@ This changelog is generated automatically by [`build/changelog.civet`](build/cha
 ## 0.1.1
 
 ## 0.1.0
+

--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -106,8 +106,9 @@ function ghPR(page: number): Promise<PRRecord[] & { numPages: number }>
 
 prData := await ghPR 1
 if prData.numPages? > 1
-  for page of [2..prData.numPages]
-    prData.push ...await ghPR page
+  await.all
+    for page of [2..prData.numPages]
+      async do prData.push ...await ghPR page
 
 prTitle: Record<string, string> := {}
 for each { number, title } of prData


### PR DESCRIPTION
This is a quick performance boost for changelog generation.

It now takes 1-2 seconds on my machine to generate a changelog. I'd be curious what it is for you (and whether you have a different bottleneck).