### PR TITLE
Range loops can provide custom skip via `by` (not just in CoffeeScript)

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1836,6 +1836,11 @@ for i of [0...array.length]
 </Playground>
 
 <Playground>
+for i of [0...n] by 2
+  console.log i, "is even"
+</Playground>
+
+<Playground>
 for [1..5]
   attempt()
 </Playground>

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -37,6 +37,8 @@ Things Kept from CoffeeScript
 - `when` inside `switch` automatically breaks
 - Multiple `,` separated `case`/`when` expressions
 - `else` → `default` in `switch`
+- `for ... when <condition>`
+- `for ... by <step>` when looping over range literals
 - Range literals `[0...10]`, `[a..b]`, `[x - 2 .. x + 2]`
 - Array slices `list[0...2]` → `list.slice(0, 2)`
 - Slice assignment `numbers[3..6] = [-3, -4, -5, -6]` → `numbers.splice(3, 4, ...[-3, -4, -5, -6])`
@@ -67,7 +69,6 @@ Civet.
 - `for from` (use JS `for of`, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for in` (use `for each of`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for own of` (use `for own in`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
-- `for ... when <condition>` (use `continue if exp` inside loop, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `a ? b` (use `a ?? b`, though it doesn't check for undeclared variables; `"civet coffeeCompat"`, or `"civet coffeeBinaryExistential"` enables `a ? b` at the cost of losing JS ternary operator)
 - `a of b` (use `a in b` as in JS, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)
 - `a not of b` (use `a not in b`, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -64,13 +64,17 @@ function gen(root: ASTNode, options: Options): string
           offset
         return ""
 
-      if node.$loc?
+      if "$loc" in node
         {token, $loc} := node
-        updateSourceMap? token, $loc.pos
+        updateSourceMap? token, $loc.pos if $loc?
         //console.log 'set', node, options.sourceMap.data.srcLine, options.sourceMap.data.srcColumn if options?.sourceMap?
         return token
 
-      if !node.children
+      unless node.children
+        // Occasionally we create ASTLeaf nodes with no $loc field
+        if node.token?
+          return node.token
+
         switch node.type
           when "Ref"
             throw new Error(`Unpopulated ref ${stringify node}`)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4550,7 +4550,7 @@ ForStatementControlWithWhen
     }
     return {
       ...control,
-      blockPrefix: [...control.blockPrefix,
+      blockPrefix: [...control.blockPrefix ?? [],
         ["", {
           type: "IfStatement",
           then: block,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -394,7 +394,7 @@ ForbiddenImplicitCalls
 
 # Binary operators that are reserved in that context
 ReservedBinary
-  /(as|of|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
+  /(as|of|by|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
 
 ArgumentsWithTrailingMemberExpressions
   Arguments:args AllowedTrailingMemberExpressions:trailing ->
@@ -4606,7 +4606,7 @@ CoffeeForStatementParameters
       const lenRef = makeRef("len")
 
       if (exp.type === "RangeExpression") {
-        return forRange(open, declaration, exp, step?.[2], close)
+        return forRange(open, declaration, exp, step && prepend(trimFirstSpace(step[0]), trimFirstSpace(step[2])), close)
       }
 
       // If exp isn't a simple identifier use a ref
@@ -4718,10 +4718,10 @@ ForStatementParameters
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
   ( Await __ )? ( (Each / Own) __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
-    return processForInOf($0, getHelperRef)
+    return processForInOf($0)
   # NOTE: Added optional parens
   ( Await __ )? ( (Each / Own) __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
-    return processForInOf($0, getHelperRef)
+    return processForInOf($0)
   ForRangeParameters
 
 ForRangeParameters
@@ -6673,7 +6673,7 @@ JSXImplicitFragment
       ],
       jsxChildren: [$1].concat($2.map(([, tag]) => tag)),
     }
-    const type = typeOfJSX(jsx, config, getHelperRef)
+    const type = typeOfJSX(jsx, config)
     return type ? [
       { ts: true, children: ["("] },
       jsx,

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -6,18 +6,25 @@ import type {
   Children
   RangeDots
   RangeExpression
+  Whitespace
 } from ./types.civet
 
 import {
-  insertTrimmingSpace
   literalValue
   makeLeftHandSideExpression
+  makeNumericLiteral
+  prepend
+  trimFirstSpace
 } from ./util.civet
 
 import {
   makeRef
   maybeRef
 } from ./ref.civet
+
+import {
+  getHelperRef
+} from ./helper.civet
 
 function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, end: ASTNode)
   ws1 = [ws1, range.children[0]] // whitespace before ..
@@ -127,17 +134,21 @@ function forRange(
 
   let stepRef, asc: boolean?
   if stepExp
-    stepExp = insertTrimmingSpace(stepExp, "")
+    stepExp = trimFirstSpace(stepExp)
     stepRef = maybeRef(stepExp, "step")
   else if infinite
-    stepExp = stepRef = "1"
+    stepExp = stepRef = makeNumericLiteral 1
   else if increasing?
     if increasing
-      stepExp = stepRef = "1"
+      stepExp = stepRef = makeNumericLiteral 1
       asc = true
     else
-      stepExp = stepRef = "-1"
+      stepExp = stepRef = makeNumericLiteral -1
       asc = false
+  stepValue := if stepExp?.type is "Literal"
+    try literalValue stepExp // ignore invalid literals
+  if stepValue <? "number"
+    asc = stepValue > 0
 
   // start needs to be ref'd to compute start <= end, unless we know direction
   startRef .= if stepRef then start else maybeRef(start, "start")
@@ -153,15 +164,16 @@ function forRange(
       . stepRef
 
   let ascDec: ASTNode[] = [], ascRef
-  if stepRef
+  if stepExp
     unless stepRef is stepExp
       ascDec = [", ", stepRef, " = ", stepExp]
 
-  else if "Literal" is start.type is end.type
+  else if start?.type is "Literal" is end?.type
+    // @ts-ignore Allow comparison of any literal values, as in JS
     asc = literalValue(start) <= literalValue(end)
     if "StringLiteral" is start.subtype is end.subtype
-      startRef = literalValue(start).charCodeAt(0).toString()
-      endRef = literalValue(end).charCodeAt(0).toString()
+      startRef = (literalValue(start) as string).charCodeAt(0).toString()
+      endRef = (literalValue(end) as string).charCodeAt(0).toString()
 
   else
     ascRef = makeRef("asc")
@@ -171,7 +183,7 @@ function forRange(
   if forDeclaration?.declare // var/let/const declaration of variable
     if forDeclaration.declare.token is "let"
       varName := forDeclaration.children.splice(1)  // strip let
-      varAssign = [...insertTrimmingSpace(varName, ""), " = "]
+      varAssign = [...trimFirstSpace(varName), " = "]
       varLet = [",", ...varName, " = ", counterRef]
     else // const or var: put inside loop
       // TODO: missing indentation
@@ -192,14 +204,14 @@ function forRange(
     : [counterRef, " < ", endRef, " : ", counterRef, " > ", endRef]
 
   condition :=
-    infinite ? [] :
+    infinite or stepValue is 0 ? [] :
     asc? ? (asc ? counterPart[0...3] : counterPart[4..]) :
     stepRef ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"] :
     [ascRef, " ? ", ...counterPart]
 
   increment :=
-    stepRef === "1" ? [...varAssign, "++", counterRef] :
-    stepRef === "-1" ? [...varAssign, "--", counterRef] :
+    stepValue is +1 ? [...varAssign, "++", counterRef] :
+    stepValue is -1 ? [...varAssign, "--", counterRef] :
     stepRef
       ? [...varAssign, counterRef, " += ", stepRef]
       : ascRef
@@ -213,22 +225,25 @@ function forRange(
   }
 
 function processForInOf($0: [
-  awaits: ASTNode,
-  eachOwn: undefined | [ASTLeaf, ASTNode],
-  open: ASTNode,
-  declaration: ASTNode,
-  declaration2: [ws1: ASTNode, comma: ASTLeaf, ws2: ASTNode, decl2: ASTNode],
-  ws: ASTNode,
-  inOf: ASTLeaf,
-  exp: ASTNodeBase,
-  step: ASTNode,
-  close: ASTNode
-], getRef)
+  awaits: ASTNode
+  eachOwn: [ASTLeaf, ASTNode] | undefined
+  open: ASTLeaf
+  declaration: ASTNode
+  declaration2: [ws1: ASTNode, comma: ASTLeaf, ws2: ASTNode, decl2: ASTNode]
+  ws: ASTNode
+  inOf: ASTLeaf
+  exp: ASTNodeBase
+  step: [Whitespace, ASTLeaf, ASTNode]
+  close: ASTLeaf
+])
   [awaits, eachOwn, open, declaration, declaration2, ws, inOf, exp, step, close] .= $0
 
   if exp.type is "RangeExpression" and inOf.token is "of" and !declaration2
     // TODO: add support for `declaration2` to efficient `forRange`
-    return forRange(open, declaration, exp, step, close)
+    return forRange
+      open, declaration, exp
+      step and prepend(trimFirstSpace(step[0]), trimFirstSpace(step[2])) // omit "by" token
+      close
   else if step
     throw new Error("for..of/in cannot use 'by' except with range literals")
 
@@ -248,24 +263,24 @@ function processForInOf($0: [
       if declaration2
         const [, , ws2, decl2] = declaration2  // strip __ Comma __
         blockPrefix.push(["", [
-          insertTrimmingSpace(ws2, ""), decl2, " = ", counterRef
+          trimFirstSpace(ws2), decl2, " = ", counterRef
         ], ";"])
         assignmentNames.push(...decl2.names)
 
       expRefDec := (expRef !== exp)
         // Trim a single leading space if present
-        ? [insertTrimmingSpace(expRef, " "), " = ", insertTrimmingSpace(exp, ""), ", "]
+        ? [trimFirstSpace(expRef), " = ", trimFirstSpace(exp), ", "]
         : []
 
       blockPrefix.push ["", {
         type: "Declaration"
-        children: [declaration, " = ", insertTrimmingSpace(expRef, ""), "[", counterRef, "]"]
+        children: [declaration, " = ", trimFirstSpace(expRef), "[", counterRef, "]"]
         names: assignmentNames
       }, ";"]
 
       declaration =
         type: "Declaration"
-        children: ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", insertTrimmingSpace(expRef, ""), ".length"]
+        children: ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", trimFirstSpace(expRef), ".length"]
         names: []
 
       condition := [counterRef, " < ", lenRef, "; "]
@@ -317,7 +332,7 @@ function processForInOf($0: [
     return {
       declaration
       blockPrefix
-      children: [awaits, eachOwnError, open, declaration, ws, inOf, expRef ?? exp, step, close] // omit declaration2, replace eachOwn with eachOwnError, replace exp with expRef
+      children: [awaits, eachOwnError, open, declaration, ws, inOf, expRef ?? exp, close] // omit declaration2, replace eachOwn with eachOwnError, replace exp with expRef
     }
 
   let ws2: ASTNode?, decl2: ASTNode?
@@ -333,7 +348,7 @@ function processForInOf($0: [
       }
       blockPrefix.push ["", {
         type: "Declaration"
-        children: [insertTrimmingSpace(ws2, ""), decl2, " = ", counterRef, "++"]
+        children: [trimFirstSpace(ws2), decl2, " = ", counterRef, "++"]
         names: decl2.names
       }, ";"]
 
@@ -350,12 +365,12 @@ function processForInOf($0: [
           children: [" ", expRef, " =", exp]
       // for own..in
       if own
-        const hasPropRef = getRef("hasProp")
-        blockPrefix.push ["", ["if (!", hasPropRef, "(", insertTrimmingSpace(expRef, ""), ", ", insertTrimmingSpace(pattern, ""), ")) continue"], ";"]
+        hasPropRef := getHelperRef("hasProp")
+        blockPrefix.push ["", ["if (!", hasPropRef, "(", trimFirstSpace(expRef), ", ", trimFirstSpace(pattern), ")) continue"], ";"]
       if decl2
         blockPrefix.push ["", {
           type: "Declaration"
-          children: [insertTrimmingSpace(ws2, ""), decl2, " = ", insertTrimmingSpace(expRef, ""), "[", insertTrimmingSpace(pattern, ""), "]"]
+          children: [trimFirstSpace(ws2), decl2, " = ", trimFirstSpace(expRef), "[", trimFirstSpace(pattern), "]"]
           names: decl2.names
         }, ";"]
 
@@ -364,7 +379,7 @@ function processForInOf($0: [
 
   return {
     declaration,
-    children: [awaits, eachOwnError, open, declaration, ws, inOf, exp, step, close], // omit declaration2, replace each with eachOwnError
+    children: [awaits, eachOwnError, open, declaration, ws, inOf, exp, close], // omit declaration2, replace each with eachOwnError
     blockPrefix,
     hoistDec,
   }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -104,7 +104,6 @@ export type OtherNode =
   | PinProperty
   | Placeholder
   | PropertyAccess
-  | RangeDots
   | RangeExpression
   | ReturnValue
   | SliceExpression
@@ -158,6 +157,9 @@ export type ASTLeaf =
   parent?: Parent
   children?: never
 
+export type ASTLeafWithType<T extends string> =
+  Exclude<ASTLeaf, "type"> & { type: T }
+
 export type CommentNode =
   type: "Comment"
   $loc: Loc
@@ -172,6 +174,7 @@ export type BinaryOp = (string &
   assoc?: never
   type?: undefined
 ) | (ASTLeaf &
+  type?: undefined
   special?: true
   // The following are allowed only when special is true:
   prec?: string | number | undefined
@@ -951,13 +954,13 @@ export type FieldDefinition
 export type Literal =
   type: "Literal"
   subtype?: "NumericLiteral" | "StringLiteral"
-  children: Children & [ LiteralContentNode ]
+  children: Children & LiteralContentNode[]
   parent?: Parent
   raw: string
 
-export type LiteralContentNode = ASTLeaf & {
-  type?: "NumericLiteral" | "StringLiteral"
-}
+export type LiteralContentNode =
+  | ASTLeaf
+  | ASTLeafWithType "NumericLiteral" | "StringLiteral"
 
 export type RangeExpression
   type: "RangeExpression"
@@ -1053,7 +1056,7 @@ export type TypeLiteral =
   children: Children
   parent?: Parent
 
-export type VoidType = ASTLeaf & type: "VoidType"
+export type VoidType = ASTLeafWithType "VoidType"
 
 export type TypeLiteralNode = ASTLeaf | VoidType
 

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -1,8 +1,8 @@
 import type {
   ArrayExpression
+  ASTLeaf
   ASTNode
   Existence
-  Literal
 } from ./types.civet
 
 import {
@@ -16,7 +16,7 @@ import {
 } from ./util.civet
 
 function processUnaryExpression(pre: ASTNode[], exp: ASTNode, post?: ASTNode[]): ASTNode
-  if (!(pre.length or post)) return exp
+  return exp unless pre# or post
   // Handle "?" postfix
   if post?.token is "?"
     post =
@@ -47,23 +47,17 @@ function processUnaryExpression(pre: ASTNode[], exp: ASTNode, post?: ASTNode[]):
     return exp
 
   // Combine unary -/+ to become numeric literals
-  if exp.type is "Literal"
-    if pre.length is 1
-      {token} := pre[0]
-      if token is "-" or token is "+"
-        children := [pre[0], ...exp.children]
-        literal: Literal := {
-          type: "Literal"
-          children
-          raw: `${token}${exp.raw}`
-        }
-        if (post)
-          return {
-            type: "UnaryExpression",
-            children: [literal, post]
-          }
-
-        return literal
+  if exp?.type is "Literal" and pre#
+    [ ..., last ] .= pre
+    if (last as ASTLeaf?)?.token is like "+", "-"
+      last = last as ASTLeaf
+      exp = {
+        ...exp
+        children: [last, ...exp.children]
+        raw: `${last.token}${exp.raw}`
+      }
+      pre = pre[...-1]
+      return exp unless pre# or post
 
   // Await ops
   while l := pre.length

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -9,6 +9,7 @@ import type {
   IsToken
   IterationStatement
   Literal
+  NumericLiteral
   StatementNode
   TypeSuffix
   ReturnTypeAnnotation
@@ -332,38 +333,45 @@ function inplacePrepend(prefix: ASTNode, node: ASTNode): void
 
 // Convert (non-Template) Literal to actual JavaScript value
 function literalValue(literal: Literal)
-  let { raw } = literal
-  switch (raw) {
+  { raw } .= literal
+  switch raw
     case "null": return null
     case "true": return true
     case "false": return false
-  }
-  if (
-    (raw.startsWith('"') and raw.endsWith('"')) ||
-    (raw.startsWith("'") and raw.endsWith("'"))
-  ) {
-    return raw.slice(1, -1)
-  }
-  const numeric = literal.children.find(
-    (child) => child.type is "NumericLiteral"
-  )
-  if (numeric) {
-    raw = raw.replace(/_/g, "")
-    const { token } = numeric
-    if (token.endsWith("n")) {
-      return BigInt(raw.slice(0, -1))
-    } else if (token.match(/[\.eE]/)) {
-      return parseFloat(raw)
-    } else if (token.startsWith("0")) {
-      switch (token.charAt(1).toLowerCase()) {
-        case "x": return parseInt(raw.replace(/0[xX]/, ""), 16)
-        case "b": return parseInt(raw.replace(/0[bB]/, ""), 2)
-        case "o": return parseInt(raw.replace(/0[oO]/, ""), 8)
-      }
-    }
-    return parseInt(raw, 10)
-  }
-  throw new Error("Unrecognized literal " + JSON.stringify(literal))
+  switch literal.subtype
+    when "StringLiteral"
+      assert.equal
+        (or)
+          raw.startsWith('"') and raw.endsWith('"')
+          raw.startsWith("'") and raw.endsWith("'")
+        true, "String literal should begin and end in single or double quotes"
+      return raw[1...-1]
+    when "NumericLiteral"
+      raw = raw.replace(/_/g, "")
+      if raw.endsWith("n")
+        return BigInt raw[0...-1]
+      else if raw.match(/[\.eE]/)
+        return parseFloat(raw)
+      else if [ , base ] := raw.match(/^[+-]?0(.)/)
+        switch base.toLowerCase()
+          case "x": return parseInt(raw.replace(/0[xX]/, ""), 16)
+          case "b": return parseInt(raw.replace(/0[bB]/, ""), 2)
+          case "o": return parseInt(raw.replace(/0[oO]/, ""), 8)
+      return parseInt(raw, 10)
+    else
+      throw new Error("Unrecognized literal " + JSON.stringify(literal))
+
+function makeNumericLiteral(n: number): Literal
+  s := n.toString()
+  type: "Literal"
+  subtype: "NumericLiteral"
+  raw: s
+  children: [
+    {
+      type: "NumericLiteral"
+      token: s
+    } as NumericLiteral // missing $loc
+  ]
 
 function startsWith(target: ASTNode, value: RegExp)
   if (!target) return
@@ -724,6 +732,7 @@ export {
   literalValue
   makeLeftHandSideExpression
   makeNode
+  makeNumericLiteral
   maybeWrap
   maybeUnwrap
   parenthesizeExpression

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -176,7 +176,7 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a;
-    for (let i = a = x; 2 !== 0 && (2 > 0 ? i <= y : i >= y); a = i += 2) {
+    for (let i = a = x; i <= y; a = i += 2) {
       console.log(a)
     }
   """

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -236,6 +236,16 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    by when
+    ---
+    "civet coffee-compat"
+    as = (a for a in [x..y] by 2 when good a)
+    ---
+    var as;
+    as = (()=>{var a;const results=[];for (let i = a = x; i <= y; a = i += 2) { if (!good(a)) continue;results.push(a) }return results})()
+  """
+
+  testCase """
     postfix
     ---
     "civet coffeeCompat"

--- a/test/for.civet
+++ b/test/for.civet
@@ -1072,3 +1072,37 @@ describe "for", ->
     ---
     bigSquares = (function*(){for (const x of y) { if (!(x > 5)) continue;yield x*x };return})()
   """
+
+  describe "by", ->
+    testCase """
+      for of in variable range with literal step
+      ---
+      for a of [x..y] by 2
+        console.log a
+      ---
+      for (let i = x; i <= y; i += 2) {const a = i;
+        console.log(a)
+      }
+    """
+
+    testCase """
+      for of range start and end variable with step
+      ---
+      for a of [x...y] by z
+        console.log a
+      ---
+      for (let i = x; z !== 0 && (z > 0 ? i < y : i > y); i += z) {const a = i;
+        console.log(a)
+      }
+    """
+
+    testCase """
+      for of range with ref start, end, step
+      ---
+      for a of [x()...y()] by z()
+        console.log a
+      ---
+      for (let end = y(), i = x(), step = z(); step !== 0 && (step > 0 ? i < end : i > end); i += step) {const a = i;
+        console.log(a)
+      }
+    """

--- a/test/for.civet
+++ b/test/for.civet
@@ -1086,6 +1086,14 @@ describe "for", ->
     """
 
     testCase """
+      by when
+      ---
+      as := a for a of [x..y] by 2 when good a
+      ---
+      const as =(()=>{const results=[];for (let i = x; i <= y; i += 2) { const a = i;if (!good(a)) continue;results.push( a) }return results})()
+    """
+
+    testCase """
       for of range start and end variable with step
       ---
       for a of [x...y] by z


### PR DESCRIPTION
I apparently already tried to add this, because the parse rules were all there. They just didn't activate ever because `by` wasn't in `ReservedBinary`. Now fixed, and fixed the actual code that handled `by` (previously, `by` was in the output).

I also cleaned up some literal handling code, in particular to deal with these new step values, and let us figure out whether we're stepping upward or downard when the step is a literal.