### PR TITLE
Add missing parens in ampersand functions starting with object literal

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3291,6 +3291,7 @@ SnugNamedProperty
     return {
       type: "Property",
       children: [name, colon, expression],
+      name,
       names: expression.names || [],
     }
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,12 +1,14 @@
 import type {
   ASTNode
   ASTNodeBase
+  BlockStatement
   CallExpression
   FunctionNode
   IterationExpression
   IterationFamily
   LabeledStatement
   Parameter
+  ParametersNode
   StatementTuple
   TypeIdentifierNode
   TypeNode
@@ -46,6 +48,7 @@ import {
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
   makeNode
+  startsWithPredicate
   updateParentPointers
   wrapIIFE
   wrapWithReturn
@@ -656,7 +659,7 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
   unless ref?
     ref = makeRef "$"
     inplacePrepend ref, body
-  if body?.type is "ObjectExpression"
+  if startsWithPredicate(body, .type is "ObjectExpression")
     body = makeLeftHandSideExpression body
 
   parameters := makeNode {

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -46,6 +46,7 @@ export type ExpressionNode =
   | Literal
   | MethodDefinition
   | NewExpression
+  | ObjectExpression
   | ParenthesizedExpression
   | PipelineExpression
   | StatementExpression
@@ -90,7 +91,7 @@ export type ASTString = string & (type?: undefined) & (token?: undefined)
 // so that they have a parent, needed for e.g. `replaceNode`.
 export type ASTWrapper =
   type: "Wrapper"
-  children: [ ASTNode ]
+  children: Children & [ ASTNode ]
   parent?: Parent
 
 export type ASTError =
@@ -102,6 +103,7 @@ export type ASTError =
   column?: number
   offset?: number
   parent?: Parent
+  children: never
 
 export type Loc =
   pos: number
@@ -112,12 +114,14 @@ export type ASTLeaf =
   $loc: Loc
   token: string
   parent?: Parent
+  children: never
 
 export type CommentNode =
   type: "Comment"
   $loc: Loc
   token: string
   parent?: Parent
+  children: never
 
 export type BinaryOp = (string &
   name?: never
@@ -159,6 +163,7 @@ export type ChainOp
   type: "ChainOp"
   special: true
   prec: number
+  children: never
 
 export type AssignmentExpression
   type: "AssignmentExpression"
@@ -231,7 +236,7 @@ export type IfStatement
 
 export type ElseClause
   type: "ElseClause"
-  children: [ Whitespace | ASTString, ElseToken, BlockStatement ]
+  children: Children & [ Whitespace | ASTString, ElseToken, BlockStatement ]
   parent?: Parent
   block: BlockStatement
 
@@ -378,6 +383,7 @@ export type ASTRef =
   token?: undefined
   /** NOTE: Currently parent may be inaccurate since multiple copies of the same ASTRef can exist in the tree. */
   parent?: Parent
+  children: never
 
 export type AtBinding =
   type: "AtBinding"
@@ -417,14 +423,14 @@ export type Binding =
 export type Initializer =
   type: "Initializer"
   expression: ASTNode
-  children: [ASTNode, ASTNode, ASTNode]
+  children: Children & [ASTNode, ASTNode, ASTNode]
   parent?: Parent
 
 export type Identifier =
   type: "Identifier"
   name: string
   names: string[]
-  children: [ ASTLeaf ]
+  children: Children & [ ASTLeaf ]
   parent?: Parent
 
 export type ReturnValue =
@@ -467,7 +473,7 @@ export type TryStatement
 
 export type CatchClause
   type: "CatchClause"
-  children: [ Whitespace | ASTString, CatchToken, BlockStatement ]
+  children: Children & [ Whitespace | ASTString, CatchToken, BlockStatement ]
   parent?: Parent
   block: BlockStatement
 
@@ -475,7 +481,7 @@ export type CatchToken = "catch(e) " | { $loc: Loc, token: "finally" }
 
 export type FinallyClause
   type: "FinallyClause"
-  children: [ Whitespace | ASTString, FinallyToken, BlockStatement ]
+  children: Children & [ Whitespace | ASTString, FinallyToken, BlockStatement ]
   parent?: Parent
   block: BlockStatement
 
@@ -529,9 +535,24 @@ export type BindingPatternContent = unknown[]
 
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",
-  children: [Whitespace, ASTLeaf, BindingPatternContent, WSNode, ASTLeaf]
+  children: Children & [Whitespace, ASTLeaf, BindingPatternContent, WSNode, ASTLeaf]
   names: string[]
   properties: BindingPatternContent
+
+export type ObjectExpression
+  type: "ObjectExpression"
+  children: Children
+  names: string[]
+  properties: Property[]
+  parent?: Parent
+
+export type Property
+  type: "Property"
+  children: Children
+  parent?: Parent
+  name: string
+  names: string[]
+  value: ASTNode
 
 export type FunctionExpression =
   type: "FunctionExpression"
@@ -551,7 +572,7 @@ export type AmpersandBlockBody =
 
 export type PipelineExpression =
   type: "PipelineExpression"
-  children: [
+  children: Children & [
     ws: Whitespace
     head: ASTNode
     tail: [
@@ -646,7 +667,7 @@ export type FunctionNode = FunctionExpression | ArrowFunction | MethodDefinition
 export type Literal =
   type: "Literal",
   subtype?: "NumericLiteral" | "StringLiteral"
-  children: [ LiteralContentNode ]
+  children: Children & [ LiteralContentNode ]
   parent?: Parent
   raw: string
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -1,17 +1,14 @@
 import type {
-  AmpersandBlockBody
-  ArrowFunction
   ASTLeaf
   ASTNode
   ASTNodeBase
   ASTNodeObject
   ASTNodeParent
-  BlockStatement
+  Children
   FunctionNode
   IsParent
   IsToken
   Literal
-  ParametersNode
   StatementNode
   TypeSuffix
   ReturnTypeAnnotation
@@ -19,16 +16,9 @@ import type {
 } from ./types.civet
 
 import {
-  braceBlock
-} from ./block.civet
-
-import {
   gatherRecursiveWithinFunction
+  type Predicate
 } from ./traversal.civet
-
-import {
-  makeRef
-} from ./ref.civet
 
 assert := {
   equal(a: unknown, b: unknown, msg: string): void
@@ -150,7 +140,7 @@ function isStatement(node: ASTNode): node is StatementNode
     node.type?  // forbid leaf
     statementTypes.has node.type
 
-function isWhitespaceOrEmpty(node): boolean {
+function isWhitespaceOrEmpty(node): boolean
   if (!node) return true
   if (node.type is "Ref") return false
   if (node.token) return /^\s*$/.test(node.token)
@@ -159,7 +149,6 @@ function isWhitespaceOrEmpty(node): boolean {
   if (typeof node is "string") return /^\s*$/.test(node)
   if (Array.isArray(node)) return node.every(isWhitespaceOrEmpty)
   return false
-}
 
 /**
  * Does this statement force exit from normal flow, or loop forever,
@@ -335,17 +324,30 @@ function startsWith(target: ASTNode, value: RegExp)
   if (target.children) return startsWith target.children, value
   if (target.token) return value.test target.token
 
+function startsWithPredicate<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>, skip = isWhitespaceOrEmpty): T | undefined
+  return undefined if not node? or node <? "string"
+
+  if Array.isArray node
+    for each child of node
+      continue if skip child
+      return startsWithPredicate child, predicate
+    return
+
+  return node if predicate node
+  return unless node.children?
+  startsWithPredicate node.children, predicate
+
 /**
  * Does this expression have an `await` in it and thus needs to be `async`?
  * Skips over nested functions, which have their own async behavior.
  */
-function hasAwait(exp)
+function hasAwait(exp: ASTNode)
   gatherRecursiveWithinFunction(exp, .type is "Await").length > 0
 
-function hasYield(exp)
+function hasYield(exp: ASTNode)
   gatherRecursiveWithinFunction(exp, .type is "Yield").length > 0
 
-function hasImportDeclaration(exp)
+function hasImportDeclaration(exp: ASTNode)
   gatherRecursiveWithinFunction(exp, .type is "ImportDeclaration").length > 0
 
 /**
@@ -396,7 +398,6 @@ skipParens := new Set [
   "JSXElement"
   "JSXFragment"
   "Literal"
-  "MemberExpression"
   "NewExpression"
   "ParenthesizedExpression"
   "Ref"
@@ -413,6 +414,8 @@ function makeLeftHandSideExpression(expression: ASTNode)
   if isASTNodeObject expression
     return expression if expression.parenthesized
     return expression if skipParens.has expression.type
+    return expression if expression.type is "MemberExpression" and
+      not startsWithPredicate(expression, .type is "ObjectExpression")
 
   makeNode {
     type: "ParenthesizedExpression"
@@ -619,6 +622,7 @@ export {
   removeParentPointers
   skipIfOnlyWS
   startsWith
+  startsWithPredicate
   trimFirstSpace
   updateParentPointers
   wrapIIFE

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -431,6 +431,16 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    object expression wrapping
+    ---
+    x.map {u: 'up', d: 'down'}[&]
+    x.map {x: &} + 'end'
+    ---
+    x.map($ => ({u: 'up', d: 'down'}[$]))
+    x.map($1 => ({x: $1} + 'end'))
+  """
+
+  testCase """
     ternary expression
     ---
     a := & ? & : 0


### PR DESCRIPTION
Reported by @bbrk24 on Discord

Also add some more types. Total number of errors reduced from 641 to 627 (as measured by `civet --typecheck source/**/*civet`).