### PR TITLE
Improve indentation handling with union/intersection types

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -36,6 +36,7 @@ uncacheable := new Set [
   "PopIndent"
   "TrackIndented"
   "BulletIndent"
+  "PushExtraIndent1"
 
   // JSX
   "PushJSXOpeningElement"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7483,6 +7483,9 @@ MaybeNestedType
   # NOTE: Let InterfaceBlock take first crack at an indented block
   # But don't prevent parsing a braced type with unary suffix like {}[]
   NestedInterfaceBlock
+  # NOTE: Next check for consistently indented binary operations (e.g. |)
+  # at beginning of each line.
+  NestedTypeBinaryChain
   PushIndent ( Nested Type )? PopIndent ->
     if (!$2) return $skip
     return $2
@@ -7528,11 +7531,21 @@ Type
   TypeWithPostfix
 
 TypeBinary
-  ( __ TypeBinaryOp __ )?:optionalPrefix TypeUnary:t ( __ TypeBinaryOp __ TypeUnary )*:ops ->
+  ( NotDedented TypeBinaryOp __ )?:optionalPrefix TypeUnary:t ( NotDedented TypeBinaryOp __ TypeUnary )*:ops ->
     if (!ops.length && !optionalPrefix) return t
     if (!ops.length) return [optionalPrefix, t]
     if (!optionalPrefix) return [t, ...ops]
     return [optionalPrefix, t, ops]
+
+NestedTypeBinaryChain
+  PushIndent NestedTypeBinary* PopIndent ->
+    if (!$2.length) return $skip
+    return $2
+
+NestedTypeBinary
+  Nested:indent TypeBinaryOp:op PushExtraIndent1 TypeUnary?:t PopIndent ->
+    if (!t) return $skip
+    return [ indent, op, t ]
 
 TypeUnary
   ( __ TypeUnaryOp )*:prefix TypePrimary:t TypeUnarySuffix*:suffix ->
@@ -8291,3 +8304,14 @@ NotDedented
 
 Dedented
   !IndentedAtLeast EOS -> $2
+
+PushExtraIndent1
+  "" ->
+    const indent = {
+      token: "",
+      $loc,
+      level: state.currentIndent.level + 1,
+    }
+    if (config.verbose) console.log("pushing bonus indent", indent)
+    state.indentLevels.push(indent)
+    return indent

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -262,6 +262,22 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    nested binary
+    ---
+    type X
+      | type: 'single', input: Input
+      | type: 'chord', input:
+        & Input[]
+        & duration: number
+    ---
+    type X =
+      | {type: 'single', input: Input}
+      | {type: 'chord', input:
+        & Input[]
+        & {duration: number}}
+  """
+
+  testCase """
     typeof
     ---
     const data = [1, 2, 3]


### PR DESCRIPTION
Fixes #1355

* As expected, some `__`s needed to be `NotDedented`. I just changed the minimal amount here, around binary operators. (Plausibly more should change, but not for this issue.)
* I added a special rule for matching properly indented binary-operator chains like this:
  ```ts
  | T1
  | T2
  ```
* All this still wasn't enough, because the indentation level was already 2 in this case. I needed to add an indentation level of +1 for these items so that `NotDedented` doesn't allow for grabbing the second item.

This feels related to https://github.com/DanielXMoore/Civet/issues/1121#issuecomment-2292132835 as well. (I could use feedback on those ideas too, though doesn't need to happen before this PR lands.)