### PR TITLE
Add `repository` to `package.json`, fixing Dependabot changelog detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "CoffeeScript style syntax for TypeScript",
   "main": "dist/main.js",
   "module": "dist/main.mjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DanielXMoore/Civet.git"
+  },
   "exports": {
     ".": {
       "import": "./dist/main.mjs",


### PR DESCRIPTION
Should allow dependabot to fetch the changelog