### PR TITLE
Add changelog to eslint plugin

### DIFF
--- a/integration/eslint/CHANGELOG.md
+++ b/integration/eslint/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Civet eslint plugin changelog
+
+## v0.0.5 (2024-08-26)
+* Support Node 22+ (switch to `import...with`)
+* Fix `typescipt-eslint` dependency to be truly optional
+* Upgrade build process to latest Civet and other deps
+
+## v0.0.4 (2024-05-05)
+* Set engines requirement for `import...assert`
+* Use `comptime` for plugin version, resulting in smaller build
+
+## v0.0.3 (2024-05-04)
+* Loosen eslint dependencies
+
+## v0.0.2 (2024-05-03)
+* Add prepublish script to eslint
+
+## v0.0.1 (2024-05-03)
+* Enable JSX in eslint, as Civet can output it
+
+## v0.0.0 (2024-05-03)
+* Initial working version

--- a/integration/eslint/CHANGELOG.md
+++ b/integration/eslint/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Civet eslint plugin changelog
 
 ## v0.0.5 (2024-08-26)
-* Support Node 22+ (switch to `import...with`)
-* Fix `typescipt-eslint` dependency to be truly optional
-* Upgrade build process to latest Civet and other deps
+* [[#1378](https://github.com/DanielXMoore/Civet/pull/1378)]:
+  * Support Node 22+ (switch to `import...with`)
+  * Fix `typescipt-eslint` dependency to be truly optional
+  * Upgrade build process to latest Civet and other deps
 
 ## v0.0.4 (2024-05-05)
 * Set engines requirement for `import...assert`

--- a/integration/eslint/package.json
+++ b/integration/eslint/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/DanielXMoore/Civet#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DanielXMoore/Civet.git"
+    "url": "git+https://github.com/DanielXMoore/Civet.git",
+    "directory": "integration/eslint"
   },
   "keywords": [
     "eslint"


### PR DESCRIPTION
This changelog is manually maintained, and currently no tags or explicit links. But I think it's a pretty small effort to manually update changelogs for these smaller subprojects, and seems less crucial to have tags. (`git log integration/eslint` can be used to see all relevant commits; it's what I used to make this changelog.)