### PR TITLE
Compiler directives `iife` and `repl` for wrapping program, fix `comptime` implicitly returned from function

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -320,41 +320,16 @@ export function repl(args: string[], options: Options)
             return callback null, undefined
           return callback null, output
 
+        parseOptions := {...options.parseOptions,
+          repl: true
+        }
+
         let ast: BlockStatement
         try
-          ast = await compile input, {...options, filename, ast: true}
+          ast = await compile input, {...options, parseOptions, filename, ast: true}
         catch error
           showError error
           return callback null, undefined
-
-        // Wrap in IIFE if there's a top-level await or import
-        // Use Civet's async do, so Civet does implicit return of last value
-        // (copied from playground.worker.js)
-        topLevelAwait := lib.hasAwait(ast) or lib.hasImportDeclaration(ast)
-        if topLevelAwait
-          [prologue, rest] := parse input,
-            startRule: 'ProloguePrefix'
-            filename: '--civet argument'
-          prefix := input.slice 0, -rest.length
-          coffee := prologue.some (p) => p.type is "CivetPrologue" and
-            (p.config.coffeeCompat or p.config.coffeeDo)
-          ast = await compile
-            prefix +
-            (coffee ? '(do ->\n' : 'async do\n') +
-            rest.replace(/^/gm, ' ') +
-            (coffee ? ')' : ''),
-            {...options, filename, ast: true}
-          // Hoist top-level declarations outside the IIFE wrapper
-          topBlock :=
-            if coffee
-              lib.gatherRecursive(ast.children, &.type is 'BlockStatement')[0]
-            else
-              lib.gatherRecursive(ast.children, &.type is 'DoStatement')[0].block
-          for each [, statement] of topBlock.expressions
-            if statement is like {type: 'Declaration'}
-              statement.children.shift() // const/let/var
-              ast = [ast] unless Array.isArray ast
-              ast.unshift `var ${statement.names.join ','};`
 
         errors: ASTError[] .= []
         try
@@ -379,7 +354,7 @@ export function repl(args: string[], options: Options)
         catch error
           return callback error as Error, undefined
 
-        if topLevelAwait
+        if ast.topLevelAwait
           // If there was a top-level await, the result is a promise
           // that we need to await before returning it.
           try

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -190,6 +190,7 @@ Program
       children: [reset, init, ws1, statements, ws2],
       bare: true,
       root: true,
+      topLevelAwait: hasAwait(statements),
     }
     processProgram(program)
     return program
@@ -4147,8 +4148,7 @@ AwaitOp
 
 # https://262.ecma-international.org/#prod-ModuleItem
 ModuleItem
-  ImportDeclaration
-  ExportDeclaration
+  IsBare ( ImportDeclaration / ExportDeclaration ) -> $2
   StatementListItem
 
 # https://262.ecma-international.org/#prod-StatementListItem
@@ -8443,6 +8443,10 @@ ObjectIsEnabled
     if(config.objectIs) return
     return $skip
 
+IsBare
+  "" ->
+    if(config.iife || config.repl) return $skip
+
 # Reset module level data
 Reset
   "" ->
@@ -8487,12 +8491,14 @@ Reset
       coffeePrototype: false,
       defaultElement: "div",
       globals: [],
+      iife: false,
       implicitReturns: true,
       jsxCode: false,
       objectIs: false,
       react: false,
       solid: false,
       client: false, // default behavior: client only
+      repl: false,
       rewriteTsImports: true,
       server: false,
       tab: undefined, // default behavior = same as space

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -6,6 +6,7 @@
 vm from "node:vm"
 
 import type {
+  BlockStatement
   ComptimeExpression
   ComptimeStatement
   StatementTuple
@@ -13,12 +14,31 @@ import type {
 
 import {
   gatherRecursive
-} from "./traversal.civet"
+} from ./traversal.civet
+
+import {
+  hasAwait
+  makeNode
+  wrapIIFE
+} from ./util.civet
 
 { extractPreludeFor } from "./helper.civet"
 { getFilename, getInitialConfig, getSync } from "../parser.hera"
 
 generate, { prune, type Options } from "../generate.civet"
+
+/**
+Transform ComptimeStatement into ComptimeExpression,
+with IIFE wrapper inside the ComptimeExpression, and no await
+*/
+function expressionizeComptime(statement: ComptimeStatement): ComptimeExpression
+  { expressions } := statement.block
+  expression := wrapIIFE expressions, hasAwait expressions
+  makeNode {
+    type: "ComptimeExpression"
+    expression
+    children: [expression]
+  }
 
 function processComptime(statements: StatementTuple[]): void | Promise<void>
   // Prevent comptime setting from being overridden by directives
@@ -116,6 +136,9 @@ function runComptime(statements: StatementTuple[]): unknown[]
       // but we still might need to await the output
       promise = output
       exp.children = []
+      if exp.parent is like {type: "BlockStatement", bare: true} and
+         not (exp.parent as BlockStatement).root
+        exp.children.push ";"
     promise
 
 function serialize(value: ???, context?: NodeJS.Dict<any>): string
@@ -263,6 +286,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
   recurse value
 
 export {
+  expressionizeComptime
   processComptime
   serialize
 }

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -12,7 +12,6 @@ import type {
   IterationStatement
   Parameter
   ParametersNode
-  Ref
   StatementTuple
   SwitchStatement
   TypeNode

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -29,6 +29,14 @@ import {
 } from ./binding.civet
 
 import {
+  expressionizeComptime
+} from ./comptime.civet
+
+import {
+  replaceNode
+} from ./lib.civet
+
+import {
   findAncestor
   findChildIndex
   gatherNodes
@@ -343,7 +351,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
         if node.parent.type is "CatchClause"
           node.expressions.push(["return"])
       return
-    // NOTE: "CaseClause"s don't get a return statements inserted
+    // NOTE: "CaseClause"s don't get a return statement inserted
     when "WhenClause"
       // Remove inserted `break;` if it hasn't already been removed
       node.children.splice node.children.indexOf(node.break), 1 if node.break
@@ -500,10 +508,22 @@ function wrapIterationReturningResults(
   collect?: (node: ASTNode) => ASTNode
 ): void
   if statement.type is "DoStatement" or statement.type is "ComptimeStatement"
-    if collect
-      assignResults(statement.block, collect)
+    let results: ASTNode
+    if statement.type is "ComptimeStatement"
+      // Always wrap comptime in IIFE
+      insertReturn statement.block, outer
+      expression := expressionizeComptime statement
+      replaceNode statement, expression
+      parent := expression.parent as BlockStatement?
+      results = parent?.expressions?[findChildIndex parent?.expressions, expression]
+      assert.equal (results as StatementTuple)?[1], expression,
+        "comptime statement found outside statement tuple"
     else
-      insertReturn(statement.block, outer)
+      results = statement.block
+    if collect
+      assignResults results, collect
+    else
+      insertReturn results, outer
     return
 
   assert.equal statement.resultsRef, undefined,

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1195,13 +1195,22 @@ function processProgram(root: BlockStatement): void
   config := getConfig()
 
   // invariants
-  assert.equal(state.forbidBracedApplication.length, 1, "forbidBracedApplication")
-  assert.equal(state.forbidClassImplicitCall.length, 1, "forbidClassImplicitCall")
-  assert.equal(state.forbidIndentedApplication.length, 1, "forbidIndentedApplication")
-  assert.equal(state.forbidNestedBinaryOp.length, 1, "forbidNestedBinaryOp")
-  assert.equal(state.forbidNewlineBinaryOp.length, 1, "forbidNewlineBinaryOp")
-  assert.equal(state.forbidTrailingMemberProperty.length, 1, "forbidTrailingMemberProperty")
-  assert.equal(state.JSXTagStack.length, 1, "JSXTagStack")
+  assert.equal state.forbidBracedApplication#, 1, "forbidBracedApplication"
+  assert.equal state.forbidClassImplicitCall#, 1, "forbidClassImplicitCall"
+  assert.equal state.forbidIndentedApplication#, 1, "forbidIndentedApplication"
+  assert.equal state.forbidNestedBinaryOp#, 1, "forbidNestedBinaryOp"
+  assert.equal state.forbidNewlineBinaryOp#, 1, "forbidNewlineBinaryOp"
+  assert.equal state.forbidTrailingMemberProperty#, 1, "forbidTrailingMemberProperty"
+  assert.equal state.JSXTagStack#, 1, "JSXTagStack"
+
+  let rootIIFE: ASTNode
+  if config.iife or config.repl
+    // Avoid top-level await if code is async (same as CoffeeScript),
+    // so that code works in CommonJS environment and so REPL can eval it
+    rootIIFE = wrapIIFE root.expressions, root.topLevelAwait
+    newExpressions: StatementTuple[] := [['', rootIIFE]]
+    root.children = root.children.map & is root.expressions ? newExpressions : &
+    root.expressions = newExpressions
 
   addParentPointers(root)
 
@@ -1245,6 +1254,15 @@ function processProgram(root: BlockStatement): void
 
   populateRefs(statements)
   adjustAtBindings(statements)
+
+  // REPL wants all top-level variables hoisted to outermost scope
+  if config.repl
+    topBlock :=
+      gatherRecursive(rootIIFE!, .type is 'BlockStatement')[0]
+    for each [, statement] of topBlock.expressions
+      if statement is like {type: 'Declaration'}
+        statement.children.shift() // remove const/let/var
+        root.expressions.unshift ['', `var ${statement.names.join ','};`]
 
   // Run synchronous versions of async steps in case we're in sync mode
   if getSync()

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -17,6 +17,7 @@ import type {
   BlockStatement
   CallExpression
   CatchClause
+  ComptimeStatement
   Condition
   DeclarationStatement
   DoStatement
@@ -129,7 +130,7 @@ import {
   processUnaryNestedExpression
 } from ./unary.civet
 import { createConstLetDecs, createVarDecs } from ./auto-dec.civet
-import { processComptime } from ./comptime.civet
+import { expressionizeComptime, processComptime } from ./comptime.civet
 import { getHelperRef } from ./helper.civet
 
 import {
@@ -1146,15 +1147,9 @@ function processStatementExpressions(statements: StatementTuple[]): void
             replaceNode statement, wrapIIFE([["", statement]]), exp
         when "IterationExpression"
           if statement.subtype is "ComptimeStatement"
-            // Transform ComptimeStatement into ComptimeExpression,
-            // with IIFE wrapper inside the ComptimeExpression, and no await
-            { expressions } := statement.statement.block
-            expression := wrapIIFE expressions, hasAwait expressions
-            replaceNode statement, makeNode({
-              type: "ComptimeExpression"
-              expression
-              children: [expression]
-            }), exp
+            replaceNode statement,
+              expressionizeComptime statement.statement as ComptimeStatement
+              exp
           // else do nothing, handled separately currently
         else
           replaceNode statement, wrapIIFE([["", statement]]), exp

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -466,7 +466,8 @@ export type BlockStatement =
   empty?: boolean  // empty block
   implicit?: boolean  // implicit empty block
   implicitlyReturned?: boolean  // fat arrow function with no braces
-  root?: boolean
+  root?: boolean  // is this the global root block for the program?
+  topLevelAwait?: boolean // for root block, is there top-level `await`? (before any IIFE wrapping)
   parent?: Parent
 
 export type ImportDeclaration
@@ -884,9 +885,9 @@ export type TypeIdentifier =
   children: Children
   parent?: Parent
   raw: string
-  args: TypeArgumentsNode
+  args: TypeArguments
 
-export type TypeArgumentsNode =
+export type TypeArguments =
   type: "TypeArguments"
   ts: true
   types: TypeNode[]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -570,8 +570,8 @@ function parenthesizeType(type: ASTNode)
   ["(", type, ")"]
 
 /**
- * Wrap an expression in an IIFE, adding async/await if expression
- * uses await, or just adding async if specified.
+ * Wrap expressions in an IIFE, adding async/await if expressions
+ * use await, or just adding async if specified.
  * Uses function* instead of arrow function if given generator star.
  * Returns an Array suitable for `children`.
  */

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -28,6 +28,14 @@ describe "comptime", ->
 
   """, options
 
+  testCase """
+    one-line statement in loop
+    ---
+    loop comptime x := 5
+    ---
+    while(true) ;
+  """, options
+
   it "statement has no side effect on globalThis", =>
     globalThis.outside = 0
     await compile "comptime globalThis.outside = 7", options
@@ -62,6 +70,22 @@ describe "comptime", ->
     value := 1 + comptime 2+3
     ---
     const value = 1 + 5
+  """, options
+
+  testCase """
+    implicit return from function
+    ---
+    => comptime 1+2
+    ---
+    () => { return 3 }
+  """, options
+
+  testCase """
+    implicit return from loop
+    ---
+    value := loop comptime 1+2
+    ---
+    const results=[];while(true) results.push(3);const value =results
   """, options
 
   testCase """
@@ -207,6 +231,14 @@ describe "comptime", ->
       const value = (()=>{
         const x = 5
         return x * x})()
+    """
+
+    testCase """
+      implicit return from function
+      ---
+      => comptime 1+2
+      ---
+      () => { return (()=>{ return 1+2})() }
     """
 
     testCase """

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -33,6 +33,8 @@ declare module "@danielx/civet" {
     tab: number
     verbose: boolean
     comptime: boolean
+    iife: boolean
+    repl: boolean
   }>
   export type CompileOptions = {
     filename?: string


### PR DESCRIPTION
Fixes #1195 as shown here:

![image](https://github.com/user-attachments/assets/31abf2d9-5de9-4168-8cce-0fb5c0f68c0a)

More generally, I followed the idea in https://github.com/DanielXMoore/Civet/issues/1195#issuecomment-2081269154 to add two general mechanisms for wrapping programs in IIFEs:
* `"civet iife"` adds a wrapper similar to CoffeeScript, except that we also support `import` (via dynamizing `import`). This can be useful when running non-module scripts in the browser (to avoid `var` becoming a global) or when concatenating CJS scripts together (to avoid declarations from earlier scripts from being visible to later scripts). But in particular a step toward:
* `"civet repl"` additionally pulls top-level declarations out, like we had a ton of gross code to do in both the CLI and Playground. Now it's just adding an option and we get exactly the code we need to `eval`!

This approach has an added benefit of correctly returning the last value of a code block from Civet's perspective. For example:

```
🐱> i .= 5
... while i < 10
...   i++
...
[ 5, 6, 7, 8, 9 ]
🐱> do
...   i .= 5
...   while i < 10
...     i++
...
[ 5, 6, 7, 8, 9 ]
```

By contrast, these examples previously returned `9` (see https://github.com/DanielXMoore/Civet/issues/1195#issuecomment-2081268241 ).

To finish #1195, I noticed another problem: `=> comptime 1+2` [crashed](https://civet.dev/playground?code=PT4gY29tcHRpbWUgMSsy) when `comptime: true`. It turns out that `comptime` got expressionized (wrapped in its own IIFE) only when it was used in a true expression context, like `1 + comptime 2+3`. When it was implicitly returned by a function, or added to a loop results array, it didn't work. This was particularly annoying in `"civet repl"` mode because we automatically get a function wrapper. The second commit fixes this bug.