### PR TITLE
Fix CLI with complex `NODE_OPTIONS`, LSP cleanup

### DIFF
--- a/.civet/hera-plugin.mjs
+++ b/.civet/hera-plugin.mjs
@@ -4,15 +4,13 @@ const { compile: heraCompile } = Hera
 export default {
   transpilers: [{
     extension: ".hera",
-    target: ".cjs",
+    target: ".mjs",
     compile: function (path, source) {
-      const code = heraCompile(source, {
+      return heraCompile(source, {
         filename: path,
+        module: true,
+        sourceMap: true,
       })
-
-      return {
-        code
-      }
     }
   }],
 }

--- a/lsp/build/build.civet
+++ b/lsp/build/build.civet
@@ -17,7 +17,7 @@ build({
   minify
   platform: 'node'
   plugins: [
-    civetPlugin()
+    civetPlugin ts: 'civet'
   ]
   outfile: 'dist/extension.js'
 }).catch ->
@@ -50,7 +50,7 @@ build({
   minify
   platform: 'node'
   plugins: [
-    civetPlugin()
+    civetPlugin ts: 'civet'
   ]
 }).catch ->
   process.exit 1

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -254,8 +254,6 @@ export function repl(args: string[], options: Options)
         // On Node <20.6.0, we need to use `--loader` for the ESM loader.
         execArgv.push '--loader', '@danielx/civet/esm'
       */
-      if process.env.NODE_OPTIONS
-        execArgv.push process.env.NODE_OPTIONS
       { fork } from node:child_process
       fork __filename, args, {
         execArgv
@@ -563,8 +561,6 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
 
         debugRe := /--debug|--inspect/
         isDebug := v8debug <? "object" or debugRe.test(process.execArgv.join(' ')) or debugRe.test(process.env.NODE_OPTIONS ?? '')
-        if process.env.NODE_OPTIONS
-          execArgv.push process.env.NODE_OPTIONS
         if isDebug
           execArgv.push "--inspect=" + (process.debugPort + 1)
         child := fork filename, [

--- a/source/main.civet
+++ b/source/main.civet
@@ -1,11 +1,11 @@
-import { parse, parseProgram, ParseError, getConfig, getStateKey } from "./parser.hera"
-import generate, { prune } from "./generate.civet"
-import * as lib from "./parser/lib.civet"
-import * as sourcemap from "./sourcemap.civet"
+import { parse, parseProgram, ParseError, getConfig, getStateKey } from ./parser.hera
+import generate, { prune } from ./generate.civet
+import * as lib from ./parser/lib.civet
+import * as sourcemap from ./sourcemap.civet
 { SourceMap } := sourcemap
 export { parse, parseProgram, ParseError, generate, prune, lib, sourcemap, SourceMap }
-import type { BlockStatement } from ./types.civet
-export type { ASTError, BlockStatement } from ./types.civet
+import type { BlockStatement } from ./parser/types.civet
+export type { ASTError, BlockStatement } from ./parser/types.civet
 
 import StateCache from "./state-cache.civet"
 


### PR DESCRIPTION
For some reason, the CLI was adding `NODE_OPTIONS` as a command-line option when running Node. This isn't necessary (`NODE_OPTIONS` is already treated by Node as a command-line prefix), and it has long broke LSP building from VSCode on my Windows machine because VSCode set `NODE_OPTIONS= --require c:/Users/edemaine/AppData/Roaming/Code/User/workspaceStorage/1f20d4e8ff5068acfb8c92639172c1b4/ms-vscode.js-debug/bootloader.js` which is multiple arguments, not one, and we were adding it as one.

I also improved the Hera plugin slightly to use ESM mode (removing the common "`parse` isn't exported" error), and to use sourcemaps.

Originally I was aiming to fix the crash in the LSP when loading `source/main.civet`, or any file that `import`s from `parser.hera`, but I haven't been able to track that down yet. Let me know if you have ideas!