### PR TITLE
Indented calls in `if` conditions with explicit `then` clause (#1090)

### DIFF
--- a/build/perf-compare.sh
+++ b/build/perf-compare.sh
@@ -3,7 +3,7 @@
 # Simple performance comparison
 
 count=10
-testFile=source/lib.civet
+testFile=source/**/*.civet
 
 function get_times {
   cmd=$1
@@ -11,7 +11,7 @@ function get_times {
 
   times=()
   for ((i = 1; i <= count; i++)) {
-    time=$( (time $cmd < $testFile > /dev/null) 2>&1 | awk '/real/ {print $2}' | awk -Fm '{print $1*60+$2}' )
+    time=$( (time $cmd -c $testFile -o /dev/null) 2>&1 | awk '/real/ {print $2}' | awk -Fm '{print $1*60+$2}' )
     echo $time
     times+=($time)
   }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4194,7 +4194,20 @@ LabelledItem
 
 # https://262.ecma-international.org/#prod-IfStatement
 IfStatement
-  # NOTE: Added paren-less condition
+  # NOTE: Allow indentation in condition when there's an explicit `then` clause
+  ( If / Unless ):kind _?:ws BoundedCondition:condition Then BlockOrEmpty:block ElseClause?:e ->
+    if (kind.negated) {
+      kind = { ...kind, token: "if" }
+      condition = negateCondition(condition)
+    }
+    return {
+      type: "IfStatement",
+      children: [ kind, ws, condition, block, e],
+      condition,
+      negated: kind.negated,
+      then: block,
+      else: e,
+    }
   # NOTE: Block isn't Statement so we can handle implied braces by nesting
   IfClause:clause BlockOrEmpty:block ElseClause?:e ->
     return {
@@ -4811,9 +4824,23 @@ Condition
       children: [open, expression, close],
       expression,
     }
+  # NOTE: Added paren-less condition
   # NOTE: Unindented condition forbids nested function application
   # to avoid ambiguity with 'then' clause
   InsertOpenParen:open ExpressionWithObjectApplicationForbidden:expression InsertCloseParen:close ->
+    // Don't double wrap parethesized expressions
+    if (expression.type === "ParenthesizedExpression") return expression
+    expression = trimFirstSpace(expression)
+    return {
+      type: "ParenthesizedExpression",
+      children: [open, expression, close],
+      expression,
+    }
+
+# Variation of Condition where there's a trailing token (e.g. `then`)
+# that is guaranteed afterward, so we can use indented application.
+BoundedCondition
+  InsertOpenParen:open ExtendedExpression:expression InsertCloseParen:close ->
     // Don't double wrap parethesized expressions
     if (expression.type === "ParenthesizedExpression") return expression
     expression = trimFirstSpace(expression)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -423,6 +423,9 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
           type: "ParenthesizedExpression",
           children: ["(", ...call.children, ")"]
         : { ...call, type: "ParenthesizedExpression" }
+      // If nothing left to this CallExpression, remove the wrapper
+      if children# is 1
+        return children[0]
 
   // Process globs and bind shorthand
   for (let i = 0; i < children.length; i++) {

--- a/test/if.civet
+++ b/test/if.civet
@@ -184,6 +184,42 @@ describe "if", ->
   """
 
   testCase """
+    condition with indentation and explicit then
+    ---
+    if (and)
+      cond1
+      cond2
+    then
+      console.log 'yes'
+    else
+      console.log 'no'
+    ---
+    if ((
+      cond1)&&(
+      cond2)) {
+      console.log('yes')
+    }
+    else {
+      console.log('no')
+    }
+  """
+
+  testCase """
+    expression with condition with indentation
+    ---
+    return if (and)
+      upper.test exactOrAny.toString()
+      lower.test exactOrAny.toString()
+    then exactOrAny
+    else undefined
+    ---
+    return ((
+      upper.test(exactOrAny.toString()))&&(
+      lower.test(exactOrAny.toString()))? exactOrAny
+    : undefined)
+  """
+
+  testCase """
     if inline
     ---
     if (x) y else z


### PR DESCRIPTION
Inspired by https://github.com/DanielXMoore/Civet/pull/1364#pullrequestreview-2244181171

> There’s probably more we can do here eventually [...]

and specifically https://github.com/DanielXMoore/Civet/issues/1090#issuecomment-1981438104

> Perhaps we could make an exception when there's an explicit `then`.

This PR allows for indented function calls in an `if` condition when there's an explicit `then` to indicate the `then` block. Unlike usual `then`, this one allows for an indented block after it, symmetric to `else`. This lets us write:

```js
if (and)
  cond1
  cond2
then
  // match
else
  // no match
```

as well as #1090's original request:

```js
return if (and)
  upper.test exactOrAny.toString()
  lower.test exactOrAny.toString()
then exactOrAny
else undefined
```

## Performance

One potential issue is that this involves parsing each `if` twice, first with indentation calls enabled, but then failing if there isn't a `then` immediately after, and second with indentation calls disabled.

Running `build/perf-compare.sh` (modified here to parse the entire Civet codebase), the slowdown is a bit inconsistent but I'd say about 5% slowdown (from ~2.25s to ~2.4s parse time). Is this worth it? I'm not sure. (If not, I should cherry-pick some of the small improvements in this PR.)

If you see a way to make the common case more efficient, I'm all ears. Unfortunately, I think we need to check for the `then`-terminated condition before we check the "normal" case; otherwise, we misparse and can't recover.