### PR TITLE
Typing of object/array pattern components via `::`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1915,12 +1915,12 @@ BindingPropertyList
 # NOTE: Simplified from spec
 ArrayBindingPattern
   _?:ws1 OpenBracket:open ArrayBindingPatternContent:c __:ws2 CloseBracket:close ->
-    return {
+    return gatherBindingPatternTypeSuffix({
       ...c, // names, blockPrefix, length
       type: "ArrayBindingPattern",
       elements: c.children,
       children: [ws1, open, c.children, ws2, close],
-    }
+    })
 
 ArrayBindingPatternContent
   # NOTE: Added indentation based binding elements
@@ -1979,7 +1979,7 @@ BindingProperty
   BindingRestProperty
 
   # NOTE: Allow ::T type suffix before value
-  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value BindingPropertyTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "BindingProperty",
       children: [$1, name, $3, $4, $5, value, initializer],  // omit typeSuffix
@@ -1990,7 +1990,7 @@ BindingProperty
       names: value.names,
     }
 
-  _?:ws Caret?:pin BindingIdentifier:binding BindingPropertyTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _?:ws Caret?:pin BindingIdentifier:binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     $0 = [ws, binding, initializer]  // omit pin and typeSuffix
 
     // TODO make this work with pin
@@ -2044,7 +2044,7 @@ BindingProperty
 
 # https://262.ecma-international.org/#prod-BindingRestProperty
 BindingRestProperty
-  _?:ws DotDotDot:dots BindingIdentifier:id BindingPropertyTypeSuffix?:typeSuffix ->
+  _?:ws DotDotDot:dots BindingIdentifier:id BindingTypeSuffix?:typeSuffix ->
     return {
       ...id,
       type: "BindingRestProperty",
@@ -2060,7 +2060,7 @@ BindingRestProperty
       children: [...(ws || []), dots, ...id.children],
     }
 
-BindingPropertyTypeSuffix
+BindingTypeSuffix
   _? QuestionMark?:optional _? DoubleColonAsColon:colon MaybeNestedType:t ->
     return {
       type: "TypeSuffix",
@@ -2084,7 +2084,7 @@ BindingElement
   BindingRestElement
 
   # NOTE: Merged in SingleNameBinding
-  _?:ws ( BindingIdentifier / BindingPattern ):binding Initializer?:initializer ->
+  _?:ws ( BindingIdentifier / BindingPattern ):binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     // NOTE: RegExpLiteral doesn't have children so it will lose the initializer
     // for now
     if (binding.children) {
@@ -2096,27 +2096,30 @@ BindingElement
     }
 
     return {
+      type: "BindingElement",
       names: binding.names,
-      children: [ws, binding]
+      typeSuffix,
+      binding,
+      children: [ws, binding],
     }
 
   # NOTE: Merged in ElisionElement
   &( _? "," ) ->
     return {
-      children: [{
-        type: "ElisionElement",
-        children: [""],
-      }],
+      type: "ElisionElement",
+      children: [""],
       names: [],
     }
 
 # https://262.ecma-international.org/#prod-BindingRestElement
 BindingRestElement
-  _?:ws DotDotDot:dots ( BindingIdentifier / BindingPattern / EmptyBindingPattern ):binding ->
+  _?:ws DotDotDot:dots ( BindingIdentifier / BindingPattern / EmptyBindingPattern ):binding BindingTypeSuffix?:typeSuffix ->
     return {
       type: "BindingRestElement",
       children: [ws, [dots, binding]],
+      dots,
       binding,
+      typeSuffix,
       name: binding.name,
       names: binding.names,
       rest: true,
@@ -2126,6 +2129,7 @@ BindingRestElement
     return {
       type: "BindingRestElement",
       children: [...(ws || []), dots, binding],
+      dots,
       binding,
       name: binding.name,
       names: binding.names,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -43,6 +43,7 @@ import {
   maybeRefAssignment,
   modifyString,
   negateCondition,
+  objectBindingPatternTypeSuffix,
   prepend,
   processAssignmentDeclaration,
   processBinaryOpExpression,
@@ -1883,11 +1884,14 @@ BindingPattern
 # NOTE: Simplified from spec
 ObjectBindingPattern
   _?:ws1 OpenBrace:open ObjectBindingPatternContent:c __:ws2 CloseBrace:close ->
+    const properties = c.children
+    const typeSuffix = objectBindingPatternTypeSuffix(properties)
     return {
       type: "ObjectBindingPattern",
-      children: [ws1, open, c.children, ws2, close],
+      children: [ws1, open, c.children, ws2, close, typeSuffix],
+      typeSuffix,
       names: c.names,
-      properties: c.children,
+      properties,
     }
 
 ObjectBindingPatternContent
@@ -1975,23 +1979,28 @@ BindingProperty
   # NOTE: Must be checked first to pick up trailing "..." form
   BindingRestProperty
 
-  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value Initializer?:initializer ->
+  # NOTE: Allow ::T type suffix before value
+  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value BindingPropertyTypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "BindingProperty",
-      children: $0,
+      children: [$1, name, $3, $4, $5, value, initializer],  // omit typeSuffix
       name,
       value,
+      typeSuffix,
       initializer,
       names: value.names,
     }
 
-  _?:ws Caret?:pin BindingIdentifier:binding Initializer?:initializer ->
+  _?:ws Caret?:pin BindingIdentifier:binding BindingPropertyTypeSuffix?:typeSuffix Initializer?:initializer ->
+    $0 = [ws, binding, initializer]  // omit pin and typeSuffix
+
     // TODO make this work with pin
     if (binding.type === "AtBinding") {
       return {
         type: "AtBindingProperty",
         children: $0,
         binding,
+        typeSuffix,
         ref: binding.ref,
         initializer,
         names: [],
@@ -1999,9 +2008,22 @@ BindingProperty
     }
 
     if (pin) {
+      const children = [ws, binding]
+      if (typeSuffix) {
+        children.push({
+          type: "Error",
+          message: "Pinned properties cannot have type annotations",
+        })
+      }
+      if (initializer) {
+        children.push({
+          type: "Error",
+          message: "Pinned properties cannot have initializers",
+        })
+      }
       return {
         type: "PinProperty",
-        children: [ws, binding],
+        children,
         name: binding,
         value: {
           type: "PinPattern",
@@ -2015,6 +2037,7 @@ BindingProperty
       children: $0,
       name: binding,
       value: undefined,
+      typeSuffix,
       initializer,
       names: binding.names,
       identifier: binding,
@@ -2022,10 +2045,11 @@ BindingProperty
 
 # https://262.ecma-international.org/#prod-BindingRestProperty
 BindingRestProperty
-  _?:ws DotDotDot:dots BindingIdentifier:id ->
+  _?:ws DotDotDot:dots BindingIdentifier:id BindingPropertyTypeSuffix?:typeSuffix ->
     return {
       ...id,
       type: "BindingRestProperty",
+      typeSuffix,
       children: [...(ws || []), dots, ...id.children],
     }
 
@@ -2033,7 +2057,18 @@ BindingRestProperty
     return {
       ...id,
       type: "BindingRestProperty",
+      typeSuffix: undefined,
       children: [...(ws || []), dots, ...id.children],
+    }
+
+BindingPropertyTypeSuffix
+  _? QuestionMark?:optional _? DoubleColonAsColon:colon MaybeNestedType:t ->
+    return {
+      type: "TypeSuffix",
+      ts: true,
+      optional,
+      t,
+      children: $0,
     }
 
 NestedBindingElements
@@ -6077,6 +6112,10 @@ DotDotDot
 DoubleColon
   "::" ->
     return { $loc, token: $1 }
+
+DoubleColonAsColon
+  "::" ->
+    return { $loc, token: ":" }
 
 DoubleQuote
   "\"" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1936,6 +1936,7 @@ BindingElementList
     return elements.map(([element, delim]) => {
       return {
         ...element,
+        delim,
         // BindingElement.children is a tuple of the form [ws, element]
         children: [...element.children, delim],
       }
@@ -1991,13 +1992,13 @@ BindingProperty
     }
 
   _?:ws Caret?:pin BindingIdentifier:binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
-    $0 = [ws, binding, initializer]  // omit pin and typeSuffix
+    let children = [ws, binding, initializer]  // omit pin and typeSuffix
 
     // TODO make this work with pin
     if (binding.type === "AtBinding") {
       return {
         type: "AtBindingProperty",
-        children: $0,
+        children,
         binding,
         typeSuffix,
         ref: binding.ref,
@@ -2007,7 +2008,7 @@ BindingProperty
     }
 
     if (pin) {
-      const children = [ws, binding]
+      children = [ws, binding]
       if (typeSuffix) {
         children.push({
           type: "Error",
@@ -2033,7 +2034,7 @@ BindingProperty
 
     return {
       type: "BindingProperty",
-      children: $0,
+      children,
       name: binding,
       value: undefined,
       typeSuffix,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -22,6 +22,7 @@ import {
   expressionizeTypeIf,
   forRange,
   gatherBindingCode,
+  gatherBindingPatternTypeSuffix,
   gatherRecursive,
   getHelperRef,
   getIndentLevel,
@@ -43,7 +44,6 @@ import {
   maybeRefAssignment,
   modifyString,
   negateCondition,
-  objectBindingPatternTypeSuffix,
   prepend,
   processAssignmentDeclaration,
   processBinaryOpExpression,
@@ -1793,9 +1793,10 @@ FunctionRestParameter
 # NOTE: Similar to BindingElement but appears in formal parameters list
 ParameterElement
   _? AccessModifier?:accessModifier _? ( NWBindingIdentifier / BindingPattern ):binding TypeSuffix?:typeSuffix Initializer?:initializer ParameterElementDelimiter:delim ->
+    typeSuffix ??= binding.typeSuffix
     return {
       type: "Parameter",
-      children: $0,
+      children: [ $1, accessModifier, $3, binding, typeSuffix, initializer, delim ],
       names: binding.names,
       typeSuffix,
       accessModifier,
@@ -1885,14 +1886,12 @@ BindingPattern
 ObjectBindingPattern
   _?:ws1 OpenBrace:open ObjectBindingPatternContent:c __:ws2 CloseBrace:close ->
     const properties = c.children
-    const typeSuffix = objectBindingPatternTypeSuffix(properties)
-    return {
+    return gatherBindingPatternTypeSuffix({
       type: "ObjectBindingPattern",
-      children: [ws1, open, c.children, ws2, close, typeSuffix],
-      typeSuffix,
+      children: [ws1, open, properties, ws2, close],
       names: c.names,
       properties,
-    }
+    })
 
 ObjectBindingPatternContent
   # NOTE: Added indentation based binding properties
@@ -5543,10 +5542,11 @@ TypeAssignment
 LexicalBinding
   BindingPattern:pattern TypeSuffix?:suffix Initializer:initializer ->
     const [splices, thisAssignments] = gatherBindingCode(pattern)
+    suffix ??= pattern.typeSuffix
 
     return {
       type: "Binding",
-      children: $0,
+      children: [ pattern, suffix, initializer ],
       names: pattern.names,
       pattern,
       suffix,

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -1,6 +1,9 @@
 import type {
-  ASTNode,
-  AtBinding,
+  ASTNode
+  ASTString
+  AtBinding
+  Children
+  ObjectBindingPattern
   ThisAssignments
 } from ./types.civet
 
@@ -8,7 +11,9 @@ import {
   gatherRecursiveAll
 } from ./traversal.civet
 
-import { insertTrimmingSpace } from ./util.civet
+import {
+  trimFirstSpace
+} from ./util.civet
 
 /**
  * Adjusts `@binding` inside object properties that need to be aliased
@@ -73,7 +78,7 @@ function adjustBindingElements(elements: ASTNodeBase[])
 
       blockPrefix = {
         type: "PostRestBindingElements",
-        children: ["[", insertTrimmingSpace(after, ""), "] = ", restIdentifier, ".splice(-", l.toString(), ")"],
+        children: ["[", trimFirstSpace(after, ""), "] = ", restIdentifier, ".splice(-", l.toString(), ")"],
         names: after.flatMap((p) => p.names),
       }
     }
@@ -140,9 +145,47 @@ function arrayElementHasTrailingComma(elementNode)
   const lastChild = elementNode.children.-1
   return lastChild and lastChild[lastChild.length - 1]?.token is ","
 
+// If an ObjectBindingPattern doesn't have a typeSuffix, this function
+// extracts one from typeSuffixes for the binding properties (if present).
+function gatherBindingPatternTypeSuffix(obj: ObjectBindingPattern): ObjectBindingPattern
+  return obj unless obj?
+  return obj unless obj.type is "ObjectBindingPattern"
+  return obj if obj.typeSuffix?
+  count .= 0
+  let restType: ASTNode?
+  types: ASTNode[] :=
+    for each prop of obj.properties
+      typeSuffix .= prop.typeSuffix
+      typeSuffix ??= prop.value?.typeSuffix
+      count++ if typeSuffix
+      typeSuffix ??=
+        type: "TypeSuffix"
+        ts: true
+        children: [": unknown"]
+      switch prop.type
+        when "BindingProperty"
+          ws := prop.children[...prop.children.indexOf prop.name]
+          [ ...ws, prop.name, typeSuffix, "," as ASTString ] as Children
+        when "AtBindingProperty"
+          ws := prop.children[...prop.children.indexOf prop.binding]
+          [ ...ws, prop.ref.id, typeSuffix, "," as ASTString ] as Children
+        when "BindingRestProperty"
+          restType = prop.typeSuffix?.t
+          continue
+  if count
+    t: ASTNode[] := [ ": ", "{", types, "}" ]
+    t.push " & (", trimFirstSpace(restType), ")" if restType?
+    obj.typeSuffix = {
+      type: "TypeSuffix"
+      ts: true
+      t
+      children: [t]
+    }
+  obj
 
 export {
   adjustAtBindings
   adjustBindingElements
   gatherBindingCode
+  gatherBindingPatternTypeSuffix
 }

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -151,10 +151,10 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
     when "ArrayBindingPattern"
       types: ASTNode[] :=
         for each elem of pattern.elements
-          typeSuffix .= elem.typeSuffix
+          { typeSuffix } .= elem
           typeSuffix ??= elem.binding?.typeSuffix
           count++ if typeSuffix
-          typeElement .= [ typeSuffix?.t, "," ]
+          typeElement .= [ typeSuffix?.t, elem.delim ]
           if typeSuffix?.optional
             typeElement[0] = parenthesizeType typeElement[0]
             typeElement.unshift "undefined |"
@@ -176,7 +176,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
       let restType: ASTNode?
       types: ASTNode[] :=
         for each prop of pattern.properties
-          typeSuffix .= prop.typeSuffix
+          { typeSuffix } .= prop
           typeSuffix ??= prop.value?.typeSuffix
           count++ if typeSuffix
           typeSuffix ??=
@@ -186,10 +186,10 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
           switch prop.type
             when "BindingProperty"
               ws := prop.children[...prop.children.indexOf prop.name]
-              [ ...ws, prop.name, typeSuffix, "," as ASTString ] as Children
+              [ ...ws, prop.name, typeSuffix, prop.delim ] as Children
             when "AtBindingProperty"
               ws := prop.children[...prop.children.indexOf prop.binding]
-              [ ...ws, prop.ref.id, typeSuffix, "," as ASTString ] as Children
+              [ ...ws, prop.ref.id, typeSuffix, prop.delim ] as Children
             when "BindingRestProperty"
               restType = prop.typeSuffix?.t
               continue

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -1,4 +1,5 @@
 import type {
+  ArrayBindingPattern
   ASTNode
   ASTString
   AtBinding
@@ -12,6 +13,7 @@ import {
 } from ./traversal.civet
 
 import {
+  parenthesizeType
   trimFirstSpace
 } from ./util.civet
 
@@ -20,7 +22,7 @@ import {
  * see test/function.civet binding pattern
  */
 function adjustAtBindings(statements: ASTNode, asThis = false): void
-  gatherRecursiveAll(statements, (n) => n.type is "AtBindingProperty")
+  gatherRecursiveAll(statements, .type is "AtBindingProperty")
     .forEach((binding) => {
       const { ref } = binding
 
@@ -42,68 +44,63 @@ function adjustAtBindings(statements: ASTNode, asThis = false): void
     })
 
 function adjustBindingElements(elements: ASTNodeBase[])
-  const names = elements.flatMap((p) => p.names or []),
-    { length } = elements
+  names := elements.flatMap .names or []
+  { length } := elements
 
   let blockPrefix,
     restIndex = -1,
     restCount = 0
 
-  elements.forEach(({ type }, i) => {
-    if (type is "BindingRestElement") {
-      if (restIndex < 0) restIndex = i
+  for each { type }, i of elements
+    if type is "BindingRestElement"
+      restIndex = i if restIndex < 0
       restCount++
-    }
-  })
 
-  if (restCount is 0) {
+  if restCount is 0
     return {
-      children: elements,
-      names,
-      blockPrefix,
-      length,
+      children: elements
+      names
+      blockPrefix
+      length
     }
-  } else if (restCount is 1) {
-    const rest = elements[restIndex]
-    const after = elements.slice(restIndex + 1)
+  else if restCount is 1
+    rest := elements[restIndex]
+    after := elements.slice(restIndex + 1)
 
-    const restIdentifier = rest.binding.ref or rest.binding
-    names.push(...rest.names or [])
+    restIdentifier := rest.binding.ref or rest.binding
+    names.push ...rest.names or []
 
-    let l = after.length
+    l .= after#
 
-    if (l) {
+    if l
       // increment l if trailing comma
       if (arrayElementHasTrailingComma(after[l - 1])) l++
 
       blockPrefix = {
-        type: "PostRestBindingElements",
-        children: ["[", trimFirstSpace(after, ""), "] = ", restIdentifier, ".splice(-", l.toString(), ")"],
-        names: after.flatMap((p) => p.names),
+        type: "PostRestBindingElements"
+        children: ["[", trimFirstSpace(after), "] = ", restIdentifier, ".splice(-", l.toString(), ")"]
+        names: after.flatMap((p) => p.names)
       }
-    }
 
     return {
-      names,
+      names
       children: [...elements.slice(0, restIndex), {
-        ...rest,
+        ...rest
         children: rest.children.slice(0, -1) // remove trailing comma
-      }],
-      blockPrefix,
-      length,
+      }]
+      blockPrefix
+      length
     }
-  }
 
-  const err = {
-    type: "Error",
-    children: ["Multiple rest elements in array pattern"],
-  }
+  err :=
+    type: "Error"
+    children: ["Multiple rest elements in array pattern"]
 
   return {
-    names,
-    children: [...elements, err],
-    blockPrefix,
-    length,
+    names
+    children: [...elements, err]
+    blockPrefix
+    length
   }
 
 function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: boolean })
@@ -147,41 +144,65 @@ function arrayElementHasTrailingComma(elementNode)
 
 // If an ObjectBindingPattern doesn't have a typeSuffix, this function
 // extracts one from typeSuffixes for the binding properties (if present).
-function gatherBindingPatternTypeSuffix(obj: ObjectBindingPattern): ObjectBindingPattern
-  return obj unless obj?
-  return obj unless obj.type is "ObjectBindingPattern"
-  return obj if obj.typeSuffix?
+function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBindingPattern): BindingPattern
+  return pattern if pattern.typeSuffix?
   count .= 0
-  let restType: ASTNode?
-  types: ASTNode[] :=
-    for each prop of obj.properties
-      typeSuffix .= prop.typeSuffix
-      typeSuffix ??= prop.value?.typeSuffix
-      count++ if typeSuffix
-      typeSuffix ??=
-        type: "TypeSuffix"
-        ts: true
-        children: [": unknown"]
-      switch prop.type
-        when "BindingProperty"
-          ws := prop.children[...prop.children.indexOf prop.name]
-          [ ...ws, prop.name, typeSuffix, "," as ASTString ] as Children
-        when "AtBindingProperty"
-          ws := prop.children[...prop.children.indexOf prop.binding]
-          [ ...ws, prop.ref.id, typeSuffix, "," as ASTString ] as Children
-        when "BindingRestProperty"
-          restType = prop.typeSuffix?.t
-          continue
-  if count
-    t: ASTNode[] := [ ": ", "{", types, "}" ]
-    t.push " & (", trimFirstSpace(restType), ")" if restType?
-    obj.typeSuffix = {
-      type: "TypeSuffix"
-      ts: true
-      t
-      children: [t]
-    }
-  obj
+  switch pattern.type
+    when "ArrayBindingPattern"
+      types: ASTNode[] :=
+        for each elem of pattern.elements
+          typeSuffix .= elem.typeSuffix
+          typeSuffix ??= elem.binding?.typeSuffix
+          count++ if typeSuffix
+          typeElement .= [ typeSuffix?.t, "," ]
+          if typeSuffix?.optional
+            typeElement[0] = parenthesizeType typeElement[0]
+            typeElement.unshift "undefined |"
+          if elem.type is "BindingRestElement"
+            typeElement[0] ??= "unknown[]"
+            typeElement.unshift elem.dots
+          else
+            typeElement[0] ??= "unknown"
+          typeElement
+      if count
+        t: ASTNode[] := [ ": [", types, "]" ]
+        pattern.typeSuffix = {
+          type: "TypeSuffix"
+          ts: true
+          t
+          children: [t]
+        }
+    when "ObjectBindingPattern"
+      let restType: ASTNode?
+      types: ASTNode[] :=
+        for each prop of pattern.properties
+          typeSuffix .= prop.typeSuffix
+          typeSuffix ??= prop.value?.typeSuffix
+          count++ if typeSuffix
+          typeSuffix ??=
+            type: "TypeSuffix"
+            ts: true
+            children: [": unknown"]
+          switch prop.type
+            when "BindingProperty"
+              ws := prop.children[...prop.children.indexOf prop.name]
+              [ ...ws, prop.name, typeSuffix, "," as ASTString ] as Children
+            when "AtBindingProperty"
+              ws := prop.children[...prop.children.indexOf prop.binding]
+              [ ...ws, prop.ref.id, typeSuffix, "," as ASTString ] as Children
+            when "BindingRestProperty"
+              restType = prop.typeSuffix?.t
+              continue
+      if count
+        t: ASTNode[] := [ "{", types, "}" ]
+        t.push " & ", parenthesizeType(trimFirstSpace(restType)) if restType?
+        pattern.typeSuffix = {
+          type: "TypeSuffix"
+          ts: true
+          t
+          children: [": ", t]
+        }
+  pattern
 
 export {
   adjustAtBindings

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -65,7 +65,7 @@ import {
   processCallMemberExpression
 } from ./lib.civet
 
-function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix, ws: WSNode, assign: ASTLeaf, e: ASTNode)
+function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix?, ws: WSNode, assign: ASTLeaf, e: ASTNode)
   // Adjust position to space before assignment to make TypeScript remapping happier
   decl = {
     ...decl,
@@ -79,6 +79,7 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
   splices = splices.map (s) => [", ", s]
   thisAssignments := assignments.map (a) => ["", a, ";"] as const
 
+  suffix ??= pattern.typeSuffix if "typeSuffix" in pattern
   initializer := makeNode
     type: "Initializer"
     expression: e
@@ -96,13 +97,13 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
   children := [decl, binding]
 
   makeNode {
-    type: "Declaration",
-    pattern.names,
-    decl,
-    bindings: [binding],
-    splices,
-    thisAssignments,
-    children,
+    type: "Declaration"
+    pattern.names
+    decl
+    bindings: [binding]
+    splices
+    thisAssignments
+    children
   }
 
 function processDeclarations(statements: StatementTuple[]): void

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -14,12 +14,10 @@ import type {
   ASTNodeObject
   ASTNodeParent
   ASTRef
-  ASTString
   AssignmentExpression
   BlockStatement
   CallExpression
   CatchClause
-  Children
   Condition
   DeclarationStatement
   DoStatement
@@ -31,7 +29,6 @@ import type {
   IterationStatement
   MemberExpression
   MethodDefinition
-  ObjectBindingPatternContent
   Placeholder
   StatementExpression
   StatementTuple
@@ -117,6 +114,7 @@ import {
   adjustAtBindings
   adjustBindingElements
   gatherBindingCode
+  gatherBindingPatternTypeSuffix
 } from ./binding.civet
 import {
   getPrecedence
@@ -1555,36 +1553,6 @@ function typeOfJSXFragment(node, config) {
   }
 }
 
-// Extract the type suffixes from binding properties in an ObjectBindingPattern
-// into a type suffix for the whole ObjectBindingPattern
-// (or undefined if there aren't any type annotations)
-function objectBindingPatternTypeSuffix(props: ObjectBindingPatternContent): TypeSuffix?
-  count .= 0
-  let restType: ASTNode?
-  types: ASTNode[] :=
-    for each prop of props
-      count++ if prop.typeSuffix?
-      typeSuffix := prop.typeSuffix ?? ": unknown" as ASTString
-      switch prop.type
-        when "BindingProperty"
-          ws := prop.children[...prop.children.indexOf prop.name]
-          [ ...ws, prop.name, typeSuffix, "," as ASTString ] as Children
-        when "AtBindingProperty"
-          ws := prop.children[...prop.children.indexOf prop.binding]
-          [ ...ws, prop.ref.id, typeSuffix, "," as ASTString ] as Children
-        when "BindingRestProperty"
-          restType = prop.typeSuffix?.t
-          continue
-  if count
-    t: ASTNode[] := [ ": ", "{", types, "}" ]
-    t.push " & (", trimFirstSpace(restType), ")" if restType?
-    {
-      type: "TypeSuffix"
-      ts: true
-      t
-      children: [t]
-    }
-
 export {
   addPostfixStatement
   adjustBindingElements
@@ -1602,6 +1570,7 @@ export {
   expressionizeTypeIf
   forRange
   gatherBindingCode
+  gatherBindingPatternTypeSuffix
   gatherRecursive
   gatherRecursiveAll
   gatherRecursiveWithinFunction
@@ -1628,7 +1597,6 @@ export {
   maybeRefAssignment
   modifyString
   negateCondition
-  objectBindingPatternTypeSuffix
   precedenceStep
   prepend
   processAssignmentDeclaration

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -14,10 +14,12 @@ import type {
   ASTNodeObject
   ASTNodeParent
   ASTRef
+  ASTString
   AssignmentExpression
   BlockStatement
   CallExpression
   CatchClause
+  Children
   Condition
   DeclarationStatement
   DoStatement
@@ -29,6 +31,7 @@ import type {
   IterationStatement
   MemberExpression
   MethodDefinition
+  ObjectBindingPatternContent
   Placeholder
   StatementExpression
   StatementTuple
@@ -1552,6 +1555,36 @@ function typeOfJSXFragment(node, config) {
   }
 }
 
+// Extract the type suffixes from binding properties in an ObjectBindingPattern
+// into a type suffix for the whole ObjectBindingPattern
+// (or undefined if there aren't any type annotations)
+function objectBindingPatternTypeSuffix(props: ObjectBindingPatternContent): TypeSuffix?
+  count .= 0
+  let restType: ASTNode?
+  types: ASTNode[] :=
+    for each prop of props
+      count++ if prop.typeSuffix?
+      typeSuffix := prop.typeSuffix ?? ": unknown" as ASTString
+      switch prop.type
+        when "BindingProperty"
+          ws := prop.children[...prop.children.indexOf prop.name]
+          [ ...ws, prop.name, typeSuffix, "," as ASTString ] as Children
+        when "AtBindingProperty"
+          ws := prop.children[...prop.children.indexOf prop.binding]
+          [ ...ws, prop.ref.id, typeSuffix, "," as ASTString ] as Children
+        when "BindingRestProperty"
+          restType = prop.typeSuffix?.t
+          continue
+  if count
+    t: ASTNode[] := [ ": ", "{", types, "}" ]
+    t.push " & (", trimFirstSpace(restType), ")" if restType?
+    {
+      type: "TypeSuffix"
+      ts: true
+      t
+      children: [t]
+    }
+
 export {
   addPostfixStatement
   adjustBindingElements
@@ -1595,6 +1628,7 @@ export {
   maybeRefAssignment
   modifyString
   negateCondition
+  objectBindingPatternTypeSuffix
   precedenceStep
   prepend
   processAssignmentDeclaration

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -63,6 +63,7 @@ export type OtherNode =
   | ASTRef
   | ASTWrapper
   | AccessStart
+  | AtBinding
   | Call
   | CatchClause
   | CaseBlock
@@ -392,6 +393,7 @@ export type ASTRef =
 export type AtBinding =
   type: "AtBinding"
   ref: ASTRef
+  children: Children & [ASTRef]
 
 export type BlockStatement =
   type: "BlockStatement"
@@ -535,13 +537,46 @@ export type PinPattern =
 // _?, __
 export type Whitespace = (ASTLeaf | ASTString)[]?
 
-export type BindingPatternContent = unknown[]
+export type SimpleBindingProperty =
+  type: "BindingProperty"
+  children: Children
+  parent?: Parent
+  name: string
+  names: string[]
+  typeSuffix: TypeSuffix?
+  initializer: Initializer?
+
+export type AtBindingProperty =
+  type: "AtBindingProperty"
+  children: Children
+  parent?: Parent
+  binding: AtBinding
+  ref: ASTRef
+  names: string[]
+  typeSuffix: TypeSuffix?
+  initializer: Initializer?
+
+export type BindingRestProperty =
+  type: "BindingRestProperty"
+  children: Children
+  parent?: Parent
+  typeSuffix: TypeSuffix?
+  // AtBinding case
+  ref?: ASTRef
+  // Identifier case
+  name?: string
+  names?: string[]
+
+export type BindingProperty =
+  SimpleBindingProperty | AtBindingProperty | BindingRestProperty
+
+export type ObjectBindingPatternContent = BindingProperty[]
 
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",
-  children: Children & [Whitespace, ASTLeaf, BindingPatternContent, WSNode, ASTLeaf]
+  children: Children & [Whitespace, ASTLeaf, ObjectBindingPatternContent, WSNode, ASTLeaf]
   names: string[]
-  properties: BindingPatternContent
+  properties: ObjectBindingPatternContent
 
 export type ObjectExpression
   type: "ObjectExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -64,6 +64,9 @@ export type OtherNode =
   | ASTWrapper
   | AccessStart
   | AtBinding
+  | ArrayBindingPattern
+  | Binding
+  | BindingRestElement
   | Call
   | CatchClause
   | CaseBlock
@@ -73,10 +76,14 @@ export type OtherNode =
   | FinallyClause
   | Index
   | Initializer
+  | ObjectBindingPattern
   | Parameter
   | ParametersNode
+  | PinPattern
   | Placeholder
   | PropertyAccess
+  | ReturnValue
+  | TypeSuffix
   | WhenClause
 
 /** @deprecated */
@@ -543,6 +550,7 @@ export type SimpleBindingProperty =
   parent?: Parent
   name: string
   names: string[]
+  value: BindingIdentifier | BindingPattern
   typeSuffix: TypeSuffix?
   initializer: Initializer?
 
@@ -577,6 +585,7 @@ export type ObjectBindingPattern =
   children: Children & [Whitespace, ASTLeaf, ObjectBindingPatternContent, WSNode, ASTLeaf]
   names: string[]
   properties: ObjectBindingPatternContent
+  typeSuffix?: TypeSuffix?
 
 export type ObjectExpression
   type: "ObjectExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -532,6 +532,7 @@ export type BindingElement =
   names: string[]
   binding: BindingIdentifier | BindingPattern
   typeSuffix?: TypeSuffix?
+  delim: ASTNode
 
 export type BindingRestElement =
   type: "BindingRestElement"
@@ -574,6 +575,7 @@ export type BindingProperty =
   value: BindingIdentifier | BindingPattern
   typeSuffix: TypeSuffix?
   initializer: Initializer?
+  delim: ASTNode
 
 export type AtBindingProperty =
   type: "AtBindingProperty"
@@ -584,12 +586,14 @@ export type AtBindingProperty =
   names: string[]
   typeSuffix: TypeSuffix?
   initializer: Initializer?
+  delim: ASTNode
 
 export type BindingRestProperty =
   type: "BindingRestProperty"
   children: Children
   parent?: Parent
   typeSuffix: TypeSuffix?
+  delim: ASTNode
   // AtBinding case
   ref?: ASTRef
   // Identifier case

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -64,6 +64,7 @@ export type OtherNode =
   | ASTWrapper
   | AccessStart
   | AtBinding
+  | AtBindingProperty
   | ArrayBindingPattern
   | Binding
   | BindingRestElement
@@ -506,14 +507,6 @@ export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBi
 
 export type PatternExpression = BindingPattern | ConditionFragment
 
-export type BindingRestElement =
-  type: "BindingRestElement"
-  children: Children
-  parent?: Parent
-  name: string
-  names: string[]
-  rest: true
-
 export type ConditionFragment =
   type: "ConditionFragment"
   children: Children
@@ -525,8 +518,36 @@ export type ArrayBindingPattern =
   type: "ArrayBindingPattern"
   children: Children
   parent?: Parent
-  elements: BindingPattern[]
+  elements: ArrayBindingPatternContent
   length: number
+  names: string[]
+  typeSuffix?: TypeSuffix?
+
+export type ArrayBindingPatternContent =
+  (BindingElement | BindingRestElement | ElisionElement)[]
+
+export type BindingElement =
+  type: "BindingElement"
+  children: Children
+  names: string[]
+  binding: BindingIdentifier | BindingPattern
+  typeSuffix?: TypeSuffix?
+
+export type BindingRestElement =
+  type: "BindingRestElement"
+  children: Children
+  parent?: Parent
+  dots: ASTLeaf
+  name: string
+  names: string[]
+  rest: true
+  typeSuffix?: TypeSuffix?
+
+export type ElisionElement =
+  type: "ElisionElement"
+  children: Children
+  parent?: Parent
+  typeSuffix?: undefined
   names: string[]
 
 export type Placeholder =
@@ -544,7 +565,7 @@ export type PinPattern =
 // _?, __
 export type Whitespace = (ASTLeaf | ASTString)[]?
 
-export type SimpleBindingProperty =
+export type BindingProperty =
   type: "BindingProperty"
   children: Children
   parent?: Parent
@@ -575,10 +596,8 @@ export type BindingRestProperty =
   name?: string
   names?: string[]
 
-export type BindingProperty =
-  SimpleBindingProperty | AtBindingProperty | BindingRestProperty
-
-export type ObjectBindingPatternContent = BindingProperty[]
+export type ObjectBindingPatternContent =
+  (BindingProperty | AtBindingProperty | BindingRestProperty)[]
 
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -513,7 +513,7 @@ const typeNeedsNoParens = new Set [
 /**
  * Parenthesize type if it might need it in some contexts.
  */
-function parenthesizeType(type: ASTNodeBase)
+function parenthesizeType(type: ASTNode)
   return type if typeNeedsNoParens.has type.type
   ["(", type, ")"]
 

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -1,4 +1,4 @@
-{testCase} from ../helper.civet
+{testCase, throws} from ../helper.civet
 
 describe "[TS] destructuring", ->
   testCase """
@@ -11,3 +11,64 @@ describe "[TS] destructuring", ->
       return `Hello ${first} ${last}!`
     }
   """
+
+  describe ":: typing of properties", ->
+    testCase """
+      simple
+      ---
+      { first:: string, last?:: string } := person
+      ---
+      const { first, last }: { first: string, last?: string,} = person
+    """
+
+    testCase """
+      renamed
+      ---
+      { first: f:: string, last: l ?:: string } := person
+      ---
+      const { first: f, last: l }: { first: string, last ?: string,} = person
+    """
+
+    testCase """
+      at
+      ---
+      first := 'Hello'
+      { @first:: string, @last?:: string } := person
+      ---
+      const first = 'Hello'
+      const {first:  first1, last }: { first: string, last?: string,} = person;this.first = first1;this.last = last;
+    """
+
+    testCase """
+      rest
+      ---
+      { first:: string, ...rest:: { last?: string } } := person
+      ---
+      const { first, ...rest }: { first: string,} & ({ last?: string }) = person
+    """
+
+    throws """
+      pin
+      ---
+      { ^foo:: string } := person
+      ---
+      ParseErrors: unknown:1:7 Pinned properties cannot have type annotations
+    """
+
+    testCase """
+      function parameter
+      ---
+      function Component({
+        first:: string
+        last: l:: string
+        ...rest:: OtherProps
+      })
+      ---
+      function Component({
+        first,
+        last: l,
+        ...rest
+      }: {
+        first: string,
+        last: string,} & (OtherProps)){}
+    """

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -18,7 +18,7 @@ describe "[TS] destructuring", ->
       ---
       { first:: string, last?:: string } := person
       ---
-      const { first, last }: { first: string, last?: string,} = person
+      const { first, last }: { first: string, last?: string} = person
     """
 
     testCase """
@@ -26,7 +26,7 @@ describe "[TS] destructuring", ->
       ---
       const { first:: string, last?:: string } = person
       ---
-      const { first, last }: { first: string, last?: string,} = person
+      const { first, last }: { first: string, last?: string} = person
     """
 
     testCase """
@@ -34,7 +34,7 @@ describe "[TS] destructuring", ->
       ---
       { first: f:: string, last: l ?:: string } := person
       ---
-      const { first: f, last: l }: { first: string, last ?: string,} = person
+      const { first: f, last: l }: { first: string, last ?: string} = person
     """
 
     testCase """
@@ -44,7 +44,7 @@ describe "[TS] destructuring", ->
       { @first:: string, @last?:: string } := person
       ---
       const first = 'Hello'
-      const {first:  first1, last }: { first: string, last?: string,} = person;this.first = first1;this.last = last;
+      const {first:  first1, last }: { first: string, last?: string} = person;this.first = first1;this.last = last;
     """
 
     testCase """
@@ -86,7 +86,7 @@ describe "[TS] destructuring", ->
       ---
       { name: {first, last}:: Name } := person
       ---
-      const { name: {first, last} }: { name: Name,} = person
+      const { name: {first, last} }: { name: Name} = person
     """
 
     testCase """
@@ -94,7 +94,7 @@ describe "[TS] destructuring", ->
       ---
       { name: {first:: string, last?:: string} } := person
       ---
-      const { name: {first, last} }: { name: {first: string, last?: string,},} = person
+      const { name: {first, last} }: { name: {first: string, last?: string}} = person
     """
 
     testCase """
@@ -102,7 +102,7 @@ describe "[TS] destructuring", ->
       ---
       [ first:: string, last?:: string ] := person
       ---
-      const [ first, last ]: [ string,undefined | string,] = person
+      const [ first, last ]: [ string,undefined | string] = person
     """
 
     testCase """
@@ -110,7 +110,7 @@ describe "[TS] destructuring", ->
       ---
       [ first:: string, last ] := person
       ---
-      const [ first, last ]: [ string,unknown,] = person
+      const [ first, last ]: [ string,unknown] = person
     """
 
     testCase """
@@ -118,7 +118,7 @@ describe "[TS] destructuring", ->
       ---
       [ first:: string, ...rest:: string[] ] := person
       ---
-      const [ first, ...rest ]: [ string,... string[],] = person
+      const [ first, ...rest ]: [ string,... string[]] = person
     """
 
     testCase """
@@ -126,7 +126,7 @@ describe "[TS] destructuring", ->
       ---
       { name: [ first:: string, last?:: string ] } := person
       ---
-      const { name: [ first, last ] }: { name: [ string,undefined | string,],} = person
+      const { name: [ first, last ] }: { name: [ string,undefined | string]} = person
     """
 
     testCase """
@@ -134,5 +134,5 @@ describe "[TS] destructuring", ->
       ---
       [ { first:: string, last?:: string }, ...rest ] := people
       ---
-      const [ { first, last }, ...rest ]: [{ first: string, last?: string,},...unknown[],] = people
+      const [ { first, last }, ...rest ]: [{ first: string, last?: string},...unknown[]] = people
     """

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -22,6 +22,14 @@ describe "[TS] destructuring", ->
     """
 
     testCase """
+      simple const
+      ---
+      const { first:: string, last?:: string } = person
+      ---
+      const { first, last }: { first: string, last?: string,} = person
+    """
+
+    testCase """
       renamed
       ---
       { first: f:: string, last: l ?:: string } := person
@@ -71,4 +79,20 @@ describe "[TS] destructuring", ->
       }: {
         first: string,
         last: string,} & (OtherProps)){}
+    """
+
+    testCase """
+      nested with outer type
+      ---
+      { name: {first, last}:: Name } := person
+      ---
+      const { name: {first, last} }: { name: Name,} = person
+    """
+
+    testCase """
+      nested objects
+      ---
+      { name: {first:: string, last?:: string} } := person
+      ---
+      const { name: {first, last} }: { name: {first: string, last?: string,},} = person
     """

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -78,7 +78,7 @@ describe "[TS] destructuring", ->
         ...rest
       }: {
         first: string,
-        last: string,} & (OtherProps)){}
+        last: string,} & OtherProps){}
     """
 
     testCase """
@@ -95,4 +95,44 @@ describe "[TS] destructuring", ->
       { name: {first:: string, last?:: string} } := person
       ---
       const { name: {first, last} }: { name: {first: string, last?: string,},} = person
+    """
+
+    testCase """
+      array
+      ---
+      [ first:: string, last?:: string ] := person
+      ---
+      const [ first, last ]: [ string,undefined | string,] = person
+    """
+
+    testCase """
+      array with some types
+      ---
+      [ first:: string, last ] := person
+      ---
+      const [ first, last ]: [ string,unknown,] = person
+    """
+
+    testCase """
+      array with rest
+      ---
+      [ first:: string, ...rest:: string[] ] := person
+      ---
+      const [ first, ...rest ]: [ string,... string[],] = person
+    """
+
+    testCase """
+      object with nested array
+      ---
+      { name: [ first:: string, last?:: string ] } := person
+      ---
+      const { name: [ first, last ] }: { name: [ string,undefined | string,],} = person
+    """
+
+    testCase """
+      array with nested object
+      ---
+      [ { first:: string, last?:: string }, ...rest ] := people
+      ---
+      const [ { first, last }, ...rest ]: [{ first: string, last?: string,},...unknown[],] = people
     """


### PR DESCRIPTION
Fixes #126 by implementing a long-sought syntax for typing individual object properties and array elements in left-hand-side patterns (including function arguments and assignment). Basically, `:: type` can come at the end of any existing object property or array element.  For example:

```js
function Component({
  name: [first:: string, last:: string, ...rest:: string[]],
  counter:: number
  setCounter: sc:: (number) => void
})
↓↓↓
function Component({
  name: [first, last, ...rest],
  counter,
  setCounter: sc
}: {
  name: [ string, string,... string[],],
  counter: number,
  setCounter: (number) => void,}){}
```

Why this notation?
* `name:: type: value` is ambiguous: it could be interpreted as `name:: {type: value}` (typing as object). (I tried to include this as an option at first, but ran into this alternate parse.)
* `name: value: type` is similarly ambiguous: it could be interpreted as `name: {value: type}` (complex destructuring).

I admit I still often type the wrong number of `:`s when writing examples, but I imagine we'll get used to it. (Also open to better proposals for notation.)

I still need to write actual docs, but hopefully the example above and the tests give a reasonable idea.