### PR TITLE
`--trace` fixes and documentation, cleanup of `getStateKey`

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -436,6 +436,7 @@ Options:
   --no-cache       Disable compiler caching (slow, for debugging)
   --typecheck      Run TypeScript and output diagnostics
   --emit-declaration  Run TypeScript and emit .d.ts files (if no errors)
+  --trace XX       Log detailed parsing notes to a file, for parser debugging
 
 You can use - to read from stdin or (prefixed by -o) write to stdout.
 

--- a/source/main.civet
+++ b/source/main.civet
@@ -1,4 +1,4 @@
-import { parse, parseProgram, ParseError, getConfig } from "./parser.hera"
+import { parse, parseProgram, ParseError, getConfig, getStateKey } from "./parser.hera"
 import generate, { prune } from "./generate.civet"
 import * as lib from "./parser/lib.civet"
 import * as sourcemap from "./sourcemap.civet"
@@ -233,7 +233,6 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
     meta.logs = logs
 
   stateCache := new StateCache<ParseResult>
-  getStateKey: () => [number, string] .= null!
 
   stack: string[] := []
 
@@ -263,11 +262,6 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
       return
 
     exit: (ruleName: string, state: ParseState, result: ParseResult) ->
-      // special hack to get access to parser state
-      if ruleName is "Reset"
-        //@ts-ignore
-        { getStateKey } = result.value
-
       if !uncacheable.has(ruleName)
         [stateKey, tagKey] := getStateKey()
         key: CacheKey := [tagKey, stateKey, state.pos, ruleName ]

--- a/source/main.civet
+++ b/source/main.civet
@@ -262,10 +262,11 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
       return
 
     exit: (ruleName: string, state: ParseState, result: ParseResult) ->
-      if !uncacheable.has(ruleName)
-        [stateKey, tagKey] := getStateKey()
-        key: CacheKey := [tagKey, stateKey, state.pos, ruleName ]
-        stateCache.set(key, result)
+      return if uncacheable.has(ruleName)
+
+      [stateKey, tagKey] := getStateKey()
+      key: CacheKey := [tagKey, stateKey, state.pos, ruleName ]
+      stateCache.set(key, result)
 
       //@ts-ignore
       if getConfig().verbose and result

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -124,6 +124,24 @@ Object.defineProperties(state, {
   },
 })
 
+export function getStateKey() {
+  const stateInt =
+    ((state.currentIndent.level % 256) << 8) |
+    (state.classImplicitCallForbidden << 7) |
+    (state.indentedApplicationForbidden << 6) |
+    (state.bracedApplicationForbidden << 5) |
+    (state.trailingMemberPropertyForbidden << 4) |
+    (state.newlineBinaryOpForbidden << 3) |
+    // This is slightly different than the rest of the state,
+    // since it is affected by the directive prologue and may be hit
+    // by the EOL rule early in the parse. Later if we wanted to
+    // allow block scoping of the compat directives we would need to
+    // add them all here.
+    (config.coffeeComment << 2)
+
+  return [stateInt, state.currentJSXTag]
+}
+
 export function parseProgram(input, options) {
   filename = options?.filename
   initialConfig = options?.parseOptions
@@ -8395,29 +8413,6 @@ Reset
 
     // Pass in parser config from main
     Object.assign(config, initialConfig)
-
-    // Hack to pass parser state to cache key
-    return {
-      type: "ParserMeta",
-      children: [],
-      getStateKey() {
-        const stateInt =
-          ((state.currentIndent.level % 256) << 8) |
-          (state.classImplicitCallForbidden << 7) |
-          (state.indentedApplicationForbidden << 6) |
-          (state.bracedApplicationForbidden << 5) |
-          (state.trailingMemberPropertyForbidden << 4) |
-          (state.newlineBinaryOpForbidden << 3) |
-          // This is slightly different than the rest of the state,
-          // since it is affected by the directive prologue and may be hit
-          // by the EOL rule early in the parse. Later if we wanted to
-          // allow block scoping of the compat directives we would need to
-          // add them all here.
-          (config.coffeeComment << 2)
-
-        return [stateInt, state.currentJSXTag]
-      },
-    }
 
 Init
   Shebang? Prologue:directives ->


### PR DESCRIPTION
Traces have been incorrectly indented for a while because of uncacheable rules; they dedented without a matching indent. Perhaps we should log them, but for now I've just made `exit` match `enter` by not logging in both.

Also realized we no longer need the `getStateKey` hack, thanks to Hera's ` ``` `.