### PR TITLE
`await` with indented argument, or multiple arguments as array

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -835,6 +835,20 @@ await.all
       fetch url |> await |> .json() |> await
 </Playground>
 
+Both `await` and `await` operators support an indented application form.
+Multiple arguments automatically get bundled into an array:
+
+<Playground>
+// Sequential
+await
+  first()
+  second()
+// Parallel
+await.all
+  first()
+  second()
+</Playground>
+
 ### Custom Infix Operators
 
 You can also define your own infix operators;

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -61,6 +61,7 @@ import {
   reorderBindingRestProperty,
   replaceNodes,
   skipImplicitArguments,
+  stripTrailingImplicitComma,
   trimFirstSpace,
   typeOfJSX,
 } from "./parser/lib.civet"
@@ -316,9 +317,7 @@ ImplicitArguments
     // Don't treat as call if this is a postfix for/while/until/if/unless
     if (skipImplicitArguments(args)) return $skip
 
-    // Remove implicit trailing comma
-    let last = args[args.length - 1]
-    if (last?.token === "," && last.implicit) args = args.slice(0, -1)
+    args = stripTrailingImplicitComma(args)
 
     return {
       type: "Call",
@@ -3096,9 +3095,10 @@ BulletedArray
     ]
 
     // Remove implicit comma from last element
-    const last = content[content.length - 1]
+    let last = content[content.length - 1]
     if (last.children?.at(-1)?.implicit) {
-      last.children = last.children.slice(0, -1)
+      content[content.length - 1] = last =
+        { ...last, children: last.children.slice(0, -1) }
     }
 
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -472,18 +472,30 @@ NestedArgument
     return [ arg0, ...rest, comma ]
 
 SingleLineArgumentExpressions
-  ( _? ArgumentPart ) ( ( _? Comma ) ( _? ArgumentPart ) )* ->
+  WArgumentPart ( ( _? Comma ) WArgumentPart )* ->
     return [ $1, ...$2.flat() ]
+
+WArgumentPart
+  _? ArgumentPart ->
+    return prepend($1, $2)
 
 ArgumentPart
   # NOTE: Using ExtendedExpression to allow for If/Switch expressions
   # NOTE: Allow leading or trailing dots for argument splats like CoffeeScript
-  DotDotDot ExtendedExpression
-  ExtendedExpression DotDotDot? ->
-    if ($2) {
-      return [$2, $1]
+  DotDotDot:spread ExtendedExpression:expression ->
+    return {
+      type: "Argument",
+      children: $0,
+      expression,
+      spread,
     }
-    return $1
+  ExtendedExpression:expression DotDotDot?:spread ->
+    return {
+      type: "Argument",
+      children: $0,
+      expression,
+      spread,
+    }
 
 # NOTE: ArgumentPart variant that forbids top-level pipeline operators
 NonPipelineArgumentPart

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -492,7 +492,7 @@ ArgumentPart
   ExtendedExpression:expression DotDotDot?:spread ->
     return {
       type: "Argument",
-      children: $0,
+      children: spread ? [ spread, expression ] : [ expression ],
       expression,
       spread,
     }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -56,6 +56,7 @@ import {
   processProgramAsync,
   processTryBlock,
   processUnaryExpression,
+  processUnaryNestedExpression,
   quoteString,
   reorderBindingRestProperty,
   replaceNodes,
@@ -468,7 +469,7 @@ NestedArgument
   Nested:indent SingleLineArgumentExpressions:args ParameterElementDelimiter:comma ->
     // Attach indentation to first argument in SingleLineArgumentExpressions
     let [ arg0, ...rest ] = args
-    arg0 = [ indent, ...arg0 ]
+    arg0 = prepend(indent, arg0)
     return [ arg0, ...rest, comma ]
 
 SingleLineArgumentExpressions
@@ -546,6 +547,10 @@ RHS
 
 # https://262.ecma-international.org/#prod-UnaryExpression
 UnaryExpression
+  # NOTE: Added nested case, for e.g. indented await argument
+  IndentedApplicationAllowed UnaryOp+:pre ( NestedBulletedArray / NestedArgumentList ):args UnaryPostfix?:post ->
+    return processUnaryNestedExpression(pre, args, post) ?? $skip
+
   # NOTE: Merged AwaitExpression with UnaryOp
   # https://262.ecma-international.org/#prod-AwaitExpression
   # NOTE: Eliminated left recursion
@@ -3031,6 +3036,7 @@ ArrayElementExpression
     return {
       type: "SpreadElement",
       children: [ws, dots, exp],
+      expression: exp,
       names: exp.names,
     }
 
@@ -3044,12 +3050,14 @@ ArrayElementExpression
         return {
           type: "ArrayElement",
           children: [exp],
+          expression: exp,
           names: exp.names,
         }
       } else {
         return {
           type: "SpreadElement",
           children: [...spread, exp],
+          expression: exp,
           names: exp.names,
         }
       }
@@ -5203,6 +5211,12 @@ MaybeNestedExtendedExpression
     return $skip
   ExtendedExpression
 
+NestedExtendedExpression
+  NestedBulletedArray
+  PushIndent ( Nested ExtendedExpression )? PopIndent ->
+    if ($3) return $3
+    return $skip
+
 # MaybeNestedExtendedExpression but where expression needs to be output with
 # parentheses if indented, so that the expression starts on the same line.
 # (e.g. for `return` or `yield`)
@@ -6076,11 +6090,11 @@ AtAt
 
 Async
   "async" NonIdContinue ->
-    return { $loc, token: $1, type: 'Async' }
+    return { $loc, token: $1, type: "Async" }
 
 Await
   "await" NonIdContinue ->
-    return { $loc, token: $1, type: 'Await' }
+    return { $loc, token: $1, type: "Await" }
 
 Backtick
   "`" ->

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -121,7 +121,10 @@ import {
   precedenceStep
   processBinaryOpExpression
 } from ./op.civet
-import { processUnaryExpression } from ./unary.civet
+import {
+  processUnaryExpression
+  processUnaryNestedExpression
+} from ./unary.civet
 import { createConstLetDecs, createVarDecs } from ./auto-dec.civet
 import { processComptime } from ./comptime.civet
 import { getHelperRef } from ./helper.civet
@@ -1616,6 +1619,7 @@ export {
   processProgramAsync
   processTryBlock
   processUnaryExpression
+  processUnaryNestedExpression
   quoteString
   replaceNode
   reorderBindingRestProperty

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -68,6 +68,7 @@ import {
   maybeUnwrap
   parenthesizeType
   prepend
+  stripTrailingImplicitComma
   trimFirstSpace
   wrapIIFE
   wrapWithReturn
@@ -1625,6 +1626,7 @@ export {
   reorderBindingRestProperty
   replaceNodes
   skipImplicitArguments
+  stripTrailingImplicitComma
   trimFirstSpace
   typeOfJSX
   wrapIIFE

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -68,6 +68,7 @@ export type OtherNode =
   | AccessStart
   | AtBinding
   | AtBindingProperty
+  | Argument
   | ArrayBindingPattern
   | ArrayElement
   | Await
@@ -705,6 +706,13 @@ export type SpreadElement
   parent?: Parent
   expression: ASTNode
   names: string[]
+
+export type Argument
+  type: "Argument"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
+  spread: ASTNode?
 
 export type FunctionExpression =
   type: "FunctionExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -35,6 +35,7 @@ export type StatementNode =
 * Nodes that represent expressions.
 */
 export type ExpressionNode =
+  | ArrayExpression
   | AssignmentExpression
   | BinaryOp
   | CallExpression
@@ -68,6 +69,8 @@ export type OtherNode =
   | AtBinding
   | AtBindingProperty
   | ArrayBindingPattern
+  | ArrayElement
+  | Await
   | Binding
   | BindingRestElement
   | Call
@@ -89,6 +92,7 @@ export type OtherNode =
   | Placeholder
   | PropertyAccess
   | ReturnValue
+  | SpreadElement
   | TypeSuffix
   | WhenClause
 
@@ -214,6 +218,13 @@ export type UnaryExpression
   type: "UnaryExpression"
   children: Children
   parent?: Parent
+
+export type Await
+  type: "Await"
+  token: string
+  children?: Children
+  parent?: Parent
+  op?: ASTNode
 
 export type NewExpression
   type: "NewExpression"
@@ -674,6 +685,26 @@ export type Property
   name: string
   names: string[]
   value: ASTNode
+
+export type ArrayExpression
+  type: "ArrayExpression"
+  children: Children
+  parent?: Parent
+  names?: string[]
+
+export type ArrayElement
+  type: "ArrayElement"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
+  names: string[]
+
+export type SpreadElement
+  type: "SpreadElement"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
+  names: string[]
 
 export type FunctionExpression =
   type: "FunctionExpression"

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -112,8 +112,16 @@ function processUnaryNestedExpression(pre: ASTNode[], args: ArrayExpression | AS
           type: "ArrayExpression"
           children: [
             "["
-            ...args.map((arg, i) => i % 2 === 1 ? arg :
-              processUnaryExpression([last], arg))
+            ...for each arg of args
+              if arg is like {type: "Argument"}
+                expression := processUnaryExpression [last], arg.expression
+                {
+                  ...arg
+                  expression
+                  children: arg.children.map & is arg.expression ? expression : &
+                }
+              else
+                arg
             "]"
           ]
       else

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -9,6 +9,7 @@ import {
   firstNonSpace
   makeLeftHandSideExpression
   parenthesizeExpression
+  stripTrailingImplicitComma
   trimFirstSpace
 } from ./util.civet
 
@@ -91,6 +92,8 @@ function processUnaryExpression(pre: ASTNode[], exp: ASTNode, post?: ASTNode[]):
 
 function processUnaryNestedExpression(pre: ASTNode[], args: ArrayExpression | ASTNode[], post: ASTNode[])
   isArray := args.type is "ArrayExpression"
+  unless isArray
+    args = stripTrailingImplicitComma args
   // Special handling of multiple nested arguments, or any array argument
   if isArray or args# > 2 // 2 = 1 argument + 1 delimiter
     // Multiple arguments only defined for await and await operators

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -1,14 +1,18 @@
 import type {
+  ArrayExpression
+  ASTNode
   Existence
+  Literal
 } from ./types.civet
 
 import {
   firstNonSpace
   makeLeftHandSideExpression
   parenthesizeExpression
+  trimFirstSpace
 } from ./util.civet
 
-function processUnaryExpression(pre, exp, post)
+function processUnaryExpression(pre: ASTNode[], exp: ASTNode, post?: ASTNode[]): ASTNode
   if (!(pre.length or post)) return exp
   // Handle "?" postfix
   if post?.token is "?"
@@ -45,9 +49,9 @@ function processUnaryExpression(pre, exp, post)
       {token} := pre[0]
       if token is "-" or token is "+"
         children := [pre[0], ...exp.children]
-        literal := {
-          type: "Literal",
-          children,
+        literal: Literal := {
+          type: "Literal"
+          children
           raw: `${token}${exp.raw}`
         }
         if (post)
@@ -67,24 +71,68 @@ function processUnaryExpression(pre, exp, post)
           exp = ["(", exp, ")"]
 
         exp =
-          type: "CallExpression",
+          type: "CallExpression"
           children: [...last.children, "Promise", last.op, exp]
         pre = pre.slice(0, -1)
       else
         if firstNonSpace(exp) is like /^[ \t]*\n/, {token: /^[ \t]*\n/}
           exp = parenthesizeExpression exp
         exp =
-          type: "AwaitExpression",
-          children: [...last.children, exp],
+          type: "AwaitExpression"
+          children: [...last.children, exp]
         pre = pre.slice(0, -1)
     else
       break
 
   return {
-    type: "UnaryExpression",
+    type: "UnaryExpression"
     children: [...pre, exp, post]
   }
 
+function processUnaryNestedExpression(pre: ASTNode[], args: ArrayExpression | ASTNode[], post: ASTNode[])
+  isArray := args.type is "ArrayExpression"
+  // Special handling of multiple nested arguments, or any array argument
+  if isArray or args# > 2 // 2 = 1 argument + 1 delimiter
+    // Multiple arguments only defined for await and await operators
+    last := pre.-1
+    return unless last is like {type: "Await"}
+    if last.op // await ops take array argument
+      unless isArray
+        args =
+          type: "ArrayExpression"
+          children: [ "[", args, "]" ]
+    else // regular await turns into an array
+      pre.pop()
+      unless isArray
+        args = args as ASTNode[]
+        args =
+          type: "ArrayExpression"
+          children: [
+            "["
+            ...args.map((arg, i) => i % 2 === 1 ? arg :
+              processUnaryExpression([last], arg))
+            "]"
+          ]
+      else
+        args = trimFirstSpace(args) as ArrayExpression
+        args = {
+          ...args,
+          children: (args as ArrayExpression).children.map
+            (arg) =>
+              switch arg
+                {type: "ArrayElement", expression: exp, children}
+                  expression := processUnaryExpression [last], exp
+                  {
+                    ...arg
+                    expression
+                    children: children.map & is exp ? expression : &
+                  }
+                else
+                  arg
+        }
+  processUnaryExpression pre, args, post
+
 export {
   processUnaryExpression
+  processUnaryNestedExpression
 }

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -217,6 +217,13 @@ function isComma(node: ASTNode): (ASTLeaf & { token: "," }) | undefined
   else if Array.isArray(node) and node.-1?.token is ","
     node.-1
 
+function stripTrailingImplicitComma(children: ASTNode[])
+  last := children.-1
+  if isComma(last) and last.implicit
+    children[...-1]
+  else
+    children
+
 /**
  * Trims the first single space from the spacing array or node's children if present
  * Inserts string `c` in the first position.
@@ -691,6 +698,7 @@ export {
   skipIfOnlyWS
   startsWith
   startsWithPredicate
+  stripTrailingImplicitComma
   trimFirstSpace
   updateParentPointers
   wrapIIFE

--- a/test/await.civet
+++ b/test/await.civet
@@ -46,7 +46,7 @@ describe "await expression", ->
         results.push((async ()=>{{
           return await item.process()
         }})())
-      }return results})(),)
+      }return results})())
   """
 
   testCase """
@@ -70,7 +70,7 @@ describe "await expression", ->
     ---
     [await (
       a),await (
-      b),]
+      b)]
   """
 
   testCase """
@@ -94,7 +94,7 @@ describe "await expression", ->
     ---
     await Promise.all([
       a,
-      b,])
+      b])
   """
 
   testCase """
@@ -106,5 +106,5 @@ describe "await expression", ->
     ---
     [await (
       a),await  b,await (
-      c),await  d,]
+      c),await  d]
   """

--- a/test/await.civet
+++ b/test/await.civet
@@ -68,9 +68,9 @@ describe "await expression", ->
       a
       b
     ---
-    [await (
-      a),await (
-      b)]
+    [
+      await a,
+      await b]
   """
 
   testCase """
@@ -103,8 +103,10 @@ describe "await expression", ->
     await
       a, b
       c, d
+      f e
     ---
-    [await (
-      a),await  b,await (
-      c),await  d]
+    [
+      await a, await b,
+      await c, await d,
+      await f(e)]
   """

--- a/test/await.civet
+++ b/test/await.civet
@@ -62,6 +62,16 @@ describe "await expression", ->
   """
 
   testCase """
+    await with indented argument
+    ---
+    await
+      a
+    ---
+    await (
+      a)
+  """
+
+  testCase """
     await with multiple indented arguments
     ---
     await

--- a/test/await.civet
+++ b/test/await.civet
@@ -46,5 +46,65 @@ describe "await expression", ->
         results.push((async ()=>{{
           return await item.process()
         }})())
-      }return results})())
+      }return results})(),)
+  """
+
+  testCase """
+    await with bulleted list
+    ---
+    await
+      . a
+      . b
+    ---
+    [
+        await a,
+        await b]
+  """
+
+  testCase """
+    await with multiple indented arguments
+    ---
+    await
+      a
+      b
+    ---
+    [await (
+      a),await (
+      b),]
+  """
+
+  testCase """
+    await op with bulleted list
+    ---
+    await.all
+      . a
+      . b
+    ---
+    await Promise.all( [
+        a,
+        b])
+  """
+
+  testCase """
+    await op with multiple indented arguments
+    ---
+    await.all
+      a
+      b
+    ---
+    await Promise.all([
+      a,
+      b,])
+  """
+
+  testCase """
+    await with multiple indented arguments and commas
+    ---
+    await
+      a, b
+      c, d
+    ---
+    [await (
+      a),await  b,await (
+      c),await  d,]
   """

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -503,8 +503,10 @@ describe "function application", ->
     CoffeeScript style splat
     ---
     CoffeeScript.run param...
+    console.log(a..., b, c)
     ---
     CoffeeScript.run(...param)
+    console.log(...a, b, c)
   """
 
   // TODO: Maybe this could be allowed eventually


### PR DESCRIPTION
As suggested in #1429 and #1431, adds support for

```js
await
  indented expression
↓↓↓
await (
  indented expression
)
```

Then as further suggested by @STRd6 on Discord, you can list multiple expressions too. They get bundled into an array:

```js
await
  e1
  e2
↓↓↓
[
  await e1,
  await e2]
```

Bulleted arrays behave the same, too, in case you think that looks nicer:

```js
await
  . e1
  . e2
```

This is in parallel to a previous way to use `await.op`. You can use those without bullets too:

```js
await.op
  e1
  e2
↓↓↓
await.op([
  e1,
  e2])
```

Note that there's a bit of asymmetry here: with a single argument, it's passed directly into `await.op`, in case it's an array.  More than one argument gets wrapped into an array. I think this is the most useful behavior, but I'm not certain.
