### PR TITLE
Remove final implicit comma in nested arguments, better matching source

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -296,6 +296,10 @@ ImplicitArguments
     // Don't treat as call if this is a postfix for/while/until/if/unless
     if (skipImplicitArguments(args)) return $skip
 
+    // Remove implicit trailing comma
+    let last = args[args.length - 1]
+    if (last?.token === "," && last.implicit) args = args.slice(0, -1)
+
     return {
       type: "Call",
       args,

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -44,7 +44,7 @@ describe "function application", ->
     ---
     x(y,
       z, a, b,
-      c, d, e,)
+      c, d, e)
   """
 
   testCase """
@@ -56,7 +56,7 @@ describe "function application", ->
     ---
     f(
       a,
-      b,)
+      b)
   """
 
   testCase """
@@ -74,7 +74,7 @@ describe "function application", ->
       b,
       g(
         c,
-        d,),)
+        d))
   """
 
   testCase """
@@ -88,7 +88,7 @@ describe "function application", ->
     f(
       ...a,
       ...b,
-      g,)
+      g)
   """
 
   testCase """
@@ -116,7 +116,7 @@ describe "function application", ->
       ...wrapIIFE y
     ---
     children.splice(i, 1,
-      ...wrapIIFE(y),)
+      ...wrapIIFE(y))
   """
 
   testCase """
@@ -440,7 +440,7 @@ describe "function application", ->
         return execute()
       },
       options,
-      true,)
+      true)
   """
 
   // https://coffeescript.org/#try:x%20if%203%0A%20%20b%0Aelse%0A%20%20c

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -510,7 +510,7 @@ describe "&. function block shorthand", ->
       }
       else {
         return $.baz
-      }})(),)
+      }})())
   """
 
   testCase """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -221,7 +221,7 @@ describe "pipe", ->
     ---
     func.call(this,
       op2(op1(arg1)),
-      op4(op3(arg2)),)
+      op4(op3(arg2)))
   """
 
   testCase """
@@ -427,7 +427,7 @@ describe "pipe", ->
         pendingExecs.get(id) || [] ||> .push exec
       ---
       let ref;pendingExecs.set(id,
-        ((ref = pendingExecs.get(id) || []).push(exec),ref),)
+        ((ref = pendingExecs.get(id) || []).push(exec),ref))
     """
 
     testCase """

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -443,7 +443,7 @@ describe "property access", ->
       foo.bar.bind(foo,\u0020
         a,
         b,
-        c,)
+        c)
     """
 
   describe "possessive form", ->


### PR DESCRIPTION
Currently, nested implicit arguments create an extra implicit comma at the end of the arguments.

I had to fix this for #1391 because type arguments can't have a trailing comma in TypeScript.

This led the way to fixing it for function calls too.