### PR TITLE
Remove Svelte label `$:` exception

### DIFF
--- a/civet.dev/comparison.md
+++ b/civet.dev/comparison.md
@@ -206,14 +206,11 @@ e.g., by appending an underscore.
 ## Labels
 
 In Civet, labels are written `:label` instead of `label:`.
-(The one exception is `$:` which can be written as `$:`
-for Svelte compatibility.)
 
 <Playground>
 :label while (true) {
   break label
 }
-$: document.title = title
 </Playground>
 
 (This is to enable most object literals not needing braces.)

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -139,15 +139,6 @@ obj :=
     y: 'cool'
 </Playground>
 
-`$:` behaves specially for Svelte compatibility.  If you want a key of `$`,
-wrap it in quotes or use explicit braces.
-
-<Playground>
-$: document.title = title
-"$": "dollar"
-{$: "dollar"}
-</Playground>
-
 ### Braced Literals
 
 With braces, the `{x}` shorthand generalizes to any
@@ -1683,12 +1674,7 @@ while item?
 ::: info
 Labels have the colon on the left to avoid conflict with implicit object
 literals.  The colons are optional in `break` and `continue`.
-As a special case, Svelte's `$:` can be used with the colon on the right.
 :::
-
-<Playground>
-$: document.title = title
-</Playground>
 
 ## Other Blocks
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4073,9 +4073,8 @@ StatementListItem
   # NOTE: Allow bulleted array literals as top-level statements.
   BulletedArrayWithTrailing:array
   # NOTE: Allow multi-line implicit object literals as top-level statements.
-  # Leave $: for Svelte labels though.
-  !"$:" ImplicitObjectLiteral ->
-    return makeLeftHandSideExpression($2)
+  ImplicitObjectLiteral ->
+    return makeLeftHandSideExpression($1)
   # NOTE: Added postfix conditionals/loops
   PostfixedStatement
 
@@ -4133,8 +4132,6 @@ Statement
 
   EmptyStatement
 
-  # NOTE: LabelledStatment is before ExpressionStatement so that `$:` is
-  # treated as a label, not an implicit object literal, for Svelte compatibility
   LabelledStatement
 
   CommaExpressionStatement
@@ -4185,8 +4182,6 @@ Label
   # NOTE: `:label` instead of `label:` to not clash with implicit object literal
   Colon:colon Identifier:id Whitespace:w ->
     return [ id, colon, w ]
-  # NOTE: Make $: into label, not implicit object literal, for Svelte compat
-  "$:" Whitespace
 
 LabelledItem
   Statement

--- a/test/label.civet
+++ b/test/label.civet
@@ -31,30 +31,6 @@ describe "labels", ->
     }
   """
 
-  testCase """
-    Svelte $:
-    ---
-    $: a = 1
-    ---
-    $: a = 1
-  """
-
-  testCase """
-    $ as object key via quotes
-    ---
-    "$": a = 1
-    ---
-    ({"$": a = 1})
-  """
-
-  testCase """
-    $ as object key via braces
-    ---
-    {$: a = 1}
-    ---
-    ({$: a = 1})
-  """
-
   describe "break/continue", ->
     wrapper """
       foo: while(true) {


### PR DESCRIPTION
Svelte 5 no longer uses `$:` labels.
If you need `$:` labels in Civet, use `:$` instead.