### PR TITLE
CLI exposes top-level declarations with top-level `await`

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,4 +1,4 @@
-{ compile, generate, parse, lib, isCompileError, SourceMap, type ParseError, type ParseErrors } from ./main.civet
+{ compile, generate, parse, lib, isCompileError, SourceMap, type BlockStatement, type ParseError, type ParseErrors } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
 // unplugin ends up getting installed in the same dist directory
@@ -344,13 +344,16 @@ export function repl(args: string[], options: Options)
             (coffee ? ')' : ''),
             {...options, filename, ast: true}
           // Hoist top-level declarations outside the IIFE wrapper
-          lib.gatherRecursive ast, .type is 'BlockStatement'
-          .forEach (topBlock) =>
-            lib.gatherRecursiveWithinFunction topBlock, .type is 'Declaration'
-            .forEach (decl) =>
-              type := decl.children.shift() // const/let/var
+          topBlock :=
+            if coffee
+              lib.gatherRecursive(ast.children, &.type is 'BlockStatement')[0]
+            else
+              lib.gatherRecursive(ast.children, &.type is 'DoStatement')[0].block
+          for each [, statement] of topBlock.expressions
+            if statement is like {type: 'Declaration'}
+              statement.children.shift() // const/let/var
               ast = [ast] unless Array.isArray ast
-              ast.unshift `var ${decl.names.join ','};`
+              ast.unshift `var ${statement.names.join ','};`
 
         errors: unknown[] .= []
         try


### PR DESCRIPTION
I was thinking about https://github.com/DanielXMoore/Civet/issues/1195#issuecomment-2081269154, and noticed that the CLI had two bugs when running code with top-level `await` (where it builds an IIFE wrapper):
* It no longer correctly found the `BlockStatement` of the IIFE, instead getting distracted by the (relatively new) `BlockStatement` at the very top of the AST and the extra braced block wrapper.
* The search for `BlockStatement` was also broken in `coffee-do` mode.
* All declarations not wrapped in functions were lifted, instead of just the top-level ones (not inside a nested block). Should now match the non-async behavior (except `const` becomes `var`).

Tests:

![image](https://github.com/user-attachments/assets/c2d742ff-4cb5-40f1-af29-5c31c82b1cab)

This probably wants to be a separate function, with tests, but at least it's working for now. I'm hoping to add this as a less hacky feature in the future.