### PR TITLE
Fix one-line arrow functions with `@` arguments

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -675,6 +675,7 @@ function processParams(f): void
       expressions.splice(index + 1, 0, ...prefix)
       return
   expressions.unshift(...prefix)
+  braceBlock block
 
 function processSignature(f: FunctionNode): void
   {block, signature} := f

--- a/test/function.civet
+++ b/test/function.civet
@@ -415,6 +415,14 @@ describe "function", ->
       })
     """
 
+    testCase """
+      short fat arrow
+      ---
+      (@a) => 1
+      ---
+      (a) => {this.a = a;return  1}
+    """
+
   testCase """
     longhand
     ---


### PR DESCRIPTION
Fixes #1489