### PR TITLE
Pipeline doesn't unwrap in multi-`&` function shorthand

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,6 +1,5 @@
 import type {
   ASTNode
-  ASTNodeBase
   ASTNodeObject
   BlockStatement
   BreakStatement
@@ -13,9 +12,9 @@ import type {
   IterationStatement
   Parameter
   ParametersNode
+  Ref
   StatementTuple
   SwitchStatement
-  TypeIdentifier
   TypeNode
   Whitespace
 } from ./types.civet
@@ -802,7 +801,14 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
     braceBlock block
     // Prevent unrolling braced block
     fn.ampersandBlock = false
-    delete fn.body
+
+  // Prevent unrolling if placeholder is used multiple times
+  // (to avoid evaluating the argument twice)
+  if gatherRecursiveWithinFunction(
+       block
+       (is ref) as (x: ASTNode) => x is Ref
+     )# > 1
+    fn.ampersandBlock = false
 
   fn
 

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -23,10 +23,9 @@ function constructInvocation(fn, arg) {
 
   // Unwrap ampersand blocks
   let expr = fn.expr
-  while (expr.type is "ParenthesizedExpression") {
+  while expr.type is "ParenthesizedExpression"
     expr = expr.expression
-  }
-  if (expr.ampersandBlock) {
+  if expr.ampersandBlock
     const { ref, body } = expr
 
     ref.type = "PipedExpression"
@@ -37,7 +36,6 @@ function constructInvocation(fn, arg) {
       type: "UnwrappedExpression",
       children: [skipIfOnlyWS(fn.leadingComment), body, skipIfOnlyWS(fn.trailingComment)],
     }
-  }
 
   expr = fn.expr
   const lhs = makeLeftHandSideExpression(expr)

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -327,6 +327,14 @@ describe "pipe", ->
       ($: number) => Math.ceil(($+ 1)/2)
     """
 
+    testCase """
+      double use of &
+      ---
+      x() |> &+&
+      ---
+      ($ => $+$)(x())
+    """
+
   describe "thicc", ->
     testCase """
       basic


### PR DESCRIPTION
Fixes #1172

I opted to keep the ampersand function a function here, instead of unwrapping and using refs, because:
* it was easier to implement
* it seems slightly closer to the input