### PR TITLE
Pattern matching `catch`

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,7 +17,7 @@ civet --no-config build/esbuild.civet "$@"
 
 # built types
 for name in astro esbuild rollup unplugin vite webpack; do
-  sed 's/\.civet"/\.js"/' dist/unplugin/source/unplugin/$name.civet.d.ts >dist/unplugin/$name.d.ts
+  sed 's/\.civet"/\.js"/' dist/unplugin/source/unplugin/$name.d.ts >dist/unplugin/$name.d.ts
 done
 rm -rf dist/unplugin/source
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1910,6 +1910,29 @@ else
   callback result
 </Playground>
 
+You can also specify multiple `catch` blocks using
+[pattern matching](#pattern-matching):
+
+<Playground>
+try
+  foo()
+catch <? RangeError, <? ReferenceError
+  console.log "R...Error"
+catch {message: /bad/}
+  console.log "bad"
+catch e
+  console.log "other", e
+</Playground>
+
+If you omit a catch-all at the end,
+the default behavior is to re-`throw` the error:
+
+<Playground>
+try
+  foo()
+catch {message: /^EPIPE:/}
+</Playground>
+
 ### Do Blocks
 
 To put multiple lines in a scope and possibly an expression,

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "unplugin": "^1.12.2"
   },
   "devDependencies": {
-    "@danielx/civet": "0.7.30",
+    "@danielx/civet": "0.8.4",
     "@danielx/hera": "^0.8.16",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4833,12 +4833,12 @@ CaseClause
       children: $0
     }
   # NOTE: Added else from CoffeeScript
-  Else ImpliedColon ( ThenClause / BracedBlock / EmptyBlock ):block ->
-    $1.token = "default"
+  Else:e ImpliedColon:colon ( ThenClause / BracedBlock / EmptyBlock ):block ->
+    e = { ...e, token: "default" }
     return {
       type: "DefaultClause",
       block,
-      children: $0
+      children: [ e, colon, block ]
     }
 
 PatternExpressionList
@@ -4890,24 +4890,35 @@ IgnoreColon
 
 # https://262.ecma-international.org/#prod-TryStatement
 TryStatement
-  Try !":" NoPostfixBracedOrEmptyBlock CatchClause? ElseClause? FinallyClause? ->
+  Try !":" NoPostfixBracedOrEmptyBlock CatchClause* ElseClause? FinallyClause? ->
     return processTryBlock($0)
 
 # https://262.ecma-international.org/#prod-Catch
 CatchClause
-  ( Nested / _ ) Catch CatchBind? ( BracedThenClause / BracedOrEmptyBlock ):block ->
+  ( Nested / _ ) Catch CatchBinding?:binding ( BracedThenClause / BracedOrEmptyBlock ):block ->
     return {
       type: "CatchClause",
       children: $0,
       block,
+      binding,
     }
 
 # NOTE: Added optional parentheses to catch binding
-CatchBind
-  _? OpenParen __ CatchParameter __ CloseParen
-  _:ws InsertOpenParen:open !EOS ForbidIndentedApplication CatchParameter?:param RestoreIndentedApplication InsertCloseParen:close ->
-    if (!param) return $skip
-    return [ ws, open, param, close ]
+CatchBinding
+  _?:ws1 OpenParen:open __:ws2 AllowAll CatchParameter?:parameter RestoreAll __:ws3 CloseParen:close ->
+    if (!parameter) return $skip
+    return {
+      type: "CatchBinding",
+      parameter,
+      children: [ ws1, open, ws2, parameter, ws3, close ],
+    }
+  _:ws InsertOpenParen:open !EOS ForbidIndentedApplication CatchParameter?:parameter RestoreIndentedApplication InsertCloseParen:close ->
+    if (!parameter) return $skip
+    return {
+      type: "CatchBinding",
+      parameter,
+      children: [ ws, open, parameter, close ]
+    }
 
 # https://262.ecma-international.org/#prod-Finally
 FinallyClause
@@ -4920,8 +4931,26 @@ FinallyClause
 
 # https://262.ecma-international.org/#prod-CatchParameter
 CatchParameter
-  BindingIdentifier TypeSuffix?
-  BindingPattern TypeSuffix?
+  BindingIdentifier:binding TypeSuffix?:typeSuffix ->
+    return {
+      type: "CatchParameter",
+      binding,
+      typeSuffix,
+      children: $0,
+    }
+  ( ObjectBindingPattern / ArrayBindingPattern ):binding TypeSuffix:typeSuffix ->
+    return {
+      type: "CatchParameter",
+      binding,
+      typeSuffix,
+      children: [ binding, typeSuffix ],
+    }
+  PatternExpressionList ->
+    return {
+      type: "CatchPattern",
+      children: $0,
+      patterns: $1,
+    }
 
 # An expression with explicit or implied parentheses, for use in if/while/switch
 Condition

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -14,8 +14,11 @@ import type {
   ASTNodeParent
   ASTRef
   AssignmentExpression
+  Bindings
   BlockStatement
   CallExpression
+  CaseBlock
+  CatchBinding
   CatchClause
   ComptimeStatement
   Condition
@@ -25,14 +28,17 @@ import type {
   ExpressionNode
   FinallyClause
   ForStatement
-  FunctionExpression
   IfStatement
+  Initializer
   IterationStatement
   MemberExpression
   MethodDefinition
+  NormalCatchParameter
+  ParenthesizedExpression
   Placeholder
   StatementExpression
   StatementTuple
+  SwitchStatement
   TypeArguments
   TypeSuffix
   WSNode
@@ -335,8 +341,112 @@ function handleThisPrivateShorthands(value)
 
   return [value, value.thisShorthand]
 
-function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause?, ElseClause?, FinallyClause?])
-  [t, , b, c, e, f] .= $0
+function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[], ElseClause?, FinallyClause?])
+  [t, , b, cs, e, f] .= $0
+
+  // Pattern matching catch clauses: transform into pattern matching switch
+  let c: CatchClause?
+  if cs.some .binding?.parameter is like {type: "CatchPattern"}
+    ref := makeRef("e")
+    binding: CatchBinding :=
+      type: "CatchBinding"
+      children: [ "(", ref, ")" ]
+      parameter: ref
+    condition: ParenthesizedExpression :=
+      type: "ParenthesizedExpression"
+      children: [ "(", ref, ")" ]
+      expression: ref
+    defaultClause .= false
+    clauses: CaseBlock["clauses"] := cs.map (clause) =>
+      if {type: "CatchPattern", patterns} := clause.binding?.parameter
+        {
+          type: "PatternClause"
+          patterns
+          block: clause.block
+          children: [ patterns, clause.block ]
+        }
+      else
+        defaultClause = true
+        parameter := clause.binding?.parameter
+        if parameter?
+          assert.equal parameter.type, "CatchParameter",
+            `Invalid catch parameter ${parameter.type}`
+          { binding: pattern, typeSuffix } := parameter as NormalCatchParameter
+          initializer: Initializer :=
+            type: "Initializer"
+            expression: ref
+            children: [ "", " = ", ref ]
+          bindings: Bindings[] := [{
+            type: "Binding"
+            names: pattern.names
+            pattern
+            typeSuffix
+            initializer
+            children: [ pattern, typeSuffix, initializer ]
+            splices: []
+            thisAssignments: []
+          }]
+          clause.block.expressions.unshift ["", {
+            type: "Declaration"
+            children: ["let", " ", bindings]
+            bindings
+            names: bindings[0].names
+            decl: "let"
+          }, ";"]
+
+        type: "DefaultClause"
+        block: clause.block
+        children: [ "default: ", clause.block ]
+
+    // If no default clause specified, add one that rethrows exception
+    unless defaultClause
+      expressions: StatementTuple[] := [["",
+        type: "ThrowStatement"
+        children: [ "throw", " ", ref ]
+      ]]
+      block: BlockStatement := {
+        type: "BlockStatement"
+        expressions
+        children: [ " {", expressions, "}" ]
+        bare: false
+      }
+      clauses.push {
+        type: "DefaultClause"
+        block
+        children: [ "default: ", block ]
+      }
+    caseBlock: CaseBlock := {
+      type: "CaseBlock"
+      clauses
+      children: [ " {", clauses, "}" ]
+    }
+    patternSwitch: SwitchStatement := {
+      type: "SwitchStatement"
+      condition
+      caseBlock
+      children: [ "switch", condition, caseBlock ]
+    }
+    block: BlockStatement :=
+      type: "BlockStatement"
+      bare: false
+      expressions: [["", patternSwitch]]
+      children: [" {", patternSwitch, "}"]
+    c = makeNode {
+      type: "CatchClause"
+      children:
+        . cs[0].children[0] // whitespace
+        . cs[0].children[1] // catch token
+        . binding, block
+      binding
+      block
+    }
+  else
+    c = cs[0]
+    if cs# > 1
+      c = append c,
+        type: "Error"
+        message: "Only one catch clause allowed unless using pattern matching"
+      as CatchClause
 
   // Default behavior catches all exceptions
   if !c and (e or !f)

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -78,10 +78,14 @@ export type OtherNode =
   | Binding
   | BindingRestElement
   | Call
+  | CatchBinding
   | CatchClause
+  | CatchPattern
   | CaseBlock
+  | CaseClause
   | CommentNode
   | ComputedPropertyName
+  | ConditionFragment
   | DefaultClause
   | ElseClause
   | FieldDefinition
@@ -90,9 +94,11 @@ export type OtherNode =
   | Initializer
   | Label
   | NonNullAssertion
+  | NormalCatchParameter
   | ObjectBindingPattern
   | Parameter
   | ParametersNode
+  | PatternClause
   | PinPattern
   | PinProperty
   | Placeholder
@@ -572,11 +578,36 @@ export type TryStatement
 
 export type CatchClause
   type: "CatchClause"
-  children: Children & [ Whitespace | ASTString, CatchToken, BlockStatement ]
+  children: Children & [ Whitespace | ASTString, CatchToken, CatchBinding, BlockStatement ]
   parent?: Parent
   block: BlockStatement
+  binding: CatchBinding?
 
-export type CatchToken = "catch(e) " | { $loc: Loc, token: "finally" }
+export type CatchToken = { $loc: Loc, token: "catch" }
+
+export type CatchBinding
+  type: "CatchBinding"
+  children: Children
+  parent?: Parent
+  parameter: CatchParameter
+
+export type CatchParameter =
+  | NormalCatchParameter
+  | CatchPattern
+  | ASTRef  // made by processTryBlock for pattern matching catch
+
+export type NormalCatchParameter =
+  type: "CatchParameter"
+  children: Children
+  parent?: Parent
+  binding: ObjectBindingPattern | ArrayBindingPattern
+  typeSuffix: TypeSuffix?
+
+export type CatchPattern
+  type: "CatchPattern"
+  children: Children
+  parent?: Parent
+  patterns: PatternExpression[]
 
 export type FinallyClause
   type: "FinallyClause"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -22,7 +22,7 @@ import {
 
 // Types need to be upfront to allow for TypeScript `asserts`
 assert: {
-  equal(a: unknown, b: unknown, msg: string): void
+  equal(a: unknown, b: unknown, msg: string): asserts a is b
   notEqual(a: unknown, b: unknown, msg: string): void
   notNull<T>(a: T, msg: string): asserts a is NonNullable<T>
 } := {

--- a/test/try.civet
+++ b/test/try.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
 
 describe "try", ->
   testCase """
@@ -363,4 +363,15 @@ describe "try", ->
         console.log('RangeError!')
       }
       else  {throw e}}
+    """
+
+    throws """
+      multiple normal blocks
+      ---
+      try
+        foo()
+      catch e1
+      catch e2
+      ---
+      ParseErrors: unknown:3:10 Only one catch clause allowed unless using pattern matching
     """

--- a/test/try.civet
+++ b/test/try.civet
@@ -319,3 +319,48 @@ describe "try", ->
         console.log('done')
       }
     """
+
+  describe "pattern matching catch", ->
+    // #1473
+    testCase """
+      original example
+      ---
+      try
+        foo()
+      catch <? RangeError, <? ReferenceError
+        console.log 'R...Error'
+      catch {message: /bad/}
+        console.log 'bad'
+      catch e
+        console.log 'other', e
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 instanceof RangeError || e1 instanceof ReferenceError) {
+        console.log('R...Error')
+      }
+      else if(typeof e1 === 'object' && e1 != null && 'message' in e1 && typeof e1.message === 'string' && /bad/.test(e1.message)) {const {message} = e1;
+        console.log('bad')
+      }
+      else  {let e = e1;
+        console.log('other', e)
+      }}
+    """
+
+    testCase """
+      without default case
+      ---
+      try
+        foo()
+      catch <? RangeError
+        console.log 'RangeError!'
+      ---
+      try {
+        foo()
+      }
+      catch(e) {if(e instanceof RangeError) {
+        console.log('RangeError!')
+      }
+      else  {throw e}}
+    """

--- a/test/types/try.civet
+++ b/test/types/try.civet
@@ -33,3 +33,19 @@ describe "[TS] try", ->
       bar(e)
     }
   """
+
+  testCase """
+    typed pattern
+    ---
+    try
+      foo()
+    catch {type, message}: TypeAndMessage
+      bar(type, message)
+    ---
+    try {
+      foo()
+    }
+    catch ({type, message}: TypeAndMessage) {
+      bar(type, message)
+    }
+  """

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,10 +150,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@0.7.30":
-  version "0.7.30"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.7.30.tgz#4fff5c4247485bcbf2d23d5ad1e81b359656e2c4"
-  integrity sha512-ZGVGge+wdDHyK0LHM0yfJ2y/ZCh0B36XWTCU207K7C5F+84f2WNOVM6ZRs8ZhZuxPSLt1Kd/rkugA3P4d0ObEg==
+"@danielx/civet@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.8.4.tgz#974574e5612d4e157433a5d50afa6b8515bdad7f"
+  integrity sha512-PwwOJzLlFLTUbuJsYiIWetOguE+0M78DxGF6szND+xKq6p9iSPle4hUlhME1rwYq0h6XjLXJLkZ2CFUi9ZGGoA==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
     "@typescript/vfs" "^1.6.0"


### PR DESCRIPTION
Fixes #1473 by following Plan 2 from https://github.com/DanielXMoore/Civet/issues/1473#issuecomment-2420337249, which seemed the most versatile.

This PR early-rewrites multiple `catch` blocks into a `catch(e) { switch(e)` with corresponding pattern matching, so any extensions to pattern matching will automatically apply.