### PR TITLE
Binary operators continue arguments only if strictly indented

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -49,6 +49,7 @@ uncacheable := new Set [
   "AllowBracedApplication"
   "AllowIndentedApplication"
   "AllowMultiLineImplicitObjectLiteral"
+  "AllowNestedBinaryOp"
   "AllowNewlineBinaryOp"
   "AllowTrailingMemberProperty"
 
@@ -56,6 +57,7 @@ uncacheable := new Set [
   "ForbidBracedApplication"
   "ForbidIndentedApplication"
   "ForbidMultiLineImplicitObjectLiteral"
+  "ForbidNestedBinaryOp"
   "ForbidNewlineBinaryOp"
   "ForbidTrailingMemberProperty"
 
@@ -65,6 +67,7 @@ uncacheable := new Set [
   "RestoreBracedApplication"
   "RestoreIndentedApplication"
   "RestoreTrailingMemberProperty"
+  "RestoreNestedBinaryOp"
   "RestoreNewlineBinaryOp"
 
 ]
@@ -256,13 +259,17 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
         }
 
       if trace
-        logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "\u2192"
+        logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "{"
         stack.push ruleName
 
       return
 
     exit: (ruleName: string, state: ParseState, result: ParseResult) ->
-      return if uncacheable.has(ruleName)
+      if uncacheable.has(ruleName)
+        if trace
+          stack.pop()
+          logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "⚠️ " + (if result then "✅" else "❌")
+        return
 
       [stateKey, tagKey] := getStateKey()
       key: CacheKey := [tagKey, stateKey, state.pos, ruleName ]
@@ -275,7 +282,7 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
 
       if trace
         stack.pop()
-        logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + " " + (if result then "✅" else "❌")
+        logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "} " + (if result then "✅" else "❌")
 
       return
   }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -112,6 +112,12 @@ Object.defineProperties(state, {
       return s[s.length-1]
     },
   },
+  nestedBinaryOpForbidden: {
+    get() {
+      const {forbidNestedBinaryOp: s} = state
+      return s[s.length-1]
+    },
+  },
   newlineBinaryOpForbidden: {
     get() {
       const {forbidNewlineBinaryOp: s} = state
@@ -133,13 +139,14 @@ export function getStateKey() {
     (state.indentedApplicationForbidden << 6) |
     (state.bracedApplicationForbidden << 5) |
     (state.trailingMemberPropertyForbidden << 4) |
-    (state.newlineBinaryOpForbidden << 3) |
+    (state.nestedBinaryOpForbidden << 3) |
+    (state.newlineBinaryOpForbidden << 2) |
     // This is slightly different than the rest of the state,
     // since it is affected by the directive prologue and may be hit
     // by the EOL rule early in the parse. Later if we wanted to
     // allow block scoping of the compat directives we would need to
     // add them all here.
-    (config.coffeeComment << 2)
+    (config.coffeeComment << 1)
 
   return [stateInt, state.currentJSXTag]
 }
@@ -313,7 +320,8 @@ Arguments
     return $skip
 
 ImplicitArguments
-  ApplicationStart InsertOpenParen:open Trimmed_?:ws NonPipelineArgumentList:args InsertCloseParen:close ->
+  ApplicationStart InsertOpenParen:open Trimmed_?:ws ForbidNestedBinaryOp NonPipelineArgumentList?:args RestoreNestedBinaryOp InsertCloseParen:close ->
+    if (!args) return $skip
     // Don't treat as call if this is a postfix for/while/until/if/unless
     if (skipImplicitArguments(args)) return $skip
 
@@ -512,7 +520,7 @@ BinaryOpExpression
     return processBinaryOpExpression($0)
 
 BinaryOpRHS
-  NotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
+  ( NestedBinaryOpAllowed / !Nested ) NotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
     return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
@@ -3879,14 +3887,14 @@ CoffeeWordAssignmentOp
 # NOTE: Similar to `NotDedented BinaryOp`,
 # but forbid Nested with custom infix operators
 NotDedentedBinaryOp
-  IndentedFurther? _? BinaryOp ->
+  IndentedFurther?:ws1 _?:ws2 BinaryOp:op ->
     const ws = []
-    if ($1) ws.push(...$1)
-    if ($2) ws.push(...$2)
-    return [ ws, $3 ]
-  Nested _? !Identifier ( !"*" / !ImportDeclaration ) BinaryOp:op ->
-    const ws = [...$1]
-    if ($2) ws.push(...$2)
+    if (ws1) ws.push(...ws1)
+    if (ws2) ws.push(...ws2)
+    return [ ws, op ]
+  NestedBinaryOpAllowed Nested:ws1 _?:ws2 !Identifier ( !"*" / !ImportDeclaration ) BinaryOp:op ->
+    const ws = [...ws1]
+    if (ws2) ws.push(...ws2)
     return [ ws, op ]
 
 IdentifierBinaryOp
@@ -5087,6 +5095,25 @@ TrailingMemberPropertyAllowed
     }
     if (state.trailingMemberPropertyForbidden) return $skip
 
+AllowNestedBinaryOp
+  "" ->
+    state.forbidNestedBinaryOp.push(false)
+
+ForbidNestedBinaryOp
+  "" ->
+    state.forbidNestedBinaryOp.push(true)
+
+RestoreNestedBinaryOp
+  "" ->
+    state.forbidNestedBinaryOp.pop()
+
+NestedBinaryOpAllowed
+  "" ->
+    if (config.verbose) {
+      console.log("forbidNestedBinaryOp:", state.forbidNestedBinaryOp)
+    }
+    if (state.nestedBinaryOpForbidden) return $skip
+
 AllowNewlineBinaryOp
   "" ->
     state.forbidNewlineBinaryOp.push(false)
@@ -5107,10 +5134,10 @@ NewlineBinaryOpAllowed
     if (state.newlineBinaryOpForbidden) return $skip
 
 AllowAll
-  AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNewlineBinaryOp
+  AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNestedBinaryOp AllowNewlineBinaryOp
 
 RestoreAll
-  RestoreTrailingMemberProperty RestoreBracedApplication RestoreIndentedApplication RestoreClassImplicitCall RestoreNewlineBinaryOp
+  RestoreTrailingMemberProperty RestoreBracedApplication RestoreIndentedApplication RestoreClassImplicitCall RestoreNestedBinaryOp RestoreNewlineBinaryOp
 
 # https://262.ecma-international.org/#prod-ExpressionStatement
 CommaExpressionStatement
@@ -8415,6 +8442,7 @@ Reset
     state.forbidIndentedApplication = [false]
     state.forbidBracedApplication = [false]
     state.forbidTrailingMemberProperty = [false]
+    state.forbidNestedBinaryOp = [false]
     state.forbidNewlineBinaryOp = [false]
     state.JSXTagStack = [undefined]
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1197,6 +1197,7 @@ function processProgram(root: BlockStatement): void
   assert.equal(state.forbidBracedApplication.length, 1, "forbidBracedApplication")
   assert.equal(state.forbidClassImplicitCall.length, 1, "forbidClassImplicitCall")
   assert.equal(state.forbidIndentedApplication.length, 1, "forbidIndentedApplication")
+  assert.equal(state.forbidNestedBinaryOp.length, 1, "forbidNestedBinaryOp")
   assert.equal(state.forbidNewlineBinaryOp.length, 1, "forbidNewlineBinaryOp")
   assert.equal(state.forbidTrailingMemberProperty.length, 1, "forbidTrailingMemberProperty")
   assert.equal(state.JSXTagStack.length, 1, "JSXTagStack")

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -710,6 +710,27 @@ describe "binary operations", ->
     a == b && b === c
   """
 
+  describe "nesting", ->
+    testCase """
+      same line within function call
+      ---
+      f x
+      + y
+      ---
+      f(x)
+      + y
+    """
+
+    testCase """
+      strictly indented within function call
+      ---
+      f x
+        + y
+      ---
+      f(x
+        + y)
+    """
+
 describe "custom identifier infix operators", ->
   testCase """
     bless


### PR DESCRIPTION
Fixes #1121 at least, as outlined in https://github.com/DanielXMoore/Civet/issues/1121#issuecomment-2331851911

#1280 shows that we also have the issue with the pipe operators, and this doesn't fix that yet. I think it could, with the same flag, but we'd first need to do `PushIndent`/`PopIndent` to recognize the indentation level of the first `|>` so that the future ones are recognized as being `Nested` and thus not valid continuations of an argument.

There *might* be other places where we need to `ForbidNestedBinaryOp`, but none come to mind yet... at least, this makes it easy to add more if necessary.