### PR TITLE
Ranges and slices with inequalities such as `[a<..<b]`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -417,7 +417,7 @@ indices := [0...array.length]
 
 An infinite range `[x..]` is supported when [looping](#range-loop).
 
-Alternatively, you can explicitly exclude endpoints with `<` or `>`,
+Alternatively, `..` can explicitly exclude endpoints with `<` or `>`,
 or include endpoints with `<=` or `>=`. These also control loop direction,
 whereas `[a..b]` determines direction based on whether `a <= b`.
 
@@ -445,6 +445,12 @@ end := numbers[-2..]
 numbers[1...-1] = []
 </Playground>
 
+Alternatively, you can exclude or include endpoints using `..` with `<` or `<=`:
+
+<Playground>
+strict := numbers[first<..<last]
+</Playground>
+
 ## Strings
 
 Strings can span multiple lines:
@@ -453,7 +459,6 @@ Strings can span multiple lines:
 console.log "Hello,
 world!"
 </Playground>
-
 
 ### Triple-Quoted Strings
 
@@ -1792,8 +1797,8 @@ for i of [1..]
   attempt i
 </Playground>
 
-You can control loop direction and include/exclude endpoints using
-`<=` or `<`:
+You can control loop direction and include or exclude endpoints using
+`..` with `<=`/`>=` or `<`/`>`:
 
 <Playground>
 for i of [first..<=last]
@@ -1804,6 +1809,8 @@ for i of [first..<=last]
 for i of [left<..<right]
   console.log array[i]
 </Playground>
+
+See also [range literals](#range-literals).
 
 ### Until Loop
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -405,7 +405,8 @@ You can also omit the name of the rest component:
 
 ### Range Literals
 
-`[x..y]` includes `x` and `y`, while `[x...y]` includes `x` but not `y`.
+`[x..y]` includes `x` and `y`, while `[x...y]` includes `x` but not `y`
+(as in Ruby and CoffeeScript).
 
 <Playground>
 letters := ['a'..'f']
@@ -415,6 +416,22 @@ indices := [0...array.length]
 </Playground>
 
 An infinite range `[x..]` is supported when [looping](#range-loop).
+
+Alternatively, you can explicitly exclude endpoints with `<` or `>`,
+or include endpoints with `<=` or `>=`. These also control loop direction,
+whereas `[a..b]` determines direction based on whether `a <= b`.
+
+<Playground>
+indices := [0..<array.length]
+</Playground>
+
+<Playground>
+reversed := [array.length>..0]
+</Playground>
+
+<Playground>
+increasing := [a..<=b]
+</Playground>
 
 ### Array/String Slicing
 
@@ -1773,6 +1790,19 @@ for [1..5]
 <Playground>
 for i of [1..]
   attempt i
+</Playground>
+
+You can control loop direction and include/exclude endpoints using
+`<=` or `<`:
+
+<Playground>
+for i of [first..<=last]
+  console.log array[i]
+</Playground>
+
+<Playground>
+for i of [left<..<right]
+  console.log array[i]
 </Playground>
 
 ### Until Loop

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -1,4 +1,4 @@
-type { ASTNode, ASTError } from './parser/types.civet'
+type { ASTNode } from './parser/types.civet'
 { removeParentPointers } from './parser/util.civet'
 { ParseError } from './parser.hera'
 
@@ -8,7 +8,7 @@ export type Options =
     data: { srcLine: number, srcColumn: number, srcOffset: number }
   js?: boolean
   filename?: string
-  errors?: ASTError[]
+  errors?: ParseError[]
 
 function stringify(node: ASTNode): string
   try
@@ -47,6 +47,8 @@ function gen(root: ASTNode, options: Options): string
         column: number | string .= '?'
         let offset: number?
         if sourceMap := options.sourceMap
+          if node.$loc?
+            sourceMap.updateSourceMap "", node.$loc.pos
           // Convert 0-based to 1-based
           line = sourceMap.data.srcLine + 1
           column = sourceMap.data.srcColumn + 1

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -54,6 +54,7 @@ import {
   processForInOf,
   processProgram,
   processProgramAsync,
+  processRangeExpression,
   processTryBlock,
   processUnaryExpression,
   processUnaryNestedExpression,
@@ -2891,75 +2892,55 @@ _ArrayLiteral
     }
   NestedBulletedArray
 
-RangeExpression
-  Expression:s __:ws ( DotDotDot / DotDot ):range Expression:e ->
-    const inclusive = range.token === ".."
-    range.token = ","
-
-    if (s.type === "Literal" && e.type === "Literal") {
-      const start = literalValue(s)
-      const end = literalValue(e)
-
-      if (typeof start !== typeof end) {
-        throw new Error("Range start and end must be of the same type")
+RangeDots
+  DotDotDot ->
+    return { ...$1,
+      type: "RangeDots",
+      left: { inclusive: true, raw: "" },
+      right: { inclusive: false, raw: "." },
+      increasing: undefined,
+      children: [],
+    }
+  RangeEnd:left _?:ws1 DotDot:dots _?:ws2 RangeEnd:right ->
+    // Inherit increasing flag from either side
+    const increasing = left.increasing ?? right.increasing
+    if (left.increasing != null && right.increasing != null &&
+        left.increasing !== right.increasing) {
+      const error = {
+        type: "Error",
+        message: `${left.raw}..${right.raw} uses inconsistent < vs. >`,
       }
-
-      if (typeof start === "string") {
-        if (start.length !== 1 || end.length !== 1) {
-          throw new Error("String range start and end must be a single character")
-        }
-
-        const startCode = start.charCodeAt(0)
-        const endCode = end.charCodeAt(0)
-        const step = startCode < endCode ? 1 : -1
-
-        const length = Math.abs(endCode - startCode) + (inclusive ? 1 : 0)
-        if (length <= 26) {
-          return {
-            type: "RangeExpression",
-            children: ["[", Array.from({ length }, (_, i) => JSON.stringify(String.fromCharCode(startCode + i * step))).join(", "), "]"],
-            inclusive,
-            start: s,
-            end: e
-          }
-        } else {
-          const inclusiveAdjust = inclusive ? " + 1" : ""
-          const children = ["((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)", inclusiveAdjust, "}, (_, i) => String.fromCharCode(s + i * step))})(", startCode.toString(), ws, range, endCode.toString(), ")"]
-          return {
-            type: "RangeExpression",
-            children,
-            inclusive,
-            start: s,
-            end: e,
-          }
-        }
-      } else if (typeof start === "number") {
-        const step = end > start ? 1 : -1
-
-        const length = Math.abs(end - start) + (inclusive ? 1 : 0)
-        if (length <= 20) {
-          // Use array of literal values
-          return {
-            type: "RangeExpression",
-            children: ["[", Array.from({ length }, (_, i) => start + i * step).join(", "), "]"],
-            inclusive,
-            start: s,
-            end: e,
-          }
-        }
+      return {
+        ...dots, left, right, increasing, error, type: "RangeDots",
+        children: [error]
       }
     }
-
-    const inclusiveAdjust = inclusive ? " + 1" : ""
-    const children = ["((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)", inclusiveAdjust, "}, (_, i) => s + i * step)})(", s, ws, range, e, ")"]
-
     return {
-      type: "RangeExpression",
-      children,
-      inclusive,
-      start: s,
-      end: e,
+      ...dots, left, right, increasing, type: "RangeDots",
+      children: [ws1, ws2]
     }
+
+RangeEnd
+  /([<>])(=?)|([≤≥])/ ->
+    let dir = $1, equal = $2, unicode = $3
+    if (unicode) {
+      equal = "="
+      if (unicode === "≤") {
+        dir = "<"
+      } else if (unicode === "≥") {
+        dir = ">"
+      }
+    }
+    return {
+      increasing: dir === "<",
+      inclusive: equal === "=",
+      raw: $0,
+    }
+  "" -> { increasing: undefined, inclusive: true, raw: "" }
+
+RangeExpression
+  Expression:start __:ws RangeDots:range Expression:end ->
+    return processRangeExpression(start, ws, range, end)
 
   # NOTE: [x..] range to infinity, valid only in for loops
   Expression:s __:ws DotDot &( __ CloseBracket ) ->
@@ -2975,6 +2956,9 @@ RangeExpression
         name: "Infinity",
         children: ["Infinity"],
       },
+      left: { inclusive: true, raw: "" },
+      right: { inclusive: true, raw: "" },
+      increasing: true,
     }
 
 ArrayLiteralContent

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1495,19 +1495,27 @@ MemberBracketContent
     }
 
 SliceParameters
-  Expression:start __:ws ( DotDotDot / DotDot ):sep Expression?:end ->
-    const inclusive = sep.token === ".."
-
+  Expression:start __:ws RangeDots:dots Expression?:end ->
     let children
+    if (!dots.left.inclusive) {
+      start = ["1 + ", makeLeftHandSideExpression(start)]
+    }
     if (end) {
       const inc = []
-      if (inclusive) {
+      if (dots.right.inclusive) {
         end = ["1 + ", makeLeftHandSideExpression(end)]
         inc./**/push(" || 1/0")
       }
-      children = [start, [...ws, {...sep, token: ", "}], [end, ...inc]]
+      children = [start, [...ws, dots.children[0], {token: ", ", $loc: dots.$loc}], [dots.children[1], end, ...inc]]
     } else {
       children = [start, ws]
+    }
+    if (dots.increasing === false) {
+      children.push({
+        type: "Error",
+        message: "Slice range cannot be decreasing",
+        $loc: dots.$loc,
+      })
     }
 
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2909,6 +2909,7 @@ RangeDots
       const error = {
         type: "Error",
         message: `${left.raw}..${right.raw} uses inconsistent < vs. >`,
+        $loc: dots.$loc,
       }
       return {
         ...dots, left, right, increasing, error, type: "RangeDots",

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -83,9 +83,10 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
   unless children?
     if range.increasing?
       sign := range.increasing ? "+" : "-"
+      end = makeLeftHandSideExpression end
       children =
-        . "((s, e) => Array.from({length: "
-        . range.increasing ? "e - s" : "s - e"
+        . "((s) => Array.from({length: "
+        . range.increasing ? [ws2, end, " - s"] : ["s - ", ws2, end]
         . lengthAdjustExpression
         . "}, (_, i) => s ", sign, " i))"
         . "("
@@ -93,7 +94,7 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
             start
           else
             [makeLeftHandSideExpression(start), ` ${sign} 1`]
-        . ...ws1, comma, ws2, end, ")"
+        . ...ws1, ")"
     else
       children =
         . "((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)"

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -3,12 +3,15 @@ import type {
   ASTNodeBase
   ASTLeaf
   ASTError
-  ExpressionNode
+  Children
+  RangeDots
+  RangeExpression
 } from ./types.civet
 
 import {
   insertTrimmingSpace
   literalValue
+  makeLeftHandSideExpression
 } from ./util.civet
 
 import {
@@ -16,35 +19,139 @@ import {
   maybeRef
 } from ./ref.civet
 
+function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, end: ASTNode)
+  ws1 = [ws1, range.children[0]] // whitespace before ..
+  ws2 := range.children[1]       // whitespace after ..
+  comma := { $loc: range.$loc, token: "," }
+  // Length of range is abs(start - end) + lengthAdjust
+  abs :=
+    switch range.increasing
+      when true
+        &: number
+      when false
+        -&: number
+      else
+        Math.abs
+  lengthAdjust :=
+    1 - Number(not range.left.inclusive) - Number(not range.right.inclusive)
+  lengthAdjustExpression :=
+    if lengthAdjust > 0 then ` + ${lengthAdjust}`
+    else if lengthAdjust < 0 then ` - ${-lengthAdjust}`
+
+  let children: Children?
+  if start is like {type: "Literal"} and end is like {type: "Literal"}
+    startValue .= literalValue start
+    endValue .= literalValue end
+
+    if startValue <? "string" and endValue <? "string"
+      unless startValue# is 1 is endValue#
+        throw new Error "String range start and end must be a single character"
+
+      startCode .= startValue.charCodeAt(0)
+      endCode .= endValue.charCodeAt(0)
+      step := startCode <= endCode ? 1 : -1
+
+      length := abs(endCode - startCode) + lengthAdjust
+      startCode += step unless range.left.inclusive
+
+      if length <= 26
+        children =
+          . "["
+          . Array.from { length }, (_, i) =>
+              JSON.stringify String.fromCharCode startCode + i * step
+            .join ", "
+          . "]"
+      else
+        children =
+          . `Array.from({length: ${length.toString()}}, `
+          . "(_, i) => String.fromCharCode(", startCode.toString()
+          . step > 0 ? " + " : " - ", "i))"
+      children.unshift range.error if range.error?
+    else if startValue <? "number" and endValue <? "number"
+      step := startValue <= endValue ? 1 : -1
+      length := abs(endValue - startValue) + lengthAdjust
+      startValue += step unless range.left.inclusive
+      if length <= 20
+        // Use array of literal values
+        children =
+          . "["
+          . Array.from({ length }, (_, i) => startValue as number + i * step)
+            .join ", "
+          . "]"
+        children.unshift range.error if range.error?
+
+  unless children?
+    if range.increasing?
+      sign := range.increasing ? "+" : "-"
+      children =
+        . "((s, e) => Array.from({length: "
+        . range.increasing ? "e - s" : "s - e"
+        . lengthAdjustExpression
+        . "}, (_, i) => s ", sign, " i))"
+        . "("
+        . if range.left.inclusive
+            start
+          else
+            [makeLeftHandSideExpression(start), ` ${sign} 1`]
+        . ...ws1, comma, ws2, end, ")"
+    else
+      children =
+        . "((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)"
+        . lengthAdjustExpression
+        . "}, (_, i) => s + i * step)})"
+        . "(", start, ...ws1, comma, ws2, end, ")"
+
+  {
+    type: "RangeExpression"
+    children, start, end
+    error: range.error
+    left: range.left
+    right: range.right
+    increasing: range.increasing
+  }
+
 // Construct for loop from RangeLiteral
 function forRange(
-  open: ASTLeaf,
-  forDeclaration,
-  range: { start: ExpressionNode, end: ExpressionNode, inclusive: boolean },
-  stepExp,
+  open: ASTLeaf
+  forDeclaration: ASTNode
+  range: RangeExpression
+  stepExp: ASTNode
   close: ASTLeaf
 )
-  { start, end, inclusive } := range
+  { start, end, left, right, increasing } := range
 
   counterRef := makeRef("i")
 
-  //infinite := if {type: "Identifier", name: "Infinity"} := end then true
-  infinite := end.type is "Identifier" and end.name is "Infinity"
+  infinite := end is like {type: "Identifier", name: "Infinity"}
 
-  let stepRef
+  let stepRef, asc: boolean?
   if stepExp
     stepExp = insertTrimmingSpace(stepExp, "")
     stepRef = maybeRef(stepExp, "step")
   else if infinite
     stepExp = stepRef = "1"
+  else if increasing?
+    if increasing
+      stepExp = stepRef = "1"
+      asc = true
+    else
+      stepExp = stepRef = "-1"
+      asc = false
 
-  startRef .= maybeRef(start, "start")
+  // start needs to be ref'd to compute start <= end, unless we know direction
+  startRef .= if stepRef then start else maybeRef(start, "start")
   endRef .= maybeRef(end, "end")
 
   startRefDec := (startRef !== start) ? [startRef, " = ", start, ", "] : []
   endRefDec := (endRef !== end) ? [endRef, " = ", end, ", "] : []
 
-  let ascDec: ASTNode[] = [], ascRef, asc
+  unless left.inclusive
+    startRef =
+      . makeLeftHandSideExpression(start)
+      . " + "
+      . stepRef
+
+  let ascDec: ASTNode[] = [], ascRef
   if stepRef
     unless stepRef is stepExp
       ascDec = [", ", stepRef, " = ", stepExp]
@@ -75,32 +182,33 @@ function forRange(
     varAssign = varLetAssign = [forDeclaration, " = "]
 
   declaration :=
-    type: "Declaration",
-    children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec],
-    names: forDeclaration?.names,
+    type: "Declaration"
+    children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec]
+    names: forDeclaration?.names
 
-  counterPart := inclusive
+  counterPart := right.inclusive
     ? [counterRef, " <= ", endRef, " : ", counterRef, " >= ", endRef]
     : [counterRef, " < ", endRef, " : ", counterRef, " > ", endRef]
 
-  condition := infinite ? [] : stepRef
-    ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"]
-    : ascRef
-      ? [ascRef, " ? ", ...counterPart]
-      : asc ? counterPart.slice(0, 3) : counterPart.slice(4)
+  condition :=
+    infinite ? [] :
+    asc? ? (asc ? counterPart[0...3] : counterPart[4..]) :
+    stepRef ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"] :
+    [ascRef, " ? ", ...counterPart]
 
-  increment := infinite
-    ? [...varAssign, "++", counterRef]
-    : stepRef
+  increment :=
+    stepRef === "1" ? [...varAssign, "++", counterRef] :
+    stepRef === "-1" ? [...varAssign, "--", counterRef] :
+    stepRef
       ? [...varAssign, counterRef, " += ", stepRef]
       : ascRef
         ? [...varAssign, ascRef, " ? ++", counterRef, " : --", counterRef]
         : [...varAssign, asc ? "++" : "--", counterRef]
 
   return {
-    declaration,
-    children: [open, declaration, "; ", ...condition, "; ", ...increment, close],
-    blockPrefix,
+    declaration
+    children: [range.error, open, declaration, "; ", ...condition, "; ", ...increment, close]
+    blockPrefix
   }
 
 function processForInOf($0: [
@@ -263,4 +371,5 @@ function processForInOf($0: [
 export {
   forRange
   processForInOf
+  processRangeExpression
 }

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -106,7 +106,7 @@ import {
 } from ./declaration.civet
 
 import { processPipelineExpressions } from ./pipe.civet
-import { forRange, processForInOf } from ./for.civet
+import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
   expressionizeIteration
   makeAmpersandFunction
@@ -1686,6 +1686,7 @@ export {
   processForInOf
   processProgram
   processProgramAsync
+  processRangeExpression
   processTryBlock
   processUnaryExpression
   processUnaryNestedExpression

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -97,6 +97,8 @@ export type OtherNode =
   | PinProperty
   | Placeholder
   | PropertyAccess
+  | RangeDots
+  | RangeExpression
   | ReturnValue
   | SpreadElement
   | TypeSuffix
@@ -902,6 +904,32 @@ export type Literal =
 export type LiteralContentNode = ASTLeaf & {
   type?: "NumericLiteral" | "StringLiteral"
 }
+
+export type RangeExpression
+  type: "RangeExpression"
+  children: Children
+  parent?: Parent
+  start: ASTNode
+  end: ASTNode
+  left: RangeEnd
+  right: RangeEnd
+  increasing: boolean?
+  error?: ASTError?
+
+export type RangeDots
+  type: "RangeDots"
+  children: Children
+  parent?: Parent
+  $loc: Loc
+  left: RangeEnd
+  right: RangeEnd
+  increasing: boolean?
+  error?: ASTError
+
+export type RangeEnd
+  increasing: boolean?
+  inclusive: boolean
+  raw: string
 
 export type TabConfig = number?
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -128,6 +128,7 @@ export type ASTError =
   type: "Error"
   subtype?: "Warning" | "Error"
   message: string
+  $loc?: Loc
   token?: undefined
   filename?: string
   line?: number

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -202,7 +202,7 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a;
-    for (let start = x(), end = y(), i = a = start, step = z(); step !== 0 && (step > 0 ? i < end : i > end); a = i += step) {
+    for (let end = y(), i = a = x(), step = z(); step !== 0 && (step > 0 ? i < end : i > end); a = i += step) {
       console.log(a)
     }
   """
@@ -217,7 +217,7 @@ describe "coffeeForLoops", ->
     ---
     var start, end, step, a;
     start = end = step = null
-    for (let start1 = x(), end1 = y(), i = a = start1, step1 = z(); step1 !== 0 && (step1 > 0 ? i < end1 : i > end1); a = i += step1) {
+    for (let end1 = y(), i = a = x(), step1 = z(); step1 !== 0 && (step1 > 0 ? i < end1 : i > end1); a = i += step1) {
       console.log(a)
     }
   """

--- a/test/for.civet
+++ b/test/for.civet
@@ -247,6 +247,82 @@ describe "for", ->
     }
   """
 
+  describe "inequalities on range", ->
+    testCase """
+      ..<
+      ---
+      for i of [a..<b]
+        i
+      ---
+      for (let i1 = a; i1 < b; ++i1) {const i = i1;
+        i
+      }
+    """
+
+    testCase """
+      <..
+      ---
+      for i of [a<..b]
+        i
+      ---
+      for (let i1 = a + 1; i1 <= b; ++i1) {const i = i1;
+        i
+      }
+    """
+
+    testCase """
+      <..<
+      ---
+      for i of [a<..<b]
+        i
+      ---
+      for (let i1 = a + 1; i1 < b; ++i1) {const i = i1;
+        i
+      }
+    """
+
+    throws """
+      <..>
+      ---
+      for i of [a<..>b]
+        i
+      ---
+      ParseErrors: unknown:1:5 <..> uses inconsistent < vs. >
+    """
+
+    testCase """
+      ..>
+      ---
+      for i of [a..>b]
+        i
+      ---
+      for (let i1 = a; i1 > b; --i1) {const i = i1;
+        i
+      }
+    """
+
+    testCase """
+      >..
+      ---
+      for i of [a>..b]
+        i
+      ---
+      for (let i1 = a + -1; i1 >= b; --i1) {const i = i1;
+        i
+      }
+    """
+
+    testCase """
+      >..>
+      ---
+      for i of [a>..>b]
+        i
+      ---
+      for (let i1 = a + -1; i1 > b; --i1) {const i = i1;
+        i
+      }
+    """
+
   describe "binding left-hand side", ->
     testCase """
       a.b

--- a/test/for.civet
+++ b/test/for.civet
@@ -287,7 +287,7 @@ describe "for", ->
       for i of [a<..>b]
         i
       ---
-      ParseErrors: unknown:1:5 <..> uses inconsistent < vs. >
+      ParseErrors: unknown:1:13 <..> uses inconsistent < vs. >
     """
 
     testCase """

--- a/test/range.civet
+++ b/test/range.civet
@@ -1,4 +1,4 @@
-{ testCase } from "./helper.civet"
+{ testCase, throws } from "./helper.civet"
 
 describe "range", ->
   testCase """
@@ -143,7 +143,7 @@ describe "range", ->
     ---
     [' '..'~']
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => String.fromCharCode(s + i * step))})(32,126)
+    Array.from({length: 95}, (_, i) => String.fromCharCode(32 + i))
   """
 
   testCase """
@@ -205,3 +205,252 @@ describe "range", ->
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)}, (_, i) => s + i * step)})(0,n)
   """
+
+  describe "inequalities on range", ->
+    testCase """
+      ..< with numbers
+      ---
+      [0..<10]
+      ---
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    """
+
+    testCase """
+      ..<= with numbers
+      ---
+      [0..<=10]
+      ---
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    """
+
+    testCase """
+      ..≤ with numbers
+      ---
+      [0..≤10]
+      ---
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    """
+
+    testCase """
+      <.. with numbers
+      ---
+      [0<..10]
+      ---
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    """
+
+    testCase """
+      <=.. with numbers
+      ---
+      [0<=..10]
+      ---
+      [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    """
+
+    testCase """
+      <..< with numbers
+      ---
+      [0<..<10]
+      ---
+      [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    """
+
+    throws """
+      <..> with numbers
+      ---
+      [0<..>10]
+      ---
+      ParseErrors: unknown:1:1 <..> uses inconsistent < vs. >
+    """
+
+    testCase """
+      ..< null with numbers
+      ---
+      [10..<0]
+      ---
+      []
+    """
+
+    testCase """
+      ..> with numbers
+      ---
+      [10..>0]
+      ---
+      [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+    """
+
+    testCase """
+      ..>= with numbers
+      ---
+      [10..>=0]
+      ---
+      [10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+    """
+
+    testCase """
+      ..< with strings
+      ---
+      ['a'..<'g']
+      ---
+      ["a", "b", "c", "d", "e", "f"]
+    """
+
+    testCase """
+      <.. with strings
+      ---
+      ['a'<..'g']
+      ---
+      ["b", "c", "d", "e", "f", "g"]
+    """
+
+    testCase """
+      <..< with strings
+      ---
+      ['a'<..<'g']
+      ---
+      ["b", "c", "d", "e", "f"]
+    """
+
+    testCase """
+      ..< long with strings
+      ---
+      [' '..<'~']
+      ---
+      Array.from({length: 94}, (_, i) => String.fromCharCode(32 + i))
+    """
+
+    testCase """
+      <.. long with strings
+      ---
+      [' '<..'~']
+      ---
+      Array.from({length: 94}, (_, i) => String.fromCharCode(33 + i))
+    """
+
+    testCase """
+      <..< long with strings
+      ---
+      [' '<..<'~']
+      ---
+      Array.from({length: 93}, (_, i) => String.fromCharCode(33 + i))
+    """
+
+    testCase """
+      <..< long with strings
+      ---
+      [' '<..<'~']
+      ---
+      Array.from({length: 93}, (_, i) => String.fromCharCode(33 + i))
+    """
+
+    throws """
+      <..> with strings
+      ---
+      ['a'<..>'g']
+      ---
+      ParseErrors: unknown:1:1 <..> uses inconsistent < vs. >
+    """
+
+    testCase """
+      ..< null with strings
+      ---
+      ['g'..<'a']
+      ---
+      []
+    """
+
+    testCase """
+      ..> with strings
+      ---
+      ['g'..>'a']
+      ---
+      ["g", "f", "e", "d", "c", "b"]
+    """
+
+    testCase """
+      ..>= with strings
+      ---
+      ['g'..>='a']
+      ---
+      ["g", "f", "e", "d", "c", "b", "a"]
+    """
+
+    testCase """
+      ..< with variables
+      ---
+      [a..<b]
+      ---
+      ((s, e) => Array.from({length: e - s}, (_, i) => s + i))(a,b)
+    """
+
+    testCase """
+      ..<= with variables
+      ---
+      [a..<=b]
+      ---
+      ((s, e) => Array.from({length: e - s + 1}, (_, i) => s + i))(a,b)
+    """
+
+    testCase """
+      <.. with variables
+      ---
+      [a<..b]
+      ---
+      ((s, e) => Array.from({length: e - s}, (_, i) => s + i))(a + 1,b)
+    """
+
+    testCase """
+      <..< with variables
+      ---
+      [a<..<b]
+      ---
+      ((s, e) => Array.from({length: e - s - 1}, (_, i) => s + i))(a + 1,b)
+    """
+
+    throws """
+      <..> with variables
+      ---
+      [a<..>b]
+      ---
+      ParseErrors: unknown:1:7 <..> uses inconsistent < vs. >
+    """
+
+    testCase """
+      ..> with variables
+      ---
+      [a..>b]
+      ---
+      ((s, e) => Array.from({length: s - e}, (_, i) => s - i))(a,b)
+    """
+
+    testCase """
+      >.. with variables
+      ---
+      [a>..b]
+      ---
+      ((s, e) => Array.from({length: s - e}, (_, i) => s - i))(a - 1,b)
+    """
+
+    testCase """
+      >.. with expressions
+      ---
+      [a ?? aa >..b]
+      ---
+      ((s, e) => Array.from({length: s - e}, (_, i) => s - i))((a ?? aa) - 1 ,b)
+    """
+
+    testCase """
+      >..> with variables
+      ---
+      [a>..>b]
+      ---
+      ((s, e) => Array.from({length: s - e - 1}, (_, i) => s - i))(a - 1,b)
+    """
+
+    testCase """
+      <..< spaced out
+      ---
+      [a /*1*/ < /*2*/ .. /*3*/ < /*4*/ b]
+      ---
+      ((s, e) => Array.from({length: e - s - 1}, (_, i) => s + i))(a + 1 /*1*/  /*2*/ , /*3*/  /*4*/ b)
+    """

--- a/test/range.civet
+++ b/test/range.civet
@@ -260,7 +260,7 @@ describe "range", ->
       ---
       [0<..>10]
       ---
-      ParseErrors: unknown:1:1 <..> uses inconsistent < vs. >
+      ParseErrors: unknown:1:4 <..> uses inconsistent < vs. >
     """
 
     testCase """
@@ -348,7 +348,7 @@ describe "range", ->
       ---
       ['a'<..>'g']
       ---
-      ParseErrors: unknown:1:1 <..> uses inconsistent < vs. >
+      ParseErrors: unknown:1:6 <..> uses inconsistent < vs. >
     """
 
     testCase """
@@ -412,7 +412,7 @@ describe "range", ->
       ---
       [a<..>b]
       ---
-      ParseErrors: unknown:1:7 <..> uses inconsistent < vs. >
+      ParseErrors: unknown:1:4 <..> uses inconsistent < vs. >
     """
 
     testCase """

--- a/test/range.civet
+++ b/test/range.civet
@@ -380,7 +380,7 @@ describe "range", ->
       ---
       [a..<b]
       ---
-      ((s, e) => Array.from({length: e - s}, (_, i) => s + i))(a,b)
+      ((s) => Array.from({length: b - s}, (_, i) => s + i))(a)
     """
 
     testCase """
@@ -388,7 +388,7 @@ describe "range", ->
       ---
       [a..<=b]
       ---
-      ((s, e) => Array.from({length: e - s + 1}, (_, i) => s + i))(a,b)
+      ((s) => Array.from({length: b - s + 1}, (_, i) => s + i))(a)
     """
 
     testCase """
@@ -396,7 +396,7 @@ describe "range", ->
       ---
       [a<..b]
       ---
-      ((s, e) => Array.from({length: e - s}, (_, i) => s + i))(a + 1,b)
+      ((s) => Array.from({length: b - s}, (_, i) => s + i))(a + 1)
     """
 
     testCase """
@@ -404,7 +404,7 @@ describe "range", ->
       ---
       [a<..<b]
       ---
-      ((s, e) => Array.from({length: e - s - 1}, (_, i) => s + i))(a + 1,b)
+      ((s) => Array.from({length: b - s - 1}, (_, i) => s + i))(a + 1)
     """
 
     throws """
@@ -420,7 +420,7 @@ describe "range", ->
       ---
       [a..>b]
       ---
-      ((s, e) => Array.from({length: s - e}, (_, i) => s - i))(a,b)
+      ((s) => Array.from({length: s - b}, (_, i) => s - i))(a)
     """
 
     testCase """
@@ -428,15 +428,15 @@ describe "range", ->
       ---
       [a>..b]
       ---
-      ((s, e) => Array.from({length: s - e}, (_, i) => s - i))(a - 1,b)
+      ((s) => Array.from({length: s - b}, (_, i) => s - i))(a - 1)
     """
 
     testCase """
       >.. with expressions
       ---
-      [a ?? aa >..b]
+      [a ?? aa >.. b ?? bb]
       ---
-      ((s, e) => Array.from({length: s - e}, (_, i) => s - i))((a ?? aa) - 1 ,b)
+      ((s) => Array.from({length: s -  (b ?? bb)}, (_, i) => s - i))((a ?? aa) - 1 )
     """
 
     testCase """
@@ -444,7 +444,7 @@ describe "range", ->
       ---
       [a>..>b]
       ---
-      ((s, e) => Array.from({length: s - e - 1}, (_, i) => s - i))(a - 1,b)
+      ((s) => Array.from({length: s - b - 1}, (_, i) => s - i))(a - 1)
     """
 
     testCase """
@@ -452,5 +452,5 @@ describe "range", ->
       ---
       [a /*1*/ < /*2*/ .. /*3*/ < /*4*/ b]
       ---
-      ((s, e) => Array.from({length: e - s - 1}, (_, i) => s + i))(a + 1 /*1*/  /*2*/ , /*3*/  /*4*/ b)
+      ((s) => Array.from({length:  /*3*/  /*4*/ b - s - 1}, (_, i) => s + i))(a + 1 /*1*/  /*2*/ )
     """

--- a/test/slice.civet
+++ b/test/slice.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "slice", ->
   testCase """
@@ -64,7 +64,7 @@ describe "slice", ->
     ---
     x[lineNum - 2 .. lineNum + 2]
     ---
-    x.slice(lineNum - 2 , 1 + ( lineNum + 2) || 1/0)
+    x.slice(lineNum - 2 ,  1 + (lineNum + 2) || 1/0)
   """
 
   // #1330
@@ -75,6 +75,55 @@ describe "slice", ->
     ---
     x.slice(0, 1 + (x|y) || 1/0)
   """
+
+  describe "inequalities on range", ->
+    testCase """
+      ..<
+      ---
+      x[a..<b]
+      ---
+      x.slice(a, b)
+    """
+
+    testCase """
+      ..<=
+      ---
+      x[a..<=b]
+      ---
+      x.slice(a, 1 + b || 1/0)
+    """
+
+    testCase """
+      <..
+      ---
+      x[a<..b]
+      ---
+      x.slice(1 + a, 1 + b || 1/0)
+    """
+
+    testCase """
+      <..<
+      ---
+      x[a<..<b]
+      ---
+      x.slice(1 + a, b)
+    """
+
+    throws """
+      ..>
+      ---
+      x[a..>b]
+      ---
+      ParseErrors: unknown:1:4 Slice range cannot be decreasing
+    """
+
+    throws """
+      <..>
+      ---
+      x[a<..>b]
+      ---
+      ParseErrors: unknown:1:5 <..> uses inconsistent < vs. >
+    """
 
   describe "assignment", ->
     testCase """

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -67,8 +67,8 @@ declare module "@danielx/civet" {
     header: string
     body: string
     filename: string
-    line: number
-    column: number
+    line: number | string
+    column: number | string
     offset: number
   }
   export type ParseErrors = {


### PR DESCRIPTION
Fixes #999 by allowing inequalities in `..` ranges/slices, inspired by [Swift's `a..<b` half-open range operator](https://developer.apple.com/documentation/swift/range):
* Each endpoint can be marked `<` or `<=` (or the Unicode equivalent, `≤`) for increasing loops, or `>` or `>=`/`≥` for decreasing loops.
* Inclusive (as in `<=` or `>=`) is the default behavior, but it forces a loop order, which can be useful.
* Slices forbid `>`, as we don't have a nice way to reverse slice (when dealing with strings).

Because we can now specify direction, the ranges and loops can be a bit more efficient (as well as more consistent/reliable). Compare the old `...`:

```js
[0...array#]
for i of [0...array#]
↓↓↓
((s, e) => {
  let step = e > s ? 1 : -1;
  return Array.from(
    { length: Math.abs(e - s) },
    (_, i) => s + i * step,
  );
})(0, array.length);
for (
  let end = array.length, i1 = 0, asc = 0 <= end;
  asc ? i1 < end : i1 > end;
  asc ? ++i1 : --i1
) {
  const i = i1;
}
```

versus the new `..<`:

```js
[0..<array#]
for i of [0..<array#]
↓↓↓
((s) =>
  Array.from(
    { length: array.length - s },
    (_, i) => s + i,
  ))(0);
for (
  let end = array.length, i1 = 0;
  i1 < end;
  ++i1
) {
  const i = i1;
}
```