### PR TITLE
`yield` in `do` yields in parent in all cases

### DIFF
--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -97,6 +97,7 @@ export type OtherNode =
   | SpreadElement
   | TypeSuffix
   | WhenClause
+  | Yield
 
 /** @deprecated */
 export type ASTNodeBase = ASTNode &
@@ -229,7 +230,7 @@ export type UnaryExpression
 
 export type Await
   type: "Await"
-  token: string
+  token?: string
   children?: Children
   parent?: Parent
   op?: ASTNode
@@ -237,6 +238,12 @@ export type Await
 export type NewExpression
   type: "NewExpression"
   children: Children
+  parent?: Parent
+
+export type Yield
+  type: "Yield"
+  token?: string
+  children?: Children
   parent?: Parent
 
 export type YieldExpression

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -570,16 +570,22 @@ function parenthesizeType(type: ASTNode)
  * Returns an Array suitable for `children`.
  */
 function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?: ASTNode): ASTNode
-  let prefix
+  let awaitPrefix: ASTNode?
 
   async := []
   if asyncFlag
     async.push "async "
   else if hasAwait expressions
     async.push "async "
-    prefix =
+    awaitPrefix =
       type: "Await"
       children: ["await "]
+
+  yieldWrap .= false
+  unless generator
+    if hasYield expressions
+      generator = "*"
+      yieldWrap = true
 
   block := makeNode {
     type: "BlockStatement"
@@ -633,13 +639,24 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
     if gatherRecursiveWithinFunction(block, (is like { token: "arguments" }))#
       children.-1 = parameters.children.-1 = "(arguments)"
 
-  exp := makeNode {
+  exp: ASTNode .= makeNode {
     type: "CallExpression"
     children
   }
 
-  if prefix
-    return makeLeftHandSideExpression [prefix, exp]
+  if yieldWrap
+    // yield* supports async iterators, so no need to await here
+    exp = makeLeftHandSideExpression makeNode
+      type: "YieldExpression"
+      star: "*"
+      expression: exp
+      children:
+        . type: "Yield"
+          children: ["yield"]
+        . "*", " "
+        . exp
+  else if awaitPrefix
+    exp = makeLeftHandSideExpression [awaitPrefix, exp]
 
   return exp
 

--- a/test/do.civet
+++ b/test/do.civet
@@ -301,6 +301,34 @@ describe "do", ->
   """
 
   testCase """
+    yield expression
+    ---
+    f = (x) ->
+      y = 1 + do
+        yield x
+    ---
+    f = function*(x) {
+      y = 1 + (yield* (function*(){{
+        yield x
+      }})())
+    }
+  """
+
+  testCase """
+    await yield expression
+    ---
+    f = (x) ->
+      y = 1 + do
+        yield await x
+    ---
+    f = function*(x) {
+      y = 1 + (yield* (async function*(){{
+        yield await x
+      }})())
+    }
+  """
+
+  testCase """
     generator
     ---
     nums := do*


### PR DESCRIPTION
Fixes #888

Most cases were already handled by IIFE unwrapping. `yield*` ought to do the right thing in expression contexts, though the behavior is admittedly weird; at least it seems to match Babel output.