### PR TITLE
Add missing parentheses with `++` concat operator

### DIFF
--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -189,12 +189,11 @@ function processBinaryOpExpression($0)
           wsOp = insertTrimmingSpace(wsOp, "")
           wsB = insertTrimmingSpace(wsB, "")
           if op.reversed
-            if (end !== i + 2) b = makeLeftHandSideExpression b
+            b = makeLeftHandSideExpression b unless b.type is "CallExpression"
             b = dotNumericLiteral b
             children = [wsB, b, wsOp, ".", op.method, "(", a, ")"]
           else
-            if start !== i - 2 or a.type === "NumericLiteral"
-              a = makeLeftHandSideExpression a
+            a = makeLeftHandSideExpression a unless a.type is "CallExpression"
             a = dotNumericLiteral a
             children = [a, wsOp, ".", op.method, "(", wsB, b, ")"]
         else if op.token

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -6,8 +6,8 @@ import type {
 } from ./types.civet
 
 import {
-  insertTrimmingSpace
   makeLeftHandSideExpression
+  trimFirstSpace
 } from ./util.civet
 
 import {
@@ -162,7 +162,7 @@ function processBinaryOpExpression($0)
           a = makeAsConst a
           b = makeAsConst b
 
-        let children
+        let children, type: string?
         if op.type is "PatternTest"
           children = [processPatternTest a, b]
         else if op.type is "ChainOp"
@@ -178,16 +178,16 @@ function processBinaryOpExpression($0)
               expandedOps[end+2].token is not '&&')
             children = ["(", ...children, ")"]
         else if op.call
-          wsOp = insertTrimmingSpace(wsOp, "")
-
+          wsOp = trimFirstSpace wsOp
           if op.reversed
-            wsB = insertTrimmingSpace(wsB, "")
+            wsB = trimFirstSpace wsB
             children = [wsOp, op.call, "(", wsB, b, ", ", a, ")", op.suffix]
           else
             children = [wsOp, op.call, "(", a, ",", wsB, b, ")", op.suffix]
+          type = "CallExpression"
         else if op.method
-          wsOp = insertTrimmingSpace(wsOp, "")
-          wsB = insertTrimmingSpace(wsB, "")
+          wsOp = trimFirstSpace wsOp
+          wsB = trimFirstSpace wsB
           if op.reversed
             b = makeLeftHandSideExpression b unless b.type is "CallExpression"
             b = dotNumericLiteral b
@@ -196,6 +196,7 @@ function processBinaryOpExpression($0)
             a = makeLeftHandSideExpression a unless a.type is "CallExpression"
             a = dotNumericLiteral a
             children = [a, wsOp, ".", op.method, "(", wsB, b, ")"]
+          type = "CallExpression"
         else if op.token
           children = [a, wsOp, op, wsB, b]
           if (op.negated) children = ["(", ...children, ")"]
@@ -205,6 +206,7 @@ function processBinaryOpExpression($0)
         children.push error if error?
 
         expandedOps.splice(start, end - start + 1, {
+          type
           children
         })
         i = start + 2

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -441,6 +441,7 @@ function removeHoistDecs(node: ASTNode): void
 
 skipParens := new Set [
   "AmpersandRef"
+  "ArrayExpression"
   "CallExpression"
   "Identifier"
   "JSXElement"
@@ -459,6 +460,8 @@ skipParens := new Set [
  * (Consider renaming and making parentheses depend on context.)
  */
 function makeLeftHandSideExpression(expression: ASTNode)
+  while [ item ] := expression
+    expression = item
   if isASTNodeObject expression
     return expression if expression.parenthesized
     return expression if skipParens.has expression.type

--- a/test/array.civet
+++ b/test/array.civet
@@ -741,8 +741,8 @@ describe "array", ->
       . d
       |> f
       ---
-      ([ a,
-        b]) as const
+      [ a,
+        b] as const
 
       f([ c,
         d])

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -414,7 +414,7 @@ describe "binary operations", ->
     ---
     0 ++ [1,2,3]++4
     ---
-    (0..concat([1,2,3])).concat(4)
+    0..concat([1,2,3]).concat(4)
   """
 
   // #1456

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -414,7 +414,16 @@ describe "binary operations", ->
     ---
     0 ++ [1,2,3]++4
     ---
-    0..concat([1,2,3]).concat(4)
+    (0..concat([1,2,3])).concat(4)
+  """
+
+  // #1456
+  testCase """
+    ++ less tight than as
+    ---
+    arr as string[] ++ y
+    ---
+    (arr as string[]).concat(y)
   """
 
   testCase """

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -336,9 +336,9 @@ describe "property access", ->
       ---
       let ref;[
         (exp.bindings?.length?
-          ([(ref = exp.bindings)[ref.length-1]])
+          [(ref = exp.bindings)[ref.length-1]]
         :
-          ([]))
+          [])
       ]
     """
 


### PR DESCRIPTION
Fixes #1456

Also removed some unnecessary parens around array expressions.

~~I'm not a fan of the extra parens in `x ++ y ++ z`: it previously compiled to `x.concat(y).concat(z)`, and now compiles to `(x.concat(y)).concat(z)`. But I didn't see an easy way to fix, because the binary expression precedence handler doesn't construct "correct" AST nodes.~~  I fixed some of the AST node types to fix this.