### PR TITLE
`break with` and `continue with` for modifying results array in a loop

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1726,6 +1726,24 @@ Labels have the colon on the left to avoid conflict with implicit object
 literals.  The colons are optional in `break` and `continue`.
 :::
 
+### Controlling Loop Value
+
+<Playground>
+function varVector(items, mean)
+  for item of items
+    continue with 0 unless item?
+    item -= mean
+    item * item
+</Playground>
+
+<Playground>
+found :=
+  loop
+    item := nextItem()
+    break with item if item.found
+    process item
+</Playground>
+
 ## Other Blocks
 
 ### Try Blocks

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4226,6 +4226,11 @@ Label
   Colon:colon Identifier:id Whitespace:w ->
     return [ id, colon, w ]
 
+# Argument to break/continue, which can include colon or not in input,
+# but should not have colon in output
+LabelIdentifier
+  Colon? Identifier:id -> id
+
 LabelledItem
   Statement
   FunctionDeclaration
@@ -5043,11 +5048,11 @@ ExpressionStatement
 KeywordStatement
   # https://262.ecma-international.org/#prod-BreakStatement
   # NOTE: Also allow `break :label` for symmetry
-  Break ( _ Colon? Identifier:id )? ->
+  Break ( _ LabelIdentifier )? ( _ With MaybeNestedExtendedExpression )? ->
     return {
       type: "BreakStatement",
-      children: $2 ? [ $1, $2[0], $2[2] ] : [ $1 ],
-                           // omit colon
+      with: $3?.[2],
+      children: [ $1, $2 ],
     }
 
   # NOTE: `continue switch` for fallthrough
@@ -5060,11 +5065,11 @@ KeywordStatement
 
   # https://262.ecma-international.org/#prod-ContinueStatement
   # NOTE: Also allow `continue :label` for symmetry
-  Continue ( _ Colon? Identifier:id )? ->
+  Continue ( _ LabelIdentifier )? ( _ With MaybeNestedExtendedExpression )? ->
     return {
       type: "ContinueStatement",
-      children: $2 ? [ $1, $2[0], $2[2] ] : [ $1 ],
-                           // omit colon
+      with: $3?.[2],
+      children: [ $1, $2 ],
     }
 
   DebuggerStatement

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,11 +1,17 @@
 import type {
   ASTNode
   ASTNodeBase
+  ASTNodeObject
   BlockStatement
+  BreakStatement
   CallExpression
+  ContinueStatement
+  Declaration
+  ForStatement
   FunctionNode
   IterationExpression
   IterationFamily
+  IterationStatement
   LabeledStatement
   Parameter
   ParametersNode
@@ -29,6 +35,7 @@ import {
   findAncestor
   findChildIndex
   gatherNodes
+  gatherRecursive
   gatherRecursiveAll
   gatherRecursiveWithinFunction
   type Predicate
@@ -40,7 +47,6 @@ import {
   hasAwait
   hasYield
   inplacePrepend
-  insertTrimmingSpace
   isEmptyBareBlock
   isExit
   isFunction
@@ -49,6 +55,7 @@ import {
   makeLeftHandSideExpression
   makeNode
   startsWithPredicate
+  trimFirstSpace
   updateParentPointers
   wrapIIFE
   wrapWithReturn
@@ -264,7 +271,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
     exp = (exp as LabeledStatement).statement
     {type} = exp
 
-  switch exp.type
+  switch type
     when "BreakStatement", "ContinueStatement", "DebuggerStatement", "EmptyStatement", "ReturnStatement", "ThrowStatement"
       return
     when "Declaration"
@@ -439,6 +446,42 @@ function insertSwitchReturns(exp): void
   exp.caseBlock.clauses.forEach (clause) =>
     insertReturn clause
 
+// Process `break with` and `continue with` within a loop
+// that already has a resultsRef attribute.
+// Returns whether the resultsRef might be modified, so should use let.
+function processBreakContinueWith(statement: IterationStatement | ForStatement): boolean
+  changed .= false
+  for control of gatherRecursive(statement.block,
+    (s: ASTNodeObject): s is BreakStatement | ContinueStatement =>
+      s.type is like "BreakStatement", "ContinueStatement"
+    (s: ASTNodeObject) =>
+      isFunction(s) or s.type is "IterationStatement"
+  )
+    function controlName: string
+      switch control.type 
+        when "BreakStatement"
+          "break"
+        when "ContinueStatement"
+          "continue"
+
+    // break with <expr> overwrites the results of the loop
+    // continue with <expr> appends to the results of the loop
+    if control.with
+      control.children.unshift
+        if control.type is "BreakStatement"
+          changed = true
+          [statement.resultsRef, ' =', control.with, ';']
+        else // control.type is "ContinueStatement"
+          [statement.resultsRef, '.push(', trimFirstSpace(control.with), ');']
+      updateParentPointers control.with, control
+
+      // Brace containing block now that it has multiple statements
+      block := control.parent
+      unless block?.type is "BlockStatement"
+        throw new Error `Expected parent of ${controlName()} to be BlockStatement`
+      braceBlock block
+  changed
+
 function wrapIterationReturningResults(
   statement: IterationFamily,
   outer: { children: StatementTuple[] },
@@ -456,9 +499,18 @@ function wrapIterationReturningResults(
 
   resultsRef := statement.resultsRef = makeRef "results"
 
-  declaration :=
+  decl .= "const"
+  if statement.type is "IterationStatement" or statement.type is "ForStatement"
+    if processBreakContinueWith statement
+      decl = "let"
+
+  declaration: Declaration := {
     type: "Declaration"
-    children: ["const ", resultsRef, "=[]"]
+    children: [decl, " ", resultsRef, "=[]"]
+    decl
+    names: []
+    bindings: []
+  }
 
   outer.children.unshift(["", declaration, ";"])
 
@@ -567,9 +619,9 @@ function expressionizeIteration(exp: IterationExpression): void
   { async, subtype, block, children, statement } := exp
   i := children.indexOf statement
   if i < 0
-    throw new Error("Could not find iteration statement in iteration expression")
+    throw new Error "Could not find iteration statement in iteration expression"
 
-  if subtype is "DoStatement" or subtype is "ComptimeStatement"
+  if subtype is like "DoStatement", "ComptimeStatement"
     // Just wrap with IIFE; insertReturn will apply to the resulting function
     children.splice(i, 1, wrapIIFE([["", statement, undefined]], async))
     updateParentPointers exp
@@ -618,7 +670,7 @@ function skipImplicitArguments(args: unknown[]): boolean
 
 /** Transform */
 function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
-  ws = insertTrimmingSpace(ws, "") as Whitespace
+  ws = trimFirstSpace(ws) as Whitespace
   args: ASTNode[] := []
   if expression is like {type: "ArrowFunction"}, {type: "FunctionExpression"}
     { parameters } := expression

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -50,6 +50,7 @@ import {
   isEmptyBareBlock
   isExit
   isFunction
+  isLoopStatement
   isStatement
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
@@ -504,19 +505,33 @@ function wrapIterationReturningResults(
     if processBreakContinueWith statement
       decl = "let"
 
+  // Check for infinite loops with only `break with`, no plain `break`
+  breakWithOnly := (and)
+    decl is "let"
+    isLoopStatement statement
+    gatherRecursive(statement.block,
+      (s): s is BreakStatement => s.type is "BreakStatement" and not s.with,
+      (s) => isFunction(s) or s.type is "IterationStatement")# is 0
+
   declaration: Declaration := {
     type: "Declaration"
-    children: [decl, " ", resultsRef, "=[]"]
+    children: [decl, " ", resultsRef]
     decl
     names: []
     bindings: []
   }
+  // Assign [] directly only in const case, so TypeScript can better infer
+  if decl is "const"
+    declaration.children.push "=[]"
+  else // decl is "let"
+    declaration.children.push ";", resultsRef, "=[]" unless breakWithOnly
 
   outer.children.unshift(["", declaration, ";"])
 
-  assignResults statement.block, (node) =>
-    // TODO: real ast node
-    [ resultsRef, ".push(", node, ")" ]
+  unless breakWithOnly
+    assignResults statement.block, (node) =>
+      // TODO: real ast node
+      [ resultsRef, ".push(", node, ")" ]
 
   if collect
     statement.children.push collect(resultsRef)

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -281,11 +281,13 @@ export type IterationStatement
   condition: Condition
   block: BlockStatement
   negated: boolean?
+  resultsRef: ASTRef?
 
 export type BreakStatement
   type: "BreakStatement"
   children: Children
   parent?: Parent
+  with: ASTNode?
 
 export type ComptimeStatement
   type: "ComptimeStatement"
@@ -304,6 +306,7 @@ export type ContinueStatement
   children: Children
   parent?: Parent
   special?: "switch"
+  with: ASTNode?
 
 export type DoStatement
   type: "DoStatement"
@@ -318,6 +321,7 @@ export type ForStatement
   declaration: DeclarationStatement?
   block: BlockStatement
   hoistDec: unknown
+  resultsRef: ASTRef?
 
 export type SwitchStatement
   type: "SwitchStatement"
@@ -424,8 +428,8 @@ export type DeclarationStatement =
   bindings: Binding[]
   parent?: Parent
   decl: "let" | "const" | "var"
-  splices: unknown
-  thisAssignments: ThisAssignments
+  splices?: unknown
+  thisAssignments?: ThisAssignments
 
 export type Binding =
   type: "Binding"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -4,10 +4,10 @@ import type {
   ASTNodeBase
   ASTNodeObject
   ASTNodeParent
-  Children
   FunctionNode
   IsParent
   IsToken
+  IterationStatement
   Literal
   StatementNode
   TypeSuffix
@@ -171,14 +171,20 @@ function isExit(node: ASTNode): boolean
     // Infinite loops
     when "IterationStatement"
       (and)
-        node.condition?.type is "ParenthesizedExpression"
-        node.condition.expression?.type is "Literal"
-        node.condition.expression?.raw is "true"
+        isLoopStatement node
         gatherRecursiveWithinFunction(node.block,
           .type is "BreakStatement").length is 0
         // TODO: Distinguish between break of this loop vs. break of inner loops
     else
       false
+
+// Is this a `loop` statement, or equivalent `while(true)`?
+function isLoopStatement(node: ASTNodeObject): node is IterationStatement
+  (and)
+    node.type is "IterationStatement"
+    node.condition?.type is "ParenthesizedExpression"
+    node.condition.expression?.type is "Literal"
+    node.condition.expression?.raw is "true"
 
 /**
  * Detects Comma, CommaDelimiter, and ParameterElementDelimiter
@@ -622,6 +628,7 @@ export {
   isEmptyBareBlock
   isExit
   isFunction
+  isLoopStatement
   isStatement
   isToken
   isWhitespaceOrEmpty

--- a/test/for.civet
+++ b/test/for.civet
@@ -774,10 +774,23 @@ describe "for", ->
         . "NaN"
       x+1
     ---
-    let results=[];for (const x of y) {
+    let results;results=[];for (const x of y) {
       if (!(x != null)) { results.push(null);continue }
       if(isNaN(x)) { results = [
           "NaN"];break}
       results.push(x+1)
     };const values =results
+  """
+
+  testCase """
+    break/continue with outside expression context
+    ---
+    for x of y
+      continue with null unless x?
+      break with x
+    ---
+    for (const x of y) {
+      if (!(x != null)) { continue }
+      break
+    }
   """

--- a/test/for.civet
+++ b/test/for.civet
@@ -764,3 +764,20 @@ describe "for", ->
         results.push(x ** 2)
       }return results})())
     """
+
+  testCase """
+    break/continue with
+    ---
+    values := for x of y
+      continue with null unless x?
+      if(isNaN x) break with
+        . "NaN"
+      x+1
+    ---
+    let results=[];for (const x of y) {
+      if (!(x != null)) { results.push(null);continue }
+      if(isNaN(x)) { results = [
+          "NaN"];break}
+      results.push(x+1)
+    };const values =results
+  """

--- a/test/loop.civet
+++ b/test/loop.civet
@@ -29,3 +29,20 @@ describe "loop", ->
     ---
     while(true);
   """
+
+  testCase """
+    break/continue with
+    ---
+    =>
+      loop
+        if finished()
+          break with 'done'
+    ---
+    () => {
+      let results=[];while(true) {
+        if (finished()) {
+          results = 'done';break
+        } else {results.push(void 0)}
+      };return results;
+    }
+  """

--- a/test/loop.civet
+++ b/test/loop.civet
@@ -31,7 +31,26 @@ describe "loop", ->
   """
 
   testCase """
-    break/continue with
+    break with
+    ---
+    =>
+      loop
+        if special()
+          break with 'done'
+        break if finished()
+    ---
+    () => {
+      let results;results=[];while(true) {
+        if (special()) {
+          results = 'done';break
+        }
+        if (finished()) { break } else {results.push(void 0)}
+      };return results;
+    }
+  """
+
+  testCase """
+    break with only
     ---
     =>
       loop
@@ -39,10 +58,10 @@ describe "loop", ->
           break with 'done'
     ---
     () => {
-      let results=[];while(true) {
+      let results;while(true) {
         if (finished()) {
           results = 'done';break
-        } else {results.push(void 0)}
+        }
       };return results;
     }
   """


### PR DESCRIPTION
Fixes #1395

TODO: Documentation

An issue with TypeScript is clear in the `loop` example: we have `let results = []` but later `results = 'done'`. Perhaps we could detect specifically a `loop` that has no plain `break` and thus will only be exited via `break with`, and then we could just write `let results`.