### PR TITLE
Loops followed by binary operators, `as` on next line

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2415,6 +2415,20 @@ You can use `as tuple` to give an array literal a
 // type readonly [1, "hello"]
 </Playground>
 
+Unlike TypeScript, assertions can start later lines:
+
+<Playground>
+"Hello, world!"
+.split /\s+/
+as [string, string]
+</Playground>
+
+<Playground>
+for value of [1, 2, 3]
+  value ** 2
+as [number, number, number]
+</Playground>
+
 ## Modules
 
 ### `from` Shorthand

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -479,7 +479,8 @@ BinaryOpExpression
     return processBinaryOpExpression($0)
 
 BinaryOpNotDedented
-  ( NestedBinaryOpAllowed / !Nested ) NotDedented -> $2
+  !NewlineBinaryOpAllowed _? -> $2
+  NewlineBinaryOpAllowed ( NestedBinaryOpAllowed / !Nested ) NotDedented -> $2
 
 BinaryOpRHS
   BinaryOpNotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -581,7 +581,7 @@ UnaryPostfix
 TypePostfix
   _:ws NWTypePostfix:postfix ->
     return prepend(ws, postfix)
-  IndentedAtLeast:indent _?:ws NWTypePostfix:postfix ->
+  &EOS BinaryOpNotDedented:indent _?:ws NWTypePostfix:postfix ->
     // TODO: Preserve comments in indent
     return prepend(ws || " ", postfix)
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -348,7 +348,7 @@ ExplicitArguments
 ApplicationStart
   # Indented argument cannot start with a binary operator or a
   # trailing member expression
-  IndentedApplicationAllowed &( IndentedFurther !IdentifierBinaryOp ) !IndentedTrailingMemberExpression
+  IndentedApplicationAllowed &( IndentedFurther !IdentifierBinaryOp !ReservedBinary ) !IndentedTrailingMemberExpression
   !EOS &( _ ( BracedApplicationAllowed / !"{" ) !ForbiddenImplicitCalls )
 
 ForbiddenImplicitCalls
@@ -581,6 +581,9 @@ UnaryPostfix
 TypePostfix
   _:ws NWTypePostfix:postfix ->
     return prepend(ws, postfix)
+  IndentedAtLeast:indent _?:ws NWTypePostfix:postfix ->
+    // TODO: Preserve comments in indent
+    return prepend(ws || " ", postfix)
 
 Tuple
   "tuple" NonIdContinue ->
@@ -4236,6 +4239,8 @@ Statement
 ShouldExpressionize
   AllowedTrailingCallExpressions
   NotDedented Pipe
+  BinaryOpRHS
+  UnaryPostfix
 
 # Variant of Statement to forbid , operator (CommaExpression)
 NoCommaStatement

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,6 +1,7 @@
 import type {
   ASTNode
   ASTNodeObject
+  ASTRef
   BlockStatement
   BreakStatement
   CallExpression
@@ -540,6 +541,22 @@ function wrapIterationReturningResults(
 
   resultsRef := statement.resultsRef = makeRef "results"
 
+  { declaration, breakWithOnly } := iterationDeclaration statement
+  outer.children.unshift(["", declaration, ";"])
+
+  unless breakWithOnly
+    assignResults statement.block, (node) =>
+      // TODO: real ast node
+      [ resultsRef, ".push(", node, ")" ]
+
+  if collect
+    statement.children.push collect(resultsRef)
+  else
+    statement.children.push(";return ", resultsRef, ";")
+
+function iterationDeclaration(statement: IterationStatement | ForStatement)
+  { resultsRef } := statement
+
   decl: "const" | "let" .= "const"
   if statement.type is "IterationStatement" or statement.type is "ForStatement"
     if processBreakContinueWith statement
@@ -566,17 +583,7 @@ function wrapIterationReturningResults(
   else // decl is "let"
     declaration.children.push ";", resultsRef, "=[]" unless breakWithOnly
 
-  outer.children.unshift(["", declaration, ";"])
-
-  unless breakWithOnly
-    assignResults statement.block, (node) =>
-      // TODO: real ast node
-      [ resultsRef, ".push(", node, ")" ]
-
-  if collect
-    statement.children.push collect(resultsRef)
-  else
-    statement.children.push(";return ", resultsRef, ";")
+  { declaration, breakWithOnly }
 
 function processParams(f): void
   { type, parameters, block } := f
@@ -702,12 +709,12 @@ function processFunctions(statements, config): void
     processReturn(f, config.implicitReturns)
 
 function expressionizeIteration(exp: IterationExpression): void
-  { async, generator, subtype, block, children, statement } := exp
+  { async, generator, block, children, statement } .= exp
   i := children.indexOf statement
   if i < 0
     throw new Error "Could not find iteration statement in iteration expression"
 
-  if subtype is like "DoStatement", "ComptimeStatement"
+  if statement.type is "DoStatement" or statement.type is "ComptimeStatement"
     // Just wrap with IIFE; insertReturn will apply to the resulting function
     children.splice(i, 1, wrapIIFE([["", statement, undefined]], async, generator))
     updateParentPointers exp
@@ -733,20 +740,22 @@ function expressionizeIteration(exp: IterationExpression): void
       ], async, generator)
     )
   else
-    exp.resultsRef ??= makeRef "results"
-    { resultsRef } := exp
+    resultsRef := statement.resultsRef ??= makeRef "results"
+
+    { declaration, breakWithOnly } := iterationDeclaration statement
 
     // insert `results.push` to gather results array
-    assignResults block, (node) =>
-      // TODO: real node
-      [ resultsRef, ".push(", node, ")" ]
-    braceBlock(block)
+    unless breakWithOnly
+      assignResults block, (node) =>
+        // TODO: real node
+        [ resultsRef, ".push(", node, ")" ]
+      braceBlock(block)
 
     // Wrap with IIFE
     children.splice(i,
       1,
       wrapIIFE([
-        ["", ["const ", resultsRef, "=[]"], ";"]
+        ["", declaration, ";"]
         ["", statement, undefined]
         ["", wrapWithReturn(resultsRef)]
       ], async)

--- a/test/for.civet
+++ b/test/for.civet
@@ -788,6 +788,31 @@ describe "for", ->
       }return results})())
     """
 
+    testCase """
+      trailing as
+      ---
+      result = for x of y
+        x ** 2
+      as number[]
+      ---
+      result = (()=>{const results=[];for (const x of y) {
+        results.push(x ** 2)
+      }return results})() as number[]
+    """
+
+    testCase """
+      trailing operator
+      ---
+      result = for x of y
+        x ** 2
+      ++ [16, 25]
+      ---
+      result = (()=>{const results=[];for (const x of y) {
+        results.push(x ** 2)
+      }return results})()
+      .concat([16, 25])
+    """
+
   testCase """
     for generator
     ---
@@ -919,4 +944,17 @@ describe "for", ->
         }results.push(results1)
       };return results;
     }
+  """
+
+  testCase """
+    break with followed by binary op
+    ---
+    for x of y
+      break with 5
+    + 1
+    ---
+    (()=>{let results;results=[];for (const x of y) {
+      results = 5;break
+    }return results})()
+    + 1
   """

--- a/test/types/as.civet
+++ b/test/types/as.civet
@@ -50,3 +50,14 @@ describe "[TS] as", ->
     ---
     [1, 2] as [number, number]
   """
+
+  testCase """
+    with implicit function call
+    ---
+    "Hello, world!"
+    .split /\s+/
+    as [string, string]
+    ---
+    "Hello, world!"
+    .split(/\s+/) as [string, string]
+  """

--- a/test/types/as.civet
+++ b/test/types/as.civet
@@ -1,4 +1,4 @@
-{testCase} from ../helper.civet
+{testCase, throws} from ../helper.civet
 
 describe "[TS] as", ->
   testCase """
@@ -60,4 +60,14 @@ describe "[TS] as", ->
     ---
     "Hello, world!"
     .split(/\s+/) as [string, string]
+  """
+
+  throws """
+    in switch
+    ---
+    switch foo
+      as number
+      5
+    ---
+    ParseError
   """

--- a/test/types/as.civet
+++ b/test/types/as.civet
@@ -32,3 +32,21 @@ describe "[TS] as", ->
     ---
     [1, 2] satisfies readonly unknown[] | []
   """
+
+  testCase """
+    as on next line
+    ---
+    [1, 2]
+    as [number, number]
+    ---
+    [1, 2] as [number, number]
+  """
+
+  testCase """
+    as indented on next line
+    ---
+    [1, 2]
+      as [number, number]
+    ---
+    [1, 2] as [number, number]
+  """


### PR DESCRIPTION
This PR originally aimed to implement (and achieves) the suggestion from https://github.com/DanielXMoore/Civet/issues/1135#issuecomment-2032593949 to support

```js
t = for i of [1..3]
  Math.sqrt i
as [number, number, number]
```

Along the way it implements:

* Binary operators after loops/ifs (building on #1375 which added pipes)
* Postfix operators after loops/ifs (`as` is one of these)
* TypeScript postfix operators (including `as`) on a following line (at same or further indentation level). It turns out that TypeScript [doesn't support this](https://www.typescriptlang.org/play/?#code/BTCUF4D4G8GMHsB2BnALgAgE4FNkFcAbVZcAbQF0BuAM3k3WARQwA915r1SByAQ2-Kh00ALAAodFlyFiAOgAOeZAAtgLUOIC+OVHkyIp+Isk2gw43snS9EATwpA), so I eat the newline in order to make TS happy.