### PR TITLE
Lexical declarations as JSX code children

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2465,6 +2465,17 @@ Implicit elements must start with `id` or `class` shorthand (`#` or `.`).
 
 :::
 
+### Declaration Children
+
+Lexical declarations can appear in the middle of JSX, allowing you to
+effectively define variables in the middle of a long JSX block.
+
+<Playground>
+<div>
+  { {first, last} := getName() }
+  Welcome, {first} {last}!
+</Playground>
+
 ### Function Children
 
 Arrow functions are automatically wrapped in braces:
@@ -2539,6 +2550,17 @@ If you need a multi-line block, use [`do`](#do-blocks):
   do
     { first, last } := getName()
     `${first} ${last.toUpperCase()}`
+</Playground>
+
+[Declaration children](#declaration-children) work too,
+but note that they are exposed to the outer block:
+
+<Playground>
+"civet jsxCode"
+<div>
+  "Welcome, "
+  { first, last } := getName()
+  `${first} ${last.toUpperCase()}`
 </Playground>
 
 You can also individually control whether children get treated as code

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -894,7 +894,7 @@ ParenthesizedExpression
 
 Placeholder
   # Partial function application: f(., x) -> $ => f($, x)
-  Dot:dot !/\p{ID_Continue}|[\u200C\u200D$.#{]/ PlaceholderTypeSuffix?:typeSuffix ->
+  Dot:dot !/\p{ID_Continue}|[\u200C\u200D$.#{=]/ PlaceholderTypeSuffix?:typeSuffix ->
     return {
       type: "Placeholder",
       subtype: ".",
@@ -7056,6 +7056,39 @@ JSXText
 
 # https://facebook.github.io/jsx/#prod-JSXChildExpression
 JSXChildExpression
+  # NOTE: Added lexical declaration, which gets hoisted,
+  # converted into an assignment, and voided to avoid rendering.
+  Whitespace? LexicalDeclaration:d ->
+    // Add refs from thisAssignments to list of names
+    let names = d.names.concat(
+      d.thisAssignments.map(a => a[1][1])
+    )
+    // Remove duplicate names
+    names.sort()
+    names = names.filter((name, i) => i === 0 || name !== names[i-1])
+    d = {
+      ...d,
+      hoistDec: {
+        type: "Declaration",
+        children: [
+          "let ",
+          names.map((n, i) => i === 0 ? [n] : [",", n]).flat()
+        ],
+      },
+      children: d.children.slice(1),  // drop LetOrConst
+    }
+    if (d.thisAssignments?.length) {
+      d.children.push(...d.splices, ",", ...d.thisAssignments.map(
+        (a, i) => a[a.length-1] === ';' ? [
+          ...a.slice(0, -1),
+          i === d.thisAssignments.length-1 ? "" : ",",
+        ] : a
+      ))
+    } else if (d.splices?.length) {
+      d.children.push(...d.splices)
+    }
+    d.children.push(",void 0")
+    return d
   # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
   Whitespace? ( DotDotDot Whitespace? )? PostfixedExpression
 

--- a/test/jsx/code.civet
+++ b/test/jsx/code.civet
@@ -75,3 +75,55 @@ describe "jsxCode", ->
         </span>)}
     </div>
   """
+
+  testCase """
+    declaration
+    ---
+    "civet jsxCode"
+    <div>
+      user := getUser()
+      if user?
+        {name} := user
+        <h1> `Welcome ${name}!`
+      <h2>Posts</h2>
+      for post of posts
+        <div .post> post.jsx()
+    ---
+    let user;<div>
+      {user = getUser(),void 0}
+      {(()=>{if (user != null) {
+        const {name} = user
+        return <h1>{`Welcome ${name}!`}
+        </h1>
+      };return})()}
+      <h2>{Posts}</h2>
+      {(()=>{const results=[];for (const post of posts) {
+        results.push(<div class="post">{post.jsx()}
+        </div>)
+      }return results})()}
+    </div>
+  """
+
+  testCase """
+    this declaration
+    ---
+    "civet jsxCode"
+    <div>
+      {@first, @last} := getUser()
+    ---
+    let first,last;<div>
+      {{first, last} = getUser(),this.first = first,this.last = last,void 0}
+    </div>
+  """
+
+  testCase """
+    splice declaration
+    ---
+    "civet jsxCode"
+    <div>
+      [first, ...middle, last] := getUser()
+    ---
+    let first,last,middle;<div>
+      {[first, ...middle] = getUser(), [last] = middle.splice(-1),void 0}
+    </div>
+  """


### PR DESCRIPTION
One more idea from #561: This PR allows for lexical declarations as JSX code children (as braced expressions, `>` expressions, or automatic code children). In particular, this example now works:

```js
<div>
  user := getUser()
  if user?
    {name} := user
    <h1> `Welcome ${name}!`
  <h2>Posts</h2>
  for post of posts
    <div .post> post.jsx()
```

Somewhat unusual for Civet is that the declaration is *not* treated as an expression, as that would cause it to render in the JSX, which seems rarely desired. Instead we automatically add `,void 0` at the end to prevent rendering and just do the assignment. The declaration itself gets lifted (though there's no way to preserve `const` semantics here).