### PR TITLE
`await`/`throw` with placeholders in pipeline, trailing `|> throw` makes statement without IIFE

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -817,7 +817,7 @@ Use `as T` to cast types in your pipeline:
 data |> JSON.parse |> as MyRecord |> addRecord
 </Playground>
 
-Use `await`, `yield`, or `return` in your pipeline:
+Use `await`, `throw`, `yield`, or `return` in your pipeline:
 
 <Playground>
 fetch url |> await
@@ -1169,6 +1169,7 @@ console.log "result:", .
 
 More generally, if you use `.` within a function call, that call gets wrapped
 in a one-argument function and `.` gets replaced by that argument.
+The wrapper also lifts above unary operations (including `await`) and `throw`.
 You can use `.` multiple times in the same function:
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -885,7 +885,7 @@ PipelineHeadItem
   ParenthesizedExpression
 
 PipelineTailItem
-  ( AwaitOp / Yield / Return / Throw ) !AccessStart -> $1
+  ( AwaitOp / Yield / Return / Throw ) !AccessStart !MaybeNestedExpression -> $1
   "import" !AccessStart ->
     return {
       type: "Identifier",

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -233,8 +233,9 @@ the statement, and the child that is in that expression.
 function blockContainingStatement(exp: ASTNodeObject)
   child .= exp
   parent .= exp.parent
-  // Skip over StatementExpression and (top-level) PipelineExpression parents
-  while parent? and parent.type is like "StatementExpression", "PipelineExpression"
+  // Skip over StatementExpression and UnwrappedExpression wrappers,
+  // and (top-level) PipelineExpression wrapper
+  while parent? and parent.type is like "StatementExpression", "PipelineExpression", "UnwrappedExpression"
     child = parent
     parent = parent.parent
   return unless parent?.type is "BlockStatement"

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -233,7 +233,8 @@ the statement, and the child that is in that expression.
 function blockContainingStatement(exp: ASTNodeObject)
   child .= exp
   parent .= exp.parent
-  while parent?.type is "StatementExpression"
+  // Skip over StatementExpression and (top-level) PipelineExpression parents
+  while parent? and parent.type is like "StatementExpression", "PipelineExpression"
     child = parent
     parent = parent.parent
   return unless parent?.type is "BlockStatement"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1266,7 +1266,8 @@ function processStatementExpressions(statements: StatementTuple[]): void
     { maybe, statement } := exp
 
     // `maybe` says not to wrap if we're at the statement level of block
-    if maybe and blockContainingStatement exp
+    if (maybe or statement.type is "ThrowStatement") and
+       blockContainingStatement exp
       replaceNode exp, statement
       continue
 
@@ -1459,7 +1460,7 @@ function processPlaceholders(statements: StatementTuple[]): void
       // including the call itself and any surrounding unary operations.
       { ancestor } = findAncestor exp, .type is "Call"
       ancestor = ancestor?.parent
-      while ancestor?.parent? and ancestor.parent.type is like "UnaryExpression", "NewExpression", "AwaitExpression", "ThrowStatement"
+      while ancestor?.parent? and ancestor.parent.type is like "UnaryExpression", "NewExpression", "AwaitExpression", "ThrowStatement", "StatementExpression"
         ancestor = ancestor.parent
       unless ancestor
         replaceNode exp,

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -90,6 +90,7 @@ import {
 } from ./ref.civet
 
 import {
+  blockContainingStatement
   blockWithPrefix
   duplicateBlock
   hoistRefDecs
@@ -1261,25 +1262,28 @@ function processTypes(node: ASTNode)
 Wrap any remaining statement expressions in IIFE.
 */
 function processStatementExpressions(statements: StatementTuple[]): void
-  gatherRecursiveAll(statements, .type is "StatementExpression")
-    .forEach (_exp) =>
-      exp := _exp as! StatementExpression
-      { statement } := exp
+  for each exp of gatherRecursiveAll statements, .type is "StatementExpression"
+    { maybe, statement } := exp
 
-      switch statement.type
-        when "IfStatement"
-          if expression := expressionizeIfStatement(statement)
-            replaceNode statement, expression, exp
-          else
-            replaceNode statement, wrapIIFE([["", statement]]), exp
-        when "IterationExpression"
-          if statement.subtype is "ComptimeStatement"
-            replaceNode statement,
-              expressionizeComptime statement.statement as ComptimeStatement
-              exp
-          // else do nothing, handled separately currently
+    // `maybe` says not to wrap if we're at the statement level of block
+    if maybe and blockContainingStatement exp
+      replaceNode exp, statement
+      continue
+
+    switch statement.type
+      when "IfStatement"
+        if expression := expressionizeIfStatement(statement)
+          replaceNode statement, expression, exp
         else
           replaceNode statement, wrapIIFE([["", statement]]), exp
+      when "IterationExpression"
+        if statement.subtype is "ComptimeStatement"
+          replaceNode statement,
+            expressionizeComptime statement.statement as ComptimeStatement
+            exp
+        // else do nothing, handled separately currently
+      else
+        replaceNode statement, wrapIIFE([["", statement]]), exp
 
 function processNegativeIndexAccess(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (n) => n.type is "NegativeIndex")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1459,7 +1459,7 @@ function processPlaceholders(statements: StatementTuple[]): void
       // including the call itself and any surrounding unary operations.
       { ancestor } = findAncestor exp, .type is "Call"
       ancestor = ancestor?.parent
-      while ancestor?.parent?.type is "UnaryExpression" or ancestor?.parent?.type is "NewExpression"
+      while ancestor?.parent? and ancestor.parent.type is like "UnaryExpression", "NewExpression", "AwaitExpression", "ThrowStatement"
         ancestor = ancestor.parent
       unless ancestor
         replaceNode exp,

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -34,8 +34,9 @@ function constructInvocation(fn, arg) {
     updateParentPointers ref
 
     return makeNode {
-      type: "UnwrappedExpression",
-      children: [skipIfOnlyWS(fn.leadingComment), body, skipIfOnlyWS(fn.trailingComment)],
+      type: "UnwrappedExpression"
+      expression: body
+      children: [skipIfOnlyWS(fn.leadingComment), body, skipIfOnlyWS(fn.trailingComment)]
     }
 
   expr = fn.expr
@@ -80,7 +81,6 @@ function constructPipeStep(fn, arg, returning)
             type: "StatementExpression"
             statement
             children: [statement]
-            maybe: true
           }
         . null
     when "return"

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -74,8 +74,14 @@ function constructPipeStep(fn, arg, returning)
         returning
       ]
     when "throw"
+      statement := { type: "ThrowStatement", children }
       return
-        . wrapIIFE [["", { type: "ThrowStatement", children }]]
+        . {
+            type: "StatementExpression"
+            statement
+            children: [statement]
+            maybe: true
+          }
         . null
     when "return"
       // Return ignores ||> returning argument

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -59,6 +59,7 @@ export type ExpressionNode =
   | StatementExpression
   | TypeNode
   | UnaryExpression
+  | UnwrappedExpression
   | YieldExpression
 
 /**
@@ -259,6 +260,12 @@ export type Await
 
 export type NewExpression
   type: "NewExpression"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
+
+export type UnwrappedExpression
+  type: "UnwrappedExpression"
   children: Children
   parent?: Parent
   expression: ASTNode

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -584,6 +584,7 @@ export type ReturnValue =
 export type StatementExpression =
   type: "StatementExpression"
   children: Children
+  parent?: Parent
   statement:
     | DebuggerStatement
     | IterationExpression
@@ -591,7 +592,7 @@ export type StatementExpression =
     | SwitchStatement
     | ThrowStatement
     | TryStatement
-  parent?: Parent
+  maybe?: boolean // don't wrap if this appears at the statement level of block
 
 export type ReturnStatement
   type: "ReturnStatement"

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -141,8 +141,7 @@ describe "pipe", ->
     }
   """
 
-  // TODO: Don't wrap in IIFE when it's not necessary
-  testCase.skip """
+  testCase """
     throw statement in pipeline
     ---
     new Error
@@ -159,6 +158,14 @@ describe "pipe", ->
     |> foo
     ---
     foo((()=>{throw new Error})())
+  """
+
+  testCase """
+    throw expression with thicc pipe
+    ---
+    x |> throw ||> y
+    ---
+    let ref;(y((ref = (()=>{throw x})())),ref)
   """
 
   testCase """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -191,7 +191,7 @@ describe "pipe", ->
     ---
     x |> throw new Error .
     ---
-    (()=>{return ($ => { throw new Error($)})})()(x)
+    throw new Error(x)
   """
 
   testCase """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -34,6 +34,24 @@ describe "pipe", ->
   """
 
   testCase """
+    pipe expression with async shorthand functions
+    ---
+    a |> await foo . |> bar
+    ---
+    bar(await foo(a))
+  """
+
+  testCase """
+    complex await pipeline
+    ---
+    buffer := await fetch url
+    |> await .arrayBuffer()
+    |> await ctx.decodeAudioData .
+    ---
+    const buffer = await ctx.decodeAudioData((await (await fetch(url)).arrayBuffer()))
+  """
+
+  testCase """
     pipe expression with right operator section
     ---
     a |> (+ 1) |> bar
@@ -166,6 +184,14 @@ describe "pipe", ->
     x |> throw ||> y
     ---
     let ref;(y((ref = (()=>{throw x})())),ref)
+  """
+
+  testCase """
+    throw with placeholder
+    ---
+    x |> throw new Error .
+    ---
+    (()=>{return ($ => { throw new Error($)})})()(x)
   """
 
   testCase """


### PR DESCRIPTION
Follow-up to #1517 to
* use `StatementExpression` instead of manual `makeIIFE`
* when dealing with `StatementExpression`, use new `blockContainingStatement` helper from #1518 to determine whether to wrap with IIFE

I tried *always* doing the latter, but it led to some broken outputs such as `check := if & then x else &` turning into the incorrect `const check = $ => if ($) x; else $`. So it only happens when explicitly requested via `maybe: true` flag.

---

I also noticed that #1517 forbade regular `throw` expressionized statements in pipelines, which could be useful when using placeholders. So I also extended `.` placeholder to lift above `await`/`throw`, which seems very similar to lifting above unary operations (indeed, `await` is mostly considered a unary operator in Civet, but `processUnaryExpression` renames it), and made sure that the special cases `|> await` and `|> throw` didn't take over these expressions.

I didn't implement `|> return ...` or `|> yield ...` which could be nice, but aren't as easy because they aren't already supported as expressions.