### PR TITLE
Require parentheses in complex `&` type annotation

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1088,11 +1088,13 @@ You can also assign properties:
 x.map .name = "Civet" + i++
 </Playground>
 
-You can also type the argument:
+You can also type the argument (but if you use type operators,
+the type needs to be wrapped in parentheses):
 
 <Playground>
 increment := &: number + 1
 show := &: ??? |> JSON.stringify |> console.log
+identity := &?: (number | string)
 </Playground>
 
 ::: info

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -952,8 +952,17 @@ Placeholder
       children: [ { token: "&" } ],
     }
 
+# One case of TypeSuffix, with no space before ?/: (for ternary ?:), and
+# Type replaced by TypePrimary: require parens where type operators
+# might be regular operators, like |, &, and ?: ternary
 PlaceholderTypeSuffix
-  &( QuestionMark? Colon ) TypeSuffix -> $2
+  QuestionMark?:optional Colon MaybeNestedTypePrimary:t -> {
+    type: "TypeSuffix",
+    ts: true,
+    optional,
+    t,
+    children: $0,
+  }
 
 # https://262.ecma-international.org/#prod-ClassDeclaration
 ClassDeclaration
@@ -7633,6 +7642,19 @@ MaybeNestedType
     if (!$2) return $skip
     return $2
   Type
+
+MaybeNestedTypePrimary
+  NestedTypeBulletedTuple
+  # NOTE: Let InterfaceBlock take first crack at an indented block
+  # But don't prevent parsing a braced type with unary suffix like {}[]
+  NestedInterfaceBlock
+  # NOTE: Next check for consistently indented binary operations (e.g. |)
+  # at beginning of each line.
+  NestedTypeBinaryChain
+  PushIndent ( Nested Type )? PopIndent ->
+    if (!$2) return $skip
+    return $2
+  TypePrimary
 
 ReturnTypeSuffix
   _? QuestionMark?:optional _? Colon ReturnType:t ->

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -779,6 +779,18 @@ describe "&. function block shorthand", ->
       ($: number) => foo($)
     """
 
+    testCase """
+      long type needs parens
+      ---
+      &: number | string
+      &: (number | string)
+      &: number < 0 ? -1 : 1
+      ---
+      ($: number) => $ | string;
+      ($1: (number | string)) => $1;
+      ($2: number) => $2 < 0 ? -1 : 1
+    """
+
 describe "(op) shorthand", ->
   testCase """
     binary op


### PR DESCRIPTION
Fixes #1225 similar to the proposal in https://github.com/DanielXMoore/Civet/issues/1225#issuecomment-2096399611: Only `TypePrimary` is allowed as a `&` type annotation, unless the type is nested in which case it can be anything. This means that any use of operators (including `|`, `&`, and ternary `?:`) need to be wrapped in parentheses.

BREAKING CHANGE: `&: number | string` is now treated as `(&: number) | string`, and `&: T ? a : b` is consistently treated as `(&: T) ? a : b`