### PR TITLE
Improved release process and changelog generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Civet Changelog
 
 This changelog is generated automatically by [`build/changelog.civet`](build/changelog.civet).
+For each version of Civet, it lists and links to all incorporated PRs,
+as well as a full diff and commit list.
+
+## Unreleased ([diff](https://github.com/DanielXMoore/Civet/compare/v0.7.23...???))
+* Fix placeholder expressions at head of pipeline [[#1366](https://github.com/DanielXMoore/Civet/pull/1366)]
+* Support length shorthand `#` when defining objects [[#1367](https://github.com/DanielXMoore/Civet/pull/1367)]
+* Generate tags for Civet releases [[#1368](https://github.com/DanielXMoore/Civet/pull/1368)]
+* Indented if/unless conditions to enable indented function calls (e.g. `(and)`) [[#1364](https://github.com/DanielXMoore/Civet/pull/1364)]
+* Indented calls in `if` conditions with explicit `then` clause (#1090) [[#1369](https://github.com/DanielXMoore/Civet/pull/1369)]
 
 ## 0.7.23 (2024-08-15, [diff](https://github.com/DanielXMoore/Civet/compare/v0.7.22...v0.7.23), [commits](https://github.com/DanielXMoore/Civet/commits/v0.7.23))
 * Optional dot in `?.` and `!.` property access: `x?y` and `x!y` [[#1352](https://github.com/DanielXMoore/Civet/pull/1352)]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,3 +168,13 @@ Feel free to ask us questions you have!
 The easiest way is to join our
 [Discord server](https://discord.gg/xkrW9GebBc) and send a message to the
 relevant channel (e.g. `#compiler` for questions about the parser).
+
+## Releasing to NPM
+
+1. Increment `version` in `package.json` (e.g. by running `yarn version`)
+2. Run `npm publish`, which will:
+   * `yarn build` to build for release
+   * `yarn test` to make sure nothing is broken
+   * `yarn changelog --release` to update `CHANGELOG.md`
+     and (ask to) create a release commit and tag it
+   * Submit files to NPM (usually requiring 2FA)

--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -1,4 +1,5 @@
 // Usage: `npm run changelog` or `civet build/changelog.civet`
+// Or `yarn changelog --gh` to run authenticated via `gh` CLI tool
 
 { spawnSync } from child_process
 { readFileSync, writeFileSync } from fs
@@ -13,6 +14,7 @@ process.chdir join (dirname fileURLToPath import.meta.url), '..'
 function run(command: string, args: string[], options?: object): string
   sub := spawnSync command, args, {
     encoding: 'utf8'
+    maxBuffer: 32 * 1024 * 1024  // 32 MB
     ...options
   }
   if sub.error
@@ -139,26 +141,68 @@ interface PRRecord
   number: number
   title: string
 
-function ghPR(page: number): Promise<PRRecord[] & { numPages: number }>
-  response := fetch `https://api.github.com/repos/DanielXMoore/Civet/pulls?state=closed&per_page=100&page=${page}`,
-    headers:
-      Accept: 'application/vnd.github+json'
-      'X-GitHub-Api-Version': '2022-11-28'
-  |> await
-  json := response.json()
-  |> await
+function ghAPI(endpoint: string, fields: Record<string, string>, headers: Record<string, string>): object
+  let json: object?
 
+  if process.argv.includes '--gh'
+    args := [
+      'api'
+      endpoint
+      '--include'  // header output
+      '--method', 'GET'
+    ]
+    for key, value in fields
+      args.push '--raw-field', `${key}=${value}`
+    for key, value in headers
+      args.push '--header', `${key}: ${value}`
+
+    response := run 'gh', args
+    [header, body] := response.split /\r?\n\r?\n/, 2
+    json = body
+    |> .replace /^[^]*?\n\n/, ''  // remove headers
+    |> JSON.parse
+
+    if match := header.match /(?:^|\n)Link:.*?<([^>]+)>; rel="last"/
+      if [, numPages] := match.1.match /[?&]page=([0-9]+)/
+        json!.numPages = numPages
+
+  else
+    url .= 'https://api.github.com'
+    url += '/' unless endpoint.startsWith '/'
+    url += endpoint
+    url += '?'
+    url += (
+      for key, value in fields
+        `${key}=${value}`
+    ).join '&'
+    response := fetch url, headers
+    |> await
+    json = response.json()
+    |> await
+
+    if match := response.headers.get('link')?.match /<([^>]+)>; rel="last"/
+      if [, numPages] := match.1.match /&page=([0-9]+)/
+        json.numPages = numPages
+
+  json = json!
   if json.message?
     console.error `API error: ${json.message} ${
       if json.documentation_url then `[${json.documentation_url}]` else ''
     }`
+    unless process.argv.includes '--gh'
+      console.log `Try authenticating with 'gh' CLI tool and run with --gh flag`
     process.exit 1
 
-  if match := response.headers.get('link')?.match /<([^>]+)>; rel="last"/
-    if [, numPages] := match.1.match /&page=([0-9]+)/
-      json.numPages = numPages
-
   json
+
+function ghPR(page: number): Promise<PRRecord[] & { numPages: number }>
+  ghAPI '/repos/DanielXMoore/Civet/pulls',
+    state: 'closed'
+    per_page: '100'
+    page: page.toString()
+  ,
+    Accept: 'application/vnd.github+json'
+    'X-GitHub-Api-Version': '2022-11-28'
 
 prData := await ghPR 1
 if prData.numPages? > 1

--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -87,7 +87,7 @@ run 'git', ['tag', '--list', '--format=%(object) %(refname:short)', 'v*']
   [commit, tag] := line.split ' '
   existingTag.set tag, commit
 
-for each version of versions
+function versionTag(version: Version): void
   tag := `v${version.version}`
   if existingTag.has tag
     if version.commit is not existingTag.get tag
@@ -96,6 +96,9 @@ for each version of versions
     console.log `Tagging ${tag} -> ${version.commit}`
     run 'git', ['tag', '-a', tag, '-m', tag, version.commit]
   version.tag = tag
+
+for each version of versions
+  versionTag version
 
 // Find pull requests between each version
 
@@ -146,8 +149,9 @@ function ghPR(page: number): Promise<PRRecord[] & { numPages: number }>
   |> await
 
   if json.message?
-    console.error `API error: ${json.message}`
-    console.log json.documentation_url if json.documentation_url?
+    console.error `API error: ${json.message} ${
+      if json.documentation_url then `[${json.documentation_url}]` else ''
+    }`
     process.exit 1
 
   if match := response.headers.get('link')?.match /<([^>]+)>; rel="last"/
@@ -229,5 +233,8 @@ if uncommitted?
         '-a'
         '-m', uncommitted.version
       ], stdio: 'inherit'
+      // Tag new commit
+      uncommitted.commit = run 'git', ['rev-parse', 'HEAD']
+      versionTag uncommitted
   else
     console.log `!! Don't forget to do a release commit with new package.json and CHANGELOG.md`

--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -1,7 +1,7 @@
 // Usage: `npm run changelog` or `civet build/changelog.civet`
 
 { spawnSync } from child_process
-{ writeFileSync } from fs
+{ readFileSync, writeFileSync } from fs
 { dirname, join } from path
 { fileURLToPath } from url
 
@@ -62,6 +62,19 @@ commitToVersion: Record<string, Version> := {}
 for each version of versions
   commitToVersion[version.commit] = version if version.commit?
 
+// Check for uncommitted local changes
+
+let uncommitted: Version?
+
+if [, version] := readFileSync('package.json', encoding: 'utf8').match /^  "version": "([^"]+)"/m
+  unless versions.find .version is version
+    console.log `+ uncommitted version ${version}`
+    now := new Date
+    versions.push uncommitted = {
+      version
+      date: `${now.getFullYear()}-${(now.getMonth()+1).toString().padStart(2, '0')}-${now.getDate().toString().padStart(2, '0')}`
+    }
+
 // Tag version commits
 
 existingTag: Map<string, string> := new Map  // tag -> commit
@@ -109,7 +122,10 @@ for each line of prLogs.split '\n'
     pr = undefined
 
 if prs#
-  versions.push { prs, version: 'Unreleased' }
+  if uncommitted?
+    uncommitted.prs = prs
+  else
+    versions.push { prs, version: 'Unreleased' }
 
 // Look up current PR titles
 
@@ -146,11 +162,13 @@ changelog .= '''\
 # Civet Changelog
 
 This changelog is generated automatically by [`build/changelog.civet`](build/changelog.civet).
+For each version of Civet, it lists and links to all incorporated PRs,
+as well as a full diff and commit list.
 
 
 '''
 
-function tagOrCommit(version: Version?): string
+function tagOrCommit(version: Version?): string?
   return unless version?
   version.tag ?? version.commit ?? '???'
 
@@ -160,7 +178,7 @@ for each version, i of versions
   prevCommit := tagOrCommit versions[i+1]
   details := [
     version.date
-    if version.commit? and prevCommit?
+    if (version.tag? or version.commit?)? and prevCommit?
       `[diff](${repoUrl}/compare/${prevCommit}...${tagOrCommit version})`
     if version.tag?
       `[commits](${repoUrl}/commits/${version.tag})`
@@ -169,10 +187,13 @@ for each version, i of versions
   ].filter &?
   detail := if details# then ` (${details.join ', '})` else ''
   changelog += `## ${version.version}${detail}\n`
-  for each pr of version.prs!
+  for each pr of version.prs ?? []
     changelog += `* ${prTitle[pr] ?? ''} [[#${pr}](${repoUrl}/pull/${pr})]\n`
     total++
   changelog += '\n'
 
 writeFileSync 'CHANGELOG.md', changelog, encoding: 'utf8'
 console.log `Wrote ${total} changes to CHANGELOG.md`
+
+if uncommitted?
+  console.log `!! Don't forget to do a release commit with new package.json and CHANGELOG.md`

--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -141,9 +141,16 @@ function ghPR(page: number): Promise<PRRecord[] & { numPages: number }>
   |> await
   json := response.json()
   |> await
+
+  if json.message?
+    console.error `API error: ${json.message}`
+    console.log json.documentation_url if json.documentation_url?
+    process.exit 1
+
   if match := response.headers.get('link')?.match /<([^>]+)>; rel="last"/
     if [, numPages] := match.1.match /&page=([0-9]+)/
       json.numPages = numPages
+
   json
 
 prData := await ghPR 1

--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -10,8 +10,11 @@ repoUrl := 'https://github.com/DanielXMoore/Civet'
 // Change to project root directory, one up from `build` where this file is
 process.chdir join (dirname fileURLToPath import.meta.url), '..'
 
-function run(command: string, args: string[]): string
-  sub := spawnSync command, args, encoding: 'utf8'
+function run(command: string, args: string[], options?: object): string
+  sub := spawnSync command, args, {
+    encoding: 'utf8'
+    ...options
+  }
   if sub.error
     console.error sub.error
     process.exit 1
@@ -202,5 +205,29 @@ for each version, i of versions
 writeFileSync 'CHANGELOG.md', changelog, encoding: 'utf8'
 console.log `Wrote ${total} changes to CHANGELOG.md`
 
+// Release commit
+
 if uncommitted?
-  console.log `!! Don't forget to do a release commit with new package.json and CHANGELOG.md`
+  if process.argv.includes '--release'
+    console.log '---------------------'
+    run 'git', [
+      'commit'
+      '-a'
+      '--verbose'
+      '--dry-run'
+    ], stdio: 'inherit'
+    readline from node:readline/promises
+    rl := readline.createInterface
+      input: process.stdin
+      output: process.stdout
+    answer := await rl.question
+      `Make new release commit for ${uncommitted.version}? `
+    rl.close()
+    if answer.toLowerCase().startsWith 'y'
+      run 'git', [
+        'commit'
+        '-a'
+        '-m', uncommitted.version
+      ], stdio: 'inherit'
+  else
+    console.log `!! Don't forget to do a release commit with new package.json and CHANGELOG.md`

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "docs:dev": "yarn build && vitepress dev civet.dev",
     "docs:build": "yarn build && vitepress build civet.dev",
     "docs:preview": "yarn build && vitepress preview civet.dev",
-    "prepublishOnly": "yarn build && yarn test && yarn changelog",
+    "prepublishOnly": "yarn build && yarn test && yarn changelog --release",
     "test": "bash ./build/test.sh",
     "test:self": "yarn build && mocha --config .mocharc-self.json",
     "changelog": "civet build/changelog.civet"


### PR DESCRIPTION
This PR improves the release process to the following:

* Increment `version` in `package.json` (e.g. `npm version patch` / `yarn version --patch`)
* *(don't manually run `git commit`)*
* `npm publish`, which runs `yarn changelog --release`
  * In this new "release" mode of the changelog script, it asks whether to run `git commit -a -m <version>` with the new changes. For example, if I increment `version` in the current state, it makes this commit:

```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 194968bd..797efd81 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This changelog is generated automatically by [`build/changelog.civet`](build/cha
 For each version of Civet, it lists and links to all incorporated PRs,
 as well as a full diff and commit list.

-## Unreleased ([diff](https://github.com/DanielXMoore/Civet/compare/v0.7.23...???))
+## 0.7.24 (2024-08-19, [diff](https://github.com/DanielXMoore/Civet/compare/v0.7.23...v0.7.24), [commits](https://github.com/DanielXMoore/Civet/commits/v0.7.24))
 * Fix placeholder expressions at head of pipeline [[#1366](https://github.com/DanielXMoore/Civet/pull/1366)]
 * Support length shorthand `#` when defining objects [[#1367](https://github.com/DanielXMoore/Civet/pull/1367)]
 * Generate tags for Civet releases [[#1368](https://github.com/DanielXMoore/Civet/pull/1368)]
diff --git a/package.json b/package.json
index 0f522df1..1535d211 100644
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@danielx/civet",
   "type": "commonjs",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "CoffeeScript style syntax for TypeScript",
   "main": "dist/main.js",
   "module": "dist/main.mjs",
```

Also improved:

* Crash with useful error message (instead of generating broken changelog) if we hit API rate limit
* When the local `package.json` has a newer `version` than any commits, that release gets the PRs instead of "Unreleased". (This addition was part of the release process)
* Document what the changelog includes.
* Add `--gh` mode that runs via `gh` CLI tool instead of `fetch`. On Windows, this is a lot slower (because process creation is slow). But it enables authentication which greatly increases the rate limit, which I was running into while testing.