### PR TITLE
Fix implicit empty body for exported functions

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -82,18 +82,22 @@ function isAsyncGeneratorVoidType(t?: TypeIdentifierNode): boolean
     (t.raw is "AsyncIterator" or t.raw is "AsyncGenerator") and
     t.args?.types?.length >= 2 and isVoidType(t.args.types[1])
 
-// Add implicit block unless followed by a method/function of the same name,
-// or block is within an ExportDeclaration.
+// Add implicit block unless followed by a method/function of the same name.
 function implicitFunctionBlock(f): void
   if (f.abstract or f.block or f.signature?.optional) return
 
   { name, parent } := f
-  if (parent?.type is "ExportDeclaration") return
-  expressions := parent?.expressions ?? parent?.elements
-  currentIndex := expressions?.findIndex(([, def]) => def is f)
-  following := currentIndex >= 0 and expressions[currentIndex + 1]?.[1]
+  ancestor .= parent
+  child .= f
+  if ancestor?.type is "ExportDeclaration"
+    child = ancestor
+    ancestor = ancestor.parent
+  expressions := ancestor?.expressions ?? ancestor?.elements
+  currentIndex := expressions?.findIndex [, def] => def is child
+  following .= currentIndex >= 0 and expressions[currentIndex + 1]?.[1]
+  following = following.declaration if following?.type is 'ExportDeclaration'
 
-  if f.type is following?.type and name and name is following.name
+  if f.type is following?.type and name? is following.name
     f.ts = true
   else
     block := makeEmptyBlock()

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -328,13 +328,26 @@ describe "[TS] function", ->
   """
 
   testCase """
-    export overload has no implicit body
+    export overload with implicit body
     ---
     export function noop(a: number, b: number): void
     export function noop(a: string, b: string): void
     ---
     export function noop(a: number, b: number): void
-    export function noop(a: string, b: string): void
+    export function noop(a: string, b: string): void{}
+  """
+
+  testCase """
+    partial export overload has no implicit body
+    ---
+    function identity(x: number): number
+    export function identity(x: string): string
+      x
+    ---
+    function identity(x: number): number
+    export function identity(x: string): string {
+      return x
+    }
   """
 
   testCase """


### PR DESCRIPTION
Fixes #1401

I incorrectly claimed that you can mix `export`ed and non-`export`ed function overrides in TypeScript. That's actually an error, but it's better to support it and let TypeScript report the error.

Previously, we never added a blank body to an `export`ed function. But this isn't really what we want. `export function ...` should always provide an implementation. Now we correctly skip over the `ExportDeclaration`s to compare functions.