### PR TITLE
Multiple generator loops at top level, unwrap top-level iterations, fix implicit loop bodies

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1801,8 +1801,19 @@ All loops have a starred form that makes a generator function,
 yielding items one at a time instead of building the entire array at once:
 
 <Playground>
-function mapIter(f, list)
-  for* item of list
+numbers := for* n of [0..]
+squares := for* n of numbers
+  n * n
+</Playground>
+
+As statements in a function, the starred forms `yield` directly,
+allowing you to do multiple such loops in the same function:
+
+<Playground>
+function mapConcatIter(f, a, b)
+  for* item of a
+    f item
+  for* item of b
     f item
 </Playground>
 

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -178,7 +178,7 @@ function createVarDecs(block: BlockStatement, scopes, pushVar?): void
 
   // recurse into for loops
   forNodes.forEach ({ block, declaration }) =>
-    scopes.push(new Set(declaration.names))
+    scopes.push(new Set(declaration?.names))
     createVarDecs(block, scopes, pushVar)
     scopes.pop()
 

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -23,6 +23,10 @@ import {
   processReturn
 } from ./function.civet
 
+import {
+  assert
+} from ./util.civet
+
 /**
  * Duplicate a block and attach statements prefixing the block.
  * Adds braces if the block is bare.
@@ -221,11 +225,29 @@ function needsPrecedingSemicolon(exp: ASTNode)
       if exp.children
         needsPrecedingSemicolon exp.children
 
+/** Is this node a top-level statement in its block? i.e. not an expression */
+function isStatementInBlock(exp: ASTNodeObject)
+  child .= exp
+  parent .= exp.parent
+  while parent?.type is "StatementExpression"
+    child = parent
+    parent = parent.parent
+  return unless parent?.type is "BlockStatement"
+  index := findChildIndex parent.expressions, child
+  assert.notEqual index, -1, "Could not find statement in parent block"
+  return unless parent.expressions[index][1] is child
+  {
+    block: parent
+    index
+    child
+  }
+
 export {
   blockWithPrefix
   braceBlock
   duplicateBlock
   getIndent
+  isStatementInBlock
   hoistRefDecs
   makeBlockFragment
   makeEmptyBlock

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -225,8 +225,12 @@ function needsPrecedingSemicolon(exp: ASTNode)
       if exp.children
         needsPrecedingSemicolon exp.children
 
-/** Is this node a top-level statement in its block? i.e. not an expression */
-function isStatementInBlock(exp: ASTNodeObject)
+/**
+Is this node a top-level statement in its block? (i.e. not an expression)
+If so, return the containing block, the index into expressions containing
+the statement, and the child that is in that expression.
+*/
+function blockContainingStatement(exp: ASTNodeObject)
   child .= exp
   parent .= exp.parent
   while parent?.type is "StatementExpression"
@@ -247,7 +251,7 @@ export {
   braceBlock
   duplicateBlock
   getIndent
-  isStatementInBlock
+  blockContainingStatement
   hoistRefDecs
   makeBlockFragment
   makeEmptyBlock

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -11,6 +11,7 @@ import type {
 } from ./types.civet
 
 import {
+  assert
   literalValue
   makeLeftHandSideExpression
   makeNumericLiteral
@@ -122,7 +123,7 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
 // Construct for loop from RangeLiteral
 function forRange(
   open: ASTLeaf
-  forDeclaration: ForDeclaration
+  forDeclaration: ForDeclaration | AssignmentExpression
   range: RangeExpression
   stepExp: ASTNode
   close: ASTLeaf
@@ -181,6 +182,7 @@ function forRange(
     ascDec = [", ", ascRef, " = ", startRef, " <= ", endRef]
 
   let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
+  let names: string[] = forDeclaration?.names
   if forDeclaration?.decl // var/let/const declaration of variable
     if forDeclaration.decl is "let"
       varName := forDeclaration.children.splice(1)  // strip let
@@ -193,12 +195,16 @@ function forRange(
         ["", [forDeclaration, " = ", value], ";"]
       ]
   else if forDeclaration // Coffee-style for loop
+    assert.equal forDeclaration.type, "AssignmentExpression",
+      "Internal error: Coffee-style for loop must be an assignment expression"
     varAssign = varLetAssign = [forDeclaration, " = "]
+    names = [] // assigned but not declared
 
-  declaration :=
+  declaration := {
     type: "Declaration"
     children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec]
-    names: forDeclaration?.names
+    names
+  }
 
   counterPart := right.inclusive
     ? [counterRef, " <= ", endRef, " : ", counterRef, " >= ", endRef]
@@ -220,7 +226,9 @@ function forRange(
         : [...varAssign, asc ? "++" : "--", counterRef]
 
   return {
-    declaration
+    // This declaration doesn't always appear in the output,
+    // but it's still helpful for determining the primary loop variable
+    declaration: forDeclaration
     children: [range.error, open, declaration, "; ", ...condition, "; ", ...increment, close]
     blockPrefix
   }

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -12,6 +12,7 @@ import type {
   IterationStatement
   Parameter
   ParametersNode
+  ReturnStatement
   StatementTuple
   SwitchStatement
   TypeArgument
@@ -561,6 +562,7 @@ function wrapIterationReturningResults(
   { ancestor, child } := findAncestor statement, .type is "BlockStatement"
   assert.notNull ancestor, `Could not find block containing ${statement.type}`
   index := findChildIndex ancestor.expressions, child
+  assert.notEqual index, -1, `Could not find ${statement.type} in containing block`
   iterationTuple := ancestor.expressions[index]
   ancestor.expressions.splice index, 0, [iterationTuple[0], declaration, ";"]
   iterationTuple[0] = '' // steal indentation from loop
@@ -794,40 +796,50 @@ function expressionizeIteration(exp: IterationExpression): void
     updateParentPointers exp
     return
 
+  let statements: StatementTuple[]
   if generator
     assignResults block, (node) =>
       type: "YieldExpression"
       expression: node
-      children: [ "yield ", node ]
+      children:
+        . type: "Yield"
+          token: "yield "
+        . node
 
-    children.splice(i,
-      1,
-      wrapIIFE([
-        ["", statement, undefined]
-        // Prevent implicit return in generator, by adding an explicit return
-        ["", {
-          type: "ReturnStatement"
-          expression: undefined
-          children: [ ";return" ]
-        }, undefined],
-      ], async, generator)
-    )
+    statements =
+      . ["", statement]
   else
     resultsRef := statement.resultsRef ??= makeRef "results"
 
     declaration := iterationDeclaration statement
 
-    // Wrap with IIFE
-    children.splice(i,
-      1,
-      wrapIIFE([
-        ["", declaration, ";"]
-        ["", statement, ";" if statement.block.bare]
-        ["", wrapWithReturn(resultsRef)]
-      ], async)
-    )
+    statements =
+      . ["", declaration, ";"]
+      . ["", statement, ";" if statement.block.bare]
+      . ["", resultsRef]
 
-  updateParentPointers exp
+  // Don't need IIFE if iteration expression is at the top level of a block
+  let done
+  if not async and exp.parent?.type is "StatementExpression" and
+     exp?.parent?.parent?.type is "BlockStatement"
+    parentBlock := exp.parent.parent
+    index := findChildIndex parentBlock.expressions, exp.parent
+    assert.notEqual index, -1, "Could not find iteration expression in parent block"
+    if parentBlock.expressions[index][1] is exp.parent
+      statements[0][0] = parentBlock.expressions[index][0] // inherit indentation
+      parentBlock.expressions[index..index] = statements
+      updateParentPointers parentBlock
+      braceBlock parentBlock
+      done = true
+  unless done
+    // Wrap with IIFE
+    statements.-1.1 = wrapWithReturn(statements.-1.1) unless generator
+    children.splice i, 1, wrapIIFE(statements, async, generator)
+    updateParentPointers exp
+
+function processIterationExpressions(statements: ASTNode): void
+  for each s of gatherRecursiveAll statements, .type is "IterationExpression"
+    expressionizeIteration s
 
 /**
 Utility function to check if an implicit function application should be skipped
@@ -948,11 +960,11 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
 
 export {
   assignResults
-  expressionizeIteration
   insertReturn
   makeAmpersandFunction
   processCoffeeDo
   processFunctions
+  processIterationExpressions
   processReturn
   skipImplicitArguments
   wrapIterationReturningResults

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -22,7 +22,7 @@ import type {
 import {
   braceBlock
   getIndent
-  isStatementInBlock
+  blockContainingStatement
   makeEmptyBlock
 } from ./block.civet
 
@@ -846,7 +846,7 @@ function expressionizeIteration(exp: IterationExpression): void
   // Don't need IIFE if iteration expression is at the top level of a block
   let done
   if not async
-    if { block: parentBlock, index } := isStatementInBlock exp
+    if { block: parentBlock, index } := blockContainingStatement exp
       statements[0][0] = parentBlock.expressions[index][0] // inherit indentation
       parentBlock.expressions[index..index] = statements
       updateParentPointers parentBlock

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -22,6 +22,7 @@ import type {
 import {
   braceBlock
   getIndent
+  isStatementInBlock
   makeEmptyBlock
 } from ./block.civet
 
@@ -844,12 +845,8 @@ function expressionizeIteration(exp: IterationExpression): void
 
   // Don't need IIFE if iteration expression is at the top level of a block
   let done
-  if not async and exp.parent?.type is "StatementExpression" and
-     exp?.parent?.parent?.type is "BlockStatement"
-    parentBlock := exp.parent.parent
-    index := findChildIndex parentBlock.expressions, exp.parent
-    assert.notEqual index, -1, "Could not find iteration expression in parent block"
-    if parentBlock.expressions[index][1] is exp.parent
+  if not async
+    if { block: parentBlock, index } := isStatementInBlock exp
       statements[0][0] = parentBlock.expressions[index][0] // inherit indentation
       parentBlock.expressions[index..index] = statements
       updateParentPointers parentBlock

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -12,7 +12,6 @@ import type {
   IterationStatement
   Parameter
   ParametersNode
-  ReturnStatement
   StatementTuple
   SwitchStatement
   TypeArgument
@@ -620,31 +619,8 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
   // insert `results.push` to gather results array
   // TODO: real ast nodes
   unless breakWithOnly
-    function fillBlock(expression: StatementTuple)
-      if block.expressions.-1 is like [, {type: "EmptyStatement", implicit: true}, ...]
-        block.expressions.pop()
-      block.expressions.push expression
-      block.empty = false
-      braceBlock block
-    if block.empty and reduction
-      switch reduction.subtype
-        when "some"
-          fillBlock [ "", [ resultsRef, " = true; break" ] ]
-          block.empty = false
-          braceBlock block
-        when "every"
-          fillBlock [ "", [ resultsRef, " = false; break" ] ]
-          block.empty = false
-          braceBlock block
-        when "count"
-          fillBlock [ "", [ "++", resultsRef ] ]
-          block.empty = false
-          braceBlock block
-      return declaration unless block.empty
-    if block.empty and statement.type is "ForStatement" and
-       statement.declaration?.type is "ForDeclaration"
-      fillBlock [ "", patternAsValue statement.declaration.binding ]
-      block.empty = false
+    if iterationDefaultBody statement
+      return declaration
     unless block.empty
       assignResults block, (node) =>
         return [ resultsRef, ".push(", node, ")" ] unless reduction
@@ -662,6 +638,47 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
           when "max" then [ resultsRef, " = Math.max(", resultsRef, ", ", node, ")" ]
 
   declaration
+
+/**
+Add default body to iteration statement with empty body.
+Returns true if the block was filled with a reduction-specific body.
+*/
+function iterationDefaultBody(statement: IterationStatement | ForStatement): boolean
+  { block, resultsRef } := statement
+  return false unless block.empty
+  reduction := statement.type is "ForStatement" and statement.reduction
+
+  function fillBlock(expression: StatementTuple)
+    if block.expressions.-1 is like [, {type: "EmptyStatement", implicit: true}, ...]
+      block.expressions.pop()
+    block.expressions.push expression
+    block.empty = false
+    braceBlock block
+
+  if reduction
+    switch reduction.subtype
+      when "some"
+        fillBlock [ "", [ resultsRef, " = true; break" ] ]
+        block.empty = false
+        braceBlock block
+        return true
+      when "every"
+        fillBlock [ "", [ resultsRef, " = false; break" ] ]
+        block.empty = false
+        braceBlock block
+        return true
+      when "count"
+        fillBlock [ "", [ "++", resultsRef ] ]
+        block.empty = false
+        braceBlock block
+        return true
+
+  if statement.type is "ForStatement" and
+     statement.declaration?.type is "ForDeclaration"
+    fillBlock [ "", patternAsValue statement.declaration.binding ]
+    block.empty = false
+
+  return false
 
 function processParams(f): void
   { type, parameters, block } := f
@@ -798,6 +815,13 @@ function expressionizeIteration(exp: IterationExpression): void
 
   let statements: StatementTuple[]
   if generator
+    if (statement as ForStatement).reduction
+      children.unshift
+        type: "Error"
+        message: `Cannot use reduction (${(statement as ForStatement).reduction!.subtype}) with generators`
+
+    iterationDefaultBody statement
+
     assignResults block, (node) =>
       type: "YieldExpression"
       expression: node

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -13,8 +13,6 @@ import type {
   ASTNodeObject
   ASTNodeParent
   ASTRef
-  AssignmentExpression
-  Bindings
   BlockStatement
   CallExpression
   CaseBlock
@@ -25,7 +23,6 @@ import type {
   DeclarationStatement
   DoStatement
   ElseClause
-  ExpressionNode
   FinallyClause
   ForStatement
   IfStatement
@@ -114,10 +111,10 @@ import {
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
-  expressionizeIteration
   makeAmpersandFunction
   processCoffeeDo
   processFunctions
+  processIterationExpressions
   skipImplicitArguments
 } from ./function.civet
 import { processPatternMatching } from ./pattern-matching.civet
@@ -1094,7 +1091,6 @@ function processAssignments(statements): void
               names: []
 
           replaceNode $2, newMemberExp
-          newMemberExp.parent = exp
           $2 = newMemberExp
 
       i--
@@ -1351,10 +1347,7 @@ function processProgram(root: BlockStatement): void
   processAssignments(statements)
   processStatementExpressions(statements)
   processPatternMatching(statements)
-
-  // Modify iteration expressions
-  gatherRecursiveAll(statements, (n) => n.type is "IterationExpression")
-    .forEach((e) => expressionizeIteration(e))
+  processIterationExpressions(statements)
 
   // Hoist hoistDec attributes to actual declarations.
   // NOTE: This should come after iteration expressions get processed

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -216,6 +216,7 @@ export type ChainOp
   special: true
   prec: number
   children?: never
+  parent?: never
 
 export type AssignmentExpression
   type: "AssignmentExpression"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -106,10 +106,10 @@ function isASTNodeObject(node: ASTNode): node is ASTNodeObject
     node?
     not Array.isArray node
 
-function isParent(node: ASTNode): node is IsParent
+function isParent(node: ASTNode): node is ASTNode & IsParent
   node? and node.children?
 
-function isToken(node: ASTNode): node is IsToken
+function isToken(node: ASTNode): node is ASTNode & IsToken
   node? and node.token?
 
 function isEmptyBareBlock(node: ASTNode): boolean

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -9,7 +9,6 @@ import type {
   IsToken
   IterationStatement
   Literal
-  NumericLiteral
   StatementNode
   TypeSuffix
   ReturnTypeAnnotation

--- a/test/do.civet
+++ b/test/do.civet
@@ -73,7 +73,11 @@ describe "do..while/until", ->
     ---
     do* i++ while i < 10
     ---
-    (function*(){do { yield i++ } while (i < 10);return})()
+    do { yield i++ } while (i < 10)
+  """, wrapper: """
+    function* wrapper() {
+      CODE
+    }
   """
 
 describe "do", ->

--- a/test/for.civet
+++ b/test/for.civet
@@ -836,9 +836,24 @@ describe "for", ->
         )
       ---
       function f() {
-        return (()=>{const results=[];let i = 0;for (const item of array) {const index = i++;
+        const results=[];let i = 0;for (const item of array) {const index = i++;
           results.push(`${index}. ${item}`)
-        }return results})()
+        }return results
+      }
+    """
+
+    testCase """
+      of with two implicit declarations inside function in expression
+      ---
+      function f
+        ['head'] ++ (for item, index of array
+          `${index}. ${item}`
+        )
+      ---
+      function f() {
+        return ['head'].concat((()=>{const results=[];let i = 0;for (const item of array) {const index = i++;
+          results.push(`${index}. ${item}`)
+        }return results})())
       }
     """
 
@@ -943,36 +958,62 @@ describe "for", ->
     ---
     f((function*(){for (const x of y) {
       yield 1
-    };return})())
+    }})())
+  """
+
+  testCase """
+    multiple for generators
+    ---
+    function double()
+      for* x of y
+        x
+      for* x of y
+        x
+    ---
+    function* double() {
+      for (const x of y) {
+        yield x
+      }
+      for (const x of y) {
+        yield x
+      }
+    }
   """
 
   testCase """
     for generator with this
     ---
-    for* x of y
-      this.x
-    for* x of y
-      @x
+    function double()
+      [
+        for* x of y
+          this.x
+        for* x of y
+          @x
+      ]
     ---
-    (function*(){for (const x of y) {
-      yield this.x
-    };return}).bind(this)();
-    (function*(){for (const x of y) {
-      yield this.x
-    };return}).bind(this)()
+    function double() {
+      return [
+        (function*(){for (const x of y) {
+          yield this.x
+        }}).bind(this)(),
+        (function*(){for (const x of y) {
+          yield this.x
+        }}).bind(this)()
+      ]
+    }
   """
 
   testCase """
     for generator with arguments
     ---
     function f()
-      for* i of x
+      return for* i of x
         arguments[i]
     ---
     function f() {
       return (function*(arguments){for (const i of x) {
         yield arguments[i]
-      };return})(arguments)
+      }})(arguments)
     }
   """
 
@@ -1104,7 +1145,7 @@ describe "for", ->
     ---
     bigSquares = (x*x for* x of y when x > 5)
     ---
-    bigSquares = (function*(){for (const x of y) { if (!(x > 5)) continue;yield x*x };return})()
+    bigSquares = (function*(){for (const x of y) { if (!(x > 5)) continue;yield x*x }})()
   """
 
   describe "by", ->
@@ -1242,13 +1283,13 @@ describe "for", ->
       for min x of y
       for max x of y
       ---
-      (()=>{let results=false;for (const x of y) {results = true; break}return results})();
-      (()=>{let results1=true;for (const x of y) {results1 = false; break}return results1})();
-      (()=>{let results2=0;for (const x of y) {++results2}return results2})();
-      (()=>{let results3=0;for (const x of y) {results3 += x}return results3})();
-      (()=>{let results4=1;for (const x of y) {results4 *= x}return results4})();
-      (()=>{let results5=Infinity;for (const x of y) {results5 = Math.min(results5, x)}return results5})();
-      (()=>{let results6=-Infinity;for (const x of y) {results6 = Math.max(results6, x)}return results6})()
+      let results=false;for (const x of y) {results = true; break}results
+      let results1=true;for (const x of y) {results1 = false; break}results1
+      let results2=0;for (const x of y) {++results2}results2
+      let results3=0;for (const x of y) {results3 += x}results3
+      let results4=1;for (const x of y) {results4 *= x}results4
+      let results5=Infinity;for (const x of y) {results5 = Math.min(results5, x)}results5
+      let results6=-Infinity;for (const x of y) {results6 = Math.max(results6, x)}results6
     """
 
     testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -958,6 +958,14 @@ describe "for", ->
     """
 
   testCase """
+    for generator range expression without body
+    ---
+    numbers := for* i of [0..]
+    ---
+    const numbers = (function*(){for (let i1 = 0; ; ++i1) {const i = i1;yield i}})()
+  """
+
+  testCase """
     for generator
     ---
     for* x of y

--- a/test/for.civet
+++ b/test/for.civet
@@ -247,6 +247,14 @@ describe "for", ->
     }
   """
 
+  testCase """
+    for range expression without body
+    ---
+    digits := for i of [1..9]
+    ---
+    const results=[];for (let i1 = 1; i1 <= 9; ++i1) {const i = i1;results.push(i)};const digits =results
+  """
+
   describe "inequalities on range", ->
     testCase """
       ..<

--- a/test/loop.civet
+++ b/test/loop.civet
@@ -1,4 +1,4 @@
-{testCase} from ./helper.civet
+{testCase, wrapper} from ./helper.civet
 
 describe "loop", ->
   testCase """
@@ -41,32 +41,50 @@ describe "loop", ->
     ++x
   """
 
-  testCase """
-    loop generator
-    ---
-    loop*
-      1
-    ---
-    (function*(){while(true) {
-      yield 1
-    };return})()
-  """
+  describe "loop*", ->
+    wrapper """
+      function* wrapper() {
+        CODE
+      }
+    """
 
-  testCase """
-    one-line loop generator
-    ---
-    loop* 1
-    ---
-    (function*(){while(true) yield 1;return})()
-  """
+    testCase """
+      loop generator
+      ---
+      loop*
+        1
+      ---
+      while(true) {
+        yield 1
+      }
+    """
 
-  testCase """
-    postfix loop generator
-    ---
-    infinite := 1 loop*
-    ---
-    const infinite =(function*(){while(true) { yield  1 };return})()
-  """
+    testCase """
+      loop generator in expression context
+      ---
+      f loop*
+        1
+      ---
+      f((function*(){while(true) {
+        yield 1
+      }})())
+    """, wrapper: ""
+
+    testCase """
+      one-line loop generator
+      ---
+      loop* 1
+      ---
+      while(true) yield 1
+    """
+
+    testCase """
+      postfix loop generator
+      ---
+      infinite := 1 loop*
+      ---
+      const infinite =(function*(){while(true) { yield  1 }})()
+    """
 
   testCase """
     break with

--- a/test/while.civet
+++ b/test/while.civet
@@ -239,15 +239,18 @@ describe "while", ->
     testCase """
       while* and until*
       ---
-      while* x < 3
-        x++
-      until* x < 3
-        x++
+      function* f
+        while* x < 3
+          x++
+        until* x < 3
+          x++
       ---
-      (function*(){while (x < 3) {
-        yield x++
-      };return})();
-      (function*(){while (!(x < 3)) {
-        yield x++
-      };return})()
+      function* f() {
+        while (x < 3) {
+          yield x++
+        }
+        while (!(x < 3)) {
+          yield x++
+        }
+      }
     """


### PR DESCRIPTION
This started as an optimization to not wrap top-level iterations in IIFEs, which also enables use of `break`/`continue`/`return` in more cases.

As a bonus, it changes the behavior of generator iterations (e.g. `for*`) when at the top level: they now directly `yield` to the parent function, instead of only being useful as immediately returned generators. This makes it a lot easier to make generator functions without having to type `yield`!

This is also a breaking change, but only in the case of unreturned generator expressions, which should have been a bug in your code anyway (as previous discussed with @bbrk24 in Discord).

Also fix implicit `for` loop bodies in two cases (separate commits):
* Range iteration
* Generator `for*`