### PR TITLE
Stop implicitly returning final value from generators

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -901,6 +901,8 @@ Implicit return of the last value in a function can be avoided by
 specifying a `void` return type (or `Promise<void>` for async functions),
 adding a final semicolon or explicit `return`,
 or globally using the directive `"civet -implicitReturns"`.
+Generators also don't implicitly `return`
+(use explicit `return` to return a special final value).
 :::
 
 <Playground>
@@ -916,6 +918,13 @@ function abort: void
 <Playground>
 function run(command: string): Promise<void>
   await exec command
+</Playground>
+
+<Playground>
+function count()
+  yield 1
+  yield 2
+  yield 3
 </Playground>
 
 ### One-Line Functions
@@ -1867,7 +1876,6 @@ neighbors := do*
   yield [x+1, y]
   yield [x, y-1]
   yield [x, y+1]
-  return
 </Playground>
 
 ### Comptime Blocks

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -100,6 +100,7 @@ Things Changed from CoffeeScript
 - `x?()` → `x?.()` instead of `if (typeof x === 'function') { x() }`
 - Functions don't implicitly return the last value if there's a semicolon
   at the end: `-> x` returns `x` but `-> x;` does not
+- Generators don't implicitly return the last value (as this is rarely useful)
 - Backtick embedded JS has been replaced with JS template literals.
 - No longer allowing multiple postfix `if/unless` on the same line (use `&&` or `and` to combine conditions).
 - `#{}` interpolation in `""` strings only when `"civet coffeeCompat"` or `"civet coffeeInterpolation"`

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -118,16 +118,18 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
     isMethod := f.type is "MethodDefinition"
     isConstructor := isMethod and name is "constructor"
     isVoid := (or)
-      isVoidType(returnType?.t)
+      generator
+      isVoidType returnType?.t
       (and)
         async
-        (or)
-          isPromiseVoidType(returnType?.t)
-          generator and isAsyncGeneratorVoidType(returnType?.t)
-      (and)
-        not async
-        generator
-        isGeneratorVoidType(returnType?.t)
+        isPromiseVoidType returnType?.t
+        //(or)
+        //  isPromiseVoidType returnType?.t
+        //  generator and isAsyncGeneratorVoidType returnType?.t
+      //(and)
+      //  not async
+      //  generator
+      //  isGeneratorVoidType(returnType?.t)
 
     if block?.type is "BlockStatement"
       if isVoid or set or isConstructor

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -123,13 +123,6 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
       (and)
         async
         isPromiseVoidType returnType?.t
-        //(or)
-        //  isPromiseVoidType returnType?.t
-        //  generator and isAsyncGeneratorVoidType returnType?.t
-      //(and)
-      //  not async
-      //  generator
-      //  isGeneratorVoidType(returnType?.t)
 
     if block?.type is "BlockStatement"
       if isVoid or set or isConstructor

--- a/test/class.civet
+++ b/test/class.civet
@@ -1060,7 +1060,7 @@ describe "class", ->
       ---
       class A {
         *f() {
-          return yield 3
+          yield 3
         }
       }
     """
@@ -1074,7 +1074,7 @@ describe "class", ->
       ---
       class A {
         *f() {
-          return yield 3
+          yield 3
         }
       }
     """
@@ -1089,7 +1089,7 @@ describe "class", ->
       ---
       class A {
         async *f() {
-          return yield await 3
+          yield await 3
         }
       }
     """
@@ -1103,7 +1103,7 @@ describe "class", ->
       ---
       class A {
         async *f() {
-          return yield await 3
+          yield await 3
         }
       }
     """

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -41,7 +41,7 @@ describe "coffeeClasses", ->
     ---
     class Foo {
       *bar() {
-        return yield x
+        yield x
       }
     }
   """

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -357,10 +357,10 @@ describe "serialize", ->
       'Object.defineProperties({"x":1},{"y":{"value":1,"writable":false,"enumerable":false,"configurable":false}})'
 
     // Technically a default descriptor, but symbol keys are weird in some ways
-    obj3 := { [Symbol.iterator]: -> yield 5 }
+    obj3 := { [Symbol.iterator]: -> yield 5; }
     assert.equal
       serialize obj3
-      '{[Symbol.iterator]:function*() { return yield 5 }}'
+      '{[Symbol.iterator]:function*() { yield 5;  }}'
   it "Non-extensible objects", =>
     obj1 := Object.preventExtensions x: 1
     assert.equal serialize(obj1), 'Object.preventExtensions({"x":1})'

--- a/test/do.civet
+++ b/test/do.civet
@@ -296,7 +296,7 @@ describe "do", ->
     f = function*(x) {
       let ref;{
         ref = yield x
-      };return y = ref
+      };y = ref
     }
   """
 
@@ -311,6 +311,6 @@ describe "do", ->
     const nums = (function*(){{
       yield 1
       yield 2
-      return yield 3
+      yield 3
     }})()
   """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -579,7 +579,7 @@ describe "&. function block shorthand", ->
     ---
     -> yield &.foo
     ---
-    (function*() { return yield $ => $.foo })
+    (function*() { yield $ => $.foo })
   """
 
   testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -205,7 +205,7 @@ describe "function", ->
         yield 5
       ---
       (function*() {
-        return yield 5
+        yield 5
       })
     """
 
@@ -218,10 +218,10 @@ describe "function", ->
         yield x
       ---
       const f = function*() {
-        return yield 5
+        yield 5
       }
       const g = function*<T>(x: T) {
-        return yield x
+        yield x
       }
     """
 
@@ -232,7 +232,7 @@ describe "function", ->
         yield 5
       ---
       (function*() {
-        return yield 5
+        yield 5
       })
     """
 
@@ -243,7 +243,7 @@ describe "function", ->
         yield 5
       ---
       (function*() {
-        return yield 5
+        yield 5
       })
     """
 
@@ -1496,6 +1496,19 @@ describe "function", ->
 
     testCase """
       async generator implicit
+      ---
+      f1 := ->
+        await Promise.resolve()
+        yield 5
+      ---
+      const f1 = async function*() {
+        await Promise.resolve()
+        yield 5
+      }
+    """
+
+    testCase """
+      async generator implicit with void return type
       ---
       f1 := :AsyncGenerator<number, void> ->
         await Promise.resolve()

--- a/test/jsx/objects.civet
+++ b/test/jsx/objects.civet
@@ -86,7 +86,7 @@ describe "JSX object shorthand", ->
     ---
     <div {* method(x){x}} />
     ---
-    <div method={function * method(x){return x}} />
+    <div method={function * method(x){x}} />
   """
 
   testCase """
@@ -94,7 +94,7 @@ describe "JSX object shorthand", ->
     ---
     <div {async* method(x){x}} />
     ---
-    <div method={async function * method(x){return x}} />
+    <div method={async function * method(x){x}} />
   """
 
   testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -553,7 +553,7 @@ describe "object", ->
     ---
     x = {
       *x() {
-        return yield 5
+        yield 5
       }
     }
   """

--- a/test/semicolon.civet
+++ b/test/semicolon.civet
@@ -11,7 +11,7 @@ describe "semicolon insertion", ->
       await foo
     ---
     (function*() {
-      return yield foo
+      yield foo
     });
     (async function() {
       return await foo


### PR DESCRIPTION
This PR turns off implicit `return` at the end of generator functions (`function*`, implicit or explicit).

I think it's extremely common not to want to have implicit `return` in generators, especially when you have loops (very common in generators); it creates a wasteful array. As you can see in this PR, an example is in the docs, where I previously had to add an explicit `return` to prevent a final `return`.

I've not yet used the special final return value of generators (which is what gets set by `return`ing a value). It's pretty hard to use, because the standard way to consume generators (`for x of gen()`) skips it completely. So I think this is the normal case that's desired.

This is a breaking change, though, so worth thinking about. It's also an incompatibility with CoffeeScript (documented here). I guess we could have a compat flag... I just can't imagine many if any people have intentionally used this feature.