### PR TITLE
CoffeeScript `do` allows unary operators beforehand, and handles nested body better

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -573,10 +573,8 @@ UnaryWithoutParenthesizedAssignment
     return processUnaryExpression(pre, exp, post)
 
 UnaryBody
-  # NOTE: This is a little hacky to match CoffeeScript's behavior
-  # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
-  CoffeeDoEnabled Do __:ws ( ArrowFunction / ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / MaybeNestedExtendedExpression ):exp ->
-    return processCoffeeDo(ws, exp)
+  CoffeeDoEnabled Do MaybeNestedCoffeeDoBody:body ->
+    return processCoffeeDo(...body)
 
   ParenthesizedAssignment
   ExpressionizedStatementWithTrailingCallExpressions
@@ -584,6 +582,17 @@ UnaryBody
   # to prevent `async do ...` from being parsed as a function call `async(...)`
   UpdateExpression
   NestedNonAssignmentExtendedExpression
+
+MaybeNestedCoffeeDoBody
+  PushIndent ( Nested CoffeeDoBody )? PopIndent ->
+    if (!$2) return $skip
+    return $2
+  _? CoffeeDoBody
+
+CoffeeDoBody
+  # NOTE: This is a little hacky to match CoffeeScript's behavior
+  # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
+  ArrowFunction / ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / MaybeNestedExtendedExpression
 
 UnaryWithoutParenthesizedAssignmentBody
   UpdateExpression

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -568,16 +568,16 @@ UnaryExpression
   UnaryOp*:pre UnaryBody:exp UnaryPostfix?:post ->
     return processUnaryExpression(pre, exp, post)
 
-  # NOTE: This is a little hacky to match CoffeeScript's behavior
-  # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
-  CoffeeDoEnabled Do __:ws ( ArrowFunction / ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / ExtendedExpression ):exp ->
-    return processCoffeeDo(ws, exp)
-
 UnaryWithoutParenthesizedAssignment
   UnaryOp*:pre UnaryWithoutParenthesizedAssignmentBody:exp UnaryPostfix?:post ->
     return processUnaryExpression(pre, exp, post)
 
 UnaryBody
+  # NOTE: This is a little hacky to match CoffeeScript's behavior
+  # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
+  CoffeeDoEnabled Do __:ws ( ArrowFunction / ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / MaybeNestedExtendedExpression ):exp ->
+    return processCoffeeDo(ws, exp)
+
   ParenthesizedAssignment
   ExpressionizedStatementWithTrailingCallExpressions
   # NOTE: ExpressionizedStatement needs to come before UpdateExpression

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -592,7 +592,7 @@ MaybeNestedCoffeeDoBody
 CoffeeDoBody
   # NOTE: This is a little hacky to match CoffeeScript's behavior
   # https://coffeescript.org/#try:do%20x%20%2B%20y%0Ado%20x%20%3D%20y%0Ado%20-%3E%20x%20%3D%201
-  ArrowFunction / ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / MaybeNestedExtendedExpression
+  ArrowFunction / ( LeftHandSideExpression !( __ AssignmentOpSymbol ) ) / ExtendedExpression
 
 UnaryWithoutParenthesizedAssignmentBody
   UpdateExpression

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -747,6 +747,7 @@ function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
 
   type: "CallExpression"
   children: [
+    ws
     makeLeftHandSideExpression expression
     {
       type: "Call"

--- a/test/compat/coffee-do.civet
+++ b/test/compat/coffee-do.civet
@@ -1,4 +1,4 @@
-{testCase} from ../helper.civet
+{testCase, throws} from ../helper.civet
 
 describe "coffeeDo", ->
   testCase """
@@ -50,6 +50,30 @@ describe "coffeeDo", ->
     await do x
     ---
     await (x)()
+  """
+
+  // https://coffeescript.org/#try:do%0A%20%20x%20%2B%20y
+  testCase """
+    nested
+    ---
+    "civet coffeeDo"
+    do
+      x + y
+    ---
+
+      (x)() + y
+  """
+
+  // #763
+  throws """
+    incorrectly nested
+    ---
+    "civet coffeeDo"
+    do
+      x
+      y
+    ---
+    ParseError
   """
 
   // https://coffeescript.org/#try:do%20(x)%20-%3E%0A%20%20setTimeout%20%3D%3E%20console.log%20x

--- a/test/compat/coffee-do.civet
+++ b/test/compat/coffee-do.civet
@@ -42,6 +42,16 @@ describe "coffeeDo", ->
     (x)() + y
   """
 
+  // https://coffeescript.org/#try:await%20do%20x
+  testCase """
+    unary ops before do
+    ---
+    "civet coffeeDo"
+    await do x
+    ---
+    await (x)()
+  """
+
   // https://coffeescript.org/#try:do%20(x)%20-%3E%0A%20%20setTimeout%20%3D%3E%20console.log%20x
   testCase """
     argument


### PR DESCRIPTION
Fixes #763 by using `PushIndent`/`PopIndent` or `_` instead of `__`, which prevents a second equally indented line from appearing to be strictly indented.

Fixes #1432 by moving `CoffeeDo` handling from `UnaryExpression` to `UnaryBody`, keeping precedence but allowing unary operators before `do`.