### PR TITLE
`"civet jsxCode"` directive treats JSX children as Civet code

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -39,6 +39,9 @@ and following ESM, require importing files with the correct extension.
 | [`autoLet`](reference#autolet) | automatically declare undeclared variables with `let` |
 | [`autoVar`](reference#autovar) | automatically declare undeclared variables with `var` |
 | [`defaultElement=tag`](reference#implicit-element) | specify default JSX tag: `<.foo>` → `<tag class="foo">` |
+| [`jsxCode`](reference#automatic-code-children) | treat all JSX children as Civet code |
+| [`jsxCodeNested`](reference#automatic-code-children) | treat indented JSX children as Civet code |
+| [`jsxCodeSameLine`](reference#automatic-code-children) | treat same-line JSX children as Civet code |
 | [`objectIs`](reference#object-is) | implement the `is` operator via `Object.is` |
 
 ## ECMAScript Compatibility

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2507,6 +2507,56 @@ To write an entire block of code, indent it inside `>`
     `Logged in as ${user.first} ${user.last}`
 </Playground>
 
+### Automatic Code Children
+
+If code is more common than text in your JSX, consider using the
+`"civet jsxCode" directive which treats JSX children as Civet expressions.
+
+<Playground>
+"civet jsxCode"
+function List({items})
+  <ul>
+    for item of items
+      <li>
+        if item.image
+          <img src=item.image>
+        if item.type is "link"
+          <a href=url>
+            'Link: '
+            item.title
+        else
+          <p> item.content
+</Playground>
+
+Note that each "line" is treated as its own child expression,
+which makes it easy to concatenate multiple expressions.
+If you need a multi-line block, use [`do`](#do-blocks):
+
+<Playground>
+"civet jsxCode"
+<div>
+  "Welcome, "
+  do
+    { first, last } := getName()
+    `${first} ${last.toUpperCase()}`
+</Playground>
+
+You can also individually control whether children get treated as code
+when on the same line as the tag (`"civet jsxCodeSameLine"`) or
+when indented (`"civet jsxCodeNested"`).
+(This distinction is only meaningful when `"civet coffeeJSX"` is disabled.)
+
+<Playground>
+"civet jsxCodeNested"
+<form>
+  <h2>Enter your name
+  for part of ["first", "last"]
+    <label>
+      part.toUpperCase() + ": "
+      <input id=part>
+  <button>Submit
+</Playground>
+
 ## [SolidJS](https://www.solidjs.com/)
 
 `link` automatically typed as `HTMLAnchorElement`

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6940,7 +6940,15 @@ InlineJSXPrimaryExpression
 JSXMixedChildren
   # NOTE: c1 matches "same-line" children, while c2 matches indented children
   # Used in indentation-based JSX
-  JSXChild*:c1 JSXNestedChildren:c2 ->
+  !JSXCodeEnabled JSXChild*:c1 JSXNestedChildren:c2 ->
+    return {
+      children: c1.concat(c2),
+      jsxChildren: c1.concat(c2.jsxChildren),
+    }
+  # NOTE: In jsxCode mode, we discard leading whitespace on same-line children,
+  # which just serves to separate JSX tag from code.
+  JSXCodeEnabled ( NonNewlineWhitespace? JSXChild )*:c1 JSXNestedChildren:c2 ->
+    c1 = c1.map(([ws, c]) => c)
     return {
       children: c1.concat(c2),
       jsxChildren: c1.concat(c2.jsxChildren),
@@ -7008,8 +7016,9 @@ JSXChild
     }
   # NOTE: >expression to avoid braces
   JSXAngleChild
+  JSXCodeEnabled JSXCodeChild -> $2
   # NOTE: JSXText must come after attempt to match ArrowFunction
-  JSXText
+  !JSXCodeEnabled JSXText -> $2
 
 # XML comments: https://www.w3.org/TR/xml/#sec-comments
 JSXComment
@@ -7049,11 +7058,14 @@ NestedJSXChildExpression
 # > followed by expression or indented block is a way to avoid wrapping
 # JSX code children in braces
 JSXAngleChild
-  CloseAngleBracket InsertInlineOpenBrace:open JSXAngleChildExpression:expression InsertCloseBrace:close ->
+  CloseAngleBracket JSXCodeChild -> $2
+
+JSXCodeChild
+  InsertInlineOpenBrace:open JSXCodeChildExpression:expression InsertCloseBrace:close ->
     if (!expression) return $skip
     return [ open, expression, close ]  // omit >
 
-JSXAngleChildExpression
+JSXCodeChildExpression
   # First check for unindented expression (same line)
   !JSXEOS ForbidNewlineBinaryOp JSXChildExpression?:expression RestoreNewlineBinaryOp ->
     if (!expression) return $skip
@@ -7986,6 +7998,11 @@ CoffeePrototypeEnabled
     if(config.coffeePrototype) return
     return $skip
 
+JSXCodeEnabled
+  "" ->
+    if(config.jsxCode) return
+    return $skip
+
 ObjectIsEnabled
   "" ->
     if(config.objectIs) return
@@ -8033,6 +8050,7 @@ Reset
       coffeePrototype: false,
       defaultElement: "div",
       implicitReturns: true,
+      jsxCode: false,
       objectIs: false,
       react: false,
       solid: false,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6940,19 +6940,18 @@ InlineJSXPrimaryExpression
 JSXMixedChildren
   # NOTE: c1 matches "same-line" children, while c2 matches indented children
   # Used in indentation-based JSX
-  !JSXCodeEnabled JSXChild*:c1 JSXNestedChildren:c2 ->
+  JSXSameLineChildren:c1 JSXNestedChildren:c2 ->
     return {
       children: c1.concat(c2),
       jsxChildren: c1.concat(c2.jsxChildren),
     }
-  # NOTE: In jsxCode mode, we discard leading whitespace on same-line children,
-  # which just serves to separate JSX tag from code.
-  JSXCodeEnabled ( NonNewlineWhitespace? JSXChild )*:c1 JSXNestedChildren:c2 ->
-    c1 = c1.map(([ws, c]) => c)
-    return {
-      children: c1.concat(c2),
-      jsxChildren: c1.concat(c2.jsxChildren),
-    }
+
+JSXSameLineChildren
+  # NOTE: In jsxCodeSameLine mode, we discard leading whitespace on same-line
+  # children, which just serves to separate JSX tag from code.
+  JSXCodeSameLineEnabled ( NonNewlineWhitespace? !EOL JSXChildForcedCode )*:children ->
+    return children.map(([, , c]) => c)
+  !JSXCodeSameLineEnabled JSXChildForcedNoCode*:children -> children
 
 # https://facebook.github.io/jsx/#prod-JSXChildren
 # JSX eats whitespace around newlines
@@ -6991,6 +6990,22 @@ JSXNested
 
 # https://facebook.github.io/jsx/#prod-JSXChild
 JSXChild
+  JSXChildGeneral
+  JSXCodeNestedEnabled JSXCodeChild -> $2
+  # NOTE: JSXText must come after attempt to match ArrowFunction
+  !JSXCodeNestedEnabled JSXText -> $2
+
+# Simulate JSXChild with JSXCodeEnabled forced true (for same-line children)
+JSXChildForcedCode
+  JSXChildGeneral
+  JSXCodeChild
+
+# Simulate JSXChild with JSXCodeEnabled forced false (for same-line children)
+JSXChildForcedNoCode
+  JSXChildGeneral
+  JSXText
+
+JSXChildGeneral
   JSXElement
   JSXFragment
   # NOTE: Adding support for XML comments
@@ -7016,9 +7031,6 @@ JSXChild
     }
   # NOTE: >expression to avoid braces
   JSXAngleChild
-  JSXCodeEnabled JSXCodeChild -> $2
-  # NOTE: JSXText must come after attempt to match ArrowFunction
-  !JSXCodeEnabled JSXText -> $2
 
 # XML comments: https://www.w3.org/TR/xml/#sec-comments
 JSXComment
@@ -7998,9 +8010,14 @@ CoffeePrototypeEnabled
     if(config.coffeePrototype) return
     return $skip
 
-JSXCodeEnabled
+JSXCodeNestedEnabled
   "" ->
-    if(config.jsxCode) return
+    if(config.jsxCodeNested) return
+    return $skip
+
+JSXCodeSameLineEnabled
+  "" ->
+    if(config.jsxCodeSameLine) return
     return $skip
 
 ObjectIsEnabled
@@ -8098,7 +8115,18 @@ Reset
       }
     })
 
-    // Hack to pass in parser config from main
+    Object.defineProperty(config, "jsxCode", {
+      set(b) {
+        for (const option of [
+          "jsxCodeNested",
+          "jsxCodeSameLine",
+        ]) {
+          config[option] = b
+        }
+      }
+    })
+
+    // Pass in parser config from main
     Object.assign(config, initialConfig)
 
     // Hack to pass parser state to cache key

--- a/test/jsx/code.civet
+++ b/test/jsx/code.civet
@@ -1,0 +1,77 @@
+{ testCase } from ../helper.civet
+
+describe "jsxCode", ->
+  testCase """
+    nested
+    ---
+    "civet jsxCodeNested"
+    Component := (items: Item[]) =>
+      <ul>
+        for item of items
+          <li>
+            if item.type === "link"
+              <a href=item.url>some link title: {item.title}
+            else
+              <p>{item.content}
+    ---
+    const Component = (items: Item[]) => {
+      return <ul>
+        {(()=>{const results=[];for (const item of items) {
+          results.push(<li>
+            {(item.type === "link"?
+              <a href={item.url}>some link title: {item.title}
+              </a>
+            :
+              <p>{item.content}
+              </p>)}
+          </li>)
+        }return results})()}
+      </ul>
+    }
+  """
+
+  testCase """
+    same line
+    ---
+    "civet jsxCodeSameLine"
+    <div>
+      Logged in as:
+      <span .name> name
+    </div>
+    ---
+    <div>
+      Logged in as:
+      <span class="name">{name}
+      </span>
+    </div>
+  """
+
+  testCase """
+    both
+    ---
+    "civet jsxCode"
+    <div>
+      if items
+        <h1> "List of items:"
+        <ul> for item in items
+          <li> <span> item
+      else
+        <span> "No items found"
+    ---
+    <div>
+      {(items?
+        <>
+        <h1>{"List of items:"}
+        </h1>
+        <ul>{(()=>{const results=[];for (const item in items) {
+          results.push(<li><span>{item}
+          </span>
+          </li>)
+        }return results})()}
+        </ul>
+        </>
+      :
+        <span>{"No items found"}
+        </span>)}
+    </div>
+  """

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -21,6 +21,7 @@ declare module "@danielx/civet" {
     coffeePrototype: boolean
     defaultElement: string
     implicitReturns: boolean
+    jsxCode: boolean
     objectIs: boolean
     react: boolean
     solid: boolean


### PR DESCRIPTION
This PR should finish the rest of and thus fixes #561.

* `"civet jsxCode"` treats all JSX children as Civet expressions.
* I went with my original proposal where each Civet line of code is treated as a separate expression wrapped in braces. I think this is the most common case, where you have many consecutive `if`s and such, each of which needs to render. And it's easy to make a larger block, using a `do` block. (See example in documentation.)
* I was less sure whether children on the same line should be treated as code, so I made it an option!
  * `"civet jsxCodeNested"` just enables the code mode for nested (indented) children.
  * `"civet jsxCodeSameLine"` just enables the code mode for same-line children (not sure why you'd do this, but I originally had in mind `"civet jsxCode -jsxCodeSameLine"`).
  * `"civet jsxCode"` turns on both of the above.

As expected, #1381 turned out to be a very helpful step in this direction, defining what a code child would look like. Most of that code is re-used here.

As future work, I could see converting strings like `"foo"` into JSX text `foo` instead of the current behavior, `{"foo"}`. But there are lots of subtle differences between strings and text, and I didn't want to get bogged down in that. (I think some JSX preprocessors might already do this anyway.)