### PR TITLE
Fix arrow type with `?` postfix

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7620,7 +7620,7 @@ TypeUnary
   ( __ TypeUnaryOp )*:prefix TypePrimary:t TypeUnarySuffix*:suffix ->
     if (!prefix.length && !suffix.length) return t
     return {
-      type: "UnaryType",
+      type: "TypeUnary",
       prefix,
       suffix,
       t,
@@ -7684,20 +7684,20 @@ TypePrimary
     }
   _? TypeLiteral:t ->
     return {
-      type: "LiteralType",
+      type: "TypeLiteral",
       t,
       children: $0,
     }
   _? UnknownAlias ->
     return {
-      type: "IdentifierType",
+      type: "TypeIdentifier",
       children: $0,
       raw: $2.token,
       args: undefined
     }
   _? Identifier (Dot IdentifierName)* ( TypeArguments / ImplicitTypeArguments )?:args ->
     return {
-      type: "IdentifierType",
+      type: "TypeIdentifier",
       children: $0,
       raw: [$2.name, ...$3.map(([dot, id]) => dot.token + id.name), ].join(''),
       args,
@@ -7709,7 +7709,7 @@ TypePrimary
   _? OpenParen AllowAll ( Type / ( EOS Type ) )? RestoreAll __ CloseParen ->
     if (!$4) return $skip
     return {
-      type: "ParenthesizedType",
+      type: "TypeParenthesized",
       children: [ $1, $2, $4, $6, $7 ],  // omit AllowAll/RestoreAll
     }
 
@@ -7964,15 +7964,19 @@ TypeBinaryOp
 
 TypeFunction
   ( Abstract _? )? ( New _? )? Parameters __ TypeArrowFunction ReturnType?:type ->
-    const ret = [ ...$0 ]
+    const children = [ ...$0 ]
     if ($1 && !$2) {
-      ret[1] = {
+      children[1] = {
         type: "Error",
         message: "abstract function types must be constructors (abstract new)",
       }
     }
-    if (!type) ret.push ("void")
-    return ret
+    if (!type) children.push ("void")
+    return {
+      type: "TypeFunction",
+      children,
+      ts: true,
+    }
 
 TypeArrowFunction
   "=>" / "⇒" / "->" / "→" ->
@@ -7982,10 +7986,10 @@ TypeArguments
   OpenAngleBracket ( __ TypeArgumentDelimited )+:args __ CloseAngleBracket ->
     args = args.map(([ws, arg]) => [ws, ...arg])
     return {
-      type: 'TypeArguments',
+      type: "TypeArguments",
       ts: true,
       types: args.map(([, t, ]) => t),
-      children: $0
+      children: $0,
     }
 
 ImplicitTypeArguments

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -15,7 +15,7 @@ import type {
   ParametersNode
   StatementTuple
   SwitchStatement
-  TypeIdentifierNode
+  TypeIdentifier
   TypeNode
   Whitespace
 } from ./types.civet
@@ -66,19 +66,19 @@ import {
 } from ./ref.civet
 
 function isVoidType(t?: TypeNode): boolean
-  return t?.type is "LiteralType" and t.t.type is "VoidType"
+  return t?.type is "TypeLiteral" and t.t.type is "VoidType"
 
-function isPromiseVoidType(t?: TypeIdentifierNode): boolean
-  return t?.type is "IdentifierType" and t.raw is "Promise" &&
+function isPromiseVoidType(t?: TypeNode): boolean
+  return t?.type is "TypeIdentifier" and t.raw is "Promise" &&
     t.args?.types?.length is 1 and isVoidType(t.args.types[0])
 
-function isGeneratorVoidType(t?: TypeIdentifierNode): boolean
-  return t?.type is "IdentifierType" and
+function isGeneratorVoidType(t?: TypeNode): boolean
+  return t?.type is "TypeIdentifier" and
     (t.raw is "Iterator" or t.raw is "Generator") and
     t.args?.types?.length >= 2 and isVoidType(t.args.types[1])
 
-function isAsyncGeneratorVoidType(t?: TypeIdentifierNode): boolean
-  return t?.type is "IdentifierType" and
+function isAsyncGeneratorVoidType(t?: TypeNode): boolean
+  return t?.type is "TypeIdentifier" and
     (t.raw is "AsyncIterator" or t.raw is "AsyncGenerator") and
     t.args?.types?.length >= 2 and isVoidType(t.args.types[1])
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -10,7 +10,6 @@ import type {
   AccessStart
   ASTLeaf
   ASTNode
-  ASTNodeBase
   ASTNodeObject
   ASTNodeParent
   ASTRef
@@ -280,7 +279,7 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
 function expressionizeTypeIf([ifOp, condition, t, e])
   children := [
     "("
-    insertTrimmingSpace condition, ""
+    trimFirstSpace condition
     "?"
   ]
   unless ifOp.negated xor condition.negated // if
@@ -468,7 +467,7 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
         [name, value] = [value, name] if glob.reversed
 
         if !suppressPrefix // Don't prefix @ shorthand
-          value = prefix.concat(insertTrimmingSpace(value, ""))
+          value = prefix.concat trimFirstSpace value
         if (wValue) value.unshift(wValue)
         if part.type is "SpreadProperty"
           parts.push {
@@ -692,7 +691,7 @@ function convertObjectToJSXAttributes(obj) {
         if (part.name.type is 'ComputedPropertyName') {
           rest.push(part)
         } else {
-          parts.push([part.name, '={', insertTrimmingSpace(part.value, ''), '}'])
+          parts.push([part.name, '={', trimFirstSpace(part.value), '}'])
         }
         break
       case 'SpreadProperty':
@@ -721,7 +720,7 @@ function convertObjectToJSXAttributes(obj) {
  */
 function makeGetterMethod(name, ws, value, returnType, block?: BlockStatement, kind: { token: "get" | "set" } = { token: "get" }, autoReturn: boolean = true): MethodDefinition
   { token } := kind
-  ws = insertTrimmingSpace(ws, "")
+  ws = trimFirstSpace ws
   let setVal
   parameters := token is "get" ?
     type: "Parameters"
@@ -1060,15 +1059,18 @@ function attachPostfixStatementAsExpression(exp, post: [WSNode, IfStatement | It
 
 function processTypes(node: ASTNode)
   // T? -> T | undefined; T?? -> T | undefined | null
-  gatherRecursiveAll node, (n) => n.type is "UnaryType"
+  gatherRecursiveAll node, (n) => n.type is "TypeUnary"
   // @ts-ignore
-  .forEach (unary: ASTNodeBase): void =>
+  .forEach (unary): void =>
     let last: ASTNode
     count .= 0
-    while unary.suffix.length and unary.suffix.-1?.token is "?"
+    while unary.suffix# and unary.suffix.-1?.token is "?"
       last = unary.suffix.pop()
       count++
     return unless count
+    // Remove UnaryType wrapper if no prefix or suffix,
+    // so we can correctly decide whether to parenthesize
+    t := if unary.suffix# or unary.prefix# then unary else unary.t
     if unary.parent?.type is "TypeTuple"
       // Leave one ? inside a type tuple
       if count is 1
@@ -1077,18 +1079,21 @@ function processTypes(node: ASTNode)
       replaceNode unary, [
         getTrimmingSpace unary
         "("
-        parenthesizeType insertTrimmingSpace unary, ""
+        parenthesizeType trimFirstSpace t
         " | null)"
         last
       ]
     else
-      replaceNode unary, [
-        getTrimmingSpace unary
-        "("
-        parenthesizeType insertTrimmingSpace unary, ""
-        count is 1 ? " | undefined" : " | undefined | null"
-        ")"
-      ]
+      replaceNode unary,
+        type: "TypeParenthesized"
+        ts: true
+        children: [
+          getTrimmingSpace unary
+          "("
+          parenthesizeType trimFirstSpace t
+          count is 1 ? " | undefined" : " | undefined | null"
+          ")"
+        ]
 
 /**
 Wrap any remaining statement expressions in IIFE.

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -793,10 +793,16 @@ export type TabConfig = number?
 
 export type ParseRule = (context: {fail: () => void}, state: {pos: number, input: string}) => ???
 
-export type TypeNode = TypeIdentifierNode | LiteralTypeNode
+export type TypeNode =
+  | TypeIdentifier
+  | TypeLiteral
+  | TypeUnary
+  | TypeTuple
+  | TypeArrowFunction
+  | TypeParenthesized
 
-export type TypeIdentifierNode =
-  type: "IdentifierType"
+export type TypeIdentifier =
+  type: "TypeIdentifier"
   children: Children
   parent?: Parent
   raw: string
@@ -809,8 +815,35 @@ export type TypeArgumentsNode =
   children: Children
   parent?: Parent
 
-export type LiteralTypeNode =
-  type: "LiteralType"
+export type TypeUnary
+  type: "TypeUnary"
+  ts: true
+  children: Children
+  parent?: Parent
+  prefix: ASTNode[]
+  suffix: ASTNode[]
+  t: TypeNode
+
+export type TypeTuple
+  type: "TypeTuple"
+  ts: true
+  children: Children
+  parent?: Parent
+
+export type TypeArrowFunction
+  type: "TypeArrowFunction"
+  ts: true
+  children: Children
+  parent?: Parent
+
+export type TypeParenthesized
+  type: "TypeParenthesized"
+  ts: true
+  children: Children
+  parent?: Parent
+
+export type TypeLiteral =
+  type: "TypeLiteral"
   t: TypeLiteralNode
   children: Children
   parent?: Parent

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -522,12 +522,11 @@ function convertOptionalType(suffix: TypeSuffix | ReturnTypeAnnotation): void
   ]
 
 const typeNeedsNoParens = new Set [
-  "IdentifierType"
+  "TypeIdentifier"
   "ImportType"
-  "LiteralType"
+  "TypeLiteral"
   "TupleType"
-  "ParenthesizedType"
-  "UnaryType"
+  "TypeParenthesized"
 ]
 /**
  * Parenthesize type if it might need it in some contexts.

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -946,6 +946,14 @@ describe "[TS] type declaration", ->
       type Names = [(string | null)?]
     """
 
+    testCase """
+      arrow type
+      ---
+      type Callback = =>?
+      ---
+      type Callback = ((()=>void) | undefined)
+    """
+
   describe "implicit type arguments", ->
     testCase """
       simple call


### PR DESCRIPTION
* Adds missing parenthesization in type `=>?`
  * Previously: `()=>void | undefined` which didn't respect how it actually parsed
  * Now: `(()=>void) | undefined`
* Clean up type AST nodes a little bit