### PR TITLE
Expressionize statements followed by trailing member access/call or pipe

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4125,10 +4125,10 @@ _PostfixStatement
 Statement
   KeywordStatement
   VariableStatement
-  IfStatement
-  IterationStatement
-  SwitchStatement
-  TryStatement
+  IfStatement !ShouldExpressionize -> $1
+  IterationStatement !ShouldExpressionize -> $1
+  SwitchStatement !ShouldExpressionize -> $1
+  TryStatement !ShouldExpressionize -> $1
 
   EmptyStatement
 
@@ -4140,6 +4140,13 @@ Statement
   BlockStatement
 
   # NOTE: no WithStatement
+
+# NOTE: Leave statement with trailing call expressions or pipe operator
+# to be expressionized by
+# ExpressionizedStatementWithTrailingCallExpressions
+ShouldExpressionize
+  AllowedTrailingCallExpressions
+  NotDedented Pipe
 
 # Variant of Statement to forbid , operator (CommaExpression)
 NoCommaStatement
@@ -4983,10 +4990,6 @@ RestoreAll
 CommaExpressionStatement
   # NOTE: semi-colons are being handled elsewhere
   # NOTE: Shouldn't need negative lookahead if shadowed in the proper order
-  # NOTE: Allow for e.g. await forms of IterationExpression that weren't
-  # already parsed as IterationStatement. Must be before AssignmentExpression
-  # to avoid treated `async do ...` like a function call `async(do ...)`.
-  IterationExpression
   # NOTE: CommaExpression allows , operator
   CommaExpression ->
     // Wrap object literal with parens to disambiguate from block statements.
@@ -5818,6 +5821,9 @@ ReservedWord
   /(?:of)(?!\p{ID_Continue})/ CoffeeOfEnabled
   # NOTE: Added `let`, Civet assumes strict mode
   /(?:and|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|not|null|or|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
+  # NOTE: `async` treated like a keyword when it's followed by for/do/...
+  # iteration statement, to avoid parsing `async do ...` as function call
+  /(?:async)(?!\p{ID_Continue})/ &( __ IterationStatement )
 
 # https://262.ecma-international.org/#sec-comments
 Comment

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -541,8 +541,10 @@ UnaryWithoutParenthesizedAssignment
 
 UnaryBody
   ParenthesizedAssignment
-  UpdateExpression
   ExpressionizedStatementWithTrailingCallExpressions
+  # NOTE: ExpressionizedStatement needs to come before UpdateExpression
+  # to prevent `async do ...` from being parsed as a function call `async(...)`
+  UpdateExpression
   NestedNonAssignmentExtendedExpression
 
 UnaryWithoutParenthesizedAssignmentBody
@@ -5821,9 +5823,6 @@ ReservedWord
   /(?:of)(?!\p{ID_Continue})/ CoffeeOfEnabled
   # NOTE: Added `let`, Civet assumes strict mode
   /(?:and|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|not|null|or|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
-  # NOTE: `async` treated like a keyword when it's followed by for/do/...
-  # iteration statement, to avoid parsing `async do ...` as function call
-  /(?:async)(?!\p{ID_Continue})/ &( __ IterationStatement )
 
 # https://262.ecma-international.org/#sec-comments
 Comment

--- a/test/do.civet
+++ b/test/do.civet
@@ -248,7 +248,7 @@ describe "do", ->
   """
 
   testCase """
-    async do assingment
+    async do assignment
     ---
     promise := async do
       result := await fetch url
@@ -258,6 +258,24 @@ describe "do", ->
       const result = await fetch(url)
       return await result.json()
     }})()
+  """
+
+  testCase """
+    async do with trailing then
+    ---
+    async do
+      result := await fetch url
+      await result.json()
+    .then (out) =>
+      console.log out
+    ---
+    (async ()=>{{
+      const result = await fetch(url)
+      return await result.json()
+    }})()
+    .then((out) => {
+      return console.log(out)
+    })
   """
 
   testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -739,3 +739,28 @@ describe "for", ->
           results.push(`-${char}`)
         };args.splice(i, 1 + i - i, ...results)
     """
+
+    testCase """
+      trailing call expression
+      ---
+      for x of y
+        x ** 2
+      .toString()
+      ---
+      (()=>{const results=[];for (const x of y) {
+        results.push(x ** 2)
+      }return results})()
+      .toString()
+    """
+
+    testCase """
+      trailing pipeline
+      ---
+      for x of y
+        x ** 2
+      |> f
+      ---
+      f((()=>{const results=[];for (const x of y) {
+        results.push(x ** 2)
+      }return results})())
+    """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -554,6 +554,55 @@ describe "switch", ->
       };x = ref
     """
 
+    testCase """
+      trailing call expression
+      ---
+      switch @rank
+        when Rank.Ace then 'A'
+        when Rank.King then 'K'
+        when Rank.Queen then 'Q'
+        when Rank.Jack then 'J'
+        else @rank
+      .toString()
+      ---
+      (()=>{switch(this.rank) {
+        case Rank.Ace: { return 'A'
+        }
+        case Rank.King: { return 'K'
+        }
+        case Rank.Queen: { return 'Q'
+        }
+        case Rank.Jack: { return 'J'
+        }
+        default: { return this.rank }
+      }})()
+      .toString()
+    """
+
+    testCase """
+      trailing pipeline
+      ---
+      switch @rank
+        when Rank.Ace then 'A'
+        when Rank.King then 'K'
+        when Rank.Queen then 'Q'
+        when Rank.Jack then 'J'
+        else @rank
+      |> (+ @suit)
+      ---
+      (()=>{switch(this.rank) {
+        case Rank.Ace: { return 'A'
+        }
+        case Rank.King: { return 'K'
+        }
+        case Rank.Queen: { return 'Q'
+        }
+        case Rank.Jack: { return 'J'
+        }
+        default: { return this.rank }
+      }})()+ this.suit
+    """
+
   describe "expressionless", ->
     testCase """
       basic


### PR DESCRIPTION
Fixes #1168 in a surprisingly simple way: don't parse `if`/`switch`/`try`/iterations as `Statement`s if they're followed by an `AllowedTrailingCallExpression` or `Pipe` operator, leaving them to be parsed as expressions later on.

Also found a simpler way to avoid `async do` and `async for` from being parsed as calls to a function `async`: swapping the order so that `ExpressionizedStatement` gets checked before `UpdateExpression` (which includes `CallExpression`). This brings these into alignment with `async function` and so on which had no special handling.  (This was also a necessary step; the workaround from before didn't work with the rest of this PR.)