### PR TITLE
change types order in package.json exports; default config exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/main.mjs",
-      "require": "./dist/main.js",
-      "types": "./dist/types.d.ts"
+      "require": "./dist/main.js"
     },
     "./babel-plugin": {
       "require": "./dist/babel-plugin.js",
@@ -24,39 +24,39 @@
     "./esbuild-plugin": "./dist/esbuild-plugin.js",
     "./register": "./register.js",
     "./config": {
+      "types": "./dist/config.d.ts",
       "require": "./dist/config.js",
-      "import": "./dist/config.mjs",
-      "types": "./dist/config.d.ts"
+      "import": "./dist/config.mjs"
     },
     "./unplugin": {
+      "types": "./dist/unplugin/unplugin.d.ts",
       "require": "./dist/unplugin/unplugin.js",
-      "import": "./dist/unplugin/unplugin.mjs",
-      "types": "./dist/unplugin/unplugin.d.ts"
+      "import": "./dist/unplugin/unplugin.mjs"
     },
     "./vite": {
+      "types": "./dist/unplugin/vite.d.ts",
       "require": "./dist/unplugin/vite.js",
-      "import": "./dist/unplugin/vite.mjs",
-      "types": "./dist/unplugin/vite.d.ts"
+      "import": "./dist/unplugin/vite.mjs"
     },
     "./webpack": {
+      "types": "./dist/unplugin/webpack.d.ts",
       "require": "./dist/unplugin/webpack.js",
-      "import": "./dist/unplugin/webpack.mjs",
-      "types": "./dist/unplugin/webpack.d.ts"
+      "import": "./dist/unplugin/webpack.mjs"
     },
     "./rollup": {
+      "types": "./dist/unplugin/rollup.d.ts",
       "require": "./dist/unplugin/rollup.js",
-      "import": "./dist/unplugin/rollup.mjs",
-      "types": "./dist/unplugin/rollup.d.ts"
+      "import": "./dist/unplugin/rollup.mjs"
     },
     "./esbuild": {
+      "types": "./dist/unplugin/esbuild.d.ts",
       "require": "./dist/unplugin/esbuild.js",
-      "import": "./dist/unplugin/esbuild.mjs",
-      "types": "./dist/unplugin/esbuild.d.ts"
+      "import": "./dist/unplugin/esbuild.mjs"
     },
     "./astro": {
+      "types": "./dist/unplugin/astro.d.ts",
       "require": "./dist/unplugin/astro.js",
-      "import": "./dist/unplugin/astro.mjs",
-      "types": "./dist/unplugin/astro.d.ts"
+      "import": "./dist/unplugin/astro.mjs"
     },
     "./ts-diagnostic": {
       "require": "./dist/ts-diagnostic.js",

--- a/source/config.civet
+++ b/source/config.civet
@@ -103,3 +103,9 @@ export function loadConfig(pathname: string): Promise<CompileOptions>
   // Forbid enabling comptime in the config file
   delete data?.parseOptions?.comptime
   data
+
+export default {
+  findConfig
+  findInDir
+  loadConfig
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -127,8 +127,8 @@ declare module "@danielx/civet/config" {
     path: string
   ): Promise<import("@danielx/civet").CompileOptions>
   export default {
-    findInDir: typeof findInDir,
-    findConfig: typeof findConfig,
-    loadConfig: typeof loadConfig,
+    findInDir,
+    findConfig,
+    loadConfig,
   }
 }


### PR DESCRIPTION
Latest esbuild had a warning about our order when declaring exports so I changed it:

```
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    ../package.json:49:6:
      49 │       "types": "./dist/unplugin/rollup.d.ts"
         ╵       ~~~~~~~
```

I also added default exports to config, and fixed up the types for the default export.