### PR TITLE
CLI REPL supports (strips) TypeScript

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,4 +1,5 @@
-{ compile, generate, parse, lib, isCompileError, SourceMap, type BlockStatement, type ParseError, type ParseErrors } from ./main.civet
+{ compile, generate, parse, lib, isCompileError, SourceMap } from ./main.civet
+type { ASTError, BlockStatement, ParseError, ParseErrors } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
 // unplugin ends up getting installed in the same dist directory
@@ -355,9 +356,9 @@ export function repl(args: string[], options: Options)
               ast = [ast] unless Array.isArray ast
               ast.unshift `var ${statement.names.join ','};`
 
-        errors: unknown[] .= []
+        errors: ASTError[] .= []
         try
-          output = generate ast, { errors }
+          output = generate ast, { ...options, errors, sourceMap: undefined }
         catch error
           //console.error "Failed to transpile Civet:"
           console.error error
@@ -365,7 +366,7 @@ export function repl(args: string[], options: Options)
         if errors#
           // Rerun with sourceMap
           errors = []
-          generate ast, { errors, sourceMap: SourceMap(input) }
+          generate ast, { ...options, errors, sourceMap: SourceMap(input) }
           showError errors[0]
           return callback null, undefined
 

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -3,7 +3,7 @@ type { ASTNode, ASTError } from './parser/types.civet'
 { ParseError } from './parser.hera'
 
 export type Options =
-  sourceMap?:
+  sourceMap?: undefined |
     updateSourceMap: (token: string, pos?: number) => void
     data: { srcLine: number, srcColumn: number, srcOffset: number }
   js?: boolean
@@ -46,7 +46,7 @@ function gen(root: ASTNode, options: Options): string
         line: number | string .= '?'
         column: number | string .= '?'
         let offset: number?
-        if { sourceMap } := options
+        if sourceMap := options.sourceMap
           // Convert 0-based to 1-based
           line = sourceMap.data.srcLine + 1
           column = sourceMap.data.srcColumn + 1

--- a/source/main.civet
+++ b/source/main.civet
@@ -4,8 +4,8 @@ import * as lib from "./parser/lib.civet"
 import * as sourcemap from "./sourcemap.civet"
 { SourceMap } := sourcemap
 export { parse, parseProgram, ParseError, generate, prune, lib, sourcemap, SourceMap }
-type { BlockStatement } from "./types.hera"
-export type BlockStatement
+import type { BlockStatement } from ./types.civet
+export type { ASTError, BlockStatement } from ./types.civet
 
 import StateCache from "./state-cache.civet"
 


### PR DESCRIPTION
As reported by @bbrk24 in Discord.

![image](https://github.com/user-attachments/assets/61810295-9156-4997-ab57-f631911cfcb4)

Also fixed some type errors that might have been actual bugs (don't pass in a `boolean` `sourceMap` option to `generate` by setting it to `undefined`, but then handle `undefined` `sourceMap`).