### PR TITLE
Fix automatic private fields from constructor `@args`

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -639,7 +639,6 @@ function processParams(f): void
           continue if fields.has id
           classExpressions.splice index++, 0, [fStatement[0], {
             type: "FieldDefinition"
-            ts: true
             id
             typeSuffix
             children: [id, typeSuffix]

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -512,3 +512,14 @@ describe "[TS] class", ->
         #name: string;#id: number;constructor(name: string, id: number){this.#name = name;this.#id = id;}
       }
     """
+
+    testCase.js """
+      private JS
+      ---
+      class UserAccount
+        @(#name: string, #id: number)
+      ---
+      class UserAccount {
+        #name;#id;constructor(name, id){this.#name = name;this.#id = id;}
+      }
+    """


### PR DESCRIPTION
@bbrk24 reported that [private fields](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties) need `#field` in the class body, and these were absent from such fields created automatically via `@(#field)` (#1469) when outputting JavaScript (not TypeScript).

They now match the behavior of regular field definitions in Civet: the name remains in JavaScript mode (even when not private), but the type suffix disappears in JavaScript mode.