### PR TITLE
Document how to use Civet Web Workers in Vite

### DIFF
--- a/source/unplugin/README.md
+++ b/source/unplugin/README.md
@@ -1,10 +1,19 @@
 # unplugin-civet
 
-Use Civet in your projects with Vite, Webpack, Rspack, Rollup and esbuild, with `dts` generation supported.
+Use Civet in your projects bundled with Vite, Webpack, Rspack, Rollup, or esbuild, with `.d.ts` generation support.
 
 ## Usage
 
-The only setup required is adding it your bundler's config:
+The only setup required is adding the plugin to your bundler's config.
+Jump to:
+
+* [Vite](#vite)
+* [Astro](#astro)
+* [Rollup](#rollup)
+* [ESBuild](#esbuild)
+* [Webpack](#webpack)
+
+You probably also want to pass in [options](#options).
 
 ### Vite
 
@@ -23,6 +32,40 @@ export default defineConfig({
 });
 ```
 
+To use Civet files as Web Workers, use a variation on
+[Vite's constructor syntax](https://vitejs.dev/guide/features.html#import-with-constructors):
+(note the added `.tsx` extension)
+
+```ts
+worker = new Worker(new URL('./worker.civet.tsx', import.meta.url))
+```
+
+You'll also need to pass the 
+`civetVitePlugin` in the
+[`worker.plugins` option](https://vitejs.dev/config/worker-options#worker-plugins):
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import civetVitePlugin from '@danielx/civet/vite';
+
+export default defineConfig({
+  // ...
+  plugins: [
+    civetVitePlugin({
+      // options
+    }),
+  ],
+  worker: {
+    plugins: () => [
+      civetVitePlugin({
+        // options
+      }),
+    ],
+  },
+});
+```
+
 ### Astro
 
 ```ts
@@ -38,6 +81,36 @@ export default defineConfig({
       // options
     }),
   ],
+});
+```
+
+To use Civet files as Web Workers, see the [Vite directions](#vite) above.
+You'll also need to import and pass the Civet Vite plugin via the
+[`vite.worker.plugins` option](https://vitejs.dev/config/worker-options#worker-plugins):
+
+```ts
+// astro.config.ts
+import { defineConfig } from 'astro/config';
+import civet from '@danielx/civet/astro';
+import civetVitePlugin from '@danielx/civet/vite';
+
+// https://astro.build/config
+export default defineConfig({
+  // ...
+  integrations: [
+    civet({
+      // options
+    }),
+  ],
+  vite: {
+    worker: {
+      plugins: () => [
+        civetVitePlugin({
+          // options
+        }),
+      ],
+    },
+  },
 });
 ```
 
@@ -140,5 +213,5 @@ interface PluginOptions {
 
 ## Examples
 
-See also [full examples of unplugin](../../integration/unplugin-examples).
+See also [full examples of unplugin](../../integration/unplugin-examples)
 in Astro, esbuild, NextJS, Rollup, Vite, and Webpack.

--- a/source/unplugin/README.md
+++ b/source/unplugin/README.md
@@ -38,10 +38,11 @@ To use Civet files as Web Workers, use a variation on
 
 ```ts
 worker = new Worker(new URL('./worker.civet.tsx', import.meta.url))
+//or
+worker = new Worker(new URL('./worker.civet.tsx', import.meta.url), { type: 'module' })
 ```
 
-You'll also need to pass the 
-`civetVitePlugin` in the
+You'll also need to pass the `civetVitePlugin` via the
 [`worker.plugins` option](https://vitejs.dev/config/worker-options#worker-plugins):
 
 ```ts
@@ -62,6 +63,7 @@ export default defineConfig({
         // options
       }),
     ],
+    // format: "es",  // if using { type: 'module' }
   },
 });
 ```
@@ -109,6 +111,7 @@ export default defineConfig({
           // options
         }),
       ],
+      // format: "es",  // if using { type: 'module' }
     },
   },
 });


### PR DESCRIPTION
I just did some testing with getting `.civet` files to work as Web Workers using [Vite's Web Worker support](https://vitejs.dev/guide/features.html#web-workers).
1. Thanks to chee on Discord, it seems that the first method (with constructors) works if we add a `.tsx` extension to the `.civet` filename.  I'm not really sure why this is necessary. 
2. Unfortunately, the `?worker` import syntax doesn't seem to work, perhaps because our plugin needs to do something special in this case.  (I get complaints of no default export, despite it seeming like it should be created automatically.)

This PR documents the current state, and also raises the opportunity for anyone to chime in on how the above two issues could be improved by modifying the plugin.

Annoyingly, for `vite build` to work, it seems like the plugin needs to be specified a second time under [`worker.plugins`](https://vitejs.dev/config/worker-options#worker-plugins).  It seems that it's not possible for a plugin to add itself to the `worker.plugins` list:

> The function should return new plugin instances as they are used in parallel rollup worker builds. As such, modifying `config.worker` options in the `config` hook will be ignored.

I could have added this as automatic configuration to our Astro integration specifically, but I worry that that would prevent someone from adding any additional worker plugins, because I'd be specifying a function returning a list of one item instead of whatever they wanted. So documenting what additional configuration you need seemed to be the best approach... But again, I'm open to better ideas!

Personally I was "happy" to discover these options because I wanted to change [`worker.format`](https://vitejs.dev/config/worker-options#worker-format) from the default `iife` to `es` anyway...