### PR TITLE
Prevent stray `await` from pipeline expansion

### DIFF
--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -60,46 +60,32 @@ function constructInvocation(fn, arg) {
   }
 }
 
-function constructPipeStep(fn, arg, returning) {
+function constructPipeStep(fn, arg, returning)
+  returning = null unless returning
   children .= [[fn.leadingComment, fn.expr, fn.trailingComment].map(skipIfOnlyWS), " ", arg]
 
   // Handle special non-function cases
-  switch (fn.expr.token) {
-    case "yield":
-    case "await":
-      if fn.expr.op
-        children = processUnaryExpression([fn.expr], arg, undefined)
-
-      if (returning) {
-        return [
-          children,
-          returning
-        ]
-      }
-
+  switch fn.expr.token
+    when "await"
+      children = processUnaryExpression([fn.expr], arg, undefined)
+      continue switch
+    when "yield"
       return [
         children,
-        null
+        returning
       ]
 
-    case "return":
+    when "return"
       // Return ignores ||> returning argument
       return [{
-        type: "ReturnStatement",
-        children,
+        type: "ReturnStatement"
+        children
       }, null]
-  }
 
-  if (returning) {
-    return [
-      constructInvocation(fn, arg),
-      returning
-    ]
-
-  }
-
-  return [constructInvocation(fn, arg), null]
-}
+  return [
+    constructInvocation(fn, arg)
+    returning
+  ]
 
 
 // head: expr

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -3,7 +3,9 @@ import type {
 } from ./types.civet
 
 import {
+  firstNonSpace
   makeLeftHandSideExpression
+  parenthesizeExpression
 } from ./util.civet
 
 function processUnaryExpression(pre, exp, post)
@@ -20,7 +22,7 @@ function processUnaryExpression(pre, exp, post)
       if lastPre.token is "!"
         post.token = " == null"
         pre = pre.slice(0, -1)
-      // Chec for `not a?`
+      // Check for `not a?`
       else if lastPre.length is 2 and lastPre[0].token is "!"
         post.token = " == null"
         pre = pre.slice(0, -1)
@@ -69,6 +71,8 @@ function processUnaryExpression(pre, exp, post)
           children: [...last.children, "Promise", last.op, exp]
         pre = pre.slice(0, -1)
       else
+        if firstNonSpace(exp) is like /^[ \t]*\n/, {token: /^[ \t]*\n/}
+          exp = parenthesizeExpression exp
         exp =
           type: "AwaitExpression",
           children: [...last.children, exp],

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -150,6 +150,25 @@ function isWhitespaceOrEmpty(node): boolean
   if (Array.isArray(node)) return node.every(isWhitespaceOrEmpty)
   return false
 
+// Returns leading space as a string, or undefined if none
+function firstNonSpace(node: ASTNode): ASTNode
+  return unless node?
+  if Array.isArray node
+    for each child of node
+      if first := firstNonSpace child
+        return first
+    return undefined
+  else if isParent node
+    if first := firstNonSpace node.children
+      return first
+    else
+      return node
+  else if isToken node
+    return if node.token is like /^[ \t]*$/
+  else if node <? "string"
+    return if node is like /^[ \t]*$/
+  node
+
 /**
  * Does this statement force exit from normal flow, or loop forever,
  * implying that the line after this one can never execute?
@@ -246,7 +265,7 @@ function inplaceInsertTrimmingSpace(target: ASTNode, c: string): void
     target.token = target.token.replace(/^ ?/, c)
 
 // Returns leading space as a string, or undefined if none
-function getTrimmingSpace(target: ASTNode)
+function getTrimmingSpace(target: ASTNode): string?
   return unless target?
   if Array.isArray target
     getTrimmingSpace target[0]
@@ -435,7 +454,9 @@ function makeLeftHandSideExpression(expression: ASTNode)
     return expression if skipParens.has expression.type
     return expression if expression.type is "MemberExpression" and
       not startsWithPredicate(expression, .type is "ObjectExpression")
+  parenthesizeExpression expression
 
+function parenthesizeExpression(expression: ASTNode)
   makeNode {
     type: "ParenthesizedExpression"
     children: ["(", expression, ")"]
@@ -639,6 +660,7 @@ export {
   clone
   convertOptionalType
   deepCopy
+  firstNonSpace
   flatJoin
   getTrimmingSpace
   hasAwait
@@ -661,6 +683,7 @@ export {
   makeNode
   maybeWrap
   maybeUnwrap
+  parenthesizeExpression
   parenthesizeType
   prepend
   removeHoistDecs

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -615,3 +615,14 @@ describe "pipe", ->
     ---
     await import(x)
   """
+
+  testCase """
+    await on next line
+    ---
+    foo:
+      foo()
+      |> await
+    ---
+    ({foo:await (
+      foo())})
+  """


### PR DESCRIPTION
Fixes #1429

I haven't added support yet for the following: (maybe a future PR)

```js
await
  foo
```