### PR TITLE
Fix `catch` type annotation by forbidding indented type arguments in `catch`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4890,7 +4890,9 @@ CatchClause
 # NOTE: Added optional parentheses to catch binding
 CatchBind
   _? OpenParen __ CatchParameter __ CloseParen
-  _ InsertOpenParen !EOS CatchParameter InsertCloseParen
+  _:ws InsertOpenParen:open !EOS ForbidIndentedApplication CatchParameter?:param RestoreIndentedApplication InsertCloseParen:close ->
+    if (!param) return $skip
+    return [ ws, open, param, close ]
 
 # https://262.ecma-international.org/#prod-Finally
 FinallyClause

--- a/test/types/try.civet
+++ b/test/types/try.civet
@@ -1,0 +1,35 @@
+{testCase} from ../helper.civet
+
+describe "[TS] try", ->
+  testCase """
+    typed catch
+    ---
+    try
+      foo()
+    catch e: any
+      bar
+    ---
+    try {
+      foo()
+    }
+    catch (e: any) {
+      bar
+    }
+  """
+
+  // #1445
+  testCase """
+    typed catch followed by function call
+    ---
+    try
+      foo()
+    catch e: any
+      bar(e)
+    ---
+    try {
+      foo()
+    }
+    catch (e: any) {
+      bar(e)
+    }
+  """


### PR DESCRIPTION
Fixes #1445