### PR TITLE
`:"symbol name"` symbol shorthand with quotes

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -547,6 +547,12 @@ magicSymbol := :magic
 iteratorSymbol := :iterator
 </Playground>
 
+Symbol names that aren't valid identifiers can be wrapped in quotes:
+
+<Playground>
+magicSymbol := :"magic-symbol"
+</Playground>
+
 ## Operators
 
 ### All JavaScript/TypeScript Operators

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2838,24 +2838,40 @@ CoffeeScriptBooleanLiteral
 
 # NOTE: Added :symbol shorthand for Symbol.symbol or Symbol.for("symbol")
 SymbolLiteral
-  Colon:colon IdentifierName:id ->
-    const { name, children: [ token ] } = id
+  Colon:colon ( IdentifierName / StringLiteral ):id ->
+    let name, token
+    if (id.type === "Identifier") {
+      ({ name, children: [ token ] } = id)
+    } else {
+      name = literalValue({
+        type: "Literal",
+        subtype: "StringLiteral",
+        raw: id.token,
+        children: [id],
+      })
+      token = id
+    }
     if (config.symbols.includes(name)) { // well-known symbol
       return {
         type: "SymbolLiteral",
-        children: [
-          { ...colon, token: "Symbol." },
-          token,
-        ],
+        children:
+          id.type === "Identifier" ? [
+            { ...colon, token: "Symbol." },
+            token,
+          ] : [
+            { ...colon, token: "Symbol[" },
+            token,
+            "]",
+          ],
         name,
       }
     } else { // use global symbol registry
       return {
         type: "SymbolLiteral",
         children: [
-          { ...colon, token: 'Symbol.for("' },
-          token,
-          '")'
+          { ...colon, token: 'Symbol.for(' },
+          id.type === "Identifier" ? [ '"', token, '"' ] : token,
+          ')'
         ],
         name,
       }

--- a/test/symbol.civet
+++ b/test/symbol.civet
@@ -12,6 +12,16 @@ describe ":symbol literals", ->
   """
 
   testCase """
+    string
+    ---
+    => :"foo-bar"
+    => :"iterator"
+    ---
+    () => Symbol.for("foo-bar");
+    () => Symbol["iterator"]
+  """
+
+  testCase """
     well-known
     ---
     [


### PR DESCRIPTION
Fixes #1511