### PR TITLE
`repl` directive hoists function and class declarations too, fix one-line declarations in `if`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -977,10 +977,12 @@ ClassDeclaration
 ClassExpression
   Decorators?:decorators ( Abstract __ )?:abstract Class !":" ClassBinding?:binding ClassHeritage?:heritage ClassBody:body ->
     return {
+      type: "ClassExpression",
       decorators,
       abstract,
       binding,
       id: binding?.[0],
+      name: binding?.[0].name,
       heritage,
       body,
       children: $0,
@@ -5717,6 +5719,7 @@ VariableStatement
       ...$3,
       names: $3.names,
       children: [$1, ...$2, ...$3.children],
+      decl: "var",
     }
 
 # https://262.ecma-international.org/#prod-VariableDeclarationList

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2510,7 +2510,7 @@ Block
 
   ThenClause
   # NOTE: !EOS prevents capturing a following unindented Statement
-  _?:ws !EOS Statement:s ->
+  _?:ws !EOS DeclarationOrStatement:s ->
     const expressions = [[ws, s]]
     return {
       type: "BlockStatement",

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -206,7 +206,7 @@ function processReturnValue(func: FunctionNode)
 
   return true
 
-function patternAsValue(pattern)
+function patternAsValue(pattern): ASTNode
   switch (pattern.type) {
     case "ArrayBindingPattern": {
       const children = [...pattern.children]
@@ -371,36 +371,45 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
   return if isExit exp
 
   outer := exp
-  {type} .= exp
-  if type is "LabelledStatement"
+  if exp.type is "LabelledStatement"
     exp = exp.statement
-    {type} = exp
 
-  switch type
+  switch exp.type
     when "BreakStatement", "ContinueStatement", "DebuggerStatement", "EmptyStatement", "ReturnStatement", "ThrowStatement"
       return
     when "Declaration"
       value := if exp.bindings?.#
         [" ", patternAsValue(exp.bindings.-1.pattern)]
       else
-        []
-      exp.children.push ["", {
+        [] as ASTNode
+      parent := outer.parent as BlockStatement?
+      index := findChildIndex parent?.expressions, outer
+      assert.notEqual index, -1, "Could not find declaration in parent"
+      parent!.expressions.splice index+1, 0, ["", {
         type: "ReturnStatement"
+        expression: value
         children: [
-          ";return",
-          ...value
+          ";" unless parent!.expressions[index][2] is ";"
+          "return"
+          value
         ]
         parent: exp
       }]
+      braceBlock parent!
       return
     when "FunctionExpression"
       // Add return after function declaration if it has an id to not interfere with hoisting
       if exp.id
-        exp.children.push ["",
+        parent := outer.parent as BlockStatement?
+        index := findChildIndex parent?.expressions, outer
+        assert.notEqual index, -1, "Could not find function declaration in parent"
+        parent!.expressions.splice index+1, 0, ["",
           type: "ReturnStatement"
+          expression: exp.id
           children: [";return ", exp.id]
           parent: exp
         ]
+        braceBlock parent!
         return
       /* c8 ignore next 3 */
       // This is currently never hit because anonymous FunctionExpressions are already wrapped in parens by this point

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1252,31 +1252,7 @@ function processProgram(root: BlockStatement): void
   adjustAtBindings(statements)
 
   // REPL wants all top-level variables hoisted to outermost scope
-  if config.repl
-    topBlock :=
-      gatherRecursive(rootIIFE!, .type is "BlockStatement")[0]
-    i .= 0
-    // Hoist top-level declarations and all var declarations
-    for each decl of gatherRecursiveWithinFunction topBlock, .type is "Declaration"
-      if decl.parent is topBlock or decl.decl is "var"
-        decl.children.shift() // remove const/let/var
-        root.expressions.splice i++, 0, ["", `var ${decl.names.join ','};`]
-    // Hoist all function declarations, and hoist values when top-level
-    for each func of gatherRecursive topBlock, .type is "FunctionExpression"
-      if func.name and func.parent?.type is "BlockStatement" // declaration
-        if func.parent is topBlock
-          // Top-level => hoist to beginning
-          replaceNode func, undefined
-          root.expressions.splice i++, 0, ["", func]
-          func.parent = root
-        else
-          func.children.unshift func.name, "="
-          root.expressions.splice i++, 0, ["", `var ${func.name};`]
-    // Hoist top-level class declarations (like `let`)
-    for each classExp of gatherRecursiveWithinFunction topBlock, .type is "ClassExpression"
-      if classExp.name and classExp.parent is topBlock
-          classExp.children.unshift classExp.name, "="
-          root.expressions.splice i++, 0, ["", `var ${classExp.name};`]
+  processRepl root, rootIIFE if config.repl
 
   // Run synchronous versions of async steps in case we're in sync mode
   if getSync()
@@ -1287,8 +1263,34 @@ async function processProgramAsync(root: BlockStatement): Promise<void>
   { expressions: statements } := root
   await processComptime(statements)
 
+function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
+  topBlock :=
+    gatherRecursive(rootIIFE!, .type is "BlockStatement")[0]
+  i .= 0
+  // Hoist top-level declarations and all var declarations
+  for each decl of gatherRecursiveWithinFunction topBlock, .type is "Declaration"
+    if decl.parent is topBlock or decl.decl is "var"
+      decl.children.shift() // remove const/let/var
+      root.expressions.splice i++, 0, ["", `var ${decl.names.join ','};`]
+  // Hoist all function declarations, and hoist values when top-level
+  for each func of gatherRecursive topBlock, .type is "FunctionExpression"
+    if func.name and func.parent?.type is "BlockStatement" // declaration
+      if func.parent is topBlock
+        // Top-level => hoist to beginning
+        replaceNode func, undefined
+        root.expressions.splice i++, 0, ["", func]
+        func.parent = root
+      else
+        func.children.unshift func.name, "="
+        root.expressions.splice i++, 0, ["", `var ${func.name};`]
+  // Hoist top-level class declarations (like `let`)
+  for each classExp of gatherRecursiveWithinFunction topBlock, .type is "ClassExpression"
+    if classExp.name and classExp.parent is topBlock
+        classExp.children.unshift classExp.name, "="
+        root.expressions.splice i++, 0, ["", `var ${classExp.name};`]
+
 function populateRefs(statements: ASTNode): void {
-  const refNodes = gatherRecursive(statements, ({ type }) => type is "Ref")
+  const refNodes = gatherRecursive(statements, .type is "Ref")
 
   if (refNodes.length) {
     // Find all ids within nested scopes

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1285,9 +1285,9 @@ function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
         root.expressions.splice i++, 0, ["", `var ${func.name};`]
   // Hoist top-level class declarations (like `let`)
   for each classExp of gatherRecursiveWithinFunction topBlock, .type is "ClassExpression"
-    if classExp.name and classExp.parent is topBlock
-        classExp.children.unshift classExp.name, "="
-        root.expressions.splice i++, 0, ["", `var ${classExp.name};`]
+    if classExp.name and classExp.parent is topBlock or classExp.parent is like {type: "ReturnStatement", parent: ^topBlock}
+      classExp.children.unshift classExp.name, "="
+      root.expressions.splice i++, 0, ["", `var ${classExp.name};`]
 
 function populateRefs(statements: ASTNode): void {
   const refNodes = gatherRecursive(statements, .type is "Ref")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -25,6 +25,7 @@ import type {
   ExpressionNode
   FinallyClause
   ForStatement
+  FunctionExpression
   IfStatement
   IterationStatement
   MemberExpression
@@ -1253,11 +1254,29 @@ function processProgram(root: BlockStatement): void
   // REPL wants all top-level variables hoisted to outermost scope
   if config.repl
     topBlock :=
-      gatherRecursive(rootIIFE!, .type is 'BlockStatement')[0]
-    for each [, statement] of topBlock.expressions
-      if statement is like {type: 'Declaration'}
-        statement.children.shift() // remove const/let/var
-        root.expressions.unshift ['', `var ${statement.names.join ','};`]
+      gatherRecursive(rootIIFE!, .type is "BlockStatement")[0]
+    i .= 0
+    // Hoist top-level declarations and all var declarations
+    for each decl of gatherRecursiveWithinFunction topBlock, .type is "Declaration"
+      if decl.parent is topBlock or decl.decl is "var"
+        decl.children.shift() // remove const/let/var
+        root.expressions.splice i++, 0, ["", `var ${decl.names.join ','};`]
+    // Hoist all function declarations, and hoist values when top-level
+    for each func of gatherRecursive topBlock, .type is "FunctionExpression"
+      if func.name and func.parent?.type is "BlockStatement" // declaration
+        if func.parent is topBlock
+          // Top-level => hoist to beginning
+          replaceNode func, undefined
+          root.expressions.splice i++, 0, ["", func]
+          func.parent = root
+        else
+          func.children.unshift func.name, "="
+          root.expressions.splice i++, 0, ["", `var ${func.name};`]
+    // Hoist top-level class declarations (like `let`)
+    for each classExp of gatherRecursiveWithinFunction topBlock, .type is "ClassExpression"
+      if classExp.name and classExp.parent is topBlock
+          classExp.children.unshift classExp.name, "="
+          root.expressions.splice i++, 0, ["", `var ${classExp.name};`]
 
   // Run synchronous versions of async steps in case we're in sync mode
   if getSync()

--- a/source/parser/traversal.civet
+++ b/source/parser/traversal.civet
@@ -19,7 +19,7 @@ function gatherRecursiveWithinFunction<T extends ASTNodeObject>(node: ASTNode, p
  * which is useful for working with e.g. the `expressions` property.
  * Returns -1 if `child` cannot be found.
  */
-function findChildIndex(parent: ASTNodeObject | Children, child: ASTNode)
+function findChildIndex(parent: (ASTNodeObject | Children)?, child: ASTNode)
   return -1 unless parent?
   children := Array.isArray(parent) ? parent : (parent as {children?: Children}).children
   return -1 unless children?

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -41,6 +41,7 @@ export type ExpressionNode =
   | AssignmentExpression
   | BinaryOp
   | CallExpression
+  | ClassExpression
   | ComptimeExpression
   | Existence
   | FunctionNode
@@ -868,6 +869,17 @@ type ParameterElementDelimiter = ASTNode
 export type TypeParameters = unknown
 
 export type FunctionNode = FunctionExpression | ArrowFunction | MethodDefinition
+
+export type ClassExpression
+  type: "ClassExpression"
+  children: Children
+  parent?: Parent
+  name: string
+  id: Identifier
+  heritage: ASTNode
+  body: ClassBody
+
+export type ClassBody = BlockStatement & { subtype: "ClassBody" }
 
 export type Literal =
   type: "Literal"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -370,22 +370,26 @@ export type CaseBlock
   type: "CaseBlock"
   clauses: (PatternClause | CaseClause | WhenClause | DefaultClause)[]
   children: Children
+  parent?: Parent
 
 export type PatternClause
   type: "PatternClause"
   children: Children
+  parent?: Parent
   patterns: PatternExpression[]
   block: BlockStatement
 
 export type CaseClause
   type: "CaseClause"
   children: Children
+  parent?: Parent
   cases: ASTNode[]
   block: BlockStatement
 
 export type WhenClause
   type: "WhenClause"
   children: Children
+  parent?: Parent
   cases: ASTNode[]
   break: ASTNode
   block: BlockStatement
@@ -393,6 +397,7 @@ export type WhenClause
 export type DefaultClause
   type: "DefaultClause"
   children: Children
+  parent?: Parent
   block: BlockStatement
 
 export type EmptyStatement
@@ -456,6 +461,7 @@ export type AtBinding =
   type: "AtBinding"
   ref: ASTRef
   children: Children & [ASTRef]
+  parent?: Parent
 
 export type BlockStatement =
   type: "BlockStatement"
@@ -498,6 +504,7 @@ export type DeclarationStatement =
 export type Binding =
   type: "Binding"
   children: Children
+  parent?: Parent
   names: string[]
   pattern: BindingIdentifier | BindingPattern
   typeSuffix: TypeSuffix?
@@ -638,6 +645,7 @@ export type Placeholder =
 export type PinPattern =
   type: "PinPattern"
   children: Children
+  parent?: Parent
   expression: ExpressionNode
 
 // _?, __
@@ -701,6 +709,7 @@ export type ObjectBindingPatternContent =
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",
   children: Children & [Whitespace, ASTLeaf, ObjectBindingPatternContent, WSNode, ASTLeaf]
+  parent?: Parent
   names: string[]
   properties: ObjectBindingPatternContent
   typeSuffix?: TypeSuffix?
@@ -747,11 +756,12 @@ export type Argument
   expression: ASTNode
   spread: ASTNode?
 
-export type FunctionExpression =
+export type FunctionExpression
   type: "FunctionExpression"
   children: Children
   parent?: Parent
   name: string
+  id: Identifier
   async: ASTNode[]
   generator: ASTNode[]
   signature: FunctionSignature
@@ -805,6 +815,7 @@ export type FunctionSignature =
   children: Children
   parent?: Parent
   name: string
+  id: Identifier
   optional: unknown
   modifier: MethodModifier
   returnType: ReturnTypeAnnotation?
@@ -817,6 +828,7 @@ export type TypeSuffix =
   nonnull?: ASTNode
   t?: ASTNode
   children: Children
+  parent?: Parent
 
 export type ReturnTypeAnnotation =
   type: "ReturnTypeAnnotation"
@@ -858,7 +870,7 @@ export type TypeParameters = unknown
 export type FunctionNode = FunctionExpression | ArrowFunction | MethodDefinition
 
 export type Literal =
-  type: "Literal",
+  type: "Literal"
   subtype?: "NumericLiteral" | "StringLiteral"
   children: Children & [ LiteralContentNode ]
   parent?: Parent

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -24,6 +24,9 @@ assert := {
   equal(a: unknown, b: unknown, msg: string): void
     /* c8 ignore next */
     throw new Error(`Assertion failed [${msg}]: ${a} !== ${b}`) if a !== b
+  notEqual(a: unknown, b: unknown, msg: string): void
+    /* c8 ignore next */
+    throw new Error(`Assertion failed [${msg}]: ${a} === ${b}`) if a === b
 }
 
 /**

--- a/test/function.civet
+++ b/test/function.civet
@@ -94,20 +94,6 @@ describe "function", ->
   """
 
   testCase """
-    const declaration as implicit return
-    ---
-    ->
-      fn2 := () ->
-        x
-    ---
-    (function() {
-      const fn2 = function() {
-        return x
-      };return fn2
-    })
-  """
-
-  testCase """
     async const declaration
     ---
     defaultLoad := async ->
@@ -553,25 +539,6 @@ describe "function", ->
     [ () => {
       return 1+2
     }]
-  """
-
-  testCase """
-    nested implicit return fat arrow
-    ---
-    function g() {
-      function f() {
-        y((node) =>
-            x)
-      }
-    }
-    ---
-    function g() {
-      function f() {
-        return y((node) => {
-            return x
-        })
-      };return f
-    }
   """
 
   testCase """
@@ -1113,6 +1080,20 @@ describe "function", ->
     """
 
     testCase """
+      const declaration
+      ---
+      ->
+        fn2 := () ->
+          x
+      ---
+      (function() {
+        const fn2 = function() {
+          return x
+        };return fn2
+      })
+    """
+
+    testCase """
       renamed declaration
       ---
       ->
@@ -1132,6 +1113,33 @@ describe "function", ->
       (function() {
         const [ { x: other, y = init, ...r }, z = 0, ...rest ] = list;return [ { other, y, ...r }, z, ...rest ]
       })
+    """
+
+    testCase """
+      nested implicit return fat arrow
+      ---
+      function g() {
+        function f() {
+          y((node) =>
+              x)
+        }
+      }
+      ---
+      function g() {
+        function f() {
+          return y((node) => {
+              return x
+          })
+        };return f
+      }
+    """
+
+    testCase """
+      one-line function adds braces
+      ---
+      (x) => if (x) function f() { x }
+      ---
+      (x) => { if (x) { function f() { return x };return f};return }
     """
 
     testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -422,6 +422,14 @@ describe "if", ->
   """
 
   testCase """
+    one-line declaration
+    ---
+    => if (x) y := 5
+    ---
+    () => { if (x) { const y = 5;return y};return }
+  """
+
+  testCase """
     postfix if
     ---
     return true if x

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -85,6 +85,20 @@ describe "repl directive", ->
   """
 
   testCase """
+    var declarations in functions
+    ---
+    "civet repl"
+    function f()
+      var x = 5
+    => var y = f()
+    ---
+    function f() {
+      var x = 5;return x
+    }(()=>{
+    return () => { var y = f();return y }})()
+  """
+
+  testCase """
     top-level functions
     ---
     "civet repl"

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -1,0 +1,164 @@
+{testCase} from ./helper.civet
+
+describe "iife directive", ->
+  testCase """
+    implicit return
+    ---
+    "civet iife"
+    x := 5
+    x * x
+    ---
+    (()=>{const x = 5
+    return x * x})()
+  """
+
+  testCase """
+    loop
+    ---
+    "civet iife"
+    i .= 5
+    while i < 10
+      i++
+    ---
+    (()=>{let i = 5
+    const results=[];while (i < 10) {
+      results.push(i++)
+    };return results;})()
+  """
+
+  testCase """
+    async
+    ---
+    "civet iife"
+    fetch 'https://civet.dev'
+    |> await
+    |> .status
+    |> console.log
+    ---
+    (async ()=>{return console.log((await fetch('https://civet.dev')).status)})()
+  """
+
+describe "repl directive", ->
+  testCase """
+    top-level declarations
+    ---
+    "civet repl"
+    x := 5
+    y := 10
+    ---
+    var x;var y;(()=>{x = 5
+    y = 10;return y})()
+  """
+
+  testCase """
+    inner declarations
+    ---
+    "civet repl"
+    if true
+      x := 5
+    else
+      y .= 10
+    ---
+    (()=>{if (true) {
+      const x = 5;return x
+    }
+    else {
+      let y = 10;return y
+    }})()
+  """
+
+  testCase """
+    inner var declarations
+    ---
+    "civet repl"
+    if true
+      var x = 5
+    else
+      var y = 10
+    ---
+    var x;var y;(()=>{if (true) {
+       x = 5;return x
+    }
+    else {
+       y = 10;return y
+    }})()
+  """
+
+  testCase """
+    top-level functions
+    ---
+    "civet repl"
+    f()
+    function f() console.log 'hi'
+    ---
+    function f() { return console.log('hi') }(()=>{f()
+    ;return f})()
+  """
+
+  testCase """
+    inner functions
+    ---
+    "civet repl"
+    if true
+      function f() console.log 'hi'
+    else
+      function f() console.log 'bye'
+    f()
+    ---
+    var f;var f;(()=>{if (true) {
+      f=function f() { return console.log('hi') }
+    }
+    else {
+      f=function f() { return console.log('bye') }
+    }
+    return f()})()
+  """
+
+  testCase """
+    top-level class
+    ---
+    "civet repl"
+    class C
+    new C
+    ---
+    var C;(()=>{C=class C {
+    }
+    return new C})()
+  """
+
+  testCase """
+    returned top-level class
+    ---
+    "civet repl"
+    class C
+    ---
+    var C;(()=>{return C=class C {
+    }})()
+  """
+
+  testCase """
+    inner classesj
+    ---
+    "civet repl"
+    if true
+      class C
+        value = 'yes'
+      new C
+    else
+      class C
+        value = 'no'
+      new C
+    ---
+    (()=>{if (true) {
+      class C {
+        value = 'yes'
+      }
+      return new C
+    }
+    else {
+      class C {
+        value = 'no'
+      }
+      return new C
+    }})()
+  """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1337,7 +1337,7 @@ describe "switch", ->
             foo()
       ---
       () => {
-        if(Array.isArray(x) && x.length >= 1) {const [_, ...ref] = x;return;}
+        if(Array.isArray(x) && x.length >= 1) {const [_, ...ref] = x;return}
       else  {
             return foo()
           }


### PR DESCRIPTION
Follow-up to #1463 to also hoist `function` and `class` declarations like JavaScript does:
* Top-level `function`s gets declaration and value hoisted to outside, by physically moving the declaration
* Inner `function`s get declaration hoisted outside but value remains where it is.
* `class` declarations get hoisted like `let`: only top-level get hoisted.
* Also fixed: inner `var` declarations get hoisted to outside.

As a result, the CLI behaves like this:

```
🐱> f()
... function f() console.log 'hi'
...
hi
[Function: f]
🐱> f()
...
hi
undefined
🐱> if true
...   function g() console.log 'yes'
... else
...   function g() console.log 'no'
... g()
...
yes
undefined
🐱> g()
...
yes
undefined
🐱> class C
...
[class C]
🐱> new C
...
C {}
```

A necessary step to get here was to clean up how declarations and functions get implicitly returned. Before, we added a `ReturnStatement` *inside* the declaration/function. Now it's added to the parent block, which makes more sense. Also, I realized we weren't bracing the block, leading to [the wrong thing getting returned](https://civet.dev/playground?code=PT4gaWYgKHgpIGZ1bmN0aW9uIGYoKQ%3D%3D) in examples like this:

```js
=> if (x) function f()
↓↓↓ old
() => { if (x) function f(){};return f;return }
↓↓↓ new
() => { if (x) { function f(){};return f};return }
```