### PR TITLE
Fix typed patterns in arrow function with unparenthesized parameter

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -266,6 +266,7 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
 
       [stateKey, tagKey] := getStateKey()
       key: CacheKey := [tagKey, stateKey, state.pos, ruleName ]
+      result = {...result} if result?
       stateCache.set(key, result)
 
       //@ts-ignore

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1674,15 +1674,22 @@ Parameters
 
 # Allow for [a, b] => ... or {a, b} -> ...
 ShortArrowParameters
-  ObjectBindingPattern
-  ArrayBindingPattern
+  ( ObjectBindingPattern / ArrayBindingPattern ):binding ->
+    // Based on ParameterElement
+    const { typeSuffix } = binding
+    return {
+      type: "Parameter",
+      children: [ binding, typeSuffix ],
+      names: binding.names,
+      typeSuffix,
+    }
 
 ArrowParameters
   ShortArrowParameters ->
     return {
       type: "Parameters",
-      children: ["(", $0, ")"],
-      names: $0.names,
+      children: ["(", $1, ")"],
+      names: $1.names,
     }
   Parameters
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -142,7 +142,7 @@ function arrayElementHasTrailingComma(elementNode)
   const lastChild = elementNode.children.-1
   return lastChild and lastChild[lastChild.length - 1]?.token is ","
 
-// If an ObjectBindingPattern doesn't have a typeSuffix, this function
+// If an Array or ObjectBindingPattern doesn't have a typeSuffix, this function
 // extracts one from typeSuffixes for the binding properties (if present).
 function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBindingPattern): BindingPattern
   return pattern if pattern.typeSuffix?

--- a/source/state-cache.civet
+++ b/source/state-cache.civet
@@ -11,7 +11,7 @@ type Key = [JSXTag, State, Position, RuleName ]
  */
 export default class StateCache<T>
 
-  private cache: Map<RuleName, Map<Position, Map<State, Map<JSXTag, T>>>> = new Map()
+  private cache: Map<JSXTag, Map<State, Map<Position, Map<RuleName, T>>>> = new Map()
 
   get(key: Key): T | undefined
     @cache.get(key[0])?.get(key[1])?.get(key[2])?.get(key[3])
@@ -25,22 +25,22 @@ export default class StateCache<T>
 
   set(key: Key, value: T): void
     cache0 := @cache
-    let cache1: Map<Position, Map<State, Map<JSXTag, T>>>
-    if !cache0.has key[0]
+    let cache1: Map<State, Map<Position, Map<RuleName, T>>>
+    unless cache0.has key[0]
       cache1 = new Map
       @cache.set key[0], cache1
     else
       cache1 = cache0.get(key[0])!
 
-    let cache2: Map<State, Map<JSXTag, T>>
-    if !cache1?.has key[1]
+    let cache2: Map<Position, Map<RuleName, T>>
+    unless cache1?.has key[1]
       cache2 = new Map
       cache1.set key[1], cache2
     else
       cache2 = cache1.get(key[1])!
 
-    let cache3: Map<JSXTag, T>
-    if !cache2.has(key[2])
+    let cache3: Map<RuleName, T>
+    unless cache2.has(key[2])
       cache3 = new Map
       cache2.set(key[2], cache3)
     else

--- a/test/function.civet
+++ b/test/function.civet
@@ -1611,6 +1611,22 @@ describe "function", ->
     """
 
     testCase """
+      binding object pattern params with types
+      ---
+      {a:: A, b:: B} ->
+        a
+      {a:: A, b:: B} =>
+        a
+      ---
+      (function({a, b}: {a: A, b: B}) {
+        return a
+      });
+      ({a, b}: {a: A, b: B}) => {
+        return a
+      }
+    """
+
+    testCase """
       binding array pattern params
       ---
       [a, b] ->
@@ -1622,6 +1638,22 @@ describe "function", ->
         return a
       });
       ([a, b]) => {
+        return a
+      }
+    """
+
+    testCase """
+      binding array pattern params with types
+      ---
+      [a:: A, b:: B] ->
+        a
+      [a:: A, b:: B] =>
+        a
+      ---
+      (function([a, b]: [ A, B]) {
+        return a
+      });
+      ([a, b]: [ A, B]) => {
         return a
       }
     """

--- a/test/function.civet
+++ b/test/function.civet
@@ -1611,22 +1611,6 @@ describe "function", ->
     """
 
     testCase """
-      binding object pattern params with types
-      ---
-      {a:: A, b:: B} ->
-        a
-      {a:: A, b:: B} =>
-        a
-      ---
-      (function({a, b}: {a: A, b: B}) {
-        return a
-      });
-      ({a, b}: {a: A, b: B}) => {
-        return a
-      }
-    """
-
-    testCase """
       binding array pattern params
       ---
       [a, b] ->
@@ -1638,22 +1622,6 @@ describe "function", ->
         return a
       });
       ([a, b]) => {
-        return a
-      }
-    """
-
-    testCase """
-      binding array pattern params with types
-      ---
-      [a:: A, b:: B] ->
-        a
-      [a:: A, b:: B] =>
-        a
-      ---
-      (function([a, b]: [ A, B]) {
-        return a
-      });
-      ([a, b]: [ A, B]) => {
         return a
       }
     """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -486,3 +486,36 @@ describe "[TS] function", ->
       ---
       ParseErrors: unknown:1:19 Only one typed this parameter is allowed
     """
+
+  describe ":: typing of parameters", ->
+    testCase """
+      binding array pattern params with types
+      ---
+      [a:: A, b:: B] ->
+        a
+      [a:: A, b:: B] =>
+        a
+      ---
+      (function([a, b]: [ A, B]) {
+        return a
+      });
+      ([a, b]: [ A, B]) => {
+        return a
+      }
+    """
+
+    testCase """
+      binding object pattern params with types
+      ---
+      {a:: A, b:: B} ->
+        a
+      {a:: A, b:: B} =>
+        a
+      ---
+      (function({a, b}: {a: A, b: B}) {
+        return a
+      });
+      ({a, b}: {a: A, b: B}) => {
+        return a
+      }
+    """


### PR DESCRIPTION
Fixes #1402

The main challenge here was fixing a caching bug. By `Object.freeze`ing the cache result, I found that the `value` of a cache result for `ArrayBindingPattern` was getting overwritten when `ShortArrowParameters` got parsed, via this line:

https://github.com/DanielXMoore/Hera/blob/d2aff817973973ace404b7fbe8ec705b4653e807/source/machine.ts#L443

This is specific to the `ShortArrowParameters` rule having just one thing in it (`$TS`). For example, adding a `""` to the rule fixes the problem. Though I don't see much difference between how `$TS` works and the other cases do; they all seem to modify `result.value` in-place.

I'm not sure if Hera is supposed to guarantee any kind of immutability in this case. In Civet, we already did `{...result}` on cache `get`, but didn't yet do it on cache `set`. It feels redundant to do it in both cases, but if Hera doesn't guarantee any immutability, it's necessary. Plausibly, there is a bug in Hera if it's supposed to be immutable, or else Hera should do `result = {...result}` on `get` and `set` so that every cache maker doesn't have to... Let me know what you think.