### PR TITLE
Typed `for` loops generate valid TypeScript

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1590,9 +1590,20 @@ for item, index of list
   console.log `${index}th item is ${item}`
 </Playground>
 
+You can add types to the declarations (unlike TypeScript):
+
+<Playground>
+for var item: Item? of list
+  console.log item
+if item?
+  console.log "Last item:", item
+else
+  console.log "No items"
+</Playground>
+
 ### for each..of
 
-For Arrays and other objects implementing `.length` and `[i]` indexing,
+For `Array`s and other objects implementing `.length` and `[i]` indexing,
 you can use `for each..of` as an optimized form of `for..of`
 (without building an iterator):
 
@@ -1644,6 +1655,14 @@ you can skip them with `own`:
 <Playground>
 for own key in object
   console.log key
+</Playground>
+
+You can add types to the declarations (unlike TypeScript):
+
+<Playground>
+for var key: string, value: unknown in object
+  console.log key, JSON.stringify value
+key ?= "no last key"
 </Playground>
 
 ### Loop Expressions

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -757,7 +757,7 @@ YieldExpression
 # https://262.ecma-international.org/#prod-ArrowFunction
 ArrowFunction
   ThinArrowFunction
-  ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:suffix FatArrow:arrow FatArrowBody:expOrBlock ->
+  ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:returnType FatArrow:arrow FatArrowBody:expOrBlock ->
     if (!async) async = []
 
     return {
@@ -766,13 +766,13 @@ ArrowFunction
         modifier: {
           async: !!async.length,
         },
-        returnType: suffix,
+        returnType,
       },
       parameters,
-      returnType: suffix,
+      returnType,
       async,
       block: expOrBlock,
-      children: [async, parameters, suffix, arrow, expOrBlock ],
+      children: [async, parameters, returnType, arrow, expOrBlock ],
     }
 
 FatArrow
@@ -2203,7 +2203,7 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:returnType ->
     if (!async) async = []
     if (!generator) generator = []
 
@@ -2213,7 +2213,7 @@ FunctionSignature
       id,
       name: id?.name,
       parameters,
-      returnType: suffix,
+      returnType,
       async,
       generator,
       modifier: {
@@ -2222,8 +2222,8 @@ FunctionSignature
       },
       block: null,
       children: !parameters.implicit
-        ? [ async, func, generator, wid, w, parameters, suffix ]
-        : [ async, func, generator, wid, parameters, w, suffix ],
+        ? [ async, func, generator, wid, w, parameters, returnType ]
+        : [ async, func, generator, wid, parameters, w, returnType ],
           // move whitespace w to after implicit () in parameters
     }
 
@@ -2377,7 +2377,7 @@ OperatorDeclaration
 # NOTE: Like FunctionSignature, but no async or star or @,
 # and parameters are required (to be useful).
 OperatorSignature
-  ( Async _ )?:async Operator:op ( _ Function )?:func ( _? Star )?:generator _:w1 Identifier:id OperatorBehavior?:behavior _?:w2 NonEmptyParameters:parameters ReturnTypeSuffix?:suffix ->
+  ( Async _ )?:async Operator:op ( _ Function )?:func ( _? Star )?:generator _:w1 Identifier:id OperatorBehavior?:behavior _?:w2 NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ->
     if (!async) async = []
     if (!generator) generator = []
     // Add "function" (if not already one) to replace "operator"
@@ -2391,7 +2391,7 @@ OperatorSignature
       id,
       name: id.name,
       parameters,
-      returnType: suffix,
+      returnType,
       async,
       generator,
       modifier: {
@@ -2399,7 +2399,7 @@ OperatorSignature
         generator: !!generator.length,
       },
       block: null,
-      children: [ async, func, generator, w1, id, w2, parameters, suffix ],
+      children: [ async, func, generator, w1, id, w2, parameters, returnType ],
       behavior,
     }
 
@@ -2430,7 +2430,7 @@ OperatorAssociativity
     return { assoc }
 
 ThinArrowFunction
-  ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:suffix _? Arrow:arrow NoCommaBracedOrEmptyBlock:block ->
+  ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:returnType _? Arrow:arrow NoCommaBracedOrEmptyBlock:block ->
     if (!async) async = []
     const generator = []
 
@@ -2438,7 +2438,7 @@ ThinArrowFunction
       type: "FunctionExpression",
       id: undefined,
       parameters,
-      returnType: suffix,
+      returnType,
       async,
       generator,
       block,
@@ -2450,14 +2450,14 @@ ThinArrowFunction
           async: !!async.length,
           generator: !!generator.length,
         },
-        returnType: suffix,
+        returnType,
       },
       children: [
         async,
         { $loc: arrow.$loc, token: "function" },
         generator,
         parameters,
-        suffix,
+        returnType,
         block
       ],
     }
@@ -4715,14 +4715,14 @@ ForDeclaration
 
 # https://262.ecma-international.org/#prod-ForBinding
 ForBinding
-  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:suffix ->
-    suffix ??= pattern.typeSuffix
+  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix ->
+    typeSuffix ??= pattern.typeSuffix
     return {
       type: "Binding",
-      children: [ pattern, suffix ],
+      children: [ pattern, typeSuffix ],
       names: pattern.names,
       pattern,
-      suffix,
+      typeSuffix,
       splices: [],
       thisAssignments: [],
     }
@@ -5637,28 +5637,28 @@ TypeAssignment
 # https://262.ecma-international.org/#prod-LexicalBinding
 # merged with https://262.ecma-international.org/#prod-VariableDeclaration
 LexicalBinding
-  BindingPattern:pattern TypeSuffix?:suffix Initializer:initializer ->
+  BindingPattern:pattern TypeSuffix?:typeSuffix Initializer:initializer ->
     const [splices, thisAssignments] = gatherBindingCode(pattern)
-    suffix ??= pattern.typeSuffix
+    typeSuffix ??= pattern.typeSuffix
 
     return {
       type: "Binding",
-      children: [ pattern, suffix, initializer ],
+      children: [ pattern, typeSuffix, initializer ],
       names: pattern.names,
       pattern,
-      suffix,
+      typeSuffix,
       initializer,
       splices: splices.map(s => [",", s]),
       thisAssignments: thisAssignments.map(s => ["", s, ";"]),
     }
 
-  BindingIdentifier:pattern TypeSuffix?:suffix Initializer?:initializer ->
+  BindingIdentifier:pattern TypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "Binding",
       children: $0,
       names: pattern.names,
       pattern,
-      suffix,
+      typeSuffix,
       initializer,
       splices: [],
       thisAssignments: [],
@@ -7238,13 +7238,13 @@ UsingDeclaration
     }
 
 UsingBinding
-  BindingIdentifier:pattern TypeSuffix?:suffix Initializer:initializer ->
+  BindingIdentifier:pattern TypeSuffix?:typeSuffix Initializer:initializer ->
     return {
       type: "Binding",
       children: $0,
       names: pattern.names,
       pattern,
-      suffix,
+      typeSuffix,
       initializer,
       splices: [],
       thisAssignments: [],

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -65,7 +65,7 @@ import {
   processCallMemberExpression
 } from ./lib.civet
 
-function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], suffix: TypeSuffix?, ws: WSNode, assign: ASTLeaf, e: ASTNode)
+function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], typeSuffix: TypeSuffix?, ws: WSNode, assign: ASTLeaf, e: ASTNode)
   // Adjust position to space before assignment to make TypeScript remapping happier
   decl = {
     ...decl,
@@ -79,7 +79,7 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
   splices = splices.map (s) => [", ", s]
   thisAssignments := assignments.map (a) => ["", a, ";"] as const
 
-  suffix ??= pattern.typeSuffix if "typeSuffix" in pattern
+  typeSuffix ??= pattern.typeSuffix if "typeSuffix" in pattern
   initializer := makeNode
     type: "Initializer"
     expression: e
@@ -89,9 +89,9 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
     pattern
     initializer
     splices
-    suffix
+    typeSuffix
     thisAssignments
-    children: [pattern, suffix, initializer]
+    children: [pattern, typeSuffix, initializer]
   }
 
   children := [decl, binding]
@@ -113,10 +113,10 @@ function processDeclarations(statements: StatementTuple[]): void
   .forEach (statement: DeclarationStatement) =>
     { bindings } := statement as DeclarationStatement
     bindings?.forEach (binding) =>
-      suffix := binding.suffix
-      if suffix and suffix.optional and suffix.t
+      { typeSuffix } := binding
+      if typeSuffix and typeSuffix.optional and typeSuffix.t
         // Convert `let x?: T` to `let x: undefined | T`
-        convertOptionalType suffix
+        convertOptionalType typeSuffix
 
       { initializer } := binding
       if initializer
@@ -197,8 +197,8 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
   { decl, bindings } := condition.declaration as DeclarationStatement
   // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
   binding := bindings[0]
-  { pattern, suffix, initializer } .= binding
-  nullCheck := suffix?.optional and not suffix.t and not suffix.nonnull
+  { pattern, typeSuffix, initializer } .= binding
+  nullCheck := typeSuffix?.optional and not typeSuffix.t and not typeSuffix.nonnull
 
   unless initializer?
     condition.children = [
@@ -239,14 +239,14 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
     if nullCheck
       children.unshift "("
       children.push ") != null"
-      suffix = undefined
+      typeSuffix = undefined
 
     Object.assign condition, {
       type: "AssignmentExpression"
       children
       hoistDec: unless simple
         type: "Declaration"
-        children: ["let ", ref, suffix]
+        children: ["let ", ref, typeSuffix]
         names: []
       pattern
       ref
@@ -255,7 +255,7 @@ function processDeclarationCondition(condition, rootCondition, parent: ASTNodePa
   // condition wasn't previously a child, so now needs parent pointers
   updateParentPointers condition, parent
 
-  rootCondition.blockPrefix = getPatternBlockPrefix(pattern, ref, decl, suffix)
+  rootCondition.blockPrefix = getPatternBlockPrefix(pattern, ref, decl, typeSuffix)
 
 function processDeclarationConditions(node: ASTNode): void
   gatherRecursiveAll node,

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -123,7 +123,7 @@ function processForInOf($0: [
   else if step
     throw new Error("for..of/in cannot use 'by' except with range literals")
 
-  let eachOwnError: ASTError | undefined
+  let eachOwnError: ASTError?
   let hoistDec, blockPrefix: ASTNode[] = []
 
   // for each item[, index] of array
@@ -168,27 +168,55 @@ function processForInOf($0: [
         message: "'each' is only meaningful in for..of loops",
 
   // for own..in
-  let own = eachOwn and eachOwn[0].token is "own";
-  let expRef: ASTNode | undefined
+  own .= eachOwn and eachOwn[0].token is "own"
+  let expRef: ASTNode?
   if own and inOf.token is not "in"
     own = false
     eachOwnError =
       type: "Error"
       message: "'own' is only meaningful in for..in loops"
 
-  if !declaration2 and !own
+  // TypeScript doesn't support typed declarations in for loops,
+  // so pull such declarations inside the loop:
+  //   for var x: T of y -> for (const x1 of y) {var x: T = x1;
+  // for..in loops need a similar ref-based declaration
+  // for dereferencing to get the associated value.
+  { binding } := declaration
+  pattern .= binding?.pattern
+  if binding?.typeSuffix or (
+    inOf.token is "in" and declaration2 and pattern.type is not "Identifier"
+  )
+    keyRef := makeRef "key"
+    blockPrefix.push ["", {
+      type: "Declaration"
+      children: [declaration, " = ", keyRef]
+      names: declaration.names
+    }, ";"]
+    pattern = keyRef
+    declaration =
+      type: "ForDeclaration"
+      binding: {
+        type: "Binding"
+        pattern
+        children: [ pattern ]
+        names: []
+      }
+      children: ["const ", keyRef]
+      names: []
+
+  unless declaration2 or own
     return {
       declaration
       blockPrefix
       children: [awaits, eachOwnError, open, declaration, ws, inOf, expRef ?? exp, step, close] // omit declaration2, replace eachOwn with eachOwnError, replace exp with expRef
     }
 
-  let ws2: ASTNode | undefined, decl2: ASTNode | undefined
+  let ws2: ASTNode?, decl2: ASTNode?
   if (declaration2) [, , ws2, decl2] = declaration2  // strip __ Comma __
 
   switch inOf.token
     when "of" // for item, index of iter
-      const counterRef = makeRef("i")
+      counterRef := makeRef "i"
       hoistDec = {
         type: "Declaration"
         children: ["let ", counterRef, " = 0"]
@@ -211,27 +239,6 @@ function processForInOf($0: [
         exp =
           type: "AssignmentExpression"
           children: [" ", expRef, " =", exp]
-      // Replace key with single identifier if it's a pattern,
-      // so that we can use it to dereference value.
-      { binding } := declaration
-      { pattern } .= binding
-      unless pattern.type is "Identifier"
-        const keyRef = makeRef("key")
-        blockPrefix.push ["", [
-          declaration, " = ", keyRef
-        ], ";"]
-        pattern = keyRef
-        declaration =
-          type: "ForDeclaration"
-          binding: {
-            type: "Binding"
-            pattern
-            children: [ pattern ]
-            names: []
-            binding.suffix
-          }
-          children: ["const ", keyRef]
-          names: []
       // for own..in
       if own
         const hasPropRef = getRef("hasProp")

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -139,9 +139,8 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
  */
 function processReturnValue(func: FunctionNode)
   { block } := func
-  values: ASTNodeBase[] := (gatherRecursiveWithinFunction block,
-    ({ type }) => type is "ReturnValue") as ASTNodeBase[]
-  return false unless values.length
+  values := gatherRecursiveWithinFunction block, .type is "ReturnValue"
+  return false unless values#
 
   ref := makeRef "ret"
 
@@ -150,9 +149,10 @@ function processReturnValue(func: FunctionNode)
     value.children = [ref]
 
     // Check whether return.value already declared within this function
-    { ancestor, child } := findAncestor(value,
-      ({ type }) => type is "Declaration",
-      isFunction)
+    { ancestor, child } := findAncestor
+      value
+      .type is "Declaration"
+      isFunction
     declaration ??= child if ancestor  // remember binding
 
   // Compute default return type
@@ -167,8 +167,8 @@ function processReturnValue(func: FunctionNode)
 
   // Modify existing declaration, or add declaration of return.value after {
   if declaration
-    unless declaration.suffix?
-      declaration.children[1] = declaration.suffix = returnType
+    unless declaration.typeSuffix?
+      declaration.children[1] = declaration.typeSuffix = returnType
   else
     block.expressions.unshift [
       getIndent block.expressions[0]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -475,7 +475,7 @@ export type Binding =
   children: Children
   names: string[]
   pattern: BindingIdentifier | BindingPattern
-  suffix: TypeSuffix?
+  typeSuffix: TypeSuffix?
   initializer: Initializer?
   splices: unknown[]
   thisAssignments: unknown[]
@@ -496,6 +496,7 @@ export type Identifier =
 export type ReturnValue =
   type: "ReturnValue"
   children: Children
+  parent?: Parent
 
 export type StatementExpression =
   type: "StatementExpression"

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -5,32 +5,66 @@ describe "[TS] for", ->
     explicit declaration
     ---
     for var x: T of y
+      console.log x
     ---
-    for (var x: T of y);
+    for (const key of y) {var x: T = key;
+      console.log(x)
+    }
   """
 
   testCase """
     for..of
     ---
     for x: T of y
+      console.log x
     ---
-    for (const x: T of y);
+    for (const key of y) {const x: T = key;
+      console.log(x)
+    }
+  """
+
+  testCase """
+    for each..of
+    ---
+    for each x: T of y
+      console.log x
+    ---
+    for (let i = 0, len = y.length; i < len; i++) {const x: T = y[i];
+      console.log(x)
+    }
   """
 
   testCase """
     for..in
     ---
     for x: T in y
+      console.log x
     ---
-    for (const x: T in y);
+    for (const key in y) {const x: T = key;
+      console.log(x)
+    }
+  """
+
+  testCase """
+    for..in with two declarations
+    ---
+    for x: T, y in z
+      console.log x, y
+    ---
+    for (const key in z) {const x: T = key;const y = z[key];
+      console.log(x, y)
+    }
   """
 
   testCase """
     parenthesized
     ---
     for (x: T of y)
+      console.log x
     ---
-    for (const x: T of y);
+    for (const key of y) {const x: T = key;
+      console.log(x)
+    }
   """
 
   describe ":: typing of properties", ->
@@ -38,14 +72,20 @@ describe "[TS] for", ->
       array
       ---
       for [type:: TokenType, token] of Object.entries(tokens)
+        console.log type, token
       ---
-      for (const [type, token]: [ TokenType,unknown] of Object.entries(tokens));
+      for (const key of Object.entries(tokens)) {const [type, token]: [ TokenType,unknown] = key;
+        console.log(type, token)
+      }
     """
 
     testCase """
       object
       ---
       for {type:: TokenType, token} of items
+        console.log type, token
       ---
-      for (const {type, token}: {type: TokenType, token: unknown} of items);
+      for (const key of items) {const {type, token}: {type: TokenType, token: unknown} = key;
+        console.log(type, token)
+      }
     """


### PR DESCRIPTION
It turns out that the code generated by #1418 [generates a TypeScript error](https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEA3W8CeAueAKARACxAggHsd4AfeHAd2JgmBwEoBtAXQG4BYAKADM62MMQB2AZwAu8AB6ZJMAJYiA5vGJ80TeAG9e8eMPHEIIAHQllWaUz3679-QHpHAPQD8vAL5A):

> The left-hand side of a 'for...of' statement cannot use a type annotation

TypeScript seems to ignore the annotation, so we need to compile to something else. This PR implements the obvious fix: redeclaring the variable inside the loop. We already had code to do this (for loops like `for {length}, value in foo`, where we needed to keep track of the original key and destructure inside the loop, so that we can find `value`).

Also adds documentation, cleans up a little code, and cleans up some AST to use `typeSuffix` instead of `suffix`.