### PR TITLE
Reverse slices and inequality slices with implicit parts

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -451,6 +451,12 @@ Alternatively, you can exclude or include endpoints using `..` with `<` or `<=`:
 strict := numbers[first<..<last]
 </Playground>
 
+Slices are increasing by default, but you can reverse them with `>` or `>=`:
+
+<Playground>
+reversed := x[..>=]
+</Playground>
+
 ## Strings
 
 Strings can span multiple lines:

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1473,12 +1473,13 @@ MemberBracketContent
   OpenBracket:open ( SliceParameters / PostfixedExpression ):expression __:ws CloseBracket:close ->
     // Some kind of slice
     if (expression.type === "SliceParameters") {
-      const {start, end, children} = expression
+      const {start, end, reversed, children} = expression
 
       return {
         type: "SliceExpression",
         start,
         end,
+        reversed,
         children: [
           {...open, token: ".slice("},
           ...children,
@@ -1495,68 +1496,47 @@ MemberBracketContent
     }
 
 SliceParameters
-  Expression:start __:ws RangeDots:dots Expression?:end ->
+  Loc:ls Expression?:start __:ws RangeDots:dots Loc:le Expression?:end ->
+    const reversed = dots.increasing === false
+    const sign = reversed ? "-" : "+"
     let children
+    start ??= {
+      $loc: ls.$loc,
+      token: reversed ? "-1" : "0",
+    }
+    if (!end) {
+      if (reversed) {
+        end = {
+          $loc: le.$loc,
+          token: "0",
+        }
+      } else if (!dots.right.inclusive && !dots.triple) {
+        end = {
+          $loc: le.$loc,
+          token: "-1",
+        }
+      }
+    }
     if (!dots.left.inclusive) {
-      start = ["1 + ", makeLeftHandSideExpression(start)]
+      start = [makeLeftHandSideExpression(start), ` ${sign} 1`]
     }
     if (end) {
       const inc = []
       if (dots.right.inclusive) {
-        end = ["1 + ", makeLeftHandSideExpression(end)]
-        inc./**/push(" || 1/0")
+        end = [makeLeftHandSideExpression(end), ` ${sign} 1`]
+        if (!reversed) inc./**/push(" || 1/0")
       }
       children = [start, [...ws, dots.children[0], {token: ", ", $loc: dots.$loc}], [dots.children[1], end, ...inc]]
     } else {
       children = [start, ws]
     }
-    if (dots.increasing === false) {
-      children.push({
-        type: "Error",
-        message: "Slice range cannot be decreasing",
-        $loc: dots.$loc,
-      })
-    }
 
     return {
       type: "SliceParameters",
       start,
       end,
+      reversed,
       children,
-    }
-
-  Loc:l __:ws ( DotDotDot / DotDot ):sep Expression:end ->
-    const inclusive = sep.token === ".."
-
-    const inc = []
-    if (inclusive) {
-      end = ["1 + ", end]
-      inc./**/push(" || 1/0")
-    }
-
-    const start = {
-      $loc: l.$loc,
-      token: "0",
-    }
-
-    return {
-      type: "SliceParameters",
-      start,
-      end,
-      children: [start, [...ws, {...sep, token: ", "}], [end, ...inc]]
-    }
-
-  Loc:l __:ws ( DotDot / DotDotDot ) &( __ CloseBracket ) ->
-    const start = {
-      $loc: l.$loc,
-      token: "0",
-    }
-
-    return {
-      type: "SliceParameters",
-      start,
-      end: undefined,
-      children: [start, ws],
     }
 
 AccessStart
@@ -2907,6 +2887,7 @@ RangeDots
       left: { inclusive: true, raw: "" },
       right: { inclusive: false, raw: "." },
       increasing: undefined,
+      triple: true,
       children: [],
     }
   RangeEnd:left _?:ws1 DotDot:dots _?:ws2 RangeEnd:right ->

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -64,6 +64,24 @@ declareHelper := {
       }
       "\n"
     ]]
+  rslice(rsliceRef): void
+    state.prelude.push ["", [
+      preludeVar
+      rsliceRef
+      ts [ ": <E, T extends string | E[]>(a: T, start?: number, end?: number) => T extends string ? string : T extends (infer F)[] ? F[] : unknown[]" ]
+      " = ((a, start, end) => {\n"
+      "  const l = a.length\n"
+      "  start = ", getHelperRef("modulo"), "(start ?? -1, l)\n"
+      "  end = ", getHelperRef("modulo"), "((end ?? -1) + 1, l)\n"
+      "  if (typeof a === 'string') {\n"
+      `    let r = ""\n`
+      "    for (let i = start; i >= end; --i) r += a[i]\n"
+      "    return r", asAny, "\n"
+      "  } else {\n"
+      "    return a.slice(end, start + 1).reverse()\n"
+      "  }\n"
+      "});\n"
+    ]]
   div(divRef): void
     state.prelude.push ["", [ // [indent, statement]
       preludeVar
@@ -157,6 +175,10 @@ function getHelperRef(base: HelperName): ASTRef
   declareHelper[base](ref)
   state.helperRefs[base] = ref
 
+// Get helper ref if it exists; otherwise return undefined
+function peekHelperRef(base: HelperName): ASTRef?
+  state.helperRefs[base]
+
 /**
  * Extract a subarray of the prelude array that just contains the
  * helper functions used in the given subtree
@@ -169,4 +191,5 @@ function extractPreludeFor(node: ASTNode): ASTNode[]
 export {
   extractPreludeFor
   getHelperRef
+  peekHelperRef
 }

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -132,7 +132,7 @@ import {
 } from ./unary.civet
 import { createConstLetDecs, createVarDecs } from ./auto-dec.civet
 import { expressionizeComptime, processComptime } from ./comptime.civet
-import { getHelperRef } from ./helper.civet
+import { getHelperRef, peekHelperRef } from ./helper.civet
 
 import {
   dedentBlockString
@@ -398,7 +398,7 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause?, 
 /**
  * Process globs, bind shorthand, and call shortcuts, in Call/MemberExpression
  */
-function processCallMemberExpression(node: ASTNodeParent): ASTNode
+function processCallMemberExpression(node: CallExpression | MemberExpression): ASTNode
   { children } := node
 
   // Parenthesized operator like (+), immediately called, expands to
@@ -428,7 +428,7 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
     if args.length
       children.splice 0, 2,
         commaCount ?
-          type: "ParenthesizedExpression",
+          type: "ParenthesizedExpression"
           children: ["(", ...call.children, ")"]
         : { ...call, type: "ParenthesizedExpression" }
       // If nothing left to this CallExpression, remove the wrapper
@@ -436,11 +436,10 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
         return children[0]
 
   // Process globs and bind shorthand
-  for (let i = 0; i < children.length; i++) {
-    const glob = children[i]
-    if (glob?.type is "PropertyGlob") {
-      let prefix = children.slice(0, i)
-      const parts = []
+  for each glob, i of children
+    if glob?.type is "PropertyGlob"
+      prefix .= children[...i]
+      parts := []
       let hoistDec, refAssignmentComma
       // add ref to ensure object base evaluated only once
       if prefix.length > 1
@@ -524,7 +523,7 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
         ...node,
         children: [object, ...children.slice(i + 1)]
       })
-    } else if (glob?.type is "PropertyBind") {
+    else if glob?.type is "PropertyBind"
       // TODO: add ref to ensure object base evaluated only once
       const prefix = children.slice(0, i)
       return processCallMemberExpression({  // in case there are more
@@ -546,8 +545,29 @@ function processCallMemberExpression(node: ASTNodeParent): ASTNode
           ...children.slice(i + 1)
         ]
       })
-    }
-  }
+    else if glob is like {type: "SliceExpression", reversed: true}
+      args := [
+        { ...node, children: node.children[...i] }
+        { ...glob.children[0] as ASTLeaf, token: ", " }
+        ...glob.children[1...-1]
+      ]
+      return makeNode {...node,
+        children: [
+          type: "CallExpression" as const
+          children: [
+            getHelperRef "rslice"
+            makeNode {
+              type: "Call"
+              args
+              children: [
+                "("
+                args
+                glob.children.-1
+              ]
+            }
+          ]
+        ]
+      }
   return node
 
 /**
@@ -902,6 +922,12 @@ function processAssignments(statements): void {
           if lhs.type is "MemberExpression"
             members := lhs.children
             lastMember := members[members.length - 1]
+
+            if lastMember is like {type: "CallExpression", children: [^peekHelperRef("rslice"), ...]}
+              lastMember.children.push
+                type: "Error"
+                message: "Slice range cannot be decreasing in assignment"
+              break
 
             // TODO: this is kind of bonkers
             if lastMember.type is "SliceExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -50,6 +50,7 @@ export type ExpressionNode =
   | IterationExpression
   | Literal
   | MethodDefinition
+  | MemberExpression
   | NewExpression
   | ObjectExpression
   | ParenthesizedExpression
@@ -100,6 +101,7 @@ export type OtherNode =
   | RangeDots
   | RangeExpression
   | ReturnValue
+  | SliceExpression
   | SpreadElement
   | TypeSuffix
   | WhenClause
@@ -448,6 +450,22 @@ export type Index
   children: Children
   optional?: Optional?
   parent?: Parent
+
+export type SliceExpression
+  type: "SliceExpression"
+  children: Children
+  parent?: Parent
+  start: ASTNode
+  end: ASTNode
+  reversed: boolean
+
+export type SliceParameters
+  type: "SliceParameters"
+  children: Children
+  parent?: Parent
+  start: ASTNode
+  end: ASTNode
+  reversed: boolean
 
 export type Optional
   type: "Optional"
@@ -925,6 +943,7 @@ export type RangeDots
   left: RangeEnd
   right: RangeEnd
   increasing: boolean?
+  triple?: boolean
   error?: ASTError
 
 export type RangeEnd

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -474,6 +474,7 @@ function makeLeftHandSideExpression(expression: ASTNode)
   while [ item ] := expression
     expression = item
   if isASTNodeObject expression
+    return expression if expression.token
     return expression if expression.parenthesized
     return expression if skipParens.has expression.type
     return expression if expression.type is "MemberExpression" and

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -182,7 +182,7 @@ describe "example code", ->
     ---
     var fragment, i;
     for (let i1 = fragments.length - 1; i1 >= 0; i1 += -1) {fragment = fragments[i=i1];if (!(fragment.fragments)) continue;
-      fragments.splice(i, 1 + i - i, ...this.expand(fragment.fragments))
+      fragments.splice(i, i + 1 - i, ...this.expand(fragment.fragments))
     }
   """
 
@@ -195,7 +195,7 @@ describe "example code", ->
     ---
     var fragment, i;
     for (let i1 = 0, len = fragments.length; i1 < len; i1 += 1) {fragment = fragments[i=i1];if (!(fragment.fragments)) continue;
-      fragments.splice(i, 1 + i - i, ...this.expand(fragment.fragments))
+      fragments.splice(i, i + 1 - i, ...this.expand(fragment.fragments))
     }
   """
 

--- a/test/for.civet
+++ b/test/for.civet
@@ -835,7 +835,7 @@ describe "for", ->
       ---
       const results=[];for (let ref = arg.slice(1), i1 = 0, len = ref.length; i1 < len; i1++) {const char = ref[i1];
           results.push(`-${char}`)
-        };args.splice(i, 1 + i - i, ...results)
+        };args.splice(i, i + 1 - i, ...results)
     """
 
     testCase """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -121,7 +121,7 @@ describe "&. function block shorthand", ->
     ---
     x.map &[0..2]
     ---
-    x.map($ => $.slice(0, 1 + 2 || 1/0))
+    x.map($ => $.slice(0, 2 + 1 || 1/0))
   """
 
   testCase """
@@ -129,7 +129,7 @@ describe "&. function block shorthand", ->
     ---
     x.map &.profile?.name?[0..2]
     ---
-    x.map($ => $.profile?.name?.slice(0, 1 + 2 || 1/0))
+    x.map($ => $.profile?.name?.slice(0, 2 + 1 || 1/0))
   """
 
   testCase """

--- a/test/slice.civet
+++ b/test/slice.civet
@@ -1,4 +1,4 @@
-{testCase, throws} from ./helper.civet
+{evalsTo, testCase, throws} from ./helper.civet
 
 describe "slice", ->
   testCase """
@@ -40,7 +40,7 @@ describe "slice", ->
     ---
     x[0..10]
     ---
-    x.slice(0, 1 + 10 || 1/0)
+    x.slice(0, 10 + 1 || 1/0)
   """
 
   testCase """
@@ -48,7 +48,7 @@ describe "slice", ->
     ---
     x[0..b]
     ---
-    x.slice(0, 1 + b || 1/0)
+    x.slice(0, b + 1 || 1/0)
   """
 
   testCase """
@@ -64,7 +64,7 @@ describe "slice", ->
     ---
     x[lineNum - 2 .. lineNum + 2]
     ---
-    x.slice(lineNum - 2 ,  1 + (lineNum + 2) || 1/0)
+    x.slice(lineNum - 2 ,  (lineNum + 2) + 1 || 1/0)
   """
 
   // #1330
@@ -73,7 +73,7 @@ describe "slice", ->
     ---
     x[0..x|y]
     ---
-    x.slice(0, 1 + (x|y) || 1/0)
+    x.slice(0, (x|y) + 1 || 1/0)
   """
 
   describe "inequalities on range", ->
@@ -81,40 +81,56 @@ describe "slice", ->
       ..<
       ---
       x[a..<b]
+      x[a..<]
+      x[..<b]
+      x[..<]
       ---
       x.slice(a, b)
+      x.slice(a, -1)
+      x.slice(0, b)
+      x.slice(0, -1)
     """
 
     testCase """
       ..<=
       ---
       x[a..<=b]
+      x[a..<=]
+      x[..<=b]
+      x[..<=]
       ---
-      x.slice(a, 1 + b || 1/0)
+      x.slice(a, b + 1 || 1/0)
+      x.slice(a)
+      x.slice(0, b + 1 || 1/0)
+      x.slice(0)
     """
 
     testCase """
       <..
       ---
       x[a<..b]
+      x[<..b]
+      x[a<..]
+      x[<..]
       ---
-      x.slice(1 + a, 1 + b || 1/0)
+      x.slice(a + 1, b + 1 || 1/0)
+      x.slice(0 + 1, b + 1 || 1/0)
+      x.slice(a + 1)
+      x.slice(0 + 1)
     """
 
     testCase """
       <..<
       ---
       x[a<..<b]
+      x[<..<b]
+      x[a<..<]
+      x[<..<]
       ---
-      x.slice(1 + a, b)
-    """
-
-    throws """
-      ..>
-      ---
-      x[a..>b]
-      ---
-      ParseErrors: unknown:1:4 Slice range cannot be decreasing
+      x.slice(a + 1, b)
+      x.slice(0 + 1, b)
+      x.slice(a + 1, -1)
+      x.slice(0 + 1, -1)
     """
 
     throws """
@@ -123,6 +139,81 @@ describe "slice", ->
       x[a<..>b]
       ---
       ParseErrors: unknown:1:5 <..> uses inconsistent < vs. >
+    """
+
+    testCase """
+      decreasing
+      ---
+      x[a..>=b]
+      x[a..>b]
+      x[a>..b]
+      x[a>..>b]
+      ---
+      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      var rslice: <E, T extends string | E[]>(a: T, start?: number, end?: number) => T extends string ? string : T extends (infer F)[] ? F[] : unknown[] = ((a, start, end) => {
+        const l = a.length
+        start = modulo(start ?? -1, l)
+        end = modulo((end ?? -1) + 1, l)
+        if (typeof a === 'string') {
+          let r = ""
+          for (let i = start; i >= end; --i) r += a[i]
+          return r as any
+        } else {
+          return a.slice(end, start + 1).reverse()
+        }
+      });
+      rslice(x, a, b - 1)
+      rslice(x, a, b)
+      rslice(x, a - 1, b - 1)
+      rslice(x, a - 1, b)
+    """
+
+    it "decreasing examples", =>
+      evalsTo """
+        . "civet"[..>=]
+        . "civet"[..>=0]
+        . "civet"[-1..>=]
+        . "civet"[-1..>=0]
+        . "civet"[..>]
+        . "civet"[..>0]
+        . "civet"[-1..>]
+        . "civet"[-1..>0]
+        . "civet"[>..]
+        . "civet"[>..0]
+        . "civet"[-1>..]
+        . "civet"[-1>..0]
+        . "civet"[>..>]
+        . "civet"[>..>0]
+        . "civet"[-1>..>]
+        . "civet"[-1>..>0]
+        . "civet"[3..>=1]
+        . [1,2,3,4,5][3..>=1]
+      """,
+        . "tevic"
+        . "tevic"
+        . "tevic"
+        . "tevic"
+        . "tevi"
+        . "tevi"
+        . "tevi"
+        . "tevi"
+        . "evic"
+        . "evic"
+        . "evic"
+        . "evic"
+        . "evi"
+        . "evi"
+        . "evi"
+        . "evi"
+        . "evi"
+        . [4,3,2]
+
+    throws """
+      ..> assignment
+      ---
+      x[a..>b] = c
+      ---
+      ParseErrors: unknown:1:9 Slice range cannot be decreasing in assignment
     """
 
   describe "assignment", ->
@@ -157,5 +248,5 @@ describe "slice", ->
       ---
       x[0..10] = [a, b, c]
       ---
-      x.splice(0, 1 + 10 - 0, ...[a, b, c])
+      x.splice(0, 10 + 1 - 0, ...[a, b, c])
     """


### PR DESCRIPTION
This was mostly for fun, and for code golfers to be able to reverse a string with `x[..>=]`. It ended up a little bigger than I expected, to get the many cases working...

* Slices remain increasing by default (even without `<`/`<=` modifier)
* With explicit `>` or `>=`, slices are reversed, similar to a range, so normally left ≥ right. For example, `x[..>=]` is equivalent to `x[-1 ..>= 0]` which is equivalent to `x[x.length - 1 ..>= 0]`
* Also fix increasing slices with implicit parts, like `x[..<]`