### PR TITLE
`await` with array literal awaits the items

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -849,6 +849,21 @@ await.all
   second()
 </Playground>
 
+Alternatively, you can use array literals:
+
+<Playground>
+// Sequential
+await [ first(), second() ]
+await
+  . first()
+  . second()
+// Parallel
+await.all [ first(), second() ]
+await.all
+  . first()
+  . second()
+</Playground>
+
 ### Custom Infix Operators
 
 You can also define your own infix operators;

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -558,8 +558,8 @@ RHS
 
 # https://262.ecma-international.org/#prod-UnaryExpression
 UnaryExpression
-  # NOTE: Added nested case, for e.g. indented await argument
-  IndentedApplicationAllowed UnaryOp+:pre ( NestedBulletedArray / NestedArgumentList ):args UnaryPostfix?:post ->
+  # NOTE: Added nested/array case, for e.g. indented await argument
+  IndentedApplicationAllowed UnaryOp+:pre ( ArrayLiteral / NestedArgumentList ):args UnaryPostfix?:post ->
     return processUnaryNestedExpression(pre, args, post) ?? $skip
 
   # NOTE: Merged AwaitExpression with UnaryOp

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -7,8 +7,10 @@ import type {
 
 import {
   firstNonSpace
+  getTrimmingSpace
   makeLeftHandSideExpression
   parenthesizeExpression
+  prepend
   stripTrailingImplicitComma
   trimFirstSpace
 } from ./util.civet
@@ -132,7 +134,8 @@ function processUnaryNestedExpression(pre: ASTNode[], args: ArrayExpression | AS
             (arg) =>
               switch arg
                 {type: "ArrayElement", expression: exp, children}
-                  expression := processUnaryExpression [last], exp
+                  expression .= processUnaryExpression [last], trimFirstSpace exp
+                  expression = prepend getTrimmingSpace(exp), expression
                   {
                     ...arg
                     expression

--- a/test/await.civet
+++ b/test/await.civet
@@ -50,6 +50,14 @@ describe "await expression", ->
   """
 
   testCase """
+    await with literal list
+    ---
+    await [a, b]
+    ---
+    [await a, await b]
+  """
+
+  testCase """
     await with bulleted list
     ---
     await


### PR DESCRIPTION
This PR brings `await [x, y]` into alignment with
```js
await
  . x
  . y
```
and
```js
await
  x
  y
```

(but `await x, y` remains as is, for JS compatibility)

It's mostly a 1-word change (`NestedBulletedArray` → `ArrayExpression`), but I added a little more code to make the spacing come out better.