### PR TITLE
Improve project root detection in LSP

### DIFF
--- a/lsp/build/build.sh
+++ b/lsp/build/build.sh
@@ -9,3 +9,4 @@ node_modules/.bin/civet build/build.civet
 
 mkdir -p dist/lib
 cp node_modules/typescript/lib/lib.*.d.ts dist/lib
+cp source/tsconfig.json dist/lib

--- a/lsp/source/tsconfig.json
+++ b/lsp/source/tsconfig.json
@@ -1,0 +1,7 @@
+// This is the tsconfig used for interpreting lib files
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": []
+  }
+}


### PR DESCRIPTION
This is an attempt at #1094. It seems to work better in development, but there are some aspects specific to dev vs. actual extension that might differ.

* Populate `dist/lib` with a `tsconfig.json` (from new `source/tsconfig.json`). This helps the LSP figure out that the provided lib files are in their own project root.
* Detect project roots in more ways, to handle cases with no `tsconfig.json`:
  * If we're in a `node_modules/foo` directory, use that. This takes priority over `tsconfig.json` because [`findConfigFile`](https://github.com/microsoft/TypeScript/blob/bd1641f7691909450147cc38cc6f5e55b79e0545/src/compiler/program.ts#L336) searches in  *all* ancestor directories, which could go very far up.
  * Fallback to source project directory only if the opened file is inside that directory. Otherwise, fallback to the directory containing the file (isolation).

I'm still getting the following errors about duplicate definitions. I'm not quite sure why; it seems like TypeScript is loading some `lib`s despite my asking it not to? But at least it's only seven errors, and it seems isolated to the `.d.ts` file.

![image](https://github.com/user-attachments/assets/89e64caf-75db-45ba-97f6-291ecb633c9c)
