### PR TITLE
Fix bracing in implicitly returned one-line for loops

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -164,7 +164,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
       // @ts-ignore
       pre.unshift refDec
     else
-      wrapIterationReturningResults statement, children: blockStatement, ->
+      wrapIterationReturningResults statement, => undefined
       ref = initializer.expression = initializer.children[2] = statement.resultsRef
   else
     ref = initializer.expression = initializer.children[2] = makeRef()

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -725,7 +725,6 @@ function expressionizeIteration(exp: IterationExpression): void
       type: "YieldExpression"
       expression: node
       children: [ "yield ", node ]
-    braceBlock(block)
 
     children.splice(i,
       1,

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -542,7 +542,13 @@ function wrapIterationReturningResults(
   resultsRef := statement.resultsRef = makeRef "results"
 
   { declaration, breakWithOnly } := iterationDeclaration statement
-  outer.children.unshift(["", declaration, ";"])
+  { ancestor, child } := findAncestor statement, .type is "BlockStatement"
+  assert.notNull ancestor, `Could not find block containing ${statement.type}`
+  index := findChildIndex ancestor.expressions, child
+  iterationTuple := ancestor.expressions[index]
+  ancestor.expressions.splice index, 0, [iterationTuple[0], declaration, ";"]
+  iterationTuple[0] = '' // steal indentation from loop
+  braceBlock ancestor
 
   unless breakWithOnly
     assignResults statement.block, (node) =>

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,7 +1,6 @@
 import type {
   ASTNode
   ASTNodeObject
-  ASTRef
   BlockStatement
   BreakStatement
   CallExpression
@@ -299,7 +298,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       // Add return in normal way for functions without ids
       break
     when "ForStatement", "IterationStatement", "DoStatement", "ComptimeStatement"
-      wrapIterationReturningResults(exp, outer, collect)
+      wrapIterationReturningResults exp, collect
       return
     when "BlockStatement"
       return if node.expressions.some isExit
@@ -338,7 +337,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   node[1] = collect(node[1])
 
 // [indent, statement, semicolon]
-function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
+function insertReturn(node: ASTNode): void
   if (!node) return
   // TODO: unify this with the `exp` switch
   switch node.type
@@ -417,7 +416,7 @@ function insertReturn(node: ASTNode, outerNode: ASTNode = node): void
       // Add return in normal way for functions without ids
       break
     when "ForStatement", "IterationStatement", "DoStatement", "ComptimeStatement"
-      wrapIterationReturningResults(exp, outer)
+      wrapIterationReturningResults exp
       return
     when "BlockStatement"
       insertReturn(exp.expressions[exp.expressions.length - 1])
@@ -514,14 +513,13 @@ function processBreakContinueWith(statement: IterationStatement | ForStatement):
 
 function wrapIterationReturningResults(
   statement: IterationFamily,
-  outer: { children: StatementTuple[] },
   collect?: (node: ASTNode) => ASTNode
 ): void
   if statement.type is "DoStatement" or statement.type is "ComptimeStatement"
     let results: ASTNode
     if statement.type is "ComptimeStatement"
       // Always wrap comptime in IIFE
-      insertReturn statement.block, outer
+      insertReturn statement.block
       expression := expressionizeComptime statement
       replaceNode statement, expression
       parent := expression.parent as BlockStatement?
@@ -533,7 +531,7 @@ function wrapIterationReturningResults(
     if collect
       assignResults results, collect
     else
-      insertReturn results, outer
+      insertReturn results
     return
 
   assert.equal statement.resultsRef, undefined,

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -20,13 +20,21 @@ import {
   type Predicate
 } from ./traversal.civet
 
-assert := {
+// Types need to be upfront to allow for TypeScript `asserts`
+assert: {
   equal(a: unknown, b: unknown, msg: string): void
+  notEqual(a: unknown, b: unknown, msg: string): void
+  notNull<T>(a: T, msg: string): asserts a is NonNullable<T>
+} := {
+  equal(a, b, msg): void
     /* c8 ignore next */
     throw new Error(`Assertion failed [${msg}]: ${a} !== ${b}`) if a !== b
-  notEqual(a: unknown, b: unknown, msg: string): void
+  notEqual(a, b, msg): void
     /* c8 ignore next */
     throw new Error(`Assertion failed [${msg}]: ${a} === ${b}`) if a === b
+  notNull(a, msg)
+    /* c8 ignore next */
+    throw new Error(`Assertion failed [${msg}]: got null`) unless a?
 }
 
 /**

--- a/test/for.civet
+++ b/test/for.civet
@@ -215,6 +215,17 @@ describe "for", ->
   """
 
   testCase """
+    double range without declaration
+    ---
+    => for [1..10] for [1..10]
+      '*'
+    ---
+    () => { const results=[];for (let i = 1; i <= 10; ++i) { const results1=[];for (let i1 = 1; i1 <= 10; ++i1) {
+      results1.push('*')
+    }results.push(results1)};return results; }
+  """
+
+  testCase """
     for of character range
     ---
     for letter of ['a'..'z']
@@ -719,7 +730,7 @@ describe "for", ->
         for item, index of array
           `${index}. ${item}`
       ---
-      let i = 0;const results=[];for (const item of array) {const index = i++;
+      const results=[];let i = 0;for (const item of array) {const index = i++;
           results.push(`${index}. ${item}`)
         };const strings =results
     """

--- a/test/loop.civet
+++ b/test/loop.civet
@@ -42,6 +42,14 @@ describe "loop", ->
   """
 
   testCase """
+    one-line loop generator
+    ---
+    loop* 1
+    ---
+    (function*(){while(true) yield 1;return})()
+  """
+
+  testCase """
     postfix loop generator
     ---
     infinite := 1 loop*


### PR DESCRIPTION
Fixes #1471

Also a couple little cleanups I noticed:
* Remove unnecessary bracing in one-line loop generators (`for*` etc)
* Remove no-longer-used "outer" mechanism in `insertReturn` and `wrapIteration...`. `insertReturn` hasn't used `outerNode` in a while, and this PR removed the use in `wrapIteration...`
* New `asserts.notNull` with a TypeScript assertion to make guarding automatic