### PR TITLE
Nested function arguments support trailing member access/call

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -436,7 +436,7 @@ ArgumentList
     ]
 
 NestedArgumentList
-  PushIndent AllowPipeline NestedArgument*:args RestorePipeline PopIndent ->
+  PushIndent AllowPipeline AllowTrailingMemberProperty NestedArgument*:args RestoreTrailingMemberProperty RestorePipeline PopIndent ->
     if (!args.length) return $skip
     return args.flat()
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -151,7 +151,7 @@ function processReturnValue(func: FunctionNode)
     // Check whether return.value already declared within this function
     { ancestor, child } := findAncestor
       value
-      .type is "Declaration"
+      &.type is "Declaration"
       isFunction
     declaration ??= child if ancestor  // remember binding
 

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -572,3 +572,24 @@ describe "function application", ->
     }
       , 100)
   """
+
+  // #869
+  testCase """
+    trailing member in nested argument
+    ---
+    v
+      v 2, 4
+        .length()
+      0.5
+    f
+      x
+      .y
+    ---
+    v(
+      v(2, 4)
+        .length(),
+      0.5)
+    f(
+      x
+      .y)
+  """


### PR DESCRIPTION
Fixes #869 by re-allowing trailing member/call in *properly nested* arguments (where it's no longer ambiguous whether the trailing applies to the argument or the function result).

A breaking change is that this parse changes:

```js
f
  a
  .b
```

[Previous transpilation](https://civet.dev/playground?code=ZgogIGEKICAuYg%3D%3D):

```js
f(
  a,
  $ => $.b)
```

New transpilation:

```js
f(
  a
  .b)
```

I'm not totally sure which is more intuitive; this is a fundamental ambiguity we've had for a while. But perhaps a good analogy is this:

```js
=>
  a
  .b
```

This returns `a.b`, not `$ => $.b`. This PR matches that behavior in arguments too.

An alternative would be to do different things depending on whether `.b` is indented the same or further than `a`. This would be harder to implement, though, and I guess inconsistent with our not-in-arguments behavior.