### PR TITLE
Document how to use with React Native / Metro bundler

### DIFF
--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -15,6 +15,7 @@ title: Integrations
   - [Older Vite plugin](https://github.com/edemaine/vite-plugin-civet) (no longer recommended)
 - [ESM/CJS loader](https://github.com/DanielXMoore/Civet/blob/main/register.js) for `import`/`require` to support `.civet` files
 - [Babel plugin](https://github.com/DanielXMoore/Civet/blob/main/source/babel-plugin.civet)
+  - Including [React Native / Metro](https://github.com/DanielXMoore/Civet/blob/main/integration/metro)
 - [Jest plugin](https://github.com/DanielXMoore/Civet/blob/main/integration/jest)
 - [Gulp plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/gulp)
 - [Bun plugin](https://github.com/DanielXMoore/Civet/blob/main/source/bun-civet.civet)

--- a/integration/metro/README.md
+++ b/integration/metro/README.md
@@ -1,0 +1,26 @@
+# Civet in React Native / Metro
+
+To use Civet with [React Native](https://reactnative.dev/),
+you need to configure the [Metro bundler](https://reactnative.dev/docs/metro) to:
+
+1. [Allow the `.civet` extension](https://metrobundler.dev/docs/configuration/#sourceexts)
+2. Add the [Civet Babel plugin](https://github.com/DanielXMoore/Civet/blob/main/source/babel-plugin.civet)
+
+Here is an example diff for the configuration:
+
+```diff
+// include .civet files to module resolution in metro.config.js
+-const config = {};
++const config = {
++  resolver: {
++    sourceExts: ['js', 'jsx', 'json', 'ts', 'tsx', 'civet'],
++  },
++};
+
+// add plugin in babel.config.js
+ module.exports = {
+   presets: ['module:@react-native/babel-preset'],
++  plugins: [['@danielx/civet/babel-plugin']],
++  sourceMaps: 'inline',
+ };
+```


### PR DESCRIPTION
Based on https://github.com/DanielXMoore/Civet/issues/536#issuecomment-2282182234 by @etherealHero

Instead of including a large block in `integrations.md`, I opted to make a new file to link to. It could go in `notes` or `integrations`; I opted for the latter. It's maybe a little weird to have a directory with just a README, but `integrations` is already a bit of a grab-bag... Other ideas welcome!