### PR TITLE
Pipes in arguments require strict indentation

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -519,8 +519,11 @@ BinaryOpExpression
     if (!$2.length) return $1
     return processBinaryOpExpression($0)
 
+BinaryOpNotDedented
+  ( NestedBinaryOpAllowed / !Nested ) NotDedented -> $2
+
 BinaryOpRHS
-  ( NestedBinaryOpAllowed / !Nested ) NotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
+  BinaryOpNotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
     return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
@@ -858,7 +861,7 @@ ShortCircuitExpression
   BinaryOpExpression
 
 PipelineExpression
-  _?:ws PipelineHeadItem:head ( NotDedented Pipe __ PipelineTailItem )+:body ->
+  _?:ws PipelineHeadItem:head PipelineExpressionBody:body ->
     if (head.type === "ArrowFunction" && head.ampersandBlock) {
       const expressions = [ {
         type: "PipelineExpression",
@@ -877,6 +880,23 @@ PipelineExpression
       type: "PipelineExpression",
       children: [ws, head, body]
     }
+
+PipelineExpressionBody
+  # First check for properly indented chain of |>s,
+  # in which case we use PushIndent to track this indentation level.
+  # This helps distinguish inside vs. outside when we ForbidNestedBinaryOps
+  PipelineExpressionBodySameLine:first PushIndent ( ( Nested Pipe __ PipelineTailItem ) PipelineExpressionBodySameLine )*:rest PopIndent ->
+    if (!rest.length) return $skip
+    return [
+      ...first,
+      ...rest.map(([nested, line]) => [nested, ...line]).flat()
+    ]
+
+  # Otherwise allow for any not-dedented chain
+  ( BinaryOpNotDedented Pipe __ PipelineTailItem )+
+
+PipelineExpressionBodySameLine
+  ( _? Pipe __ PipelineTailItem )*
 
 PipelineHeadItem
   # Needed to avoid left recursion

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -626,3 +626,31 @@ describe "pipe", ->
     ({foo:await (
       foo())})
   """
+
+  testCase """
+    strictly nested
+    ---
+    fetch(url)
+      |> await
+      |> .arrayBuffer()
+      |> await 
+      |> new Blob [.], type: "application/javascript"
+      |> URL.createObjectURL
+      |> new Worker
+    ---
+    new Worker(URL.createObjectURL(new Blob([(await (await fetch(url)).arrayBuffer())], {type: "application/javascript"})))
+  """
+
+  testCase """
+    nested
+    ---
+    fetch(url)
+    |> await
+    |> .arrayBuffer()
+    |> await 
+    |> new Blob [.], type: "application/javascript"
+    |> URL.createObjectURL
+    |> new Worker
+    ---
+    new Worker(URL.createObjectURL(new Blob([(await (await fetch(url)).arrayBuffer())], {type: "application/javascript"})))
+  """


### PR DESCRIPTION
Fixes #1280 by applying the same `ForbidNestedBinaryOps` mechanism from #1438 to pipe operators.

The challenge here was handling the indented `|>` form in the #1438 example, which required a `PushIndent` to track the indentation.

Note that we already had a different mechanism that aimed to do this same thing of forbidding pipelines inside arguments, which is that `ImplicitArguments` used `NonPipelineArgumentList`. This didn't work with contained complex structures like `ObjectExpression` (though it could plausibly be extended to do so, making a `NonPipelineObjectExpression` variant that).

Anyway, the result of the old mechanism is that we still have the following behavior:

```js
fetch url
  |> .foo
---
fetch(url).foo
//not: fetch(url.foo)
```

This is inconsistent with how binary operators work now.  I think it should remain so: `|>` is really intended to be lower precedence than implicit function calls, no matter the indentation. Another example is the single-line behavior (also unaffected by this PR):

```js
fetch url, headers |> .foo
---
fetch(url, headers).foo
//not: fetch(url, headers.foo)
```

Here's a relevant example: Both before and after this PR, we have

```js
fetch url, headers: foo
  |> .foo
---
fetch(url, {headers: foo.foo})
//not: fetch(url, {headers: foo}).foo
```

This PR only fixes the following unindented case, because that's what we decided for binary operators:

```js
fetch url, headers: foo
|> .foo
---
fetch(url, {headers: foo}).foo
```

I see a few options:

1. Fix `NonPipelineArgumentList` to use a new `NonPipelineObjectExpression` so that it propagates the "no pipeline at top level" request.
2. Replace this `NonPipeline` business with a flag.
3. Re-use the `ForbidNestedBinaryOp` flag for this purpose, so instead of forbidding `Nested Pipe`, we forbid all `Pipe`. A bit of a misnomer then; `ForbidNestedBinaryOp` might be better named `InImplicitArguments`...

In cases 1 and 2, this PR might not be needed, actually. Though the `PushIndent` part might still be useful, to track indentation...