### PR TITLE
Allow `|> throw`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -885,7 +885,7 @@ PipelineHeadItem
   ParenthesizedExpression
 
 PipelineTailItem
-  ( AwaitOp / Yield / Return ) !AccessStart -> $1
+  ( AwaitOp / Yield / Return / Throw ) !AccessStart -> $1
   "import" !AccessStart ->
     return {
       type: "Identifier",

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -10,6 +10,7 @@ type {
   removeHoistDecs
   skipIfOnlyWS
   updateParentPointers
+  wrapIIFE
 } from ./util.civet
 {
   makeRef
@@ -72,7 +73,10 @@ function constructPipeStep(fn, arg, returning)
         children,
         returning
       ]
-
+    when "throw"
+      return
+        . wrapIIFE [["", { type: "ThrowStatement", children }]]
+        . null
     when "return"
       // Return ignores ||> returning argument
       return [{

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -141,6 +141,26 @@ describe "pipe", ->
     }
   """
 
+  // TODO: Don't wrap in IIFE when it's not necessary
+  testCase.skip """
+    throw statement in pipeline
+    ---
+    new Error
+    |> throw
+    ---
+    throw new Error
+  """
+
+  testCase """
+    throw expression in pipeline
+    ---
+    new Error
+    |> throw
+    |> foo
+    ---
+    foo((()=>{throw new Error})())
+  """
+
   testCase """
     return in pipeline
     ---


### PR DESCRIPTION
Fixes #1513 

Currently, always wraps it in an IIFE, since there's no easy way to tell whether it's in statement vs expression position.