### PR TITLE
`for some/every/count/sum/product/min/max` reduction loops, empty for loop default behavior, fix unwrapping multiple loops ina  row

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1841,7 +1841,8 @@ the body values according to one of the following reductions.
 `for some` returns whether any body value is truthy,
 shortcutting once one is found (like
 [`Array.prototype.some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some)).
-If there is no body, any iteration counts as truthy.
+If there is no body, any iteration counts as truthy,
+so it measures whether the iteration is nonempty.
 
 <Playground>
 anyEven := for some item of array
@@ -1852,12 +1853,16 @@ nonEmpty := for some key in object
 `for every` returns whether every body value is truthy,
 shortcutting if a falsey value is found (like
 [`Array.prototype.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every)).
-If there is no body, any iteration counts as truthy.
+If there is no body, any iteration counts as falsey,
+so it measures whether the iteration is empty.
 
 <Playground>
 allEven := for every item of array
   item % 2 === 0
-empty := for every key in object
+</Playground>
+
+<Playground>
+emptyOwn := for every own key in object
 </Playground>
 
 `for count` counts how many body values are truthy.

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1771,6 +1771,14 @@ so you cannot use `return` inside such a loop,
 nor can you `break` or `continue` any outer loop.
 :::
 
+If you don't specify a body, `for` loops list the item being iterated over:
+
+<Playground>
+array := for item of iterable
+coordinates := for {x, y} of objects
+keys := for key in object
+</Playground>
+
 Loops that use `await` automatically get `await`ed.
 If you'd rather obtain the promise for the results so you can `await` them
 yourself, use `async for`.
@@ -1816,8 +1824,76 @@ squared := v * v for v of list when v?
 squared := for v of list when v? then v * v
 </Playground>
 
+If you don't specify a loop body, you get a filter:
+
+<Playground>
+evens := for v of list when v % 2 === 0
+</Playground>
+
 To make a generator instead of an array, use
 [`for*`](#generator-expressions) instead of `for`.
+
+### Reductions
+
+Instead of accumulating the results in an array, `for` loops can combine
+the body values according to one of the following reductions.
+
+`for some` returns whether any body value is truthy,
+shortcutting once one is found (like
+[`Array.prototype.some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some)).
+If there is no body, any iteration counts as truthy.
+
+<Playground>
+anyEven := for some item of array
+  item % 2 === 0
+nonEmpty := for some key in object
+</Playground>
+
+`for every` returns whether every body value is truthy,
+shortcutting if a falsey value is found (like
+[`Array.prototype.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every)).
+If there is no body, any iteration counts as truthy.
+
+<Playground>
+allEven := for every item of array
+  item % 2 === 0
+empty := for every key in object
+</Playground>
+
+`for count` counts how many body values are truthy.
+If there is no body, any iteration counts as truthy.
+
+<Playground>
+numEven := for count item of array
+  item % 2 === 0
+numKeys := for count key in object
+</Playground>
+
+`for sum` adds up the body values with `+`.
+If there is no body, it adds the item being looped over.
+
+<Playground>
+sumOfSquares := for sum item of array
+  item * item
+sum := for sum item of array
+</Playground>
+
+`for product` multiples the body values with `*`.
+If there is no body, it multiplies the item being looped over.
+
+<Playground>
+prod := for product item of array
+nonZeroProd := for product item of array when item
+</Playground>
+
+`for min/max` finds the minimum/maximum body value,
+or `+Infinity`/`-Infinity` if there are none.
+If there is no body, it uses the item being looped over.
+
+<Playground>
+min := for min item of array
+max := for max item of array
+</Playground>
 
 ### Infinite Loop
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -297,14 +297,7 @@ StatementExpression
     // because it might be a postfix `if`
     if (!$1.else && $1.then.implicit) return $skip
     return $1
-  IterationExpression ->
-    // Forbid expressionizing `while condition` with no block,
-    // because it might be a postfix `while`
-    // But allow empty `do` and `comptime` which can't be postfix
-    if ($1.block.implicit && $1.subtype !== "DoStatement" && $1.subtype !== "ComptimeStatement") {
-      return $skip
-    }
-    return $1
+  IterationExpression
   SwitchStatement
   ThrowStatement
   TryStatement
@@ -4245,6 +4238,8 @@ Statement
   IterationStatement !ShouldExpressionize ->
     // Leave generator forms for IterationExpression
     if ($1.generator) return $skip
+    // Leave `for` reductions for IterationExpression
+    if ($1.reduction) return $skip
     return $1
   SwitchStatement !ShouldExpressionize -> $1
   TryStatement !ShouldExpressionize -> $1
@@ -4528,15 +4523,17 @@ ForClause
     return {
       type: "ForStatement",
       children: [$1, ...$3, ...children],
-      declaration: declaration,
+      declaration,
       block: null,
       blockPrefix: c.blockPrefix,
       hoistDec: c.hoistDec,
+      reduction: c.reduction,
       generator,
     }
 
 ForStatementControlWithWhen
-  ForStatementControl:control WhenCondition?:condition ->
+  ForReduction?:reduction ForStatementControl:control WhenCondition?:condition ->
+    if (reduction) control = { ...control, reduction }
     if (!condition) return control
     const expressions = [["", {
       type: "ContinueStatement",
@@ -4557,6 +4554,14 @@ ForStatementControlWithWhen
           children: ["if (!", makeLeftHandSideExpression(trimFirstSpace(condition)), ") ", block],
         }, ";"]
       ],
+    }
+
+ForReduction
+  ( "some" / "every" / "count" / "sum" / "product" / "min" / "max" ):subtype NonIdContinue __:ws ->
+    return {
+      type: "ForReduction",
+      subtype,
+      children: [ ws ],
     }
 
 ForStatementControl
@@ -4742,7 +4747,7 @@ ForDeclaration
     return {
       type: "ForDeclaration",
       children: [c, binding],
-      declare: c,
+      decl: c.token,
       binding,
       names: binding.names,
     }
@@ -4753,7 +4758,7 @@ ForDeclaration
     return {
       type: "ForDeclaration",
       children: [c, binding],
-      declare: c,
+      decl: c.token,
       binding,
       names: binding.names,
     }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4284,7 +4284,7 @@ EmptyStatement
 
 InsertEmptyStatement
   InsertSemicolon ->
-    return { type: "EmptyStatement", children: [$1] }
+    return { type: "EmptyStatement", children: [$1], implicit: true }
 
 # https://262.ecma-international.org/#prod-BlockStatement
 BlockStatement

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -4,6 +4,7 @@ import type {
   ASTLeaf
   ASTError
   Children
+  ForDeclaration
   RangeDots
   RangeExpression
   Whitespace
@@ -121,7 +122,7 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
 // Construct for loop from RangeLiteral
 function forRange(
   open: ASTLeaf
-  forDeclaration: ASTNode
+  forDeclaration: ForDeclaration
   range: RangeExpression
   stepExp: ASTNode
   close: ASTLeaf
@@ -180,8 +181,8 @@ function forRange(
     ascDec = [", ", ascRef, " = ", startRef, " <= ", endRef]
 
   let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
-  if forDeclaration?.declare // var/let/const declaration of variable
-    if forDeclaration.declare.token is "let"
+  if forDeclaration?.decl // var/let/const declaration of variable
+    if forDeclaration.decl is "let"
       varName := forDeclaration.children.splice(1)  // strip let
       varAssign = [...trimFirstSpace(varName), " = "]
       varLet = [",", ...varName, " = ", counterRef]

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -575,7 +575,7 @@ function wrapIterationReturningResults(
 // so that the caller can add it to the containing block.
 // Also wraps the body to collect the loop results.
 function iterationDeclaration(statement: IterationStatement | ForStatement)
-  { resultsRef } := statement
+  { resultsRef, block } := statement
 
   reduction := statement.type is "ForStatement" and statement.reduction
   decl: "const" | "let" .= reduction ? "let" : "const"
@@ -587,7 +587,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
   breakWithOnly := (and)
     decl is "let"
     isLoopStatement statement
-    gatherRecursive(statement.block,
+    gatherRecursive(block,
       (s): s is BreakStatement => s.type is "BreakStatement" and not s.with,
       (s) => isFunction(s) or s.type is "IterationStatement")# is 0
 
@@ -618,34 +618,33 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
   // insert `results.push` to gather results array
   // TODO: real ast nodes
   unless breakWithOnly
-    if statement.block.empty and reduction
+    function fillBlock(expression: StatementTuple)
+      if block.expressions.-1 is like [, {type: "EmptyStatement", implicit: true}, ...]
+        block.expressions.pop()
+      block.expressions.push expression
+      block.empty = false
+      braceBlock block
+    if block.empty and reduction
       switch reduction.subtype
         when "some"
-          statement.block.expressions[..] = [[ "",
-            [ resultsRef, " = true; break" ]
-          ] as StatementTuple]
-          statement.block.empty = false
-          braceBlock statement.block
+          fillBlock [ "", [ resultsRef, " = true; break" ] ]
+          block.empty = false
+          braceBlock block
         when "every"
-          statement.block.expressions[..] = [[ "",
-            [ resultsRef, " = false; break" ]
-          ] as StatementTuple]
-          statement.block.empty = false
-          braceBlock statement.block
+          fillBlock [ "", [ resultsRef, " = false; break" ] ]
+          block.empty = false
+          braceBlock block
         when "count"
-          statement.block.expressions[..] = [[ "",
-            [ "++", resultsRef ]
-          ] as StatementTuple]
-          statement.block.empty = false
-      return declaration unless statement.block.empty
-    if statement.block.empty and statement.type is "ForStatement" and
+          fillBlock [ "", [ "++", resultsRef ] ]
+          block.empty = false
+          braceBlock block
+      return declaration unless block.empty
+    if block.empty and statement.type is "ForStatement" and
        statement.declaration?.type is "ForDeclaration"
-      statement.block.expressions[..] = [[ "",
-        patternAsValue statement.declaration.binding
-      ] as StatementTuple]
-      statement.block.empty = false
-    unless statement.block.empty
-      assignResults statement.block, (node) =>
+      fillBlock [ "", patternAsValue statement.declaration.binding ]
+      block.empty = false
+    unless block.empty
+      assignResults block, (node) =>
         return [ resultsRef, ".push(", node, ")" ] unless reduction
         switch reduction.subtype
           when "some"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -716,16 +716,14 @@ function processSignature(f: FunctionNode): void
       signature.modifier.generator = true
 
 function processFunctions(statements, config): void
-  gatherRecursiveAll(statements, ({ type }) => type is "FunctionExpression" or type is "ArrowFunction")
-  .forEach (f) =>
+  for each f of gatherRecursiveAll statements, .type is "FunctionExpression" or .type is "ArrowFunction"
     if f.type is "FunctionExpression"
       implicitFunctionBlock(f)
     processSignature(f)
     processParams(f)
     processReturn(f, config.implicitReturns)
 
-  gatherRecursiveAll(statements, ({ type }) => type is "MethodDefinition")
-  .forEach (f) =>
+  for each f of gatherRecursiveAll statements, .type is "MethodDefinition"
     implicitFunctionBlock(f)
     processParams(f)
     processReturn(f, config.implicitReturns)

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -557,7 +557,7 @@ function wrapIterationReturningResults(
 
   resultsRef := statement.resultsRef = makeRef "results"
 
-  { declaration, breakWithOnly } := iterationDeclaration statement
+  declaration := iterationDeclaration statement
   { ancestor, child } := findAncestor statement, .type is "BlockStatement"
   assert.notNull ancestor, `Could not find block containing ${statement.type}`
   index := findChildIndex ancestor.expressions, child
@@ -566,20 +566,19 @@ function wrapIterationReturningResults(
   iterationTuple[0] = '' // steal indentation from loop
   braceBlock ancestor
 
-  unless breakWithOnly
-    assignResults statement.block, (node) =>
-      // TODO: real ast node
-      [ resultsRef, ".push(", node, ")" ]
-
   if collect
     statement.children.push collect(resultsRef)
   else
     statement.children.push(";return ", resultsRef, ";")
 
+// Creates and returns a declaration for the results of a loop,
+// so that the caller can add it to the containing block.
+// Also wraps the body to collect the loop results.
 function iterationDeclaration(statement: IterationStatement | ForStatement)
   { resultsRef } := statement
 
-  decl: "const" | "let" .= "const"
+  reduction := statement.type is "ForStatement" and statement.reduction
+  decl: "const" | "let" .= reduction ? "let" : "const"
   if statement.type is "IterationStatement" or statement.type is "ForStatement"
     if processBreakContinueWith statement
       decl = "let"
@@ -599,13 +598,69 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
     names: []
     bindings: []
   }
-  // Assign [] directly only in const case, so TypeScript can better infer
-  if decl is "const"
-    declaration.children.push "=[]"
-  else // decl is "let"
-    declaration.children.push ";", resultsRef, "=[]" unless breakWithOnly
 
-  { declaration, breakWithOnly }
+  if reduction
+    declaration.children.push "=" +
+      switch reduction.subtype
+        when "some" then "false"
+        when "every" then "true"
+        when "min" then "Infinity"
+        when "max" then "-Infinity"
+        when "product" then "1"
+        else "0"
+  else
+    // Assign [] directly only in const case, so TypeScript can better infer
+    if decl is "const"
+      declaration.children.push "=[]"
+    else // decl is "let"
+      declaration.children.push ";", resultsRef, "=[]" unless breakWithOnly
+
+  // insert `results.push` to gather results array
+  // TODO: real ast nodes
+  unless breakWithOnly
+    if statement.block.empty and reduction
+      switch reduction.subtype
+        when "some"
+          statement.block.expressions[..] = [[ "",
+            [ resultsRef, " = true; break" ]
+          ] as StatementTuple]
+          statement.block.empty = false
+          braceBlock statement.block
+        when "every"
+          statement.block.expressions[..] = [[ "",
+            [ resultsRef, " = false; break" ]
+          ] as StatementTuple]
+          statement.block.empty = false
+          braceBlock statement.block
+        when "count"
+          statement.block.expressions[..] = [[ "",
+            [ "++", resultsRef ]
+          ] as StatementTuple]
+          statement.block.empty = false
+      return declaration unless statement.block.empty
+    if statement.block.empty and statement.type is "ForStatement" and
+       statement.declaration?.type is "ForDeclaration"
+      statement.block.expressions[..] = [[ "",
+        patternAsValue statement.declaration.binding
+      ] as StatementTuple]
+      statement.block.empty = false
+    unless statement.block.empty
+      assignResults statement.block, (node) =>
+        return [ resultsRef, ".push(", node, ")" ] unless reduction
+        switch reduction.subtype
+          when "some"
+            [ "if (", node, ") {", resultsRef, " = true; break}" ]
+          when "every"
+            [ "if (!", makeLeftHandSideExpression(node), ") {",
+              resultsRef, " = false; break}" ]
+          when "count"
+            [ "if (", node, ") ++", resultsRef ]
+          when "sum" then [ resultsRef, " += ", node ]
+          when "product" then [ resultsRef, " *= ", node ]
+          when "min" then [ resultsRef, " = Math.min(", resultsRef, ", ", node, ")" ]
+          when "max" then [ resultsRef, " = Math.max(", resultsRef, ", ", node, ")" ]
+
+  declaration
 
 function processParams(f): void
   { type, parameters, block } := f
@@ -761,21 +816,14 @@ function expressionizeIteration(exp: IterationExpression): void
   else
     resultsRef := statement.resultsRef ??= makeRef "results"
 
-    { declaration, breakWithOnly } := iterationDeclaration statement
-
-    // insert `results.push` to gather results array
-    unless breakWithOnly
-      assignResults block, (node) =>
-        // TODO: real node
-        [ resultsRef, ".push(", node, ")" ]
-      braceBlock(block)
+    declaration := iterationDeclaration statement
 
     // Wrap with IIFE
     children.splice(i,
       1,
       wrapIIFE([
         ["", declaration, ";"]
-        ["", statement, undefined]
+        ["", statement, ";" if statement.block.bare]
         ["", wrapWithReturn(resultsRef)]
       ], async)
     )

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -919,214 +919,208 @@ function processBindingPatternLHS(lhs, tail): void
   // TODO: This isn't quite right for compound assignments, may need to wrap with parens and use comma to return the complete value
   tail.push(...splices.map((s) => [", ", s]), ...thisAssignments.map((a) => [", ", a]))
 
-function processAssignments(statements): void {
+function processAssignments(statements): void
   // Move assignments/updates within LHS of assignments/updates
   // to run earlier via comma operator
-  gatherRecursiveAll(statements, (n) => n.type is "AssignmentExpression" or n.type is "UpdateExpression")
-    .forEach (exp) =>
-      function extractAssignment(lhs)
-        expr .= lhs
-        while expr.type is "ParenthesizedExpression"
-          expr = expr.expression
-        if expr.type is like "AssignmentExpression", "UpdateExpression"
-          if expr.type is "UpdateExpression" and
-             expr.children[0] is expr.assigned  // postfix update
-            pre.push("(")
-            post.push([", ", lhs, ")"])
-          else
-            pre.push(["(", lhs, ", "])
-            post.push(")")
-          // TODO: use ref to avoid duplicating function calls
-          return expr.assigned
-
-      const pre = [], post = []
-      switch exp.type
-        when "AssignmentExpression"
-          if (!exp.lhs) return
-          exp.lhs.forEach (lhsPart, i) =>
-            if newLhs := extractAssignment(lhsPart[1])
-              lhsPart[1] = newLhs
-        when "UpdateExpression"
-          if newLhs := extractAssignment(exp.assigned)
-            i := exp.children.indexOf(exp.assigned)
-            exp.assigned = exp.children[i] = newLhs
-      if (pre.length) exp.children.unshift(...pre)
-      if (post.length) exp.children.push(...post)
-      // TODO: need to make this a parenthesized expression when when we add parens
-
-      if exp.type is "UpdateExpression"
-        { assigned } := exp
-        ref := makeRef()
-        newMemberExp := unchainOptionalMemberExpression assigned, ref, (children) =>
-          exp.children.map & is assigned ? children : &
-
-        if newMemberExp !== assigned
-          if newMemberExp.usesRef
-            newMemberExp.hoistDec = {
-              type: "Declaration"
-              children: ["let ", ref]
-              names: []
-            }
-          replaceNode exp, newMemberExp
-
-  replaceNodesRecursive statements,
-    (n) => n.type is "AssignmentExpression" and n.names is null,
-    (exp: AssignmentExpression): AssignmentExpression | BlockStatement | ExpressionNode => {
-      let { lhs: $1, expression: $2 } = exp, tail = [], len = $1.length
-
-      let block?: BlockStatement
-      // Extract StatementExpression as block
-      if exp.parent?.type is "BlockStatement" and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
-        block = makeBlockFragment()
-        if ref := prependStatementExpressionBlock(
-          {type: "Initializer", expression: $2, children: [undefined, undefined, $2]}
-          block
-        )
-          exp.children = exp.children.map & is $2 ? ref : &
-          // @ts-ignore
-          $2 = ref
+  for each exp of gatherRecursiveAll statements, .type is "AssignmentExpression" or .type is "UpdateExpression"
+    function extractAssignment(lhs)
+      expr .= lhs
+      while expr.type is "ParenthesizedExpression"
+        expr = expr.expression
+      if expr.type is like "AssignmentExpression", "UpdateExpression"
+        if expr.type is "UpdateExpression" and
+            expr.children[0] is expr.assigned  // postfix update
+          pre.push("(")
+          post.push([", ", lhs, ")"])
         else
-          block = undefined
+          pre.push(["(", lhs, ", "])
+          post.push(")")
+        // TODO: use ref to avoid duplicating function calls
+        return expr.assigned
 
-      // identifier=, xor=, ++=
-      if $1.some &.-1.special
-        if ($1.length !== 1) throw new Error("Only one assignment with id= is allowed")
-        [, lhs, , op] := $1[0]
-        { call, omitLhs } := op
-        // Wrap right-hand side with call
-        index := exp.children.indexOf($2)
-        if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
-        exp.children.splice index, 1,
-          exp.expression = $2 = [call, "(", lhs, ", ", $2, ")"]
-        if omitLhs
-          return $2
+    const pre = [], post = []
+    switch exp.type
+      when "AssignmentExpression"
+        continue unless exp.lhs
+        exp.lhs.forEach (lhsPart, i) =>
+          if newLhs := extractAssignment(lhsPart[1])
+            lhsPart[1] = newLhs
+      when "UpdateExpression"
+        if newLhs := extractAssignment(exp.assigned)
+          i := exp.children.indexOf(exp.assigned)
+          exp.assigned = exp.children[i] = newLhs
+    exp.children.unshift(...pre) if pre#
+    exp.children.push(...post) if post#
+    // TODO: need to make this a parenthesized expression when when we add parens
 
-      // Force parens around destructuring object assignments
-      // Walk from left to right the minimal number of parens are added and enclose all destructured assignments
-      // TODO: Could validate some lhs ecmascript rules here if we wanted to
-      wrapped .= false
-      i .= 0
-      while i < len
-        lastAssignment := $1[i++]
-        [, lhs, , op] := lastAssignment
-        continue unless op.token is "="
+    if exp.type is "UpdateExpression"
+      { assigned } := exp
+      ref := makeRef()
+      newMemberExp := unchainOptionalMemberExpression assigned, ref, (children) =>
+        exp.children.map & is assigned ? children : &
 
-        if lhs.type is like "ObjectExpression", "ObjectBindingPattern"
-          // Wrap with parens to distinguish from braced blocks
-          unless wrapped
-            wrapped = true
-            lhs.children.splice(0, 0, "(")
-            tail.push(")")
-
-      refsToDeclare := new Set<ASTRef>
-
-      // Walk from right to left to handle splices
-      i = len - 1
-      while i >= 0
-        lastAssignment := $1[i]
-
-        if lastAssignment[3].token is "="
-          lhs := lastAssignment[1]
-
-          // Splice assignment
-          if lhs.type is "MemberExpression"
-            members := lhs.children
-            lastMember := members[members.length - 1]
-
-            if lastMember is like {type: "CallExpression", children: [^peekHelperRef("rslice"), ...]}
-              lastMember.children.push
-                type: "Error"
-                message: "Slice range cannot be decreasing in assignment"
-              break
-
-            // TODO: this is kind of bonkers
-            if lastMember.type is "SliceExpression"
-              const { start, end, children: c } = lastMember
-              // TODO: don't lose as many source mappings
-              c[0].token = ".splice("
-              c[1] = start
-              c[2] = ", "
-              if (end)
-                c[3] = [end, " - ", start]
-              else
-                c[3] = ["1/0"]
-              c[4] = [", ...", $2]
-              c[5] = ")"
-
-              // Remove assignment token
-              lastAssignment.pop()
-              if (isWhitespaceOrEmpty(lastAssignment[2])) lastAssignment.pop()
-              // TODO: this only works for the last assignment, not multiple splice assignments, or splice assignments earlier in the chain
-              if $1.length > 1
-                throw new Error("Not implemented yet! TODO: Handle multiple splice assignments")
-
-              exp.children = [$1]
-              exp.names = []
-              break
-          else if lhs.type is like "ObjectBindingPattern", "ArrayBindingPattern"
-            processBindingPatternLHS(lhs, tail)
-            // Extract temp refs that need to be declared from lhs
-            gatherRecursiveAll(lhs, .type is "Ref").forEach refsToDeclare@add
-
-          // NOTE: currently not processing any non-binding pattern ObjectExpression or ArrayExpressions
-          // This might not be correct in all situations, esp BindingPatterns nested inside ObjectExpressions
-        i--
-
-      // Handle optional chain ?. in lhs of assignments
-      i = len - 1
-      optionalChainRef := makeRef()
-      while i >= 0
-        assignment := $1[i]
-        [ws1, lhs, ws2, op] := assignment
-
-        if lhs.type is "MemberExpression" or lhs.type is "CallExpression"
-          newMemberExp := unchainOptionalMemberExpression lhs, optionalChainRef, (children) =>
-            // NOTE: This only executes when lhs contains chains
-            // this mutates the assignments array to account for the parts moved into the conditionals
-            assigns := $1.splice(i + 1, len - 1 - i)
-            $1.pop()
-            [ws1, ...children, ws2, op, ...assigns, $2]
-
-          if newMemberExp !== lhs
-            if newMemberExp.usesRef
-              exp.hoistDec =
-                type: "Declaration"
-                children: ["let ", optionalChainRef]
-                names: []
-
-            replaceNode $2, newMemberExp
-            newMemberExp.parent = exp
-            $2 = newMemberExp
-
-        i--
-
-      // Add any additional binding refs that need to be declared to our hoisted declarations
-      if refsToDeclare.size
-        if exp.hoistDec
-          exp.hoistDec.children.push [...refsToDeclare].map [",", &]
-        else
-          exp.hoistDec =
+      if newMemberExp !== assigned
+        if newMemberExp.usesRef
+          newMemberExp.hoistDec = {
             type: "Declaration"
-            children: ["let ", [...refsToDeclare].map (r, i) => i ? [",", r] : r]
+            children: ["let ", ref]
             names: []
+          }
+        replaceNode exp, newMemberExp
 
-      // Gather all identifier names from the lhs array
-      exp.names = $1.flatMap(([, l]) => l.names or [])
+  for each exp of gatherRecursiveAll statements, .type is "AssignmentExpression"
+    continue unless exp.names is null
+    let { lhs: $1, expression: $2 } = exp, tail = [], len = $1.length
 
-      if tail#
-        index := exp.children.indexOf($2)
-        if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
-        exp.children.splice(index + 1, 0, ...tail)
+    let block?: BlockStatement
+    // Extract StatementExpression as block
+    if exp.parent?.type is "BlockStatement" and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
+      block = makeBlockFragment()
+      if ref := prependStatementExpressionBlock(
+        {type: "Initializer", expression: $2, children: [undefined, undefined, $2]}
+        block
+      )
+        exp.children = exp.children.map & is $2 ? ref : &
+        // @ts-ignore
+        $2 = ref
+      else
+        block = undefined
 
-      if block
-        block.parent = exp.parent
-        block.expressions.push(["", exp])
-        exp.parent = block
-        return block
+    // identifier=, xor=, ++=
+    if $1.some &.-1.special
+      if ($1.length !== 1) throw new Error("Only one assignment with id= is allowed")
+      [, lhs, , op] := $1[0]
+      { call, omitLhs } := op
+      // Wrap right-hand side with call
+      index := exp.children.indexOf($2)
+      if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
+      exp.children.splice index, 1,
+        exp.expression = $2 = [call, "(", lhs, ", ", $2, ")"]
+      if omitLhs
+        replaceNode exp, $2
+        continue
 
-      return exp
-    }
-}
+    // Force parens around destructuring object assignments
+    // Walk from left to right the minimal number of parens are added and enclose all destructured assignments
+    // TODO: Could validate some lhs ecmascript rules here if we wanted to
+    wrapped .= false
+    i .= 0
+    while i < len
+      lastAssignment := $1[i++]
+      [, lhs, , op] := lastAssignment
+      continue unless op.token is "="
+
+      if lhs.type is like "ObjectExpression", "ObjectBindingPattern"
+        // Wrap with parens to distinguish from braced blocks
+        unless wrapped
+          wrapped = true
+          lhs.children.splice(0, 0, "(")
+          tail.push(")")
+
+    refsToDeclare := new Set<ASTRef>
+
+    // Walk from right to left to handle splices
+    i = len - 1
+    while i >= 0
+      lastAssignment := $1[i]
+
+      if lastAssignment[3].token is "="
+        lhs := lastAssignment[1]
+
+        // Splice assignment
+        if lhs.type is "MemberExpression"
+          members := lhs.children
+          lastMember := members[members.length - 1]
+
+          if lastMember is like {type: "CallExpression", children: [^peekHelperRef("rslice"), ...]}
+            lastMember.children.push
+              type: "Error"
+              message: "Slice range cannot be decreasing in assignment"
+            break
+
+          // TODO: this is kind of bonkers
+          if lastMember.type is "SliceExpression"
+            const { start, end, children: c } = lastMember
+            // TODO: don't lose as many source mappings
+            c[0].token = ".splice("
+            c[1] = start
+            c[2] = ", "
+            if (end)
+              c[3] = [end, " - ", start]
+            else
+              c[3] = ["1/0"]
+            c[4] = [", ...", $2]
+            c[5] = ")"
+
+            // Remove assignment token
+            lastAssignment.pop()
+            if (isWhitespaceOrEmpty(lastAssignment[2])) lastAssignment.pop()
+            // TODO: this only works for the last assignment, not multiple splice assignments, or splice assignments earlier in the chain
+            if $1.length > 1
+              throw new Error("Not implemented yet! TODO: Handle multiple splice assignments")
+
+            exp.children = [$1]
+            exp.names = []
+            break
+        else if lhs.type is like "ObjectBindingPattern", "ArrayBindingPattern"
+          processBindingPatternLHS(lhs, tail)
+          // Extract temp refs that need to be declared from lhs
+          gatherRecursiveAll(lhs, .type is "Ref").forEach refsToDeclare@add
+
+        // NOTE: currently not processing any non-binding pattern ObjectExpression or ArrayExpressions
+        // This might not be correct in all situations, esp BindingPatterns nested inside ObjectExpressions
+      i--
+
+    // Handle optional chain ?. in lhs of assignments
+    i = len - 1
+    optionalChainRef := makeRef()
+    while i >= 0
+      assignment := $1[i]
+      [ws1, lhs, ws2, op] := assignment
+
+      if lhs.type is "MemberExpression" or lhs.type is "CallExpression"
+        newMemberExp := unchainOptionalMemberExpression lhs, optionalChainRef, (children) =>
+          // NOTE: This only executes when lhs contains chains
+          // this mutates the assignments array to account for the parts moved into the conditionals
+          assigns := $1.splice(i + 1, len - 1 - i)
+          $1.pop()
+          [ws1, ...children, ws2, op, ...assigns, $2]
+
+        if newMemberExp !== lhs
+          if newMemberExp.usesRef
+            exp.hoistDec =
+              type: "Declaration"
+              children: ["let ", optionalChainRef]
+              names: []
+
+          replaceNode $2, newMemberExp
+          newMemberExp.parent = exp
+          $2 = newMemberExp
+
+      i--
+
+    // Add any additional binding refs that need to be declared to our hoisted declarations
+    if refsToDeclare.size
+      if exp.hoistDec
+        exp.hoistDec.children.push [...refsToDeclare].map [",", &]
+      else
+        exp.hoistDec =
+          type: "Declaration"
+          children: ["let ", [...refsToDeclare].map (r, i) => i ? [",", r] : r]
+          names: []
+
+    // Gather all identifier names from the lhs array
+    exp.names = $1.flatMap(([, l]) => l.names or [])
+
+    if tail#
+      index := exp.children.indexOf($2)
+      if (index < 0) throw new Error("Assertion error: exp not in AssignmentExpression")
+      exp.children.splice(index + 1, 0, ...tail)
+
+    if block
+      replaceNode exp, block
+      block.expressions.push(["", exp])
+      exp.parent = block
 
 function unchainOptionalMemberExpression(exp: MemberExpression | CallExpression, ref: ASTRef, innerExp: (exp) => ASTNode)
   j .= 0
@@ -1670,28 +1664,6 @@ function replaceNodes(root, predicate, replacer)
       array[i] = replacer node, root
     else
       replaceNodes node, predicate, replacer
-
-  return root
-
-function replaceNodesRecursive(root, predicate, replacer)
-  return root unless root?
-
-  array := Array.isArray(root) ? root : root.children
-
-  unless array
-    if predicate root
-      return replacer root, root
-    else
-      return root
-
-  for each node, i of array
-    continue unless node?
-    if predicate node
-      ret := replacer node, root
-      replaceNodesRecursive ret, predicate, replacer
-      array[i] = ret
-    else
-      replaceNodesRecursive node, predicate, replacer
 
   return root
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -437,6 +437,7 @@ export type EmptyStatement
   type: "EmptyStatement"
   children: Children
   parent?: Parent
+  implicit?: boolean
 
 export type LabelledStatement
   type: "LabelledStatement"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -91,6 +91,7 @@ export type OtherNode =
   | ElseClause
   | FieldDefinition
   | FinallyClause
+  | ForDeclaration
   | Index
   | Initializer
   | Label
@@ -372,11 +373,24 @@ export type ForStatement
   type: "ForStatement"
   children: Children
   parent?: Parent
-  declaration: DeclarationStatement?
+  declaration: (DeclarationStatement | ForDeclaration)?
   block: BlockStatement
   hoistDec: unknown
   generator?: ASTNode
   resultsRef: ASTRef?
+  reduction?: ForReduction
+
+export type ForDeclaration
+  type: "ForDeclaration"
+  children: Children
+  parent?: Parent
+  names: string[]
+  binding: Binding
+  decl: "let" | "const" | "var"
+
+export type ForReduction
+  type: "ForReduction"
+  subtype: "some" | "every" | "count" | "sum" | "product" | "min" | "max"
 
 export type SwitchStatement
   type: "SwitchStatement"

--- a/test/for.civet
+++ b/test/for.civet
@@ -755,6 +755,22 @@ describe "for", ->
     """
 
     testCase """
+      two for..of
+      ---
+      z = for x of y
+        x*x
+      z = for x of y
+        x*x
+      ---
+      const results=[];for (const x of y) {
+        results.push(x*x)
+      };z = results
+      const results1=[];for (const x of y) {
+        results1.push(x*x)
+      };z = results1
+    """
+
+    testCase """
       async for
       ---
       async for x of y

--- a/test/for.civet
+++ b/test/for.civet
@@ -916,6 +916,24 @@ describe "for", ->
       .concat([16, 25])
     """
 
+    testCase """
+      empty body in function
+      ---
+      => for x of y
+      => for [x] of y
+      ---
+      () => { const results=[];for (const x of y)results.push(x);return results; };
+      () => { const results1=[];for (const [x] of y)results1.push([x]);return results1; }
+    """
+
+    testCase """
+      assigned empty body
+      ---
+      result = for x of y
+      ---
+      const results=[];for (const x of y)results.push(x);result = results
+    """
+
   testCase """
     for generator
     ---
@@ -1129,4 +1147,156 @@ describe "for", ->
       for (let end = y(), i = x(), step = z(); step !== 0 && (step > 0 ? i < end : i > end); i += step) {const a = i;
         console.log(a)
       }
+    """
+
+  describe "reductions", ->
+    testCase """
+      empty body
+      ---
+      z = for some x of y
+      z = for every x of y
+      z = for count x of y
+      z = for sum x of y
+      z = for product x of y
+      z = for min x of y
+      z = for max x of y
+      ---
+      let results=false;for (const x of y) {results = true; break};z = results
+      let results1=true;for (const x of y) {results1 = false; break};z = results1
+      let results2=0;for (const x of y)++results2;z = results2
+      let results3=0;for (const x of y)results3 += x;z = results3
+      let results4=1;for (const x of y)results4 *= x;z = results4
+      let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);z = results5
+      let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);z = results6
+    """
+
+    testCase """
+      indented body
+      ---
+      z = for some x of y
+        f x
+      z = for every x of y
+        f x
+      z = for count x of y
+        f x
+      z = for sum x of y
+        f x
+      z = for product x of y
+        f x
+      z = for min x of y
+        f x
+      z = for max x of y
+        f x
+      ---
+      let results=false;for (const x of y) {
+        if (f(x)) {results = true; break}
+      };z = results
+      let results1=true;for (const x of y) {
+        if (!f(x)) {results1 = false; break}
+      };z = results1
+      let results2=0;for (const x of y) {
+        if (f(x)) ++results2
+      };z = results2
+      let results3=0;for (const x of y) {
+        results3 += f(x)
+      };z = results3
+      let results4=1;for (const x of y) {
+        results4 *= f(x)
+      };z = results4
+      let results5=Infinity;for (const x of y) {
+        results5 = Math.min(results5, f(x))
+      };z = results5
+      let results6=-Infinity;for (const x of y) {
+        results6 = Math.max(results6, f(x))
+      };z = results6
+    """
+
+    testCase """
+      expression context
+      ---
+      z or for some x of y
+      z or for every x of y
+      z or for count x of y
+      z or for sum x of y
+      z or for product x of y
+      z or for min x of y
+      z or for max x of y
+      ---
+      z || (()=>{let results=false;for (const x of y) {results = true; break}return results})()
+      z || (()=>{let results1=true;for (const x of y) {results1 = false; break}return results1})()
+      z || (()=>{let results2=0;for (const x of y)++results2;return results2})()
+      z || (()=>{let results3=0;for (const x of y)results3 += x;return results3})()
+      z || (()=>{let results4=1;for (const x of y)results4 *= x;return results4})()
+      z || (()=>{let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);return results5})()
+      z || (()=>{let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);return results6})()
+    """
+
+    testCase """
+      unassigned
+      ---
+      for some x of y
+      for every x of y
+      for count x of y
+      for sum x of y
+      for product x of y
+      for min x of y
+      for max x of y
+      ---
+      (()=>{let results=false;for (const x of y) {results = true; break}return results})();
+      (()=>{let results1=true;for (const x of y) {results1 = false; break}return results1})();
+      (()=>{let results2=0;for (const x of y)++results2;return results2})();
+      (()=>{let results3=0;for (const x of y)results3 += x;return results3})();
+      (()=>{let results4=1;for (const x of y)results4 *= x;return results4})();
+      (()=>{let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);return results5})();
+      (()=>{let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);return results6})()
+    """
+
+    testCase """
+      function context
+      ---
+      => for some x of y
+      => for every x of y
+      => for count x of y
+      => for sum x of y
+      => for product x of y
+      => for min x of y
+      => for max x of y
+      ---
+      () => { let results=false;for (const x of y) {results = true; break};return results; };
+      () => { let results1=true;for (const x of y) {results1 = false; break};return results1; };
+      () => { let results2=0;for (const x of y)++results2;return results2; };
+      () => { let results3=0;for (const x of y)results3 += x;return results3; };
+      () => { let results4=1;for (const x of y)results4 *= x;return results4; };
+      () => { let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);return results5; };
+      () => { let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);return results6; }
+    """
+
+    testCase """
+      postfix
+      ---
+      a := x for some x of y
+      b := x for every x of y
+      c := x for count x of y
+      d := x for sum x of y
+      e := x for product x of y
+      f := x for min x of y
+      g := x for max x of y
+      ---
+      const a =(()=>{let results=false;for (const x of y) { if ( x) {results = true; break} }return results})()
+      const b =(()=>{let results1=true;for (const x of y) { if (! x) {results1 = false; break} }return results1})()
+      const c =(()=>{let results2=0;for (const x of y) { if ( x) ++results2 }return results2})()
+      const d =(()=>{let results3=0;for (const x of y) { results3 +=  x }return results3})()
+      const e =(()=>{let results4=1;for (const x of y) { results4 *=  x }return results4})()
+      const f =(()=>{let results5=Infinity;for (const x of y) { results5 = Math.min(results5,  x) }return results5})()
+      const g =(()=>{let results6=-Infinity;for (const x of y) { results6 = Math.max(results6,  x) }return results6})()
+    """
+
+    testCase """
+      for in
+      ---
+      nonEmpty = for some x in y
+      empty = for every x in y
+      ---
+      let results=false;for (const x in y) {results = true; break};nonEmpty = results
+      let results1=true;for (const x in y) {results1 = false; break};empty = results1
     """

--- a/test/for.civet
+++ b/test/for.civet
@@ -922,8 +922,8 @@ describe "for", ->
       => for x of y
       => for [x] of y
       ---
-      () => { const results=[];for (const x of y)results.push(x);return results; };
-      () => { const results1=[];for (const [x] of y)results1.push([x]);return results1; }
+      () => { const results=[];for (const x of y) {results.push(x)};return results; };
+      () => { const results1=[];for (const [x] of y) {results1.push([x])};return results1; }
     """
 
     testCase """
@@ -931,7 +931,7 @@ describe "for", ->
       ---
       result = for x of y
       ---
-      const results=[];for (const x of y)results.push(x);result = results
+      const results=[];for (const x of y) {results.push(x)};result = results
     """
 
   testCase """
@@ -1163,11 +1163,11 @@ describe "for", ->
       ---
       let results=false;for (const x of y) {results = true; break};z = results
       let results1=true;for (const x of y) {results1 = false; break};z = results1
-      let results2=0;for (const x of y)++results2;z = results2
-      let results3=0;for (const x of y)results3 += x;z = results3
-      let results4=1;for (const x of y)results4 *= x;z = results4
-      let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);z = results5
-      let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);z = results6
+      let results2=0;for (const x of y) {++results2};z = results2
+      let results3=0;for (const x of y) {results3 += x};z = results3
+      let results4=1;for (const x of y) {results4 *= x};z = results4
+      let results5=Infinity;for (const x of y) {results5 = Math.min(results5, x)};z = results5
+      let results6=-Infinity;for (const x of y) {results6 = Math.max(results6, x)};z = results6
     """
 
     testCase """
@@ -1224,11 +1224,11 @@ describe "for", ->
       ---
       z || (()=>{let results=false;for (const x of y) {results = true; break}return results})()
       z || (()=>{let results1=true;for (const x of y) {results1 = false; break}return results1})()
-      z || (()=>{let results2=0;for (const x of y)++results2;return results2})()
-      z || (()=>{let results3=0;for (const x of y)results3 += x;return results3})()
-      z || (()=>{let results4=1;for (const x of y)results4 *= x;return results4})()
-      z || (()=>{let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);return results5})()
-      z || (()=>{let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);return results6})()
+      z || (()=>{let results2=0;for (const x of y) {++results2}return results2})()
+      z || (()=>{let results3=0;for (const x of y) {results3 += x}return results3})()
+      z || (()=>{let results4=1;for (const x of y) {results4 *= x}return results4})()
+      z || (()=>{let results5=Infinity;for (const x of y) {results5 = Math.min(results5, x)}return results5})()
+      z || (()=>{let results6=-Infinity;for (const x of y) {results6 = Math.max(results6, x)}return results6})()
     """
 
     testCase """
@@ -1244,11 +1244,11 @@ describe "for", ->
       ---
       (()=>{let results=false;for (const x of y) {results = true; break}return results})();
       (()=>{let results1=true;for (const x of y) {results1 = false; break}return results1})();
-      (()=>{let results2=0;for (const x of y)++results2;return results2})();
-      (()=>{let results3=0;for (const x of y)results3 += x;return results3})();
-      (()=>{let results4=1;for (const x of y)results4 *= x;return results4})();
-      (()=>{let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);return results5})();
-      (()=>{let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);return results6})()
+      (()=>{let results2=0;for (const x of y) {++results2}return results2})();
+      (()=>{let results3=0;for (const x of y) {results3 += x}return results3})();
+      (()=>{let results4=1;for (const x of y) {results4 *= x}return results4})();
+      (()=>{let results5=Infinity;for (const x of y) {results5 = Math.min(results5, x)}return results5})();
+      (()=>{let results6=-Infinity;for (const x of y) {results6 = Math.max(results6, x)}return results6})()
     """
 
     testCase """
@@ -1264,11 +1264,11 @@ describe "for", ->
       ---
       () => { let results=false;for (const x of y) {results = true; break};return results; };
       () => { let results1=true;for (const x of y) {results1 = false; break};return results1; };
-      () => { let results2=0;for (const x of y)++results2;return results2; };
-      () => { let results3=0;for (const x of y)results3 += x;return results3; };
-      () => { let results4=1;for (const x of y)results4 *= x;return results4; };
-      () => { let results5=Infinity;for (const x of y)results5 = Math.min(results5, x);return results5; };
-      () => { let results6=-Infinity;for (const x of y)results6 = Math.max(results6, x);return results6; }
+      () => { let results2=0;for (const x of y) {++results2};return results2; };
+      () => { let results3=0;for (const x of y) {results3 += x};return results3; };
+      () => { let results4=1;for (const x of y) {results4 *= x};return results4; };
+      () => { let results5=Infinity;for (const x of y) {results5 = Math.min(results5, x)};return results5; };
+      () => { let results6=-Infinity;for (const x of y) {results6 = Math.max(results6, x)};return results6; }
     """
 
     testCase """
@@ -1299,4 +1299,28 @@ describe "for", ->
       ---
       let results=false;for (const x in y) {results = true; break};nonEmpty = results
       let results1=true;for (const x in y) {results1 = false; break};empty = results1
+    """
+
+    testCase """
+      for own in
+      ---
+      nonEmpty = for some own x in y
+      empty = for every own x in y
+      ---
+      var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
+      let results=false;for (const x in y) {if (!hasProp(y, x)) continue;results = true; break};nonEmpty = results
+      let results1=true;for (const x in y) {if (!hasProp(y, x)) continue;results1 = false; break};empty = results1
+    """
+
+    testCase """
+      when
+      ---
+      nonZeroProd := for product item of array when item
+      nonNullSOS := for sum item of array when item?
+        item * item
+      ---
+      let results=1;for (const item of array) {if (!item) continue;results *= item};const nonZeroProd =results
+      let results1=0;for (const item of array) {if (!(item != null)) continue;
+        results1 += item * item
+      };const nonNullSOS =results1
     """

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -485,7 +485,7 @@ describe "function application", ->
     ---
     x for y of z then y ** 2
     ---
-    x((()=>{const results=[];for (const y of z) { results.push(y ** 2)}return results})())
+    x((()=>{const results=[];for (const y of z) results.push(y ** 2);return results})())
   """
 
   testCase """

--- a/test/function.civet
+++ b/test/function.civet
@@ -1170,6 +1170,17 @@ describe "function", ->
     """
 
     testCase """
+      empty statement
+      ---
+      ->
+        ;
+      ---
+      (function() {
+        ;
+      })
+    """
+
+    testCase """
       parens
       ---
       (x) ->

--- a/test/function.civet
+++ b/test/function.civet
@@ -1170,17 +1170,6 @@ describe "function", ->
     """
 
     testCase """
-      empty statement
-      ---
-      ->
-        ;
-      ---
-      (function() {
-        ;
-      })
-    """
-
-    testCase """
       parens
       ---
       (x) ->

--- a/test/loop.civet
+++ b/test/loop.civet
@@ -30,6 +30,17 @@ describe "loop", ->
     while(true);
   """
 
+  // TODO: remove extra semicolon
+  testCase.skip """
+    empty no ASI
+    ---
+    loop
+    ++x
+    ---
+    while(true);
+    ++x
+  """
+
   testCase """
     loop generator
     ---


### PR DESCRIPTION
* The automatic unwrapping of loops at the top level of a block (to avoid IIFEs) wasn't triggering when there were multiple such loops in a row (since #1474). This is now fixed.
* Expressionized `for x of y` loops with an empty body now have an implicit body of `x`, giving a simple way to arrayify (or generatorify) a given iterable `y`. The previous behavior was to return an empty array, which didn't seem helpful
* `for some/every/count/sum/product/min/max` reduction loops!

~~TODO: not working with `when` yet~~ Now works with `when` and `own`!