### PR TITLE
Forbid pipes in non-nested implicit arguments

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -270,7 +270,6 @@ makeCache := ({hits, trace}: CacheOptions = {}): CacheEvents ->
     exit: (ruleName: string, state: ParseState, result: ParseResult) ->
       if uncacheable.has(ruleName)
         if trace
-          stack.pop()
           logs.push "".padStart(stack.length * 2, " ") + ruleName + ":" + state.pos + "⚠️ " + (if result then "✅" else "❌")
         return
 

--- a/source/main.civet
+++ b/source/main.civet
@@ -52,6 +52,7 @@ uncacheable := new Set [
   "AllowNestedBinaryOp"
   "AllowNewlineBinaryOp"
   "AllowTrailingMemberProperty"
+  "AllowPipeline"
 
   "ForbidClassImplicitCall"
   "ForbidBracedApplication"
@@ -60,6 +61,7 @@ uncacheable := new Set [
   "ForbidNestedBinaryOp"
   "ForbidNewlineBinaryOp"
   "ForbidTrailingMemberProperty"
+  "ForbidPipeline"
 
   "RestoreAll"
   "RestoreClassImplicitCall"
@@ -69,6 +71,7 @@ uncacheable := new Set [
   "RestoreTrailingMemberProperty"
   "RestoreNestedBinaryOp"
   "RestoreNewlineBinaryOp"
+  "RestorePipeline"
 
 ]
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -327,7 +327,7 @@ Arguments
     return $skip
 
 ImplicitArguments
-  ApplicationStart InsertOpenParen:open Trimmed_?:ws ForbidNestedBinaryOp ForbidPipeline NonPipelineArgumentList?:args RestorePipeline RestoreNestedBinaryOp InsertCloseParen:close ->
+  ApplicationStart InsertOpenParen:open Trimmed_?:ws ForbidNestedBinaryOp ForbidPipeline ArgumentList?:args RestorePipeline RestoreNestedBinaryOp InsertCloseParen:close ->
     if (!args) return $skip
     // Don't treat as call if this is a postfix for/while/until/if/unless
     if (skipImplicitArguments(args)) return $skip
@@ -425,32 +425,7 @@ CommaDelimiter
 # where each comma is a Comma token or an array [whitespace, commaToken]
 # (like CommaDelimiter)
 ArgumentList
-  # Check for same line arguments then nested arguments
-  ArgumentPart ( CommaDelimiter !EOS _? ArgumentPart )* ( CommaDelimiter ( NestedBulletedArray / NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
-    return [
-      $1,
-      ...$2.flatMap(([comma, eos, ws, arg]) => [comma, prepend(ws, arg)]),
-      ...$3.flatMap(([comma, args]) =>
-        Array.isArray(args) ? [comma, ...args] : [comma, args]
-      ),
-    ]
-  # NOTE: Added nested arguments on separate new lines
-  NestedBulletedArray ->
-    return [ trimFirstSpace($1) ]
-  NestedImplicitObjectLiteral ->
-    return [ trimFirstSpace($1) ]
-  NestedArgumentList
-  # NOTE: Eliminated left recursion
-  _? ArgumentPart ( CommaDelimiter _? ArgumentPart )* ->
-    return [
-      prepend($1, $2),
-      ...$3.flatMap(([comma, ws, arg]) => [comma, prepend(ws, arg)]),
-    ]
-
-# NOTE: ArgumentList variant that forbids top-level pipeline operators
-NonPipelineArgumentList
-  # Check for same line arguments then nested arguments
-  !EOS NonPipelineArgumentPart ( CommaDelimiter !EOS _? NonPipelineArgumentPart )* ( CommaDelimiter ( NestedBulletedArray / NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
+  !EOS ArgumentPart ( CommaDelimiter !EOS _? ArgumentPart )* ( CommaDelimiter ( NestedBulletedArray / NestedImplicitObjectLiteral / NestedArgumentList ) )+ ->
     return [
       $2,
       ...$3.flatMap(([comma, eos, ws, arg]) => [comma, prepend(ws, arg)]),
@@ -468,10 +443,10 @@ NonPipelineArgumentList
     ]
   NestedArgumentList
   # NOTE: Eliminated left recursion
-  NonPipelineArgumentPart ( CommaDelimiter _? NonPipelineArgumentPart )* ->
+  _? ArgumentPart ( CommaDelimiter _? ArgumentPart )* ->
     return [
-      $1,
-      ...$2.flatMap(([comma, ws, arg]) => [comma, prepend(ws, arg)]),
+      prepend($1, $2),
+      ...$3.flatMap(([comma, ws, arg]) => [comma, prepend(ws, arg)]),
     ]
 
 NestedArgumentList
@@ -511,15 +486,6 @@ ArgumentPart
       expression,
       spread,
     }
-
-# NOTE: ArgumentPart variant that forbids top-level pipeline operators
-NonPipelineArgumentPart
-  DotDotDot NonPipelineExtendedExpression
-  NonPipelineExtendedExpression DotDotDot? ->
-    if ($2) {
-      return [$2, $1]
-    }
-    return $1
 
 BinaryOpExpression
   UnaryExpression BinaryOpRHS* ->
@@ -8139,7 +8105,7 @@ ForbiddenImplicitTypeCalls
   # Abstract, Readonly, ExtendsToken, NotExtendsToken, Is
   /(extends|not|is)(?!\p{ID_Continue}|[\u200C\u200D$])/
 
-# Based on NonPipelineArgumentList
+# Based on ArgumentList
 TypeArgumentList
   # Check for same line arguments then nested arguments
   !EOS TypeArgument ( CommaDelimiter !EOS _? TypeArgument )* ( CommaDelimiter ( NestedTypeBulletedTuple / NestedInterfaceBlock / NestedTypeArgumentList ) )+ ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3090,7 +3090,7 @@ ArrayElementExpression
 
 # NOTE: Nested bulleted array starts with an indentation.
 NestedBulletedArray
-  ( InsertSpace InsertOpenBracket ):open PushIndent NestedArrayBullet*:content InsertCloseBracket:close PopIndent ->
+  ( InsertSpace InsertOpenBracket ):open PushIndent AllowPipeline NestedArrayBullet*:content RestorePipeline InsertCloseBracket:close PopIndent ->
     if (!content.length) return $skip
     content = content.flat() // combine bullets into one array
 
@@ -3234,7 +3234,7 @@ BracedObjectLiteralContent
 # NOTE: Nested implicit object literal starts with an indentation.
 # All properties can be spaced out and must have a colon.
 NestedImplicitObjectLiteral
-  InsertOpenBrace PushIndent NestedImplicitPropertyDefinitions?:properties PopIndent InsertNewline InsertIndent InsertCloseBrace ->
+  InsertOpenBrace PushIndent AllowPipeline NestedImplicitPropertyDefinitions?:properties RestorePipeline PopIndent InsertNewline InsertIndent InsertCloseBrace ->
     if (!properties) return $skip
     return {
       type: "ObjectExpression",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -124,6 +124,12 @@ Object.defineProperties(state, {
       return s[s.length-1]
     },
   },
+  pipelineForbidden: {
+    get() {
+      const {forbidPipeline: s} = state
+      return s[s.length-1]
+    },
+  },
   currentJSXTag: {
     get() {
       const {JSXTagStack: s} = state
@@ -141,12 +147,13 @@ export function getStateKey() {
     (state.trailingMemberPropertyForbidden << 4) |
     (state.nestedBinaryOpForbidden << 3) |
     (state.newlineBinaryOpForbidden << 2) |
+    (state.pipelineForbidden << 1) |
     // This is slightly different than the rest of the state,
     // since it is affected by the directive prologue and may be hit
     // by the EOL rule early in the parse. Later if we wanted to
     // allow block scoping of the compat directives we would need to
     // add them all here.
-    (config.coffeeComment << 1)
+    (config.coffeeComment << 0)
 
   return [stateInt, state.currentJSXTag]
 }
@@ -320,7 +327,7 @@ Arguments
     return $skip
 
 ImplicitArguments
-  ApplicationStart InsertOpenParen:open Trimmed_?:ws ForbidNestedBinaryOp NonPipelineArgumentList?:args RestoreNestedBinaryOp InsertCloseParen:close ->
+  ApplicationStart InsertOpenParen:open Trimmed_?:ws ForbidNestedBinaryOp ForbidPipeline NonPipelineArgumentList?:args RestorePipeline RestoreNestedBinaryOp InsertCloseParen:close ->
     if (!args) return $skip
     // Don't treat as call if this is a postfix for/while/until/if/unless
     if (skipImplicitArguments(args)) return $skip
@@ -468,7 +475,7 @@ NonPipelineArgumentList
     ]
 
 NestedArgumentList
-  PushIndent NestedArgument*:args PopIndent ->
+  PushIndent AllowPipeline NestedArgument*:args RestorePipeline PopIndent ->
     if (!args.length) return $skip
     return args.flat()
 
@@ -519,8 +526,11 @@ BinaryOpExpression
     if (!$2.length) return $1
     return processBinaryOpExpression($0)
 
+BinaryOpNotDedented
+  ( NestedBinaryOpAllowed / !Nested ) NotDedented -> $2
+
 BinaryOpRHS
-  ( NestedBinaryOpAllowed / !Nested ) NotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
+  BinaryOpNotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
     return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
   BinaryOp:op RHS:rhs ->
@@ -858,7 +868,7 @@ ShortCircuitExpression
   BinaryOpExpression
 
 PipelineExpression
-  _?:ws PipelineHeadItem:head ( NotDedented Pipe __ PipelineTailItem )+:body ->
+  PipelineAllowed _?:ws PipelineHeadItem:head PipelineExpressionBody:body ->
     if (head.type === "ArrowFunction" && head.ampersandBlock) {
       const expressions = [ {
         type: "PipelineExpression",
@@ -877,6 +887,22 @@ PipelineExpression
       type: "PipelineExpression",
       children: [ws, head, body]
     }
+
+PipelineExpressionBody
+  # First check for properly indented chain of |>s,
+  # in which case we use PushIndent to track this indentation level.
+  PipelineExpressionBodySameLine:first PushIndent ( ( Nested Pipe __ PipelineTailItem ) PipelineExpressionBodySameLine )*:rest PopIndent ->
+    if (!rest.length) return $skip
+    return [
+      ...first,
+      ...rest.map(([nested, line]) => [nested, ...line]).flat()
+    ]
+
+  # Otherwise allow for any not-dedented chain
+  ( NotDedented Pipe __ PipelineTailItem )+
+
+PipelineExpressionBodySameLine
+  ( _? Pipe __ PipelineTailItem )*
 
 PipelineHeadItem
   # Needed to avoid left recursion
@@ -5133,11 +5159,30 @@ NewlineBinaryOpAllowed
     }
     if (state.newlineBinaryOpForbidden) return $skip
 
+AllowPipeline
+  "" ->
+    state.forbidPipeline.push(false)
+
+ForbidPipeline
+  "" ->
+    state.forbidPipeline.push(true)
+
+RestorePipeline
+  "" ->
+    state.forbidPipeline.pop()
+
+PipelineAllowed
+  "" ->
+    if (config.verbose) {
+      console.log("forbidPipeline:", state.forbidPipeline)
+    }
+    if (state.pipelineForbidden) return $skip
+
 AllowAll
-  AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNestedBinaryOp AllowNewlineBinaryOp
+  AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNestedBinaryOp AllowNewlineBinaryOp AllowPipeline
 
 RestoreAll
-  RestoreTrailingMemberProperty RestoreBracedApplication RestoreIndentedApplication RestoreClassImplicitCall RestoreNestedBinaryOp RestoreNewlineBinaryOp
+  RestoreTrailingMemberProperty RestoreBracedApplication RestoreIndentedApplication RestoreClassImplicitCall RestoreNestedBinaryOp RestoreNewlineBinaryOp RestorePipeline
 
 # https://262.ecma-international.org/#prod-ExpressionStatement
 CommaExpressionStatement
@@ -8444,6 +8489,7 @@ Reset
     state.forbidTrailingMemberProperty = [false]
     state.forbidNestedBinaryOp = [false]
     state.forbidNewlineBinaryOp = [false]
+    state.forbidPipeline = [false]
     state.JSXTagStack = [undefined]
 
     state.operators = new Map

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -784,12 +784,15 @@ TrailingDeclaration
 TrailingPipe
   _? Pipe
 
+TrailingPostfix
+  _? PostfixStatement
+
 # NOTE Different from
 # https://262.ecma-international.org/#prod-ConciseBody
 FatArrowBody
   # If same-line single expression, avoid wrapping in braces
   # NOTE: Skip expressionized statements, so they get braced instead
-  !EOS !( _? ExpressionizedStatement ) NonPipelinePostfixedExpression:exp !TrailingDeclaration !TrailingPipe !SemicolonDelimiter ->
+  !EOS !( _? ExpressionizedStatement ) NonPipelineExtendedExpression:exp !TrailingDeclaration !TrailingPipe !TrailingPostfix !SemicolonDelimiter ->
     // Ensure object literal is wrapped in parens
     if (exp.type === "ObjectExpression") {
       exp = makeLeftHandSideExpression(exp)
@@ -4196,11 +4199,6 @@ PostfixedCommaExpression
       return attachPostfixStatementAsExpression(expression, post)
     }
     return $0
-
-NonPipelinePostfixedExpression
-  NonPipelineExtendedExpression:expression ( _? PostfixStatement )?:post ->
-    if (post) return attachPostfixStatementAsExpression(expression, post)
-    return expression
 
 PostfixStatement
   /(?=for|if|loop|unless|until|while)/ _PostfixStatement -> $2

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -702,9 +702,11 @@ based on the shape of the arguments.
 
 Don't treat as call if this is a postfix for/while/until/if/unless
 */
-function skipImplicitArguments(args: unknown[]): boolean
+function skipImplicitArguments(args: ASTNode[]): boolean
   if args.length is 1
     arg0 .= args[0]
+    if arg0.type is "Argument"
+      arg0 = arg0.expression
 
     if arg0.type is "StatementExpression"
       arg0 = arg0.statement

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1391,7 +1391,9 @@ function processPlaceholders(statements: StatementTuple[]): void
     // This doesn't happen with "&", but can with ".".
     let outer: boolean?
     switch parent?.type
-      when "Call"
+      when "Argument"
+        outer = ancestor is parent.expression
+      when "Call" // probably no longer necessary now that we have Argument wrappers
         outer = ancestor is
           parent.args[findChildIndex parent.args, ancestor]
       when "BlockStatement"

--- a/test/array.civet
+++ b/test/array.civet
@@ -585,12 +585,12 @@ describe "array", ->
       ---
       f
         . a
-        . b
+        . b |> g
         . c
       ---
       f([
           a,
-          b,
+          g(b),
           c])
     """
 

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -340,7 +340,7 @@ describe "function application", ->
       b: 2
     )
     ---
-    f( {
+    f({
       a: 1,
     }
     , {

--- a/test/function.civet
+++ b/test/function.civet
@@ -1768,7 +1768,7 @@ describe "function", ->
       ---
       (x) => a if x
       ---
-      (x) =>(x? a:void 0)
+      (x) => { if (x) { return a };return }
     """
 
     testCase """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -666,6 +666,18 @@ describe "pipe", ->
   """
 
   testCase """
+    object argument
+    ---
+    fetch url,
+      method: 'post' |> .toUpperCase()
+    |> await
+    ---
+    await fetch(url, {
+      method: 'post'.toUpperCase(),
+    })
+  """
+
+  testCase """
     nested in argument
     ---
     Object.assign options.parseOptions ??= {},

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -626,3 +626,64 @@ describe "pipe", ->
     ({foo:await (
       foo())})
   """
+
+  testCase """
+    strictly nested
+    ---
+    fetch(url)
+      |> await
+      |> .arrayBuffer()
+      |> await 
+      |> new Blob [.], type: "application/javascript"
+      |> URL.createObjectURL
+      |> new Worker
+    ---
+    new Worker(URL.createObjectURL(new Blob([(await (await fetch(url)).arrayBuffer())], {type: "application/javascript"})))
+  """
+
+  throws """
+    track indentation
+    ---
+    fetch(url)
+      |> (out) =>
+      console.log out
+    ---
+    ParseError: unknown:3:3 Failed to parse
+  """
+
+  testCase """
+    nested
+    ---
+    fetch(url)
+    |> await
+    |> .arrayBuffer()
+    |> await 
+    |> new Blob [.], type: "application/javascript"
+    |> URL.createObjectURL
+    |> new Worker
+    ---
+    new Worker(URL.createObjectURL(new Blob([(await (await fetch(url)).arrayBuffer())], {type: "application/javascript"})))
+  """
+
+  testCase """
+    nested in argument
+    ---
+    Object.assign options.parseOptions ??= {},
+      parse `civet ${args[++i]}`,
+        startRule: 'CivetPrologueContent'
+        filename: '--civet argument'
+        events: // remove cache in case we've compiled Civet before
+          enter: undefined
+          exit: undefined
+      |> .config
+    ---
+    Object.assign(options.parseOptions ??= {},
+      parse(`civet ${args[++i]}`, {
+        startRule: 'CivetPrologueContent',
+        filename: '--civet argument',
+        events:  {// remove cache in case we've compiled Civet before
+          enter: undefined,
+          exit: undefined,
+        },
+      }).config)
+    """


### PR DESCRIPTION
Fixes #1280 by adding a new `ForbidPipeline` flag, as discussed in #1440.

This new feature also let us unify `ArgumentList` and `NonPipelineArgumentList`. The former had gotten out-of-date, so I updated to match `NonPipelineArgumentList`, then removed the latter.

## Still some NonPipeline

I tried removing more `NonPipeline...` rules, but it's tricky specifically for parsing pipelines: `PipelineHead` needs to parse everything up to a `Pipe` operator (to avoid left recursion), but it doesn't work to use `ForbidPipeline` for this, because then it breaks code like

```js
=> x |> y
```

With `ForbidPipeline`, we'd end up parsing `=> x` as the head, which isn't what we want. But we also don't want to just `AllowPipeline` when we enter a non-indented function body, because then we'd misparse something like this:

```js
f => x
|> y
```

So it seems we need to keep (at least some of) the remaining 6 `NonPipeline...` rules. Most of them are short, at least. Oh, I could get rid of `NonPipelinePostfixedExpression` at least.

## AllowPipeline cases

I somewhat wonder whether `AllowPipeline` should be automatic with every `PushIndent`. But it's probably safer to control exactly when it's done, and add more cases as we encounter them. Right now, it should be pretty similar to the old behavior: whenever `NonPipelineArgumentList` used an indented rule, it dropped the `NonPipeline` prefix