### PR TITLE
Fix missing semicolon in if/unless followed by else

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4275,6 +4275,15 @@ IfStatement
       kind = { ...kind, token: "if" }
       condition = negateCondition(condition)
     }
+    // Ensure semicolon separating single line from `else`
+    if (block.bare && e) {
+      const semicolon = ";"
+      block = {
+        ...block,
+        semicolon,
+        children: [...block.children, semicolon],
+      }
+    }
     return {
       type: "IfStatement",
       children: [ kind, ws, condition, block, e],
@@ -4285,6 +4294,14 @@ IfStatement
     }
   # NOTE: Block isn't Statement so we can handle implied braces by nesting
   IfClause:clause BlockOrEmpty:block ElseClause?:e ->
+    // Ensure semicolon separating single line from `else`
+    if (block.bare && e) {
+      block = {
+        ...block,
+        semicolon: ";",
+        children: [...block.children, ";"],
+      }
+    }
     return {
       type: "IfStatement",
       children: [...clause.children, block, e],

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -351,8 +351,6 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
           updateParentPointers e
       else
         block := blockWithPrefix blockPrefix, s.then
-        if block.bare and e and not block.semicolon
-          block.children.push block.semicolon = ";"
         s.children = s.children.map & is s.then ? block : &
         s.then = block
         updateParentPointers s

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -269,13 +269,12 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   return unless exp
   return if isExit exp
 
+  exp = exp as ASTNodeObject
   outer := exp
-  {type} .= exp
-  if type is "LabelledStatement"
+  if exp.type is "LabelledStatement"
     exp = exp.statement
-    {type} = exp
 
-  switch type
+  switch exp.type
     when "BreakStatement", "ContinueStatement", "DebuggerStatement", "EmptyStatement", "ReturnStatement", "ThrowStatement"
       return
     when "Declaration"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -20,6 +20,7 @@ export type StatementNode =
   | DebuggerStatement
   | DeclarationStatement
   | DoStatement
+  | EmptyStatement
   | ExpressionNode
   | ForStatement
   | IfStatement
@@ -366,10 +367,15 @@ export type DefaultClause
   children: Children
   block: BlockStatement
 
+export type EmptyStatement
+  type: "EmptyStatement"
+  children: Children
+  parent?: Parent
+
 export type LabelledStatement
   type: "LabelledStatement"
   label: Label
-  statement: ASTNodeBase
+  statement: ASTNodeObject
   children: Children
   parent?: Parent
 
@@ -428,6 +434,7 @@ export type BlockStatement =
   children: Children
   expressions: StatementTuple[]
   bare: boolean  // has no braces
+  semicolon?: ";"  // ends with a semicolon (to separate from else block)
   empty?: boolean  // empty block
   implicit?: boolean  // implicit empty block
   implicitlyReturned?: boolean  // fat arrow function with no braces

--- a/test/if.civet
+++ b/test/if.civet
@@ -289,8 +289,7 @@ describe "if", ->
     }
   """
 
-  // TODO
-  testCase.skip """
+  testCase """
     if then nothing
     ---
     if x then
@@ -311,6 +310,22 @@ describe "if", ->
     if then else
     ---
     if true then y else z
+    ---
+    if (true) y; else z
+  """
+
+  testCase """
+    unless then else
+    ---
+    unless false then y else z
+    ---
+    if (!false) y; else z
+  """
+
+  testCase """
+    if else
+    ---
+    if (true) y else z
     ---
     if (true) y; else z
   """


### PR DESCRIPTION
Fixes #1422

We had a bunch of places where we add a semicolon to the `then` block of an `IfStatement` to separate it from an `else` block, but none that applied universally. Now apply the logic when building the AST, instead of when doing implicit returns from functions. There are still a couple of places with the add-semicolon logic, where we add extra `else` clauses.

Also improve more typing. This PR reduces the number of type errors from 718 to 673! (via `civet --typecheck source/*.civet`)