### PR TITLE
Enable `worker.civet?worker` import in Vite

### DIFF
--- a/source/unplugin/README.md
+++ b/source/unplugin/README.md
@@ -32,9 +32,16 @@ export default defineConfig({
 });
 ```
 
-To use Civet files as Web Workers, use a variation on
-[Vite's constructor syntax](https://vitejs.dev/guide/features.html#import-with-constructors):
-(note the added `.tsx` extension)
+To use Civet files as Web Workers, you can use
+[Vite's `?worker` query suffix](https://vite.dev/guide/features.html#import-with-query-suffixes):
+
+```ts
+import MyWorker from './worker.civet?worker'
+```
+
+If you use
+[Vite's constructor syntax](https://vitejs.dev/guide/features.html#import-with-constructors),
+you need to add a `.tsx` extension like so:
 
 ```ts
 worker = new Worker(new URL('./worker.civet.tsx', import.meta.url))

--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -51,10 +51,15 @@ const postfixRE = /[?#].*$/s;
 const isWindows = os.platform() === 'win32';
 const windowsSlashRE = /\\/g;
 
-// removes query string, hash and tsx/jsx extension
-function cleanCivetId(id: string): string {
-  return id.replace(postfixRE, '').replace(/\.[jt]sx$/, '');
-}
+// Extracts query string and hash, and removes tsx/jsx extension
+function cleanCivetId(id: string): {id: string, postfix: string}
+  let postfix = ''
+  id = id
+  .replace postfixRE, (match) =>
+    postfix = match
+    ''
+  .replace /\.[jt]sx$/, ''
+  {id, postfix}
 
 function tryStatSync(file: string): fs.Stats | undefined {
   try {
@@ -397,34 +402,35 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         }
       }
     }
-    resolveId(id, importer, options) {
-      if (/\0/.test(id)) return null;
 
-      id = cleanCivetId(id);
-      let resolvedId = path.isAbsolute(id)
-        ? resolveAbsolutePath(rootDir, id, implicitExtension)
-        : path.resolve(path.dirname(importer ?? ''), id);
-      if (!resolvedId) return null;
+    resolveId(id, importer, options)
+      if (/\0/.test(id)) return null
+
+      let postfix: string
+      {id, postfix} = cleanCivetId(id)
+      resolvedId .=
+        if path.isAbsolute id
+          resolveAbsolutePath rootDir, id, implicitExtension
+        else
+          path.resolve path.dirname(importer ?? ''), id
+      if (!resolvedId) return null
 
       // Implicit .civet extension
-      if (!resolvedId.endsWith('.civet')) {
-        if (!implicitExtension) return null;
-        const implicitId = implicitCivet(resolvedId)
-        if (!implicitId) return null;
+      unless resolvedId.endsWith '.civet'
+        if (!implicitExtension) return null
+        implicitId := implicitCivet resolvedId
+        if (!implicitId) return null
         resolvedId = implicitId
-      }
 
       // Tell Vite that this is a virtual module during dependency scanning
-      if ((options as unknown as {scan?: boolean}).scan &&
-          meta.framework === 'vite') {
+      if (options as! {scan?: boolean}).scan and meta.framework is 'vite'
         resolvedId = `\0${resolvedId}`
-      }
 
-      return resolvedId + outExt;
-    }
-    loadInclude(id) {
-      return isCivetTranspiled.test(id);
-    }
+      return resolvedId + outExt + postfix
+
+    loadInclude(id)
+      isCivetTranspiled.test id
+
     async load(id) {
       const match = isCivetTranspiled.exec(id);
       if (!match) return null;


### PR DESCRIPTION
Fix `import MyWorker from './worker.civet?worker'` by preserving query/hash in unplugin.

Also Civetify `unplugin.civet` a little.

(followup to #1403)

I also tried to get the URL notation to work with `.civet` instead of `.civet.tsx`, but it doesn't seem to reach the unplugin at all in that case...