### PR TITLE
Fix esbuild unplugin sourcemap bug

### DIFF
--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -52,7 +52,7 @@ To use TypeScript for type checking, create a `tsconfig.json` file. For example:
     "strict": true,
     "jsx": "preserve",
     "lib": ["es2021"],
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "esModuleInterop": true
@@ -60,7 +60,7 @@ To use TypeScript for type checking, create a `tsconfig.json` file. For example:
   "ts-node": {
     "transpileOnly": true,
     "compilerOptions": {
-      "module": "ES2020"
+      "module": "nodenext"
     }
   }
 }

--- a/integration/unplugin-examples/esbuild/esbuild.js
+++ b/integration/unplugin-examples/esbuild/esbuild.js
@@ -9,6 +9,7 @@ const options = {
     ts: 'esbuild',
     emitDeclaration: true,
   })],
+  sourcemap: true,
 }
 
 if (process.argv.includes('--watch')) {

--- a/integration/unplugin-examples/esbuild/tsconfig.json
+++ b/integration/unplugin-examples/esbuild/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "preserve",
+    "lib": ["es2021"],
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "compilerOptions": {
+      "module": "nodenext"
+    }
+  }
+}

--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -537,9 +537,14 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
             )
       );
 
+      // Workaround bug in unplugin that looks for `toString` property in map,
+      // but accidentally detects it in the `Object` prototype.
+      blank := Object.create(null)
+      blank[key] = value for own key, value in jsonSourceMap
+
       let transformed: TransformResult = {
         code: compiled.code,
-        map: jsonSourceMap,
+        map: blank,
       };
 
       if (options.transformOutput)


### PR DESCRIPTION
Currently, using our unplugin with esbuild and `ts: 'esbuild'` crashes (as reported by @bbrk24 on Discord), because:
* esbuild returns a string sourcemap
* We parse this as JSON (necessarily)
* unplugin attaches a `toUrl` but not `toString` method, accidentally accepting `Object.prototype.toString`
* It ends up encoding `[object Object]` (the output of the `toString` method) as the sourcemap.

This will be fixed by https://github.com/unjs/unplugin/pull/399, but here's a workaround until then.