### PR TITLE
Fix `!` negated indented argument in function call

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -227,6 +227,13 @@ matrix.0.0
 array.-1
 </Playground>
 
+You can omit the `.` in `?.` and `!.` property access:
+
+<Playground>
+json?data?value
+account!name?first
+</Playground>
+
 You can also write property access as an English possessive
 (inspired by [_hyperscript](https://hyperscript.org/expressions/possessive/)):
 
@@ -269,6 +276,24 @@ array := {0: 'a', #: 1}
 </Playground>
 
 Length shorthand looks and behaves similar to [private fields](#private-fields), with the exception that `.length` is not private.
+
+### Trailing Property Access
+
+A `.` or `?.` property access can trail on another line,
+at the same or deeper indentation:
+
+<Playground>
+getItems url
+.filter .match
+.sort()
+</Playground>
+
+<Playground>
+document
+  ?.querySelectorAll pattern
+  .forEach (element) =>
+    element.style.color = 'purple'
+</Playground>
 
 ## Arrays
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -326,7 +326,9 @@ ExplicitArguments
 
 # Start of function application, inserts an open parenthesis, maintains spacing and comments when possible
 ApplicationStart
-  IndentedApplicationAllowed &( IndentedFurther !IdentifierBinaryOp !AccessStart )
+  # Indented argument cannot start with a binary operator or a
+  # trailing member expression
+  IndentedApplicationAllowed &( IndentedFurther !IdentifierBinaryOp ) !IndentedTrailingMemberExpression
   !EOS &( _ ( BracedApplicationAllowed / !"{" ) !ForbiddenImplicitCalls )
 
 ForbiddenImplicitCalls
@@ -361,17 +363,13 @@ ArgumentsWithTrailingMemberExpressions
     return [ args, ...trailing ]
 
 TrailingMemberExpressions
+  MemberExpressionRest* IndentedTrailingMemberExpression* ->
+    return [...$1, ...$2]
+
+IndentedTrailingMemberExpression
   # NOTE: Assert "." to not match "?" or "!" as a member expression on the following line
-  MemberExpressionRest* ( IndentedAtLeast &( "?"? "." ![0-9] ) MemberExpressionRest )* ->
-    return $1.concat($2.map(([ws, , memberExpressionRest]) => {
-      if (Array.isArray(memberExpressionRest)) {
-        return [ws, ...memberExpressionRest]
-      }
-      return {
-        ...memberExpressionRest,
-        children: [ws, ...memberExpressionRest.children]
-      }
-    }))
+  IndentedAtLeast:ws &( "?"? "." ![0-9] ) MemberExpressionRest:rest ->
+    return prepend(ws, rest)
 
 AllowedTrailingMemberExpressions
   TrailingMemberPropertyAllowed TrailingMemberExpressions -> $2

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -92,6 +92,16 @@ describe "function application", ->
   """
 
   testCase """
+    nested negated argument
+    ---
+    f
+      !x
+    ---
+    f(
+      !x)
+  """
+
+  testCase """
     splat
     ---
     f ...x


### PR DESCRIPTION
As reported by @bbrk24 

Also add missing documentation for `?` and `!` shorthands for `?.` and `!.`.