### PR TITLE
`async` functions and arrow types auto-wrap return type in `Promise`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2445,7 +2445,7 @@ declare function jsonParse(json: string): ???
 declare function sign(n: number): -1 | 0 | +1
 </Playground>
 
-### Arrow Types
+### Function Types
 
 Like [arrow functions](#arrow-functions),
 arrow types can use `=>` or `->` (with equivalent meanings)
@@ -2463,6 +2463,21 @@ return types:
 function f(callback: async =>)
   callback()
 </Playground>
+
+Similarly, `async` functions (except generators) get their return type
+automatically wrapped in `Promise`:
+
+<Playground>
+function f(): number
+  await fetch 'https://civet.dev'
+  .status
+</Playground>
+
+::: info
+You can still include explicit `Promise` wrappers in your return types.
+If the wrapper is hidden behind a `type` declaration, the output will include
+an extra `Promise` wrapper, but this does not affect typechecking.
+:::
 
 ### Conditional Types
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2445,6 +2445,25 @@ declare function jsonParse(json: string): ???
 declare function sign(n: number): -1 | 0 | +1
 </Playground>
 
+### Arrow Types
+
+Like [arrow functions](#arrow-functions),
+arrow types can use `=>` or `->` (with equivalent meanings)
+and can omit parameters and/or return type:
+
+<Playground>
+function f(callback: ->)
+  callback()
+</Playground>
+
+Arrow types can use an `async` prefix as shorthand for `Promise`
+return types:
+
+<Playground>
+function f(callback: async =>)
+  callback()
+</Playground>
+
 ### Conditional Types
 
 TypeScript's ternary types can be written using `if`/`unless` expressions,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -66,6 +66,7 @@ import {
   stripTrailingImplicitComma,
   trimFirstSpace,
   typeOfJSX,
+  wrapTypeInPromise,
 } from "./parser/lib.civet"
 
 /**
@@ -8220,22 +8221,34 @@ TypeBinaryOp
     return { $loc, token: "&" }
 
 TypeFunction
-  ( Abstract _? )? ( New _? )? Parameters __ TypeArrowFunction ReturnType?:type ->
-    const children = [ ...$0 ]
-    if ($1 && !$2) {
+  ( Abstract _? )?:abstract ( Async _? )?:async ( New _? )?:new_ Parameters __ TypeFunctionArrow ( ReturnType / Loc ):returnType ->
+    const children = [ abstract, ...$0.slice(2) ] // omit async
+    if (abstract && !new_) {
       children[1] = {
         type: "Error",
         message: "abstract function types must be constructors (abstract new)",
       }
     }
-    if (!type) children.push ("void")
+    // Implicit void return type
+    if (returnType.$loc && returnType.token === "") {
+      children[children.length - 1] = returnType = {
+        type: "VoidType",
+        $loc: returnType.$loc,
+        token: "void",
+      }
+    }
+    // async wraps return type in Promise<...>
+    if (async) {
+      children[children.length - 1] = returnType = wrapTypeInPromise(returnType)
+    }
     return {
       type: "TypeFunction",
       children,
       ts: true,
+      returnType,
     }
 
-TypeArrowFunction
+TypeFunctionArrow
   "=>" / "⇒" / "->" / "→" ->
     return { $loc, token: "=>" }
 
@@ -8268,7 +8281,7 @@ TypeApplicationStart
 
 ForbiddenImplicitTypeCalls
   ReservedBinary
-  # TypeBinaryOp, ExtendsToken, NotExtendsToken, TypeArrowFunction
+  # TypeBinaryOp, ExtendsToken, NotExtendsToken, TypeFunctionArrow
   /[|&<!=\-⇒→]/
   # Abstract, Readonly, ExtendsToken, NotExtendsToken, Is
   /(extends|not|is)(?!\p{ID_Continue}|[\u200C\u200D$])/

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8231,15 +8231,25 @@ TypeFunction
     }
     // Implicit void return type
     if (returnType.$loc && returnType.token === "") {
-      children[children.length - 1] = returnType = {
+      const t = {
         type: "VoidType",
         $loc: returnType.$loc,
         token: "void",
       }
+      children[children.length - 1] = returnType = {
+        type: "ReturnTypeAnnotation",
+        ts: true,
+        t,
+        children: [t],
+      }
     }
     // async wraps return type in Promise<...>
     if (async) {
-      children[children.length - 1] = returnType = wrapTypeInPromise(returnType)
+      const t = wrapTypeInPromise(returnType.t)
+      children[children.length - 1] = returnType = {
+        ...returnType, t,
+        children: returnType.children.map($ => $ === returnType.t ? t : $),
+      }
     }
     return {
       type: "TypeFunction",

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -800,11 +800,11 @@ function processParams(f): void
 function processSignature(f: FunctionNode): void
   {block, signature} := f
 
-  if hasAwait(block) and not f.async?#
+  if not f.async?# and hasAwait(block)
     f.async.push "async "
     signature.modifier.async = true
 
-  if hasYield(block) and not f.generator?#
+  if not f.generator?# and hasYield(block)
     if f.type is "ArrowFunction"
       gatherRecursiveWithinFunction block, .type is "YieldExpression"
       .forEach (y) =>
@@ -816,6 +816,10 @@ function processSignature(f: FunctionNode): void
     else
       f.generator.push "*"
       signature.modifier.generator = true
+
+  if signature.modifier.async and not signature.modifier.generator and
+     signature.returnType and not isPromiseType signature.returnType.t
+    replaceNode signature.returnType.t, wrapTypeInPromise signature.returnType.t
 
 function processFunctions(statements, config): void
   for each f of gatherRecursiveAll statements, .type is "FunctionExpression" or .type is "ArrowFunction"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -37,6 +37,10 @@ import {
 } from ./comptime.civet
 
 import {
+  getHelperRef
+} from ./helper.civet
+
+import {
   replaceNode
 } from ./lib.civet
 
@@ -114,6 +118,7 @@ function isAsyncGeneratorVoidType(t?: TypeNode): boolean
     isVoidType args[1].t
 
 function wrapTypeInPromise(t: TypeNode): TypeNode
+  return t if isPromiseType t
   ws := getTrimmingSpace t
   t = trimFirstSpace(t) as TypeNode
   innerArgs: TypeArgument[] := [{
@@ -130,9 +135,9 @@ function wrapTypeInPromise(t: TypeNode): TypeNode
   }
   {
     type: "TypeIdentifier"
-    raw: "Promise"
+    raw: "Promise" // so Civet thinks this is a Promise wrapper
     args
-    children: [ws, "Promise", args]
+    children: [ws, getHelperRef("AutoPromise"), args]
   }
 
 // Add implicit block unless followed by a method/function of the same name.

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -15,6 +15,8 @@ import type {
   StatementTuple
   SwitchStatement
   TypeArgument
+  TypeArguments
+  TypeIdentifier
   TypeNode
   Whitespace
 } from ./types.civet
@@ -51,6 +53,7 @@ import {
 import {
   assert
   convertOptionalType
+  getTrimmingSpace
   hasAwait
   hasYield
   inplacePrepend
@@ -84,11 +87,14 @@ function getTypeArguments(args: ASTNode): TypeArgument[]
 function isVoidType(t?: TypeNode): boolean
   t is like { type: "TypeLiteral", t: { type: "VoidType" } }
 
+function isPromiseType(t?: TypeNode): t is TypeIdentifier
+  t is like { type: "TypeIdentifier", raw: "Promise" }
+
 function isPromiseVoidType(t?: TypeNode): boolean
-  let args: TypeArgument[]
+  return false unless isPromiseType t
+  args := getTypeArguments t.args?.args
   (and)
-    t is like { type: "TypeIdentifier", raw: "Promise" }
-    (args = getTypeArguments t.args?.args)# is 1
+    args# is 1
     isVoidType args[0].t
 
 function isGeneratorVoidType(t?: TypeNode): boolean
@@ -106,6 +112,28 @@ function isAsyncGeneratorVoidType(t?: TypeNode): boolean
     t.raw is "AsyncIterator" or t.raw is "AsyncGenerator"
     (args = getTypeArguments t.args?.args)# >= 2
     isVoidType args[1].t
+
+function wrapTypeInPromise(t: TypeNode): TypeNode
+  ws := getTrimmingSpace t
+  t = trimFirstSpace(t) as TypeNode
+  innerArgs: TypeArgument[] := [{
+    type: "TypeArgument"
+    ts: true
+    t
+    children: [t]
+  }]
+  args: TypeArguments := {
+    type: "TypeArguments"
+    ts: true
+    args: innerArgs
+    children: ["<", innerArgs, ">"]
+  }
+  {
+    type: "TypeIdentifier"
+    raw: "Promise"
+    args
+    children: [ws, "Promise", args]
+  }
 
 // Add implicit block unless followed by a method/function of the same name.
 function implicitFunctionBlock(f): void
@@ -989,4 +1017,5 @@ export {
   processReturn
   skipImplicitArguments
   wrapIterationReturningResults
+  wrapTypeInPromise
 }

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -142,6 +142,11 @@ declareHelper := {
       ]
       " = (lhs, rhs) => (((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
     ]]
+  AutoPromise(ref): void
+    state.prelude.push [""
+      ts [ "type ", ref, "<T> = T extends Promise<unknown> ? T : Promise<T>" ]
+      ";\n"
+    ]
   JSX(jsxRef): void
     state.prelude.push ["", // [indent, statement]
       ts ["import type { JSX as ", jsxRef, " } from 'solid-js'"]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -33,7 +33,6 @@ import type {
   NormalCatchParameter
   ParenthesizedExpression
   Placeholder
-  StatementExpression
   StatementTuple
   SwitchStatement
   TypeArguments
@@ -117,6 +116,7 @@ import {
   processFunctions
   processIterationExpressions
   skipImplicitArguments
+  wrapTypeInPromise
 } from ./function.civet
 import { processPatternMatching } from ./pattern-matching.civet
 import {
@@ -1806,4 +1806,5 @@ export {
   trimFirstSpace
   typeOfJSX
   wrapIIFE
+  wrapTypeInPromise
 }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -920,9 +920,7 @@ export type ReturnTypeAnnotation =
   type: "ReturnTypeAnnotation"
   ts: true
   optional?: ASTNode
-  t: ASTNodeBase &
-    type: string
-    t: ASTNodeBase
+  t: TypeNode
   children: Children
 
 export type MethodModifier =
@@ -1023,10 +1021,10 @@ export type TypeNode =
   | TypeUnary
   | TypeTuple
   | TypeElement
-  | TypeArrowFunction
+  | TypeFunction
   | TypeParenthesized
 
-export type TypeIdentifier =
+export type TypeIdentifier
   type: "TypeIdentifier"
   children: Children
   parent?: Parent
@@ -1071,8 +1069,8 @@ export type TypeElement
   children: Children
   parent?: Parent
 
-export type TypeArrowFunction
-  type: "TypeArrowFunction"
+export type TypeFunction
+  type: "TypeFunction"
   ts: true
   children: Children
   parent?: Parent

--- a/test/function.civet
+++ b/test/function.civet
@@ -1551,10 +1551,10 @@ describe "function", ->
       async generator pass through
       ---
       function f(): AsyncGenerator<number, void>
-        makeGenerator() |> await |> &()
+        makeGenerator()
       ---
-      async function f(): AsyncGenerator<number, void> {
-        return (await makeGenerator())()
+      function f(): AsyncGenerator<number, void> {
+        return makeGenerator()
       }
     """
 

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -255,11 +255,11 @@ describe "[TS] function", ->
   testCase """
     async function type
     ---
-    async function() : X {
+    async function() : Promise<X> {
       return "x"
     }
     ---
-    (async function() : X {
+    (async function() : Promise<X> {
       return "x"
     })
   """
@@ -530,5 +530,57 @@ describe "[TS] function", ->
       });
       ({a, b}: {a: A, b: B}) => {
         return a
+      }
+    """
+
+  describe "automatic Promise in async", ->
+    testCase """
+      thin arrow
+      ---
+      async :void ->
+      ---
+      (async function():Promise<void> {})
+    """
+
+    testCase """
+      thick arrow
+      ---
+      async :void =>
+      ---
+      async ():Promise<void> => {}
+    """
+
+    testCase """
+      function
+      ---
+      async function f(): void {}
+      ---
+      async function f(): Promise<void> {}
+    """
+
+    testCase """
+      implicit thin arrow
+      ---
+      f := :number -> await Promise.resolve 5
+      ---
+      const f = async function():Promise<number> { return await Promise.resolve(5) }
+    """
+
+    testCase """
+      implicit thick arrow
+      ---
+      f := :number => await Promise.resolve 5
+      ---
+      const f = async ():Promise<number> => await Promise.resolve(5)
+    """
+
+    testCase """
+      implicit function
+      ---
+      function f(): number
+        await Promise.resolve 5
+      ---
+      async function f(): Promise<number> {
+        return await Promise.resolve(5)
       }
     """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -539,7 +539,8 @@ describe "[TS] function", ->
       ---
       async :void ->
       ---
-      (async function():Promise<void> {})
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      (async function():AutoPromise<void> {})
     """
 
     testCase """
@@ -547,7 +548,8 @@ describe "[TS] function", ->
       ---
       async :void =>
       ---
-      async ():Promise<void> => {}
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      async ():AutoPromise<void> => {}
     """
 
     testCase """
@@ -555,7 +557,8 @@ describe "[TS] function", ->
       ---
       async function f(): void {}
       ---
-      async function f(): Promise<void> {}
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      async function f(): AutoPromise<void> {}
     """
 
     testCase """
@@ -563,7 +566,8 @@ describe "[TS] function", ->
       ---
       f := :number -> await Promise.resolve 5
       ---
-      const f = async function():Promise<number> { return await Promise.resolve(5) }
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      const f = async function():AutoPromise<number> { return await Promise.resolve(5) }
     """
 
     testCase """
@@ -571,7 +575,8 @@ describe "[TS] function", ->
       ---
       f := :number => await Promise.resolve 5
       ---
-      const f = async ():Promise<number> => await Promise.resolve(5)
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      const f = async ():AutoPromise<number> => await Promise.resolve(5)
     """
 
     testCase """
@@ -580,7 +585,8 @@ describe "[TS] function", ->
       function f(): number
         await Promise.resolve 5
       ---
-      async function f(): Promise<number> {
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      async function f(): AutoPromise<number> {
         return await Promise.resolve(5)
       }
     """

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -154,6 +154,18 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    async function type
+    ---
+    type X = async (message: string) => void
+    type Y = async (message: string) =>
+    type Z = async (message: string) => A | B | C
+    ---
+    type X = (message: string) => Promise<void>
+    type Y = (message: string) =>Promise<void>
+    type Z = (message: string) => Promise<A | B | C>
+  """
+
+  testCase """
     type parameters
     ---
     type Z<X, Y> = Array<X>

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -158,11 +158,14 @@ describe "[TS] type declaration", ->
     ---
     type X = async (message: string) => void
     type Y = async (message: string) =>
+    type X = async (message: string) => Promise<void>
     type Z = async (message: string) => A | B | C
     ---
+    type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+    type X = (message: string) => AutoPromise<void>
+    type Y = (message: string) =>AutoPromise<void>
     type X = (message: string) => Promise<void>
-    type Y = (message: string) =>Promise<void>
-    type Z = (message: string) => Promise<A | B | C>
+    type Z = (message: string) => AutoPromise<A | B | C>
   """
 
   testCase """


### PR DESCRIPTION
Fixes #1516 by making the type `async => Foo` equivalent to `() => Promise<Foo>`

I realized that this was inconsistent with how we type the return values of actual `async function`s, though, and made it consistent. So now `async function f(): Foo` is equivalent to `async function f(): Promise<Foo>`. We've discussed this before, and were worried about the case when `Foo` was already a `Promise`-wrapped type. Luckily, this [doesn't affect type checking](https://www.typescriptlang.org/play/?#code/IYZwngdgxgBAZgV2gFwJYHsLwBQQFwwQIC2ARgKYBOAlAQAqXrGojkA8DTL7RZVAfPxgBvALAAoGFJjAA7sFTIYnZqwB0lciHQAbAG7ls1CdJibkCSlggSAvifgSA9E4B6AfiA) (though it does affect hover documentation, annoyingly).

In both cases, wrapping is suppressed if the type is already `Promise`-wrapped right there. In the distant future, we could inspect the type and avoid the redundant wrapper.