### PR TITLE
Indented if/unless conditions to enable indented function calls (e.g. `(and)`)

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4802,6 +4802,16 @@ Condition
       expression,
     }
 
+  # NOTE: Indented condition allows for further nested function application
+  PushIndent InsertOpenParen:open ( Nested ExtendedExpression )?:expression InsertCloseParen:close PopIndent ->
+    if (!expression) return $skip
+    return {
+      type: "ParenthesizedExpression",
+      children: [open, expression, close],
+      expression,
+    }
+  # NOTE: Unindented condition forbids nested function application
+  # to avoid ambiguity with 'then' clause
   InsertOpenParen:open ExpressionWithObjectApplicationForbidden:expression InsertCloseParen:close ->
     // Don't double wrap parethesized expressions
     if (expression.type === "ParenthesizedExpression") return expression

--- a/test/if.civet
+++ b/test/if.civet
@@ -155,6 +155,35 @@ describe "if", ->
   """
 
   testCase """
+    indented condition
+    ---
+    if
+      (and)
+        cond1
+        cond2
+      console.log 'yes'
+    else if
+      a + b < 10
+      console.log 'small'
+    else
+      console.log 'no'
+    ---
+    if(
+      ((
+        cond1)&&(
+        cond2))) {
+      console.log('yes')
+    }
+    else if(
+      a + b < 10) {
+      console.log('small')
+    }
+    else {
+      console.log('no')
+    }
+  """
+
+  testCase """
     if inline
     ---
     if (x) y else z
@@ -406,6 +435,20 @@ describe "if", ->
     ---
     if (!(h != null)) { return "" }
     let x = 2
+  """
+
+  testCase """
+    postfix if with indented condition
+    ---
+    return if
+      (and)
+        cond1
+        cond2
+    ---
+    if(
+      ((
+        cond1)&&(
+        cond2))) { return }
   """
 
   testCase """


### PR DESCRIPTION
This PR explores the proposal from https://github.com/DanielXMoore/Civet/issues/1090#issuecomment-2291837213 :

> I wonder if it would work (and be unambiguous) to allow an *indented condition* to use (further) indented function calls:
>
> ```js
> // if/then/else
> if
>   (and)
>     x
>     y
>   console.log 'yes'
> else
>   console.log 'no'
> 
> // postfix unless
> return unless
>   (and)
>     x
>     y
> ```

It does seem to work quite well! I think this is a natural extension of various settings where we allow indented expressions (e.g. after `return` or `yield`). It looks a little weird when you don't have an indented application, but the expression still has a clear "end" (from the line break):

```js
if
  a + b < 10
  console.log 'small'
```

I'd like to propose that this fixes #1090, but that is perhaps subject to debate.