### PR TITLE
Automatically type fields using `@arg` in constructor

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2017,6 +2017,13 @@ id := @id
 obj := { @id }
 </Playground>
 
+<Playground>
+class Person
+  getName()
+    @name
+  setName(@name)
+</Playground>
+
 ### Bind
 
 Shorthand for [bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind)ing methods to their object:
@@ -2108,6 +2115,9 @@ function makeCounter
 </Playground>
 
 ### Constructor
+
+`@` is also shorthand for `constructor`.
+`@arg` arguments create typed fields if the fields are not already declared.
 
 <Playground>
 class Rectangle

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1217,12 +1217,13 @@ FieldDefinition
       default:
         return {
           type: "FieldDefinition",
+          id,
           children: [id, " = ", exp],
         }
     }
 
   # NOTE: Added readonly semantic equivalent of const field assignment
-  InsertReadonly:r ClassElementName TypeSuffix? __ ConstAssignment:ca MaybeNestedExpression ->
+  InsertReadonly:r ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedExpression ->
     // Adjust position to space before assignment to make TypeScript remapping happier
     r.children[0].$loc = {
       pos: ca.$loc.pos - 1,
@@ -1230,14 +1231,18 @@ FieldDefinition
     }
     return {
       type: "FieldDefinition",
+      id,
+      typeSuffix,
       children: $0,
     }
 
-  ( Abstract _? )? ( Readonly _? )? ClassElementName TypeSuffix? Initializer? ->
-    if ($1) return { children: $0, ts: true }
+  ( Abstract _? )? ( Readonly _? )? ClassElementName:id TypeSuffix?:typeSuffix Initializer? ->
     return {
       type: "FieldDefinition",
       children: $0,
+      ts: $1 ? true : undefined,
+      id,
+      typeSuffix,
     }
 
 ThisLiteral
@@ -1865,6 +1870,7 @@ ParameterElement
       accessModifier,
       initializer,
       delim,
+      binding,
     }
 
 ParameterElementDelimiter

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -579,37 +579,68 @@ function wrapIterationReturningResults(
     statement.children.push(";return ", resultsRef, ";")
 
 function processParams(f): void
-  const { type, parameters, block } = f
-  const isConstructor = f.name is 'constructor'
+  { type, parameters, block } := f
+  isConstructor := f.name is 'constructor'
 
   // Check for singleton TypeParameters <Foo> before arrow function,
   // which TypeScript (in tsx mode) treats like JSX; replace with <Foo,>
-  if (type is "ArrowFunction" and parameters and parameters.tp and parameters.tp.parameters.length is 1) {
+  if type is "ArrowFunction" and parameters and parameters.tp and parameters.tp.parameters# is 1
     parameters.tp.parameters.push(",")
-  }
 
-  if (!block) return
-  const { expressions } = block
-  if (!expressions) return
-  const { blockPrefix } = parameters
+  return unless block
+  { expressions } := block
+  return unless expressions
 
   let indent: string
-  if (!expressions.length) {
+  unless expressions#
     indent = ""
-  } else {
+  else
     indent = expressions[0][0]
-  }
 
-  const [splices, thisAssignments] = gatherBindingCode(parameters, {
+  [splices, thisAssignments] := gatherBindingCode parameters,
     injectParamProps: isConstructor
-  })
 
-  const delimiter = {
-    type: "SemicolonDelimiter",
-    children: [";"],
-  }
+  // `@(@x: number)` adds `x: number` declaration to class body
+  if isConstructor
+    {ancestor} := findAncestor f, .type is "ClassExpression"
+    if ancestor?
+      fields := gatherRecursiveWithinFunction ancestor, .type is "FieldDefinition"
+      .map .id
+      .filter (is like {type: "Identifier"})
+      .map .name
+      |> new Set
+      classExpressions := ancestor!.body.expressions
+      index .= findChildIndex classExpressions, f
+      assert.notEqual index, -1, "Could not find constructor in class"
+      // Put fields before all constructor overloads so they remain consecutive
+      index-- while classExpressions[index-1]?[1] is like {type: "MethodDefinition", name: "constructor"}
+      fStatement := classExpressions[index]
+      for each parameter of gatherRecursive parameters, .type is "Parameter"
+        continue unless parameter.typeSuffix
+        for each binding of gatherRecursive parameter, .type is "AtBinding"
+          // TODO: Handle typeSuffix of entire complex parameter pattern
+          // (Currently just handle `@prop ::` individual typing,
+          // where parent is AtBindingProperty or BindingElement,
+          // or when the parent is the whole Parameter.)
+          typeSuffix := binding.parent?.typeSuffix
+          continue unless typeSuffix
+          id := binding.ref.id
+          continue if fields.has id
+          classExpressions.splice index++, 0, [fStatement[0], {
+            type: "FieldDefinition"
+            ts: true
+            id
+            typeSuffix
+            children: [id, typeSuffix]
+          }, ";"]
+          // Only the first definition gets an indent, stolen from fStatement
+          fStatement[0] = ""
 
-  const prefix = splices
+  delimiter :=
+    type: "SemicolonDelimiter"
+    children: [";"]
+
+  prefix := splices
     .map (s) => ["let ", s]
     .concat(thisAssignments)
     .map((s) => s.type
@@ -621,7 +652,7 @@ function processParams(f): void
       : [indent, s, delimiter]
     )
 
-  if (!prefix.length) return
+  return unless prefix#
   // In constructor definition, insert prefix after first super() call
   if isConstructor
     superCalls := gatherNodes expressions,

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -84,6 +84,7 @@ export type OtherNode =
   | ComputedPropertyName
   | DefaultClause
   | ElseClause
+  | FieldDefinition
   | FinallyClause
   | Index
   | Initializer
@@ -863,6 +864,7 @@ export type Parameter
   accessModifier?: AccessModifier?
   initializer?: Initializer?
   delim?: ParameterElementDelimiter?
+  binding: BindingIdentifier | BindingPattern
 
 type AccessModifier = ASTNode
 type ParameterElementDelimiter = ASTNode
@@ -881,6 +883,14 @@ export type ClassExpression
   body: ClassBody
 
 export type ClassBody = BlockStatement & { subtype: "ClassBody" }
+
+export type FieldDefinition
+  type: "FieldDefinition"
+  children: Children
+  parent?: Parent
+  ts?: boolean?
+  id: ASTNode
+  typeSuffix?: TypeSuffix?
 
 export type Literal =
   type: "Literal"

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -127,12 +127,14 @@ describe "[TS] class", ->
     override method with implicit body
     ---
     class UserAccount
+      id: number
       register(): void
       register(@id: number): void
     ---
     class UserAccount {
+      id: number
       register(): void
-      register(id: number): void{this.id = id;}
+      register(id1: number): void{this.id = id1;}
     }
   """
 
@@ -140,10 +142,12 @@ describe "[TS] class", ->
     constructor with implicit body
     ---
     class UserAccount
+      id: number
       @(@id: number)
     ---
     class UserAccount {
-      constructor(id: number){this.id = id;}
+      id: number
+      constructor(id1: number){this.id = id1;}
     }
   """
 
@@ -151,12 +155,14 @@ describe "[TS] class", ->
     override constructor with implicit body
     ---
     class UserAccount
+      id: number
       @()
       @(@id: number)
     ---
     class UserAccount {
+      id: number
       constructor()
-      constructor(id: number){this.id = id;}
+      constructor(id1: number){this.id = id1;}
     }
   """
 
@@ -433,3 +439,76 @@ describe "[TS] class", ->
       }
     }
   """
+
+  describe "automatic field typing from constructor", ->
+    testCase """
+      basic
+      ---
+      class UserAccount
+        @(@name: string, @id: number)
+      ---
+      class UserAccount {
+        name: string;id: number;constructor(name: string, id: number){this.name = name;this.id = id;}
+      }
+    """
+
+    testCase """
+      existing fields
+      ---
+      class UserAccount
+        name: string | null
+        id = 0
+        @(@name: string, @id: number)
+      ---
+      class UserAccount {
+        name: string | null
+        id = 0
+        constructor(name1: string, id1: number){this.name = name1;this.id = id1;}
+      }
+    """
+
+    testCase """
+      nested object fields
+      ---
+      class UserAccount
+        @({@name:: string, @id:: number})
+      ---
+      class UserAccount {
+        name: string;id: number;constructor({name, id}: {name: string, id: number}){this.name = name;this.id = id;}
+      }
+    """
+
+    testCase """
+      nested array fields
+      ---
+      class UserAccount
+        @([@name:: string, @id:: number])
+      ---
+      class UserAccount {
+        name: string;id: number;constructor([name, id]: [ string, number]){this.name = name;this.id = id;}
+      }
+    """
+
+    testCase """
+      override
+      ---
+      class UserAccount
+        @(@name: string)
+        @(@name: string, @id: number)
+      ---
+      class UserAccount {
+        name: string;id: number;constructor(name: string)
+        constructor(name1: string, id: number){this.name = name1;this.id = id;}
+      }
+    """
+
+    testCase """
+      private
+      ---
+      class UserAccount
+        @(#name: string, #id: number)
+      ---
+      class UserAccount {
+        #name: string;#id: number;constructor(name: string, id: number){this.#name = name;this.#id = id;}
+      }
+    """


### PR DESCRIPTION
Fixes #549
Fixes #970

TODO (not for this PR): Handle type suffix of entire complex parameter pattern, e.g. `[@name, @id]: [string, number]`. I'm imagining this might compile to something like `name: [string, number][0]; id: [string, number][1]`, leaving the type computation to TypeScript. But for now we support these forms:
* Straight arguments like `@name: string`
* Individually typed pattern components like `[@name:: string, @id:: number]`