### PR TITLE
`if` conditions continued by binary op on next line

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4714,7 +4714,8 @@ ForBinding
 
 # https://262.ecma-international.org/#prod-SwitchStatement
 SwitchStatement
-  Switch ( EmptyCondition / Condition ):condition CaseBlock:caseBlock ->
+  Switch:s ForbidNewlineBinaryOp ( EmptyCondition / Condition )?:condition RestoreNewlineBinaryOp CaseBlock:caseBlock ->
+    if (!condition) return $skip
     if (condition.type === "EmptyCondition") {
       // Negate all case condition expressions. This converts them to booleans
       // and is slightly smaller than switch(true) {case: !!exp ... }
@@ -4737,7 +4738,7 @@ SwitchStatement
 
     return {
       type: "SwitchStatement",
-      children: $0,
+      children: [ s, condition, caseBlock ], // omit NewlineBinaryOp control
       condition,
       caseBlock,
     }
@@ -5009,7 +5010,7 @@ SingleLineExpressionWithIndentedApplicationForbidden
 # as arguments to implicit function calls.  This is useful in the context of
 # an `if` or `class` line where we don't want to treat the body as an object.
 ExpressionWithObjectApplicationForbidden
-  ForbidBracedApplication ForbidIndentedApplication ForbidNewlineBinaryOp Expression?:exp RestoreNewlineBinaryOp RestoreBracedApplication RestoreIndentedApplication ->
+  ForbidBracedApplication ForbidIndentedApplication Expression?:exp RestoreBracedApplication RestoreIndentedApplication ->
     if (exp) return exp
     return $skip
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -188,6 +188,19 @@ describe "if", ->
   """
 
   testCase """
+    binary op on next line
+    ---
+    if test1
+    and test2
+      yes()
+    ---
+    if (test1
+    && test2) {
+      yes()
+    }
+  """
+
+  testCase """
     indented condition
     ---
     if


### PR DESCRIPTION
Fixes #690

I think just `switch` needs `ForbidNewlineBinaryOp` (because of pattern matching conditions like `> 0`), so I moved it there.