### PR TITLE
Variance annotations (`in`/`out`) in type parameters

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8170,7 +8170,7 @@ TypeParameters
     }
 
 TypeParameter
-  __ ( "const" _? )? Identifier TypeConstraint? TypeInitializer? TypeParameterDelimiter
+  __ ( /const|in|out/ _ )* Identifier TypeConstraint? TypeInitializer? TypeParameterDelimiter
 
 TypeConstraint
   __ ExtendsToken Type

--- a/test/types/interface.civet
+++ b/test/types/interface.civet
@@ -134,6 +134,36 @@ describe "[TS] interface", ->
     }
   """
 
+  // https://www.typescriptlang.org/docs/handbook/2/generics.html#variance-annotations
+  testCase """
+    in out type parameters
+    ---
+    // Contravariant annotation
+    interface Consumer<in T>
+      consume: (arg: T) => void
+    // Covariant annotation
+    interface Producer<out T>
+      make(): T
+    // Invariant annotation
+    interface ProducerConsumer<in out T>
+      consume: (arg: T) => void
+      make(): T
+    ---
+    // Contravariant annotation
+    interface Consumer<in T> {
+      consume: (arg: T) => void
+    }
+    // Covariant annotation
+    interface Producer<out T> {
+      make(): T
+    }
+    // Invariant annotation
+    interface ProducerConsumer<in out T> {
+      consume: (arg: T) => void
+      make(): T
+    }
+  """
+
   testCase """
     comma delimited
     ---


### PR DESCRIPTION
Fixes #1455