### PR TITLE
Fix unplugin's webpack mode: `resolve.alias`, virtual modules

### DIFF
--- a/integration/unplugin-examples/astro/package.json
+++ b/integration/unplugin-examples/astro/package.json
@@ -15,6 +15,6 @@
     "solid-js": "^1.7.11"
   },
   "devDependencies": {
-    "@danielx/civet": "*"
+    "@danielx/civet": "latest"
   }
 }

--- a/integration/unplugin-examples/esbuild/package.json
+++ b/integration/unplugin-examples/esbuild/package.json
@@ -5,7 +5,7 @@
     "watch": "node esbuild.js --watch"
   },
   "devDependencies": {
-    "@danielx/civet": "*",
-    "esbuild": "*"
+    "@danielx/civet": "latest",
+    "esbuild": "latest"
   }
 }

--- a/integration/unplugin-examples/nextjs/next.config.js
+++ b/integration/unplugin-examples/nextjs/next.config.js
@@ -5,8 +5,7 @@ const nextConfig = {
   reactStrictMode: true,
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'civet'],
   webpack(config) {
-    config.plugins.push(civetWebpackPlugin({}));
-
+    config.plugins.push(civetWebpackPlugin({ts: 'preserve'}));
     return config;
   },
 };

--- a/integration/unplugin-examples/nextjs/package-lock.json
+++ b/integration/unplugin-examples/nextjs/package-lock.json
@@ -17,7 +17,7 @@
         "typescript": "5.2.2"
       },
       "devDependencies": {
-        "@danielx/civet": "*"
+        "@danielx/civet": "latest"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -33,14 +33,15 @@
       }
     },
     "node_modules/@danielx/civet": {
-      "version": "0.6.27",
-      "resolved": "https://registry.npmjs.org/@danielx/civet/-/civet-0.6.27.tgz",
-      "integrity": "sha512-XkpK+vpHe52FASxTlF5gN1X6b4xBHj9xDi6R7EmE1QCrkFhvtrgyKW1mn3bQrYTfThXEf6cT3igd2pp25ynx5g==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@danielx/civet/-/civet-0.8.7.tgz",
+      "integrity": "sha512-Myyq9ZawYOWChE9k3qsrB3tsWWdybAOhu0IsSHmNqsP+9j5xSHzRZwYbPUS3Ax5VKabRIR8+2u2rprmGxqjskg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.1",
-        "@typescript/vfs": "^1.5.0",
-        "unplugin": "^1.4.0"
+        "@typescript/vfs": "^1.6.0",
+        "unplugin": "^1.12.2"
       },
       "bin": {
         "civet": "dist/civet"
@@ -49,7 +50,13 @@
         "node": ">=19 || ^18.6.0 || ^16.17.0"
       },
       "peerDependencies": {
-        "typescript": "^4.5 || ^5.0"
+        "typescript": "^4.5 || ^5.0",
+        "yaml": "^2.4.5"
+      },
+      "peerDependenciesMeta": {
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -265,58 +272,29 @@
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@typescript/vfs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.0.tgz",
-      "integrity": "sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.0.tgz",
+      "integrity": "sha512-hvJUjNVeBMp77qPINuUvYXj4FyWeeMMKZkxEATEU3hqBAQ7qdTBCUFT7Sp0Zu0faeEtFf+ldXxMEDr/bk73ISg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/busboy": {
@@ -350,33 +328,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -388,12 +339,13 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -404,91 +356,11 @@
         }
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -507,10 +379,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -578,31 +451,10 @@
         }
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",
@@ -654,18 +506,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -712,18 +552,6 @@
         }
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -742,31 +570,33 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.4.0.tgz",
-      "integrity": "sha512-5x4eIEL6WgbzqGtF9UV8VEC/ehKptPXDS6L2b0mv4FRMkJxRtjaJfOWDd6a8+kYbqsjklix7yWP0N3SUepjXcg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.14.1.tgz",
+      "integrity": "sha512-lBlHbfSFPToDYp9pjXlUEFVxYLaue9f9T1HC+4OHlmj+HnMDdz9oZY+erXfoCe/5V/7gKUSY2jpXPb9S7f0f/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "acorn": "^8.9.0",
-        "chokidar": "^3.5.3",
-        "webpack-sources": "^3.2.3",
-        "webpack-virtual-modules": "^0.5.0"
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true,
+        "acorn": "^8.12.1",
+        "webpack-virtual-modules": "^0.6.2"
+      },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "webpack-sources": "^3"
+      },
+      "peerDependenciesMeta": {
+        "webpack-sources": {
+          "optional": true
+        }
       }
     },
     "node_modules/webpack-virtual-modules": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
-      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
-      "dev": true
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     }
   },
   "dependencies": {
@@ -780,14 +610,14 @@
       }
     },
     "@danielx/civet": {
-      "version": "0.6.27",
-      "resolved": "https://registry.npmjs.org/@danielx/civet/-/civet-0.6.27.tgz",
-      "integrity": "sha512-XkpK+vpHe52FASxTlF5gN1X6b4xBHj9xDi6R7EmE1QCrkFhvtrgyKW1mn3bQrYTfThXEf6cT3igd2pp25ynx5g==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@danielx/civet/-/civet-0.8.7.tgz",
+      "integrity": "sha512-Myyq9ZawYOWChE9k3qsrB3tsWWdybAOhu0IsSHmNqsP+9j5xSHzRZwYbPUS3Ax5VKabRIR8+2u2rprmGxqjskg==",
       "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.1",
-        "@typescript/vfs": "^1.5.0",
-        "unplugin": "^1.4.0"
+        "@typescript/vfs": "^1.6.0",
+        "unplugin": "^1.12.2"
       }
     },
     "@jridgewell/resolve-uri": {
@@ -919,44 +749,19 @@
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "@typescript/vfs": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.5.0.tgz",
-      "integrity": "sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript/vfs/-/vfs-1.6.0.tgz",
+      "integrity": "sha512-hvJUjNVeBMp77qPINuUvYXj4FyWeeMMKZkxEATEU3hqBAQ7qdTBCUFT7Sp0Zu0faeEtFf+ldXxMEDr/bk73ISg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1"
       }
     },
     "acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true
-    },
-    "anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      }
-    },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
-    },
-    "braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "requires": {
-        "fill-range": "^7.1.1"
-      }
     },
     "busboy": {
       "version": "1.6.0",
@@ -971,22 +776,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
       "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA=="
     },
-    "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
-      "requires": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      }
-    },
     "client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -998,73 +787,18 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "optional": true
-    },
-    "glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^4.0.1"
+        "ms": "^2.1.3"
       }
     },
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1080,9 +814,9 @@
       }
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "nanoid": {
@@ -1113,22 +847,10 @@
         "styled-jsx": "5.1.1"
       }
     },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
     },
     "postcss": {
       "version": "8.4.31",
@@ -1157,15 +879,6 @@
         "scheduler": "^0.23.0"
       }
     },
-    "readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "requires": {
-        "picomatch": "^2.2.1"
-      }
-    },
     "scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -1192,15 +905,6 @@
         "client-only": "0.0.1"
       }
     },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
     "tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
@@ -1212,27 +916,19 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "unplugin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.4.0.tgz",
-      "integrity": "sha512-5x4eIEL6WgbzqGtF9UV8VEC/ehKptPXDS6L2b0mv4FRMkJxRtjaJfOWDd6a8+kYbqsjklix7yWP0N3SUepjXcg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.14.1.tgz",
+      "integrity": "sha512-lBlHbfSFPToDYp9pjXlUEFVxYLaue9f9T1HC+4OHlmj+HnMDdz9oZY+erXfoCe/5V/7gKUSY2jpXPb9S7f0f/w==",
       "dev": true,
       "requires": {
-        "acorn": "^8.9.0",
-        "chokidar": "^3.5.3",
-        "webpack-sources": "^3.2.3",
-        "webpack-virtual-modules": "^0.5.0"
+        "acorn": "^8.12.1",
+        "webpack-virtual-modules": "^0.6.2"
       }
     },
-    "webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-      "dev": true
-    },
     "webpack-virtual-modules": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
-      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true
     }
   }

--- a/integration/unplugin-examples/nextjs/package.json
+++ b/integration/unplugin-examples/nextjs/package.json
@@ -18,6 +18,6 @@
     "typescript": "5.2.2"
   },
   "devDependencies": {
-    "@danielx/civet": "*"
+    "@danielx/civet": "latest"
   }
 }

--- a/integration/unplugin-examples/nextjs/pages/about.civet
+++ b/integration/unplugin-examples/nextjs/pages/about.civet
@@ -1,6 +1,5 @@
 { Button } from '../components/button.civet'
 
 export default function About()
-  <div>
-    <h1>About</h1>
-    <Button />
+  <h1>About
+  <Button>

--- a/integration/unplugin-examples/nextjs/tsconfig.json
+++ b/integration/unplugin-examples/nextjs/tsconfig.json
@@ -8,7 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/integration/unplugin-examples/rollup/package.json
+++ b/integration/unplugin-examples/rollup/package.json
@@ -5,6 +5,6 @@
     "watch": "npx rollup --config rollup.config.js --watch"
   },
   "devDependencies": {
-    "@danielx/civet": "*"
+    "@danielx/civet": "latest"
   }
 }

--- a/integration/unplugin-examples/vite-lib/package.json
+++ b/integration/unplugin-examples/vite-lib/package.json
@@ -3,6 +3,6 @@
     "build": "npx vite build"
   },
   "devDependencies": {
-    "@danielx/civet": "*"
+    "@danielx/civet": "latest"
   }
 }

--- a/integration/unplugin-examples/vite/package.json
+++ b/integration/unplugin-examples/vite/package.json
@@ -4,6 +4,6 @@
     "dev": "npx vite dev"
   },
   "devDependencies": {
-    "@danielx/civet": "^0.6.37"
+    "@danielx/civet": "latest"
   }
 }

--- a/integration/unplugin-examples/webpack/package.json
+++ b/integration/unplugin-examples/webpack/package.json
@@ -4,7 +4,7 @@
     "watch": "npx webpack build --watch"
   },
   "devDependencies": {
-    "@danielx/civet": "*",
+    "@danielx/civet": "latest",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4"
   }

--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -105,28 +105,29 @@ function implicitCivet(file: string): string | undefined {
 
 export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
 (options: PluginOptions = {}, meta) =>
-  if (options.dts) options.emitDeclaration = options.dts;
-  if (options.js) options.ts = 'civet';
-  let compileOptions: CompileOptions = {};
+  if (options.dts) options.emitDeclaration = options.dts
+  if (options.js) options.ts = 'civet'
+  compileOptions: CompileOptions .= {}
 
-  const transformTS = options.emitDeclaration || options.typecheck;
-  const outExt =
-    options.outputExtension ?? (options.ts === 'preserve' ? '.tsx' : '.jsx');
-  const implicitExtension = options.implicitExtension ?? true;
+  transformTS := options.emitDeclaration or options.typecheck
+  outExt :=
+    options.outputExtension ?? (options.ts is 'preserve' ? '.tsx' : '.jsx')
+  implicitExtension := options.implicitExtension ?? true
+  let aliasResolver: (id: string) => string
 
-  let fsMap: Map<string, string> = new Map();
-  const sourceMaps = new Map<string, SourceMap>();
-  let compilerOptions: any, compilerOptionsWithSourceMap: any;
-  let rootDir = process.cwd();
-  let esbuildOptions: BuildOptions;
-  let configErrors: Diagnostic[] | undefined;
+  fsMap: Map<string, string> .= new Map
+  sourceMaps := new Map<string, SourceMap>
+  let compilerOptions: any, compilerOptionsWithSourceMap: any
+  rootDir .= process.cwd()
+  let esbuildOptions: BuildOptions
+  let configErrors: Diagnostic[]?
   let configFileNames: string[]
 
-  const tsPromise =
+  tsPromise :=
     transformTS || options.ts === 'tsc'
       ? import('typescript').then .default
       : null;
-  const getFormatHost = (sys: System): FormatDiagnosticsHost =>
+  getFormatHost := (sys: System): FormatDiagnosticsHost =>
     return {
       getCurrentDirectory: => sys.getCurrentDirectory()
       getNewLine: => sys.newLine
@@ -137,7 +138,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
 
   const cache = options.cache ? new Map<string, {mtime: number, result: TransformResult}>() : undefined;
 
-  return {
+  plugin: ReturnType<typeof rawPlugin> & { __virtualModulePrefix?: string } := {
     name: 'unplugin-civet'
     enforce: 'pre'
     async buildStart(): Promise<void> {
@@ -407,7 +408,17 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
     }
 
     resolveId(id, importer, options)
+      id = aliasResolver id if aliasResolver?
       if (/\0/.test(id)) return null
+
+      // unplugin webpack virtualizes our resolved paths, by prepending
+      // plugin.__virtualModulePrefix and then encodeURIComponent.
+      // [https://github.com/unjs/unplugin/blob/f6ceb5092715b8047eeb069b249b919f3ef2bcfb/src/webpack/index.ts#L131]
+      // Undo this transformation on the `importer` path
+      // so we can correctly resolve its directory.
+      if plugin.__virtualModulePrefix and
+         importer?.startsWith plugin.__virtualModulePrefix
+        importer = decodeURIComponent importer[plugin.__virtualModulePrefix#..]
 
       let postfix: string
       {id, postfix} = cleanCivetId(id)
@@ -563,21 +574,19 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
       }
     }
     vite: {
-      config(config: UserConfig) {
-        rootDir = path.resolve(process.cwd(), config.root ?? '');
+      config(config: UserConfig): void
+        rootDir = path.resolve process.cwd(), config.root ?? ''
 
-        if (implicitExtension) {
-          config.resolve ??= {};
-          config.resolve.extensions ??= DEFAULT_EXTENSIONS;
-          config.resolve.extensions.push('.civet');
-        }
-      },
-      async transformIndexHtml(html) {
-        return html.replace(/<!--[^]*?-->|<[^<>]*>/g, (tag) =>
-          tag.replace(/<\s*script\b[^<>]*>/gi, (script) =>
+        if implicitExtension
+          config.resolve ??= {}
+          config.resolve.extensions ??= DEFAULT_EXTENSIONS
+          config.resolve.extensions.push '.civet'
+      async transformIndexHtml(html)
+        html.replace /<!--[^]*?-->|<[^<>]*>/g, (tag) =>
+          tag.replace /<\s*script\b[^<>]*>/gi, (script) =>
             // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-            script.replace(
-              /([:_\p{ID_Start}][:\p{ID_Continue}]*)(\s*=\s*("[^"]*"|'[^']*'|[^\s"'=<>`]*))?/gu,
+            script.replace
+              /([:_\p{ID_Start}][:\p{ID_Continue}]*)(\s*=\s*("[^"]*"|'[^']*'|[^\s"'=<>`]*))?/gu
               (attr, name, value) =>
                 name.toLowerCase() === 'src' && value
                   ? attr.replace(
@@ -586,27 +595,37 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
                         `${extension}${outExt}?transform${endQuote}`
                     )
                   : attr
-            )
-          )
-        );
-      },
-      handleHotUpdate({ file, server, modules }) {
+      handleHotUpdate({ file, server, modules })
         // `file` is an absolute path to the changed file on disk,
         // so for our case it should end with .civet extension
-        if (!file.endsWith('.civet')) return;
+        return unless file.endsWith '.civet'
         // Convert into path as would be output by `resolveId`
-        const resolvedId = slash(path.resolve(file) + outExt);
+        resolvedId := slash path.resolve(file) + outExt
         // Check for module with this name
-        const module = server.moduleGraph.getModuleById(resolvedId);
-        if (module) {
+        module := server.moduleGraph.getModuleById resolvedId
+        if module
           // Invalidate modules depending on this one
-          server.moduleGraph.onFileChange(resolvedId);
+          server.moduleGraph.onFileChange resolvedId
           // Hot reload this module
           return [ ...modules, module ]
-        }
-        return modules;
-      }
+        modules
     }
+    webpack(compiler)
+      compiler.options.resolve.extensions.unshift ".civet" if implicitExtension
+      aliasResolver = (id) =>
+        // Based on normalizeAlias from
+        // https://github.com/webpack/enhanced-resolve/blob/72999caf002f6f7bb4624e65fdeb7ba980b11e24/lib/ResolverFactory.js#L158
+        // and AliasPlugin from
+        // https://github.com/webpack/enhanced-resolve/blob/72999caf002f6f7bb4624e65fdeb7ba980b11e24/lib/AliasPlugin.js
+        for key, value in compiler.options.resolve.alias
+          if key.endsWith '$'
+            if id is key[...-1]
+              return value <? 'string' ? value : '\0'
+          else
+            if id is key or id.startsWith key + '/'
+              return '\0' unless value <? 'string'
+              return value + id[key.length..]
+        id
   }
 
 var unplugin = createUnplugin(rawPlugin)


### PR DESCRIPTION
[tough on HN](https://news.ycombinator.com/item?id=41919111) reported that the NextJS example wasn't working. I'd never tried it, but they were right! I needed to fix two things:

* NextJS makes extensive use of `resolve.alias`es. Sadly, `resolveId` doesn't seem to get the id after such aliases are resolved, so I reimplemented the alias resolver so that they function again.
* unplugin transforms our fake filenames into virtualized filenames, but the `importer` argument didn't get correctly unvirtualized. So I added this. (Will hopefully fix upstream as well.)

The source code links to the specifics that I referred to.

With all this, I can go to `integration/unplugin-examples/nextjs`, `npm install`, (`npm link @danielx/civet` to use this new unplugin), `npm run build`, and `npm run start` to get this beautiful webpage rendered:

![image](https://github.com/user-attachments/assets/afaf5478-c390-46dd-9c2b-20ede07a5bf4)

