### PR TITLE
`.d.ts` matches output extension in CLI; `declarationExtension` option in unplugin

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,9 +17,9 @@ civet --no-config build/esbuild.civet "$@"
 
 # built types
 for name in astro esbuild rollup unplugin vite webpack; do
-  sed 's/\.civet"/\.js"/' dist/unplugin/unplugin/$name.civet.d.ts >dist/unplugin/$name.d.ts
+  sed 's/\.civet"/\.js"/' dist/unplugin/source/unplugin/$name.civet.d.ts >dist/unplugin/$name.d.ts
 done
-rm -rf dist/unplugin/unplugin
+rm -rf dist/unplugin/source
 
 # cli
 BIN="dist/civet"

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -89,7 +89,7 @@ for name of ["config", "babel-plugin"]
       platform: 'node'
       format
       outdir: 'dist'
-      outExtension: ".js": if format == "esm" then ".mjs" else ".js"
+      outExtension: ".js": if format is "esm" then ".mjs" else ".js"
       plugins: [
         rewriteCivetImports
         civetPlugin()
@@ -182,12 +182,13 @@ for format of ["esm", "cjs"]
     ]
     target: "esNext"
     outdir: 'dist/unplugin'
-    outExtension: ".js": if format == "esm" then ".mjs" else ".js"
+    outExtension: ".js": if format is "esm" then ".mjs" else ".js"
     plugins: [
       rewriteCivetImports
       civetUnplugin
         ts: 'civet'
-        emitDeclaration: format == "esm"  // only run TypeScript once
+        emitDeclaration: format is "esm"  // only run TypeScript once
+        declarationExtension: ".d.ts"
         config: null
     ]
   }).catch -> process.exit 1
@@ -202,8 +203,10 @@ for format of ["esm", "cjs"]
     format
     target: "esNext"
     outdir: 'dist'
-    outExtension: ".js": if format == "esm" then ".mjs" else ".js"
+    outExtension: ".js": if format is "esm" then ".mjs" else ".js"
     plugins: [
-      civetPlugin({ emitDeclaration: true })
+      civetPlugin
+        emitDeclaration: format is "esm"
+        declarationExtension: ".d.ts"
     ]
   }).catch -> process.exit 1

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -202,8 +202,9 @@ esbuild.build({
     civetPlugin({
       // Options and their defaults:
       // emitDeclaration: false,         // generate .d.ts files?
+      // declarationExtension: '.civet.d.ts', // extension for .d.ts files
       // implicitExtension: true,        // import "./x" checks for x.civet
-      // outputExtension: '.tsx',        // appended to .civet in output
+      // outputExtension: '.tsx',        // appended to .civet internally
       // ts: 'civet',                    // TS -> JS transpilation mode
       // typecheck: false,               // check types via tsc
       // cache: false,                   // Cache compilation results based on mtime, useful for watch

--- a/integration/unplugin-examples/esbuild/esbuild.js
+++ b/integration/unplugin-examples/esbuild/esbuild.js
@@ -8,6 +8,7 @@ const options = {
   plugins: [civetEsbuildPlugin({
     ts: 'esbuild',
     emitDeclaration: true,
+    declarationExtension: '.d.ts',
   })],
   sourcemap: true,
 }

--- a/integration/unplugin-examples/esbuild/tsconfig.json
+++ b/integration/unplugin-examples/esbuild/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "."
   },
   "ts-node": {
     "transpileOnly": true,

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -471,6 +471,8 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       ...options
       ts: if options.js then 'civet' else 'preserve'
       outputExtension: '.tsx'
+      declarationExtension:
+        options.outputExt?.replace /\.[jt]sx?$/i, '.d.ts'
     }
     // TypeScript wants .civet.tsx files imported as .civet.jsx
     (unpluginOptions.parseOptions ??= {}).rewriteCivetImports = '.civet.jsx'

--- a/source/unplugin/README.md
+++ b/source/unplugin/README.md
@@ -174,30 +174,32 @@ module.exports = {
 
 ```ts
 interface PluginOptions {
-  emitDeclaration?: boolean;
-  implicitExtension?: boolean;
-  outputExtension?: string;
-  ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
-  typecheck?: boolean | string;
-  cache?: boolean;
+  emitDeclaration?: boolean
+  declarationExtesion?: string
+  implicitExtension?: boolean
+  outputExtension?: string
+  ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve'
+  typecheck?: boolean | string
+  cache?: boolean
   parseOptions?: {
-    comptime?: boolean;
-    coffeeCompat?: boolean;
+    comptime?: boolean
+    coffeeCompat?: boolean
     // ... any other Civet configuration option
   }
   transformOutput?: (
     code: string,
     id: string
-  ) => TransformResult | Promise<TransformResult>;
+  ) => TransformResult | Promise<TransformResult>
 }
 ```
 
 - `emitDeclaration`: Whether to generate `.d.ts` type definition files from the Civet source, which is useful for building libraries. Default: `false`. (Requires installing `typescript`.)
+- `declarationExtension`: Output filename extension for `.d.ts` files. Default: `".civet.d.ts"`.
 - `typecheck`: Whether to run type checking on the generated code. (Requires installing `typescript`.) Default: `false`.
   - Specifying `true` aborts the build (with an error code) on TypeScript errors.
   - Alternatively, you can specify a string with any combination of `error`, `warning`, `suggestion`, or `message` to specify which diagnostics abort the build. For example, `"none"` ignores all diagnostics, `"error+warning"` aborts on errors and warnings, and `"all"` aborts on all diagnostics.
 - `implicitExtension`: Whether to allow importing `filename.civet` via `import "filename"`. Default: `true`.
-- `outputExtension`: Output filename extension to append to `.civet`. Default: `".jsx"`, or `".tsx"` if `ts` is `"preserve"`.
+- `outputExtension`: JavaScript or TypeScript extension to append to `.civet` for internal purposes. Default: `".jsx"`, or `".tsx"` if `ts` is `"preserve"`.
 - `ts`: Mode for transpiling TypeScript features into JavaScript. Default: `"civet"`. Options:
   - `"civet"`: Use Civet's JS mode. (Not all TS features supported.)
   - `"esbuild"`: Use esbuild's transpiler. (Fast and more complete. Requires installing `esbuild`.)

--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -25,31 +25,32 @@ enum DiagnosticCategory {
   Message = 3
 }
 
-export type PluginOptions = {
-  implicitExtension?: boolean;
-  outputExtension?: string;
+export type PluginOptions
+  implicitExtension?: boolean
+  outputExtension?: string
   transformOutput?: (
-    code: string,
+    code: string
     id: string
-  ) => TransformResult | Promise<TransformResult>;
-  emitDeclaration?: boolean;
-  typecheck?: boolean | string;
-  ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve';
+  ) => TransformResult | Promise<TransformResult>
+  emitDeclaration?: boolean
+  declarationExtension?: string
+  typecheck?: boolean | string
+  ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve'
   /** @deprecated Use "ts" option instead */
-  js?: boolean;
+  js?: boolean
   /** @deprecated Use "emitDeclaration" instead */
-  dts?: boolean;
+  dts?: boolean
   /** Cache compilation results based on file mtime (useful for serve or watch mode) */
-  cache?: boolean;
+  cache?: boolean
   /** config filename, or null to not look for default config file */
-  config?: string | null | undefined;
-  parseOptions?: ParseOptions;
-};
+  config?: string? | null
+  parseOptions?: ParseOptions
 
-const isCivetTranspiled = /(\.civet)(\.[jt]sx)([?#].*)?$/;
-const postfixRE = /[?#].*$/s;
-const isWindows = os.platform() === 'win32';
-const windowsSlashRE = /\\/g;
+civetExtension := /\.civet$/
+isCivetTranspiled := /(\.civet)(\.[jt]sx)([?#].*)?$/
+postfixRE := /[?#].*$/s
+isWindows := os.platform() is 'win32'
+windowsSlashRE := /\\/g
 
 // Extracts query string and hash, and removes tsx/jsx extension
 function cleanCivetId(id: string): {id: string, postfix: string}
@@ -354,52 +355,54 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           }
         }
 
-        if (options.emitDeclaration) {
-          if (meta.framework === 'esbuild' && !esbuildOptions.outdir) {
-            console.log("WARNING: Civet unplugin's `emitDeclaration` requires esbuild's `outdir` option to be set;");
-          }
+        if options.emitDeclaration
+          if meta.framework is 'esbuild' and not esbuildOptions.outdir
+            console.log "WARNING: Civet unplugin's `emitDeclaration` requires esbuild's `outdir` option to be set;"
 
           // Removed duplicate slashed (`\`) versions of the same file for emit
-          for (const file of fsMap.keys()) {
-            const slashed = slash(file);
-            if (file !== slashed) {
-              fsMap.delete(slashed);
-            }
-          }
-          for (const file of fsMap.keys()) {
-            const sourceFile = program.getSourceFile(file)!;
-            program.emit(
-              sourceFile,
-              (filePath, content) => {
-                const pathFromDistDir = path.relative(
-                  compilerOptions.outDir ?? process.cwd(),
+          for file of fsMap.keys()
+            slashed := slash file
+            unless file is slashed
+              fsMap.delete slashed
+
+          for file of fsMap.keys()
+            sourceFile := program.getSourceFile(file)!
+            program.emit
+              sourceFile
+              (filePath, content) =>
+                if options.declarationExtension?
+                  if filePath.endsWith '.d.ts'
+                    filePath = filePath[0...-5]
+                  else
+                    console.log `WARNING: No .d.ts extension in ${filePath}`
+                  if match := filePath.match civetExtension
+                    filePath = filePath[0...-match[0]#]
+                  else
+                    console.log `WARNING: No .civet extension in ${filePath}`
+                  filePath += options.declarationExtension
+
+                pathFromDistDir .= path.relative
+                  compilerOptions.outDir ?? process.cwd()
                   filePath
-                );
 
                 // Work around unplugin+esbuild bug where it only creates the
                 // root output directory, not any subdirectories.
-                if (meta.framework === 'esbuild') {
-                  fs.mkdirSync(
+                if meta.framework is 'esbuild'
+                  fs.mkdirSync
                     path.dirname(
                       path.resolve(esbuildOptions.outdir!, pathFromDistDir)
-                    ), { recursive: true }
-                  );
-                }
+                    )
+                    recursive: true
 
-                this.emitFile({
-                  source: content,
-                  fileName: pathFromDistDir,
-                  type: 'asset',
-                });
-              },
-              undefined,
-              true, // emitDtsOnly
-              undefined,
+                this.emitFile
+                  source: content
+                  fileName: pathFromDistDir
+                  type: 'asset'
+              undefined
+              true // emitDtsOnly
+              undefined
               // @ts-ignore @internal interface
-              true, // forceDtsEmit
-            );
-          }
-        }
+              true // forceDtsEmit
       }
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     /* Modules */
     "module": "esnext",                                  /* Specify what module code is generated. */
-    "rootDir": "./source",                               /* Specify the root folder within your source files. */
+    "rootDir": ".",                                      /* Specify the root folder within your source files. */
     "moduleResolution": "bundler",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
Fixes #1316 

CLI:
* `civet` CLI still defaults to `.civet.tsx` and `.civet.d.ts` output files.
* `civet -o .js --emit-declaration` will now produce `.js` and `.d.ts` files.

unplugin gains a `declarationExtension` option that defines the output `.d.ts` extension, effectively defaulting to `.civet.d.ts` (generated by TypeScript given that our filenames are internally `.civet.ts`).

Incidentally, unplugin's `outputExtension` option seems poorly named. This is really an extension appended to the `.civet` filename to represent the intermediate file, but it's never actually saved with this name; the actual output is determined by the bundler. Is it worth renaming? I actually can't think of a purpose for setting it manually, except perhaps triggering certain other plugins in the toolchain (e.g. a plugin supports `.ts` but not `.tsx` extensions). So maybe it's good to rename it to something like `addedExtension` or `fakeExtension`?