### PR TITLE
Fix pattern matching with indented object patterns

### DIFF
--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -191,11 +191,11 @@ function getPatternConditions(
   pattern: PatternExpression,
   ref: ASTNode,
   conditions: ASTNode[] = [],
-): ASTNode[] {
+): ASTNode[]
   if (pattern.rest) return conditions // No conditions for rest elements
 
-  switch (pattern.type) {
-    case "ArrayBindingPattern": {
+  switch pattern.type
+    when "ArrayBindingPattern"
       const { elements, length } = pattern,
         hasRest = elements.some((e) => e.rest),
         l = (length - +hasRest).toString(),
@@ -215,59 +215,43 @@ function getPatternConditions(
       })
 
       // collect post rest conditions
-      const { blockPrefix } = pattern
-      if (blockPrefix) {
-        const postElements = blockPrefix.children[1],
-          { length: postLength } = postElements
+      { blockPrefix } := pattern
+      if blockPrefix
+        postElements := blockPrefix.children[1]
+        { length: postLength } := postElements
 
         postElements.forEach(({ children: [, e] }, i) => {
           const subRef = [ref, "[", ref, ".length - ", (postLength + i).toString(), "]"]
           getPatternConditions(e, subRef, conditions)
         })
-      }
 
-      break
-    }
-    case "ObjectBindingPattern": {
-      conditions.push(
-        ["typeof ", ref, " === 'object'"],
-        [ref, " != null"],
-      )
+    when "ObjectBindingPattern"
+      conditions.push
+        ["typeof ", ref, " === 'object'"]
+        [ref, " != null"]
 
-      pattern.properties.forEach((p) => {
-        switch (p.type) {
-          case "PinProperty":
-          case "BindingProperty": {
-            const { name, value } = p
+      for each p of pattern.properties
+        switch p.type
+          when "PinProperty", "BindingProperty"
+            { name, value } := p
             let subRef
-            switch (name.type) {
-              case "ComputedPropertyName":
+            switch name.type
+              when "ComputedPropertyName"
                 conditions.push([name.expression, " in ", ref])
                 subRef = [ref, name]
-                break
-              case "Literal":
-              case "StringLiteral":
-              case "NumericLiteral":
+              when "Literal", "StringLiteral", "NumericLiteral"
                 conditions.push([name, " in ", ref])
                 subRef = [ref, "[", name, "]"]
-                break
-              default:
-                conditions.push(["'", name, "' in ", ref])
-                subRef = [ref, ".", name]
-            }
+              when "Identifier"
+                conditions.push(["'", name.name, "' in ", ref])
+                subRef = [ref, ".", name.name]
+              when "AtBinding"
+                conditions.push(["'", name.ref.id, "' in ", ref])
+                subRef = [ref, ".", name.ref.id]
 
-            if (value) {
-              getPatternConditions(value, subRef, conditions)
-            }
+            getPatternConditions(value, subRef, conditions) if value
 
-            break
-          }
-        }
-      })
-
-      break
-    }
-    case "ConditionFragment": {
+    when "ConditionFragment"
       let { children } = pattern
       // Add leading space to first binary operation
       if (children.length) {
@@ -280,35 +264,28 @@ function getPatternConditions(
       conditions.push(
         processBinaryOpExpression([ref, children])
       )
-      break
-    }
-    case "RegularExpressionLiteral": {
+
+    when "RegularExpressionLiteral"
       conditions.push(
         ["typeof ", ref, " === 'string'"],
         [pattern, ".test(", ref, ")"],
       )
 
-      break
-    }
-    case "PinPattern":
+    when "PinPattern"
       conditions.push([
         ref,
         " === ",
         pattern.expression,
       ])
-      break
-    case "Literal":
+
+    when "Literal"
       conditions.push([
         ref,
         " === ",
         pattern,
       ])
-      break
-    default:
-      break
-  }
+
   return conditions
-}
 
 function getPatternBlockPrefix(
   pattern: PatternExpression

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -49,6 +49,7 @@ export type ExpressionNode =
   | ObjectExpression
   | ParenthesizedExpression
   | PipelineExpression
+  | RegularExpressionLiteral
   | StatementExpression
   | TypeNode
   | UnaryExpression
@@ -72,6 +73,7 @@ export type OtherNode =
   | CatchClause
   | CaseBlock
   | CommentNode
+  | ComputedPropertyName
   | DefaultClause
   | ElseClause
   | FinallyClause
@@ -81,6 +83,7 @@ export type OtherNode =
   | Parameter
   | ParametersNode
   | PinPattern
+  | PinProperty
   | Placeholder
   | PropertyAccess
   | ReturnValue
@@ -512,7 +515,12 @@ export type ConditionFragment =
   children: Children
   parent?: Parent
 
-export type RegularExpressionLiteral = ASTLeaf & type: "RegularExpressionLiteral"
+export type RegularExpressionLiteral =
+  type: "RegularExpressionLiteral"
+  $loc: Loc
+  token: string
+  parent?: Parent
+  children?: never
 
 export type ArrayBindingPattern =
   type: "ArrayBindingPattern"
@@ -566,16 +574,34 @@ export type PinPattern =
 // _?, __
 export type Whitespace = (ASTLeaf | ASTString)[]?
 
+type PropertyName =
+  Literal | ComputedPropertyName | Identifier
+
+type ComputedPropertyName =
+  type: "ComputedPropertyName"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
+
 export type BindingProperty =
   type: "BindingProperty"
   children: Children
   parent?: Parent
-  name: string
+  name: PropertyName | AtBinding
   names: string[]
   value: BindingIdentifier | BindingPattern
   typeSuffix: TypeSuffix?
   initializer: Initializer?
   delim: ASTNode
+
+export type PinProperty =
+  type: "PinProperty"
+  children: Children
+  parent?: Parent
+  name: PropertyName | AtBinding
+  value: PinPattern
+  delim: ASTNode
+  typeSuffix?: undefined
 
 export type AtBindingProperty =
   type: "AtBindingProperty"
@@ -601,7 +627,7 @@ export type BindingRestProperty =
   names?: string[]
 
 export type ObjectBindingPatternContent =
-  (BindingProperty | AtBindingProperty | BindingRestProperty)[]
+  (BindingProperty | PinProperty | AtBindingProperty | BindingRestProperty)[]
 
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",

--- a/test/if.civet
+++ b/test/if.civet
@@ -1046,6 +1046,23 @@ describe "if", ->
     """
 
     testCase """
+      if declaration with indented pattern
+      ---
+      if {
+        type
+        name, value
+      } := node
+        console.log type, name
+      ---
+      if ((node) && typeof node === 'object' && 'type' in node && 'name' in node && 'value' in node) {const {
+        type,
+        name, value
+      } = node;
+        console.log(type, name)
+      }
+    """
+
+    testCase """
       declaration with if else
       ---
       if x := 0


### PR DESCRIPTION

## Input

```js
if {
  type
  name, value
} := node
  console.log type, name
```

## Prior Output (Invalid JS)

```js
if ((node) && typeof node === 'object' && 'type' in node && '
  name' in node && 'value' in node) {const {
  type,
  name, value
} = node;
  console.log(type, name)
}
```

## New Output (with this PR)

```js
if ((node) && typeof node === 'object' && 'type' in node && 'name' in node && 'value' in node) {const {
  type,
  name, value
} = node;
  console.log(type, name)
}
```

## Bonus

More typing fixes (reducing number of TS errors from 611 to 607) and Civetification