### PR TITLE
Add syntax highlighting support for /d, /s and /v RegExp flags

### DIFF
--- a/civet.dev/public/shiki/languages/coffee.tmLanguage.json
+++ b/civet.dev/public/shiki/languages/coffee.tmLanguage.json
@@ -137,7 +137,7 @@
     },
     {
       "begin": "///",
-      "end": "(///)[gimuy]*",
+      "end": "(///)[dgimuvy]*",
       "name": "string.regexp.multiline.coffee",
       "beginCaptures": {
         "0": {
@@ -156,13 +156,13 @@
       ]
     },
     {
-      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$/(]))",
+      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[dgimuvy]*(?!\\s*[\\w$/(]))",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.begin.coffee"
         }
       },
-      "end": "(/)[gimuy]*(?!\\s*[\\w$/(])",
+      "end": "(/)[dgimuvy]*(?!\\s*[\\w$/(])",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.string.end.coffee"

--- a/civet.dev/public/shiki/languages/coffee.tmLanguage.json
+++ b/civet.dev/public/shiki/languages/coffee.tmLanguage.json
@@ -137,7 +137,7 @@
     },
     {
       "begin": "///",
-      "end": "(///)[dgimuvy]*",
+      "end": "(///)[dgimsuvy]*",
       "name": "string.regexp.multiline.coffee",
       "beginCaptures": {
         "0": {
@@ -156,13 +156,13 @@
       ]
     },
     {
-      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[dgimuvy]*(?!\\s*[\\w$/(]))",
+      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[dgimsuvy]*(?!\\s*[\\w$/(]))",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.begin.coffee"
         }
       },
-      "end": "(/)[dgimuvy]*(?!\\s*[\\w$/(])",
+      "end": "(/)[dgimsuvy]*(?!\\s*[\\w$/(])",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.string.end.coffee"

--- a/lsp/syntaxes/civet.json
+++ b/lsp/syntaxes/civet.json
@@ -128,7 +128,7 @@
     },
     {
       "begin": "///",
-      "end": "(///)[dgimuvy]*",
+      "end": "(///)[dgimsuvy]*",
       "name": "string.regexp.multiline.civet",
       "beginCaptures": {
         "0": {
@@ -147,13 +147,13 @@
       ]
     },
     {
-      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[dgimuvy]*(?!\\s*[\\w$/(]))",
+      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[dgimsuvy]*(?!\\s*[\\w$/(]))",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.begin.civet"
         }
       },
-      "end": "(/)[dgimuvy]*(?!\\s*[\\w$/(])",
+      "end": "(/)[dgimsuvy]*(?!\\s*[\\w$/(])",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.string.end.civet"

--- a/lsp/syntaxes/civet.json
+++ b/lsp/syntaxes/civet.json
@@ -128,7 +128,7 @@
     },
     {
       "begin": "///",
-      "end": "(///)[gimuy]*",
+      "end": "(///)[dgimuvy]*",
       "name": "string.regexp.multiline.civet",
       "beginCaptures": {
         "0": {
@@ -147,13 +147,13 @@
       ]
     },
     {
-      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$/(]))",
+      "begin": "(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[dgimuvy]*(?!\\s*[\\w$/(]))",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.begin.civet"
         }
       },
-      "end": "(/)[gimuy]*(?!\\s*[\\w$/(])",
+      "end": "(/)[dgimuvy]*(?!\\s*[\\w$/(])",
       "endCaptures": {
         "1": {
           "name": "punctuation.definition.string.end.civet"


### PR DESCRIPTION
I just replaced all instances of "gimuy" (full list of RegExp flags as of ES2017) with "dgimsuvy" (full list of RegExp flags as of current ES2024), since regex literals with the `d` or `v` flags are not currently highlighted as regexen.