### PR TITLE
Fix CLI executing ESM code from stdin or `-e`

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -486,8 +486,16 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
 
   return repl args, options if options.repl
 
+  // Ignore EPIPE errors, e.g. when piping to `head`
+  process.stdout.on "error", (e) =>
+    if e.code is in ['EPIPE', 'EOF']
+      process.exit 0
+    else
+      console.error e
+      process.exit 1
+
   errors .= 0
-  for await {filename, error, content, stdin} of readFiles filenames, options.eval
+  for await let {filename, error, content, stdin} of readFiles filenames, options.eval
     if error
       console.error `${filename} failed to load:`
       console.error error
@@ -510,14 +518,6 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       console.error error
       errors++
       continue
-
-    // Ignore EPIPE errors, e.g. when piping to `head`
-    process.stdout.on "error", (e) =>
-      if e.code is in ['EPIPE', 'EOF']
-        process.exit 0
-      else
-        console.error e
-        process.exit 1
 
     if options.ast
       process.stdout.write JSON.stringify(output, null, 2)
@@ -546,13 +546,19 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
           console.error error
           errors++
     else if options.run
-      esm := /^\s*(import|export)\b/m.test output
+      esm := do
+        if output is like /\b(await|import|export)\b/  // potentially ESM
+          ast := await compile content!, {...options, ast: true, filename}
+          (or)
+            lib.hasAwait ast
+            lib.hasImportDeclaration ast
+            lib.hasExportDeclaration ast
       if esm
         // Run ESM code via `node --import @danielx/civet/register` subprocess
         if stdin
           // If code was read on stdin via command-line argument "-", try to
           // save it in a temporary file in same directory so paths are correct.
-          filename := `.stdin-${process.pid}.civet`
+          filename = `.stdin-${process.pid}.civet`
           try
             await fs.writeFile filename, content!, {encoding}
           catch e

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -52,6 +52,7 @@ import {
   flatJoin
   getTrimmingSpace
   hasAwait
+  hasExportDeclaration
   hasImportDeclaration
   hasYield
   inplaceInsertTrimmingSpace
@@ -1622,6 +1623,7 @@ export {
   getPrecedence
   getTrimmingSpace
   hasAwait
+  hasExportDeclaration
   hasImportDeclaration
   hasYield
   insertTrimmingSpace

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -21,9 +21,11 @@ export type StatementNode =
   | DeclarationStatement
   | DoStatement
   | EmptyStatement
+  | ExportDeclaration
   | ExpressionNode
   | ForStatement
   | IfStatement
+  | ImportDeclaration
   | IterationStatement
   | LabelledStatement
   | ReturnStatement
@@ -466,6 +468,21 @@ export type BlockStatement =
   implicitlyReturned?: boolean  // fat arrow function with no braces
   root?: boolean
   parent?: Parent
+
+export type ImportDeclaration
+  type: "ImportDeclaration"
+  children: Children
+  parent?: Parent
+  ts?: boolean
+  imports?: ASTNode
+  from?: ASTNode
+
+export type ExportDeclaration
+  type: "ExportDeclaration"
+  children: Children
+  parent?: Parent
+  ts?: boolean
+  declaration?: ASTNode
 
 export type DeclarationStatement =
   type: "Declaration"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -395,6 +395,9 @@ function hasYield(exp: ASTNode)
 function hasImportDeclaration(exp: ASTNode)
   gatherRecursiveWithinFunction(exp, .type is "ImportDeclaration").length > 0
 
+function hasExportDeclaration(exp: ASTNode)
+  gatherRecursiveWithinFunction(exp, .type is "ExportDeclaration").length > 0
+
 /**
 * Copy an AST node deeply, including children.
 * Ref nodes maintain identity
@@ -688,6 +691,7 @@ export {
   flatJoin
   getTrimmingSpace
   hasAwait
+  hasExportDeclaration
   hasImportDeclaration
   hasYield
   inplaceInsertTrimmingSpace


### PR DESCRIPTION
* Move error handling attachment outside the main loop so we don't add *n* error handlers (when not running code so might be compiling several files)
* For stdin inputs (including `-e` argument), fix `filename` not being exposed to rest of code, which caused a crash whenever running ESM code
* Fix ESM detection to do an actual AST analysis, and consider code with top-level `await` to be ESM (as it crashes in CJS mode)