### PR TITLE
Run `<script type="text/civet">` in browser build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The modern way to write TypeScript.
   [Babel](source/babel-plugin.civet),
   [Jest](https://github.com/DanielXMoore/Civet/blob/main/integration/jest),
   [Gulp](integration/gulp),
-  [Bun](source/bun-civet.civet)
+  [Bun](source/bun-civet.civet),
+  [`<script>` tag](https://github.com/DanielXMoore/Civet/tree/main/integration/script)
 - Starter templates for [Solid](https://github.com/orenelbaum/solid-civet-template) and [Solid Start](https://github.com/orenelbaum/solid-start-civet-template)
 
 Quickstart Guide

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -2,7 +2,7 @@ esbuild := require "esbuild"
 heraPlugin := require "@danielx/hera/esbuild-plugin"
 // Need to use the packaged version because we may not have built our own yet
 civetPlugin := require "../node_modules/@danielx/civet/dist/esbuild-plugin.js"
-civetUnplugin := require("../node_modules/@danielx/civet/dist/esbuild.js").default
+civetUnplugin := require("../node_modules/@danielx/civet/dist/unplugin/esbuild.js").default
 
 path := require "path"
 {access} := require "fs/promises"

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -128,17 +128,18 @@ for esm of [false, true]
     ]
   }).catch -> process.exit 1
 
+// Browser build
 build({
-  entryPoints: ['source/main.civet']
+  entryPoints: ['source/browser.civet']
   globalName: "Civet"
   bundle: true
   sourcemap
   platform: 'browser'
   outfile: 'dist/browser.js'
   alias:
-    'node:module': './source/browser.civet'
-    'node:path': './source/browser.civet'
-    'node:vm': './source/browser.civet'
+    'node:module': './source/browser-shim.civet'
+    'node:path': './source/browser-shim.civet'
+    'node:vm': './source/browser-shim.civet'
   external: ['node:fs']
   plugins: [
     resolveExtensions

--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -15,10 +15,11 @@ title: Integrations
   - [Older Vite plugin](https://github.com/edemaine/vite-plugin-civet) (no longer recommended)
 - [ESM/CJS loader](https://github.com/DanielXMoore/Civet/blob/main/register.js) for `import`/`require` to support `.civet` files
 - [Babel plugin](https://github.com/DanielXMoore/Civet/blob/main/source/babel-plugin.civet)
-  - Including [React Native / Metro](https://github.com/DanielXMoore/Civet/blob/main/integration/metro)
-- [Jest plugin](https://github.com/DanielXMoore/Civet/blob/main/integration/jest)
+  - Including [React Native / Metro](https://github.com/DanielXMoore/Civet/tree/main/integration/metro)
+- [Jest plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/jest)
 - [Gulp plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/gulp)
 - [Bun plugin](https://github.com/DanielXMoore/Civet/blob/main/source/bun-civet.civet)
+- [`<script>` tag](https://github.com/DanielXMoore/Civet/tree/main/integration/script)
 - [Civetman](https://github.com/zihan-ch/civetman) automatically compiles `.civet` files, making it easy to integrate with arbitrary build chains (see also [vite-plugin-civetman](https://github.com/krist7599555/vite-plugin-civetman))
 
 ## Starter Templates

--- a/integration/script/README.md
+++ b/integration/script/README.md
@@ -1,6 +1,14 @@
 # Civet in `<script>` tags
 
-For quick hacks, you can run Civet code directly from your HTML, like so:
+For quick hacks, you can run Civet code directly from your HTML
+using `<script type="text/civet">` tags.
+First, run the browser build of Civet, for example, from CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@danielx/civet/dist/browser.js"></script>
+```
+
+Then you can run Civet scripts like so:
 
 ```html
 <script type="text/civet">
@@ -8,7 +16,7 @@ For quick hacks, you can run Civet code directly from your HTML, like so:
 </script>
 ```
 
-You can also run Civet from files, like so:
+You can also run Civet code from files, like so:
 
 ```html
 <script type="text/civet" src="filename.civet"></script>
@@ -16,6 +24,10 @@ You can also run Civet from files, like so:
 
 In the latter case, the HTML needs to be served by a web server
 (not via `file:` URL) to pass CORS.
+
+Note that `<script type="text/civet">` tags get run once,
+when the page is fully loaded.  If you need to run them at a specific time
+(e.g. after dynamically generating content), call `Civet.runScripts()`.
 
 ## Example
 

--- a/integration/script/README.md
+++ b/integration/script/README.md
@@ -1,0 +1,25 @@
+# Civet in `<script>` tags
+
+For quick hacks, you can run Civet code directly from your HTML, like so:
+
+```html
+<script type="text/civet">
+  console.log 'Hello from Civet!'
+</script>
+```
+
+You can also run Civet from files, like so:
+
+```html
+<script type="text/civet" src="filename.civet"></script>
+```
+
+In the latter case, the HTML needs to be served by a web server
+(not via `file:` URL) to pass CORS.
+
+## Example
+
+[`test.html`](test.html) is an example of running Civet code directly from
+HTML using `<script type="text/civet">` tags.
+The auxiliary [`test.civet`](test.script) script will run
+only if serving from a web server.

--- a/integration/script/README.md
+++ b/integration/script/README.md
@@ -8,7 +8,7 @@ First, run the browser build of Civet, for example, from CDN:
 <script src="https://cdn.jsdelivr.net/npm/@danielx/civet/dist/browser.js"></script>
 ```
 
-Then you can run Civet scripts like so:
+Then you can run inline Civet scripts like so:
 
 ```html
 <script type="text/civet">
@@ -25,9 +25,12 @@ You can also run Civet code from files, like so:
 In the latter case, the HTML needs to be served by a web server
 (not via `file:` URL) to pass CORS.
 
-Note that `<script type="text/civet">` tags get run once,
-when the page is fully loaded.  If you need to run them at a specific time
-(e.g. after dynamically generating content), call `Civet.runScripts()`.
+If you dynamically add `<script type="text/civet">` tags as children
+to the document's `<head>` or `<body>`, they will get automatically get
+detected and executed (via a
+[`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)).
+Be sure to set the `type` attribute to `text/civet`
+and set `innerHTML` or `src` at the same time as appending the tag.
 
 ## Example
 
@@ -35,3 +38,40 @@ when the page is fully loaded.  If you need to run them at a specific time
 HTML using `<script type="text/civet">` tags.
 The auxiliary [`test.civet`](test.script) script will run
 only if serving from a web server.
+
+## Overrides
+
+You can turn off all automatic `<script type="text/civet">` execution
+by adding a `no-scripts` attribute to the `<script>` tag that loads Civet:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@danielx/civet/dist/browser.js" no-scripts></script>
+```
+
+You can turn off automatic execution of dynamically added scripts
+(but keep initial loading of scripts) by adding a `no-auto-scripts`
+attribute:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@danielx/civet/dist/browser.js" no-auto-scripts></script>
+```
+
+You can turn off just the initial loading of scripts (but keep automatic
+execution of dynamically added scripts) by adding a `no-start-scripts`
+attribute:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@danielx/civet/dist/browser.js" no-start-scripts></script>
+```
+
+If you want to manually trigger running all `<script type="text/civet">`
+tags on the page, call `Civet.runScripts()`.  You can also run just
+a specific `<script>` tag via `Civet.runScript(scriptTag)`.
+
+If you want to manually create a `MutationObserver` to watch for added
+`<script type="text/civet">` tags, call `Civet.autoRunScripts(roots)`,
+where `roots` is an array of DOM elements to watch for added children.
+You can also specify an alternative `options` for
+[`MutationObserver.prototype.observe`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe)
+as a second argument.  For example, to watch the entire document,
+`Civet.autoRunScripts([document], {childNodes: true, subtree: true})`,

--- a/integration/script/test.civet
+++ b/integration/script/test.civet
@@ -1,0 +1,1 @@
+console.log 'Success loading script from file!'

--- a/integration/script/test.html
+++ b/integration/script/test.html
@@ -8,6 +8,11 @@
     ||> .appendChild document.createTextNode 'Hello World!'
     ||> .style.color = color
     |> document.body.appendChild
+
+  document.createElement 'script'
+  ||> document.head.appendChild
+  ||> .type = 'text/civet'
+  ||> .innerHTML = "console.log 'Success loading dynamic script!'"
 </script>
 <script type="text/civet" src="./test.civet"></script>
 </head>

--- a/integration/script/test.html
+++ b/integration/script/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../dist/browser.js"></script>
+<script type="text/civet">
+  for color of ['red', 'green', 'blue']
+    document.createElement 'h1'
+    ||> .appendChild document.createTextNode 'Hello World!'
+    ||> .style.color = color
+    |> document.body.appendChild
+</script>
+<script type="text/civet" src="./test.civet"></script>
+</head>
+<body>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "unplugin": "^1.12.2"
   },
   "devDependencies": {
-    "@danielx/civet": "0.7.16",
+    "@danielx/civet": "0.7.30",
     "@danielx/hera": "^0.8.16",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",

--- a/source/browser-shim.civet
+++ b/source/browser-shim.civet
@@ -1,0 +1,19 @@
+// Shimmed node:path and node:module for browser build
+
+// node:path
+export function dirname(path: string): string
+  path.replace /[^]*\//, ''
+export function resolve(path: string): string
+  path
+
+// node:module
+export function createRequire(path: string): (id: string) => unknown
+  (id: string) =>
+    throw new ReferenceError
+      "Civet comptime does not support 'require' on this platform"
+
+export default {
+  dirname
+  resolve
+  createRequire
+}

--- a/source/browser.civet
+++ b/source/browser.civet
@@ -3,26 +3,54 @@ import { type CompilerOptions, compile } from ./main.civet
 
 // Based on `CoffeeScript.runScripts`, from
 // https://github.com/jashkenas/coffeescript/blob/main/src/browser.coffee
-export function runScripts(type = 'text/civet'): void
+export async function runScripts(type = 'text/civet'): Promise<void>
   scripts := window.document.querySelectorAll `script[type=${JSON.stringify type}]`
 
   for each script, i of scripts
-    options: CompilerOptions :=
-      inlineMap: true
-      js: true
+    runScript script as HTMLScriptElement, `<script>${i}`
 
-    let code: string
-    if source := (script as HTMLScriptElement).src or script.getAttribute 'data-src'
-      options.filename = source
-      code = fetch source |> await |> .text() |> await
-    else
-      options.filename = script.id or `<script>${i}`
-      code = script.innerHTML
+export async function runScript(script: HTMLScriptElement, name: string = '<script>'): Promise<???>
+  options: CompilerOptions :=
+    inlineMap: true
+    js: true
 
-    js := compile code, options |> await
-    window.eval js
+  let code: string
+  if source := (script as HTMLScriptElement).src or script.getAttribute 'data-src'
+    options.filename = source
+    code = fetch source |> await |> .text() |> await
+  else
+    options.filename = script.id or name
+    code = script.innerHTML
+
+  js := compile code, options |> await
+  window.eval js
+
+export function autoRunScripts(
+  roots: HTMLElement[]
+  options: MutationObserverInit = {}
+): MutationObserver
+  observer := new MutationObserver async (mutations): Promise<void> =>
+    for each mutation of mutations
+      continue unless mutation.type is "childList"
+      for each node of mutation.addedNodes
+        if
+          (and)
+            node.nodeType is 1
+            (node as HTMLElement).tagName is "SCRIPT"
+            (node as HTMLScriptElement).type is "text/civet"
+          await runScript node as HTMLScriptElement
+  options = { ...options, childList: true }
+  for each root of roots
+    observer.observe root, options
+  observer
 
 // Check for <script type="text/civet"> automatically in browser context
 // (not e.g. worker thread)
-unless window <? 'undefined'
-  window?.addEventListener? 'DOMContentLoaded', => runScripts()
+unless window <? "undefined"
+  { currentScript } := document
+  window?.addEventListener? "DOMContentLoaded", =>
+    return if currentScript?.hasAttribute 'data-no-scripts'
+    unless currentScript?.hasAttribute 'data-no-start-scripts'
+      runScripts()
+    unless currentScript?.hasAttribute 'data-no-auto-scripts'
+      autoRunScripts [document.head, document.body]

--- a/source/browser.civet
+++ b/source/browser.civet
@@ -1,19 +1,28 @@
-// Shimmed node:path and node:module for browser build
+export * from ./main.civet
+import { type CompilerOptions, compile } from ./main.civet
 
-// node:path
-export function dirname(path: string): string
-  path.replace /[^]*\//, ''
-export function resolve(path: string): string
-  path
+// Based on `CoffeeScript.runScripts`, from
+// https://github.com/jashkenas/coffeescript/blob/main/src/browser.coffee
+export function runScripts(type = 'text/civet'): void
+  scripts := window.document.querySelectorAll `script[type=${JSON.stringify type}]`
 
-// node:module
-export function createRequire(path: string): (id: string) => unknown
-  (id: string) =>
-    throw new ReferenceError
-      "Civet comptime does not support 'require' on this platform"
+  for each script, i of scripts
+    options: CompilerOptions :=
+      inlineMap: true
+      js: true
 
-export default {
-  dirname
-  resolve
-  createRequire
-}
+    let code: string
+    if source := (script as HTMLScriptElement).src or script.getAttribute 'data-src'
+      options.filename = source
+      code = fetch source |> await |> .text() |> await
+    else
+      options.filename = script.id or `<script>${i}`
+      code = script.innerHTML
+
+    js := compile code, options |> await
+    window.eval js
+
+// Check for <script type="text/civet"> automatically in browser context
+// (not e.g. worker thread)
+unless window <? 'undefined'
+  window?.addEventListener? 'DOMContentLoaded', => runScripts()

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -234,7 +234,10 @@ encodeBase64 := (value: number) ->
 
 // Note: currently only works in node
 export base64Encode = (src: string) ->
-  return Buffer.from(src).toString('base64')
+  if Buffer !<? 'undefined'
+    Buffer.from(src).toString('base64')
+  else
+    btoa src
 
 // Accelerate VLQ decoding with a lookup table
 vlqTable := new Uint8Array(128)

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -232,7 +232,6 @@ BASE64_CHARS := 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+
 encodeBase64 := (value: number) ->
   BASE64_CHARS[value] or throw new Error "Cannot Base64 encode value: ${value}"
 
-// Note: currently only works in node
 export base64Encode = (src: string) ->
   if Buffer !<? 'undefined'
     Buffer.from(src).toString('base64')

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,14 +150,14 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@0.7.16":
-  version "0.7.16"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.16.tgz#ecb7ce76de76bbbdb3b07f3e8cd085356362a0e0"
-  integrity sha512-tc/NT1nm7Sn/fib/iwYcvbH6FK52Yd4MtD0CzMXJLnU59AvuIpy3LZNBCDk8Nn5iioS6+V+AaTMBRMuKMP7UnQ==
+"@danielx/civet@0.7.30":
+  version "0.7.30"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.30.tgz#4fff5c4247485bcbf2d23d5ad1e81b359656e2c4"
+  integrity sha512-ZGVGge+wdDHyK0LHM0yfJ2y/ZCh0B36XWTCU207K7C5F+84f2WNOVM6ZRs8ZhZuxPSLt1Kd/rkugA3P4d0ObEg==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
-    "@typescript/vfs" "^1.5.3"
-    unplugin "^1.6.0"
+    "@typescript/vfs" "^1.6.0"
+    unplugin "^1.12.2"
 
 "@danielx/hera@^0.8.16":
   version "0.8.16"
@@ -519,13 +519,6 @@
   resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz#5c9f3c617f64a9735d7b72a7cc671e166d900c40"
   integrity sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==
 
-"@typescript/vfs@^1.5.3":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.5.3.tgz#b3e9e580cbdf282d6581543dcf3b2c0e44ebf9fb"
-  integrity sha512-OSZ/o3wwD5VPZVdGGsXWk7sRGRtwrGnqA4zwmb33FTs7Wxmad0QTkQCbaNyqWA8hL09TCwAthdp8yjFA5G1lvw==
-  dependencies:
-    debug "^4.1.1"
-
 "@typescript/vfs@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.6.0.tgz#9c90d8c43f7ac53cc77d5959e5c4c9b639f0959e"
@@ -663,11 +656,6 @@ acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
-
-acorn@^8.11.2:
-  version "8.11.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
-  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
 acorn@^8.12.1:
   version "8.12.1"
@@ -812,7 +800,7 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.5.3, chokidar@^3.5.3:
+chokidar@3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -1582,16 +1570,6 @@ unplugin@^1.12.2:
     webpack-sources "^3.2.3"
     webpack-virtual-modules "^0.6.2"
 
-unplugin@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.6.0.tgz#0bd7c344182c73e685c864f4f7161531f024b942"
-  integrity sha512-BfJEpWBu3aE/AyHx8VaNE/WgouoQxgH9baAiH82JjX8cqVyi3uJQstqwD5J+SZxIK326SZIhsSZlALXVBCknTQ==
-  dependencies:
-    acorn "^8.11.2"
-    chokidar "^3.5.3"
-    webpack-sources "^3.2.3"
-    webpack-virtual-modules "^0.6.1"
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -1694,11 +1672,6 @@ webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
-
-webpack-virtual-modules@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.1.tgz#ac6fdb9c5adb8caecd82ec241c9631b7a3681b6f"
-  integrity sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==
 
 webpack-virtual-modules@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
Similar to [CoffeeScript](https://coffeescript.org/#scripts), added support for automatically running `<script type="text/civet">` code that appears in the HTML that loads the browser build of Civet.

The new `source/browser.civet` in general allows us to add code specific to the browser build.

I renamed `source/browser.civet` to `source/browser-shim.civet` but the diff doesn't show it that way.

**Motivation:** Easy to run Civet in online sandboxes without any build tools.