### PR TITLE
`continue switch` to fall through at the end of `when` clause

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1261,16 +1261,45 @@ sleep() unless
 
 ### Switch
 
+`switch` can be used in three different forms:
+[`case`](#case), [`when`](#when), and [pattern matching](#pattern-matching).
+You can mix `case` and `when`, but not the other types.
+
+### Case
+
+Similar to JavaScript, but with optional punctuation and
+multiple matches in one line:
+
 <Playground>
 switch dir
-  when '>' then civet.x++
-  when '<'
-    civet.x--
-    civet.x = 0 if civet.x < 0
-  else civet.waiting += 5
+  case 'N'
+  case 'S'
+    console.log 'vertical'
+    break
+  case 'E', 'W'
+    console.log 'horizontal'
+  default
+    console.log 'horizontal or unknown'
 </Playground>
 
-With implicit `return`:
+### When
+
+`when` is a nicer version of `case`, with an automatic `break` at the end
+(cancelable with `continue switch`)
+and a braced block to keep variable declarations local to the branch:
+
+<Playground>
+switch dir
+  when 'N', 'S'
+    console.log 'vertical'
+  when 'E', 'W'
+    console.log 'horizontal'
+    continue switch
+  else
+    console.log 'horizontal or unknown'
+</Playground>
+
+An example with implicit `return` and same-line values using `then`:
 
 <Playground>
 getX := (civet: Civet, dir: Dir) =>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5016,6 +5016,14 @@ KeywordStatement
                            // omit colon
     }
 
+  # NOTE: `continue switch` for fallthrough
+  Continue _ Switch ->
+    return {
+      type: "ContinueStatement",
+      special: $3.token,
+      children: $0,
+    }
+
   # https://262.ecma-international.org/#prod-ContinueStatement
   # NOTE: Also allow `continue :label` for symmetry
   Continue ( _ Colon? Identifier:id )? ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5021,7 +5021,7 @@ KeywordStatement
     return {
       type: "ContinueStatement",
       special: $3.token,
-      children: $0,
+      children: [],
     }
 
   # https://262.ecma-international.org/#prod-ContinueStatement

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -175,15 +175,15 @@ function processPatternMatching(statements: ASTNode): void
     (s: ASTNodeObject): s is ContinueStatement =>
       s.type is "ContinueStatement" and s.special is "switch"
   ).forEach (cont) =>
-    if cont.parent is like {
+    // `continue switch` is an empty statement,
+    // which is appropriate only at the end of a when clause
+    // (where it ate a `break` thanks to `isExit`)
+    unless cont.parent is like {
       type: "BlockStatement"
       parent: {type: 'WhenClause'}
       expressions: [..., [, ^cont, ...]]
     }
-      // `continue switch` at end of when clause just gets erased
-      replaceNode cont, undefined
-    else
-      replaceNode cont,
+      cont.children.push
         type: "Error"
         message: `'continue switch' can only be used at end of 'when' clause`
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -1,8 +1,10 @@
 import type {
   ASTNode
+  ASTNodeObject
   ASTRef
   BlockStatement
   Condition
+  ContinueStatement
   ElseClause
   ParenthesizedExpression
   ParseRule
@@ -168,6 +170,22 @@ function processPatternMatching(statements: ASTNode): void
       s.type = "PatternMatchingStatement"
       s.children = root
       updateParentPointers s
+
+  gatherRecursiveAll(statements,
+    (s: ASTNodeObject): s is ContinueStatement =>
+      s.type is "ContinueStatement" and s.special is "switch"
+  ).forEach (cont) =>
+    if cont.parent is like {
+      type: "BlockStatement"
+      parent: {type: 'WhenClause'}
+      expressions: [..., [, ^cont, ...]]
+    }
+      // `continue switch` at end of when clause just gets erased
+      replaceNode cont, undefined
+    else
+      replaceNode cont,
+        type: "Error"
+        message: `'continue switch' can only be used at end of 'when' clause`
 
 function getPatternConditions(
   pattern: PatternExpression,

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -65,7 +65,9 @@ export type OtherNode =
   | AccessStart
   | Call
   | CatchClause
+  | CaseBlock
   | CommentNode
+  | DefaultClause
   | ElseClause
   | FinallyClause
   | Index
@@ -74,6 +76,7 @@ export type OtherNode =
   | ParametersNode
   | Placeholder
   | PropertyAccess
+  | WhenClause
 
 /** @deprecated */
 export type ASTNodeBase = ASTNode &
@@ -103,7 +106,7 @@ export type ASTError =
   column?: number
   offset?: number
   parent?: Parent
-  children: never
+  children?: never
 
 export type Loc =
   pos: number
@@ -114,14 +117,14 @@ export type ASTLeaf =
   $loc: Loc
   token: string
   parent?: Parent
-  children: never
+  children?: never
 
 export type CommentNode =
   type: "Comment"
   $loc: Loc
   token: string
   parent?: Parent
-  children: never
+  children?: never
 
 export type BinaryOp = (string &
   name?: never
@@ -163,7 +166,7 @@ export type ChainOp
   type: "ChainOp"
   special: true
   prec: number
-  children: never
+  children?: never
 
 export type AssignmentExpression
   type: "AssignmentExpression"
@@ -288,6 +291,7 @@ export type ContinueStatement
   type: "ContinueStatement"
   children: Children
   parent?: Parent
+  special?: "switch"
 
 export type DoStatement
   type: "DoStatement"
@@ -383,7 +387,7 @@ export type ASTRef =
   token?: undefined
   /** NOTE: Currently parent may be inaccurate since multiple copies of the same ASTRef can exist in the tree. */
   parent?: Parent
-  children: never
+  children?: never
 
 export type AtBinding =
   type: "AtBinding"

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1550,3 +1550,65 @@ describe "switch", ->
         }
       }}
     """
+
+  describe "continue switch", ->
+    testCase """
+      in when
+      ---
+      switch x
+        when a
+          continue switch
+        when b
+          console.log 'b'
+        when c
+          console.log 'c'
+          continue switch // fall through
+        when d
+          console.log 'd'
+          continue switch
+      ---
+      switch(x) {
+        case a: {
+          
+        }
+        case b: {
+          console.log('b');break;
+        }
+        case c: {
+          console.log('c')
+          
+        } // fall through
+        case d: {
+          console.log('d')
+          
+        }
+      }
+    """
+
+    throws """
+      in case
+      ---
+      switch x
+        case a
+          continue switch
+      ---
+      ParseErrors: unknown:3:5 'continue switch' can only be used at end of 'when' clause
+    """
+
+    throws """
+      in pattern
+      ---
+      switch x
+        [...]
+          continue switch
+      ---
+      ParseErrors: unknown:3:5 'continue switch' can only be used at end of 'when' clause
+    """
+
+    throws """
+      outside
+      ---
+      continue switch
+      ---
+      ParseErrors: unknown:1:1 'continue switch' can only be used at end of 'when' clause
+    """


### PR DESCRIPTION
Part of #661

I realize the original request was for fall through in the pattern matching case. That will require more work... But at least this is a start.