### PR TITLE
One-line braced blocks with single-line statements

### DIFF
--- a/civet.dev/comparison.md
+++ b/civet.dev/comparison.md
@@ -168,6 +168,22 @@ if (condition)
 By contrast, in JavaScript, the last indented line would have been
 treated as if it were at the top level.
 
+## Braced Blocks
+
+Civet allows you to wrap your blocks in braces (or not),
+but to avoid conflicts with braced object literals,
+there are some restrictions.
+In particular, a one-line braced block must be on the same line
+as the `if` etc. it's part of:
+
+<Playground>
+// block
+if (x) { y }
+// not a block
+if (x)
+{ y }
+</Playground>
+
 ## Automatic Semicolon Insertion
 
 JavaScript has [complicated rules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1093,12 +1093,12 @@ ImplementsTarget
 # https://262.ecma-international.org/#prod-ClassBody
 # NOTE: Nesting and indentation sensitive
 ClassBody
-  __ OpenBrace NestedClassElements?:expressions __ CloseBrace  ->
-    if (!expressions) expressions = $0[2] = []
+  __:ws1 OpenBrace:open AllowAll ClassBracedContent?:expressions RestoreAll __:ws2 CloseBrace:close  ->
+    if (!expressions) expressions = []
     return {
       type: "BlockStatement",
       subtype: "ClassBody",
-      children: $0,
+      children: [ws1, open, expressions, ws2, close],
       expressions,
     }
   InsertOpenBrace NestedClassElements?:expressions InsertNewline InsertIndent InsertCloseBrace ->
@@ -1109,6 +1109,14 @@ ClassBody
       children: $0,
       expressions,
     }
+
+# based on BracedContent
+ClassBracedContent
+  NestedClassElements
+  # based on SingleLineStatements
+  ForbidNewlineBinaryOp ( ( _? !EOS ) ClassElement StatementDelimiter )*:stmts RestoreNewlineBinaryOp ->
+    if (!stmts) return $skip
+    return stmts
 
 NestedClassElements
   PushIndent NestedClassElement*:elements PopIndent ->
@@ -2473,19 +2481,12 @@ Arrow
     return { $loc, token: "->" }
 
 ExplicitBlock
-  __ OpenBrace __ CloseBrace ->
-    const expressions = []
-    return {
-      type: "BlockStatement",
-      expressions,
-      children: [$1, $2, expressions, $3, $4],
-      bare: false,
-      empty: true,
-    }
-  __ OpenBrace NestedBlockStatements:block __ CloseBrace ->
+  NotDedented:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace)?:rest RestoreAll ->
+    if (!rest) return $skip
+    const [block, ws2, close] = rest
     return {
       ...block,
-      children: [$1, $2, ...block.children, $4, $5],
+      children: [ws1, open, ...block.children, ws2, close],
       bare: false,
     }
 
@@ -2668,9 +2669,9 @@ NoCommaBracedBlock
     }
 
 NonSingleBracedBlock
-  _?:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace )? RestoreAll ->
-    if (!$4) return $skip
-    const [block, ws2, close] = $4
+  _?:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace )?:rest RestoreAll ->
+    if (!rest) return $skip
+    const [block, ws2, close] = rest
     return {
       type: "BlockStatement",
       expressions: block.expressions,
@@ -2757,6 +2758,7 @@ BracedContent
       type: "BlockStatement",
       expressions,
       children: [expressions],
+      empty: true,
     }
 
 NestedBlockStatements

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -764,6 +764,11 @@ FatArrowToken
   "=>" / "⇒" ->
     return { $loc, token: "=>" }
 
+TrailingOperator
+  _? ( BinaryOp / AssignmentOp / Dot / QuestionMark )
+  _ OperatorAssignmentOp
+  TrailingDeclaration
+
 TrailingDeclaration
   _? ( ConstAssignment / LetAssignment )
 
@@ -2481,13 +2486,32 @@ Arrow
     return { $loc, token: "->" }
 
 ExplicitBlock
-  NotDedented:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace)?:rest RestoreAll ->
-    if (!rest) return $skip
-    const [block, ws2, close] = rest
+  # Allow single-line block only when the block starts on the same line
+  _?:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / SingleLineStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ->
+    if (!block) return $skip
     return {
       ...block,
       children: [ws1, open, ...block.children, ws2, close],
       bare: false,
+    }
+  # For backward compatibility with JavaScript, allow open brace to start on
+  # the next line, as long as it's followed by a newline or close brace
+  IndentedAtLeast:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ->
+    if (!block) return $skip
+    return {
+      ...block,
+      children: [ws1, open, ...block.children, ws2, close],
+      bare: false,
+    }
+
+EmptyBracedContent
+  &( __ "}" ) ->
+    const expressions = []
+    return {
+      type: "BlockStatement",
+      expressions,
+      children: [expressions],
+      empty: true,
     }
 
 ImplicitNestedBlock
@@ -2669,16 +2693,7 @@ NoCommaBracedBlock
     }
 
 NonSingleBracedBlock
-  _?:ws1 OpenBrace:open AllowAll ( BracedContent __ CloseBrace )?:rest RestoreAll ->
-    if (!rest) return $skip
-    const [block, ws2, close] = rest
-    return {
-      type: "BlockStatement",
-      expressions: block.expressions,
-      children: [ws1, open, ...block.children, ws2, close],
-      bare: false,
-    }
-    return block
+  !EOS ExplicitBlock !TrailingOperator -> $2
 
   # NOTE: Added indentation based implied braces
   ImplicitNestedBlock
@@ -2712,10 +2727,7 @@ SingleLineStatements
     }
 
     const children = [expressions]
-
-    if (hasTrailingComment) {
-      children.push("\n")
-    }
+    if (hasTrailingComment) children.push("\n")
 
     return {
       type: "BlockStatement",
@@ -2746,19 +2758,6 @@ PostfixedSingleLineNoCommaStatements
       expressions: children,
       children,
       bare: true,
-    }
-
-BracedContent
-  NestedBlockStatements
-  SingleLineStatements
-  # Empty content
-  &( __ "}" ) ->
-    const expressions = []
-    return {
-      type: "BlockStatement",
-      expressions,
-      children: [expressions],
-      empty: true,
     }
 
 NestedBlockStatements
@@ -4930,7 +4929,7 @@ Condition
       children: [open, ws, expression, close],
       expression,
     }
-  ParenthesizedExpression !( _? ( BinaryOp / AssignmentOp / Dot / QuestionMark ) ) !( _ OperatorAssignmentOp ) -> $1
+  ParenthesizedExpression !TrailingOperator -> $1
   # NOTE: DeclarationCondition must come before the ExpressionCondition because we need to look ahead to potentially match `:=` or `.=`
   InsertOpenParen:open DeclarationCondition:expression InsertCloseParen:close ->
     return {
@@ -7965,7 +7964,7 @@ TypeBullet
     return list
 
 TypeWithPostfix
-  TypeConditional:t ( ( _ / IndentedFurther )? TypeIfClause )?:postfix ->
+  TypeConditional:t ( SameLineOrIndentedFurther TypeIfClause )?:postfix ->
     if (!postfix) return t
     return prepend(postfix[0],
       expressionizeTypeIf([ ...postfix[1], $1, undefined ]))
@@ -8046,7 +8045,7 @@ TypeLiteral
     return { $loc, token: "[]" }
 
 InlineInterfaceLiteral
-  InsertInlineOpenBrace InlineBasicInterfaceProperty ( ( IndentedFurther / _? ) InlineBasicInterfaceProperty )* InsertCloseBrace
+  InsertInlineOpenBrace InlineBasicInterfaceProperty ( SameLineOrIndentedFurther InlineBasicInterfaceProperty )* InsertCloseBrace
 
 InlineBasicInterfaceProperty
   # NOTE: Not using TypeSuffix here to require a Colon, and to forbid spaces
@@ -8055,7 +8054,7 @@ InlineBasicInterfaceProperty
 
 InlineInterfacePropertyDelimiter
   ( _? Semicolon ) / CommaDelimiter
-  &( ( IndentedFurther / _? ) InlineBasicInterfaceProperty ) InsertComma -> $2
+  &( SameLineOrIndentedFurther InlineBasicInterfaceProperty ) InsertComma -> $2
   &( __  ( ":" / ")" / "]" / "}" ) )
   &EOS
 
@@ -8648,6 +8647,13 @@ IndentedAtLeast
 
 NotDedented
   IndentedAtLeast? _? ->
+    const ws = []
+    if ($1) ws.push(...$1)
+    if ($2) ws.push(...$2)
+    return ws.flat(Infinity).filter(Boolean)
+
+SameLineOrIndentedFurther
+  IndentedFurther? _? ->
     const ws = []
     if ($1) ws.push(...$1)
     if ($2) ws.push(...$2)

--- a/test/class.civet
+++ b/test/class.civet
@@ -10,6 +10,14 @@ describe "class", ->
   """
 
   testCase """
+    one-line
+    ---
+    class X { a = 5; b = 10 }
+    ---
+    class X { a = 5; b = 10 }
+  """
+
+  testCase """
     empty statement
     ---
     class X

--- a/test/do.civet
+++ b/test/do.civet
@@ -125,6 +125,16 @@ describe "do", ->
   """
 
   testCase """
+    braces in a single line
+    ---
+    do { x } = y
+    do { x } := y
+    ---
+    { ({ x } = y) }
+    { const { x } = y }
+  """
+
+  testCase """
     expression
     ---
     x := 1

--- a/test/if.civet
+++ b/test/if.civet
@@ -14,6 +14,14 @@ describe "if", ->
   """
 
   testCase """
+    parenthesized and braced one-line
+    ---
+    if (true) { return false }
+    ---
+    if (true) { return false }
+  """
+
+  testCase """
     if with braced body that could be object literal
     ---
     if true {

--- a/test/if.civet
+++ b/test/if.civet
@@ -544,6 +544,23 @@ describe "if", ->
   """
 
   testCase """
+    postfix if with braced expression after
+    ---
+    =>
+      f(x) if x
+      {
+        x
+      }
+    ---
+    () => {
+      if (x) { f(x) }
+      return ({
+        x
+      })
+    }
+  """
+
+  testCase """
     implied parens parethesized expression
     ---
     if (fs.statSync index).isFile()

--- a/test/if.civet
+++ b/test/if.civet
@@ -14,6 +14,20 @@ describe "if", ->
   """
 
   testCase """
+    if with braces on next line
+    ---
+    if (true)
+    {
+      return false
+    }
+    ---
+    if (true)
+    {
+      return false
+    }
+  """
+
+  testCase """
     parenthesized and braced one-line
     ---
     if (true) { return false }
@@ -30,6 +44,17 @@ describe "if", ->
     ---
     if (true) {
       x
+    }
+  """
+
+  testCase """
+    if with braced body that is an object literal
+    ---
+    if true
+      { x }
+    ---
+    if (true) {
+      ({ x })
     }
   """
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -269,7 +269,7 @@ describe "object", ->
   throws """
     doesn't allow bare assignments inside
     ---
-    {x=y}
+    obj = {x=y}
     ---
     ParseError
   """
@@ -277,7 +277,7 @@ describe "object", ->
   throws """
     doesn't allow update assignments inside
     ---
-    {x+=y}
+    obj = {x+=y}
     ---
     ParseError
   """
@@ -285,7 +285,7 @@ describe "object", ->
   throws """
     doesn't allow update assignments inside
     ---
-    {x-=y}
+    obj = {x-=y}
     ---
     ParseError
   """
@@ -293,7 +293,7 @@ describe "object", ->
   throws """
     doesn't allow comparisons inside
     ---
-    {x<=y}
+    obj = {x<=y}
     ---
     ParseError
   """
@@ -1208,7 +1208,7 @@ describe "object", ->
     throws """
       no new properties
       ---
-      {new.target}
+      obj = {new.target}
       ---
       ParseError
     """
@@ -1216,7 +1216,7 @@ describe "object", ->
     throws """
       no meta properties
       ---
-      {import.meta}
+      obj = {import.meta}
       ---
       ParseError
     """


### PR DESCRIPTION
Fixes #1465 by allowing for single line of statements inside one-line braces in `class`es and `if`/`else` blocks.

For `if`/`else` blocks, I could actually make the grammar a bit smaller by using some existing rules we had for `BracedContent` (from a different branch of the tree where blocks always need to be braced, such as function bodies).