### PR TITLE
`import operator` bulk import of operators

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5113,6 +5113,17 @@ ImportDeclaration
       children: [imp, $0.slice(1)],
     }
   Import __ TypeKeyword __ ImportClause:imports __ FromClause:from -> { type: "ImportDeclaration", ts: true, children: $0, imports, from }
+  Import __ Operator OperatorBehavior?:behavior __ OperatorNamedImports:imports __ FromClause:from ->
+    imports.specifiers.forEach((spec) => {
+      state.operators.set(spec.binding.name, spec.behavior ?? behavior)
+    })
+    return {
+      type: "ImportDeclaration",
+      children: [$1, $2, trimFirstSpace($5), imports, $7, from],
+        // omit $3 = Operator and $4 = OperatorBehavior
+      imports,
+      from,
+    }
   Import __ ImportClause:imports __ FromClause:from -> { type: "ImportDeclaration", children: $0, imports, from }
   Import __ ModuleSpecifier:module -> { type: "ImportDeclaration", children: $0, module }
   # NOTE: Added import shorthand
@@ -5127,6 +5138,17 @@ ImportDeclaration
     }
     const children = [i, t, imports, w, from]
     return { type: "ImportDeclaration", ts: !!t, children, imports, from }
+  ImpliedImport:i Operator OperatorBehavior?:behavior __ OperatorNamedImports:imports __ FromClause:from ->
+    imports.specifiers.forEach((spec) => {
+      state.operators.set(spec.binding.name, spec.behavior ?? behavior)
+    })
+    return {
+      type: "ImportDeclaration",
+      children: [$1, trimFirstSpace($4), imports, $6, from],
+        // omit $2 = Operator and $3 = OperatorBehavior
+      imports,
+      from,
+    }
 
 ImpliedImport
   "" ->
@@ -5168,6 +5190,17 @@ NameSpaceImport
 # https://262.ecma-international.org/#prod-NamedImports
 NamedImports
   OpenBrace TypeAndImportSpecifier*:specifiers ( __ Comma )? __ CloseBrace ->
+    const names = specifiers.flatMap(({binding}) => binding.names)
+
+    return {
+      type: "Declaration",
+      children: $0,
+      names,
+      specifiers,
+    }
+
+OperatorNamedImports
+  OpenBrace OperatorImportSpecifier*:specifiers __ CloseBrace ->
     const names = specifiers.flatMap(({binding}) => binding.names)
 
     return {

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -964,6 +964,26 @@ describe "custom identifier infix operators", ->
   """
 
   testCase """
+    bulk import operators
+    ---
+    import operator { min, max } from 'ops'
+    a min b max c
+    ---
+    import { min, max } from 'ops'
+    max(min(a, b), c)
+  """
+
+  testCase """
+    bulk implicit import operators
+    ---
+    operator { min, max } from 'ops'
+    a min b max c
+    ---
+    import { min, max } from 'ops'
+    max(min(a, b), c)
+  """
+
+  testCase """
     operator in parens acts as function
     ---
     operator foo
@@ -1092,6 +1112,16 @@ describe "custom identifier infix operators", ->
       ---
       import { foo as bar } from 'ops'
       a+bar(b, c)+d
+    """
+
+    testCase """
+      general import precedence
+      ---
+      operator tighter (+) { foo, bar looser (+) } from 'ops'
+      a+b foo c+d bar e
+      ---
+      import { foo, bar } from 'ops'
+      bar(a+foo(b, c)+d, e)
     """
 
   describe "custom associativity", ->


### PR DESCRIPTION
Fixes #681 by supporting

```js
import operator { ... } from ...
// and implicit form
operator { ... } from ...
```

Precedence can be specified next to `operator` (to specify a default) or after the individual operators.

I didn't yet implement `import operator foo from bar` (default import).