### PR TITLE
Forbid next-line braced blocks after `return if` and `yield if`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2650,7 +2650,7 @@ EmptyBareBlock
 
 NoBlock
   # Check that there isn't a block here. Used for empty loop bodies.
-  &( EOS ) !IndentedFurther !( Nested Then )
+  &EOS !IndentedFurther !( Nested Then )
 
 # A nonempty block that must include braces
 # This version allows same-line postfixes like `while cond`.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2650,7 +2650,7 @@ EmptyBareBlock
 
 NoBlock
   # Check that there isn't a block here. Used for empty loop bodies.
-  &EOS !IndentedFurther
+  &( EOS ) !IndentedFurther !( Nested Then )
 
 # A nonempty block that must include braces
 # This version allows same-line postfixes like `while cond`.
@@ -5209,10 +5209,11 @@ KeywordStatement
 
   # https://262.ecma-international.org/#prod-ReturnStatement
   # NOTE: Modified to leave room for `return.value` and `return =`
-  Return !(":" / "." / AfterReturnShorthand) MaybeParenNestedExpression?:expression -> {
+  # NOTE: Stop parsing if there's a postfix if/etc.
+  Return:ret !(":" / "." / AfterReturnShorthand) MaybeParenNestedExpression?:expression -> {
     type: "ReturnStatement",
     expression,
-    children: $0,
+    children: [ ret, expression ],
   }
 
   ThrowStatement
@@ -5274,6 +5275,8 @@ NestedExpression
 # parentheses if indented, so that the expression starts on the same line.
 # (e.g. for `return` or `yield`)
 MaybeParenNestedExpression
+  # Skip if there's a postfix if/etc.
+  &( _? PostfixStatement NoBlock ) -> ""
   # Not nested case
   !EOS Expression -> $2
   # Avoid wrapping array/object return value in parentheses.

--- a/test/if.civet
+++ b/test/if.civet
@@ -561,6 +561,40 @@ describe "if", ->
   """
 
   testCase """
+    return postfix if with braced expression after
+    ---
+    =>
+      return if x
+      {
+        x
+      }
+    ---
+    () => {
+      if (x) { return }
+      return ({
+        x
+      })
+    }
+  """
+
+  testCase """
+    yield postfix if with braced expression after
+    ---
+    ->
+      yield if x
+      {
+        x
+      }
+    ---
+    (function*() {
+      if (x) { yield };
+      ({
+        x
+      })
+    })
+  """
+
+  testCase """
     implied parens parethesized expression
     ---
     if (fs.statSync index).isFile()
@@ -954,7 +988,7 @@ describe "if", ->
 
   describe "return if expression", ->
     testCase """
-      return if expression
+      one line
       ---
       return if y then 1 else 0
       ---
@@ -962,7 +996,7 @@ describe "if", ->
     """
 
     testCase """
-      return if expression
+      if/then/else
       ---
       return if y
       then 1
@@ -973,7 +1007,7 @@ describe "if", ->
     """
 
     testCase """
-      return if expression
+      indented if/else
       ---
       return if y
         1


### PR DESCRIPTION
During #1467, I noticed that our implicit function application magic did the following:

```js
f(x) if x
{
  x
}
↓↓↓
if (x) { f(x) }
({
  x
})
//not:
f(x)(x ? {x} : undefined)
```

I think this is reasonable, because we only need to implement braced-blocks backward compatibility with natural JS constructs, and `if` expressions are not such a construct.

This PR extends this functionality for other common patterns with `yield` and `return`:

```js
return if x
{
  x
}
↓↓↓
if (x) { return }
({
  x
})
//as opposed to the current behavior:
return x ? {x} : undefined
```

This brings argumentless `return`/`yield` into alignment with having an argument:

```js
return x if x
{
  x
}
↓↓↓ (before and after this PR)
if (x) { return x }
({
  x
})
```