### PR TITLE
Indented types after binary type operators

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7666,6 +7666,19 @@ MaybeNestedTypePrimary
     return $2
   TypePrimary
 
+MaybeNestedTypeUnary
+  NestedTypeBulletedTuple
+  # NOTE: Let InterfaceBlock take first crack at an indented block
+  # But don't prevent parsing a braced type with unary suffix like {}[]
+  NestedInterfaceBlock
+  # NOTE: Next check for consistently indented binary operations (e.g. |)
+  # at beginning of each line.
+  NestedTypeBinaryChain
+  PushIndent ( Nested Type )? PopIndent ->
+    if (!$2) return $skip
+    return $2
+  NotDedented TypeUnary
+
 ReturnTypeSuffix
   _? QuestionMark?:optional _? Colon ReturnType:t ->
     return {
@@ -7707,7 +7720,7 @@ Type
   TypeWithPostfix
 
 TypeBinary
-  ( NotDedented TypeBinaryOp __ )?:optionalPrefix TypeUnary:t ( NotDedented TypeBinaryOp __ TypeUnary )*:ops ->
+  ( NotDedented TypeBinaryOp __ )?:optionalPrefix TypeUnary:t ( NotDedented TypeBinaryOp MaybeNestedTypeUnary )*:ops ->
     if (!ops.length && !optionalPrefix) return t
     if (!ops.length) return [optionalPrefix, t]
     if (!optionalPrefix) return [t, ...ops]

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -278,6 +278,70 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    nested after binary op
+    ---
+    type BinaryOp = (string &
+      name?: never
+      special?: never
+      relational?: never
+      assoc?: never
+      type?: undefined
+    ) | (ASTLeaf &
+      special?: true
+      // The following are allowed only when special is true:
+      prec?: string | number | undefined
+      assoc?: string?
+      call?: ASTNode
+      method?: ASTNode
+      relational?: boolean
+      reversed?: boolean
+      negated?: boolean
+      asConst?: boolean
+    ) | (PatternTest &
+      token?: never
+      relational?: never
+      assoc?: never
+      asConst?: never
+    ) | (ChainOp &
+      token?: never
+      relational?: never
+      assoc?: never
+    )
+    ---
+    type BinaryOp = (string & {
+      name?: never
+      special?: never
+      relational?: never
+      assoc?: never
+      type?: undefined
+    }
+    ) | (ASTLeaf & {
+      special?: true
+      // The following are allowed only when special is true:
+      prec?: string | number | undefined
+      assoc?: (string | undefined)
+      call?: ASTNode
+      method?: ASTNode
+      relational?: boolean
+      reversed?: boolean
+      negated?: boolean
+      asConst?: boolean
+    }
+    ) | (PatternTest & {
+      token?: never
+      relational?: never
+      assoc?: never
+      asConst?: never
+    }
+    ) | (ChainOp & {
+      token?: never
+      relational?: never
+      assoc?: never
+    }
+    )
+  """
+
+  testCase """
     typeof
     ---
     const data = [1, 2, 3]


### PR DESCRIPTION
Allow indented type after a binary operator, avoiding `__` in this case. This is important because otherwise implicit type arguments can apply.

Context: I noticed that `source/types.civet` wasn't parsing correctly. The relevant snippet is now a test case.