### PR TITLE
Hyphenated object keys like `Content-Type:`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -161,6 +161,9 @@ computed property names:
 negate := {-1: +1, +1: -1}
 templated :=
   `${prefix}${suffix}`: result
+headers :=
+  Content-Type: "text/html"
+  Content-Encoding: "gzip"
 </Playground>
 
 ### Object Globs

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3395,6 +3395,12 @@ PropertyName
   # NOTE: ComputedPropertyName must be before StringLiteral,
   # so that CoffeeScript interpolated strings get checked first.
   StringLiteral
+  # NOTE: Content-Type -> "Content-Type"
+  $(IdentifierName? "-" /(?:\p{ID_Continue}|[\u200C\u200D$-])*/) ->
+    return {
+      token: `"${$1}"`,
+      $loc,
+    }
   IdentifierName
   LengthShorthand
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -215,6 +215,16 @@ describe "object", ->
   """
 
   testCase """
+    hyphenated keys
+    ---
+    Content-Type: 'text/html'
+    -x: 5
+    ---
+    ({"Content-Type": 'text/html',
+    "-x": 5})
+  """
+
+  testCase """
     multiline unnested literal
     ---
     a: b


### PR DESCRIPTION
I was looking back at old Discord messages and noticed this feature suggestion by @esthedebeste. (She also suggested spaces, but that seems harder.)

Hyphenated names are at least a small improvement that's nice for dealing with HTTP headers. Existing support for numbers take priority, so e.g. `-0n:` still turns into a key of `0`, while `-0n-x:` doesn't parse. Basically you need to start with a letter or a hyphen followed by a letter.