### PR TITLE
Fix typing of `return.value` in `async` function

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2475,8 +2475,7 @@ function f(): number
 
 ::: info
 You can still include explicit `Promise` wrappers in your return types.
-If the wrapper is hidden behind a `type` declaration, the output will include
-an extra `Promise` wrapper, but this does not affect typechecking.
+The `AutoPromise` helper avoids adding an extra `Promise` wrapper.
 :::
 
 ### Conditional Types

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7817,7 +7817,7 @@ ReturnType
     if (!t) return $skip
     if (asserts) {
       t = {
-        type: "AssertsType",
+        type: "TypeAsserts",
         t,
         children: [asserts[0], asserts[1], t],
         ts: true,

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,4 +1,5 @@
 import type {
+  ASTLeaf
   ASTNode
   ASTNodeObject
   BlockStatement
@@ -12,11 +13,13 @@ import type {
   IterationStatement
   Parameter
   ParametersNode
+  ReturnTypeAnnotation
   StatementTuple
   SwitchStatement
   TypeArgument
   TypeArguments
   TypeIdentifier
+  TypeLiteral
   TypeNode
   Whitespace
 } from ./types.civet
@@ -55,8 +58,10 @@ import {
 } from ./traversal.civet
 
 import {
+  addParentPointers
   assert
   convertOptionalType
+  deepCopy
   getTrimmingSpace
   hasAwait
   hasYield
@@ -119,6 +124,10 @@ function isAsyncGeneratorVoidType(t?: TypeNode): boolean
 
 function wrapTypeInPromise(t: TypeNode): TypeNode
   return t if isPromiseType t
+  // Use raw = "Promise" so that Civet thinks this is a Promise wrapper
+  wrapTypeInApplication t, getHelperRef("AutoPromise"), "Promise"
+
+function wrapTypeInApplication(t: TypeNode, id: ASTNode, raw?: string): TypeNode
   ws := getTrimmingSpace t
   t = trimFirstSpace(t) as TypeNode
   innerArgs: TypeArgument[] := [{
@@ -133,11 +142,15 @@ function wrapTypeInPromise(t: TypeNode): TypeNode
     args: innerArgs
     children: ["<", innerArgs, ">"]
   }
+  unless raw?
+    unless id <? "string"
+      throw new Error "wrapTypeInApplication requires string id or raw argument"
+    raw = id
   {
     type: "TypeIdentifier"
-    raw: "Promise" // so Civet thinks this is a Promise wrapper
+    raw
     args
-    children: [ws, getHelperRef("AutoPromise"), args]
+    children: [ws, id, args]
   }
 
 // Add implicit block unless followed by a method/function of the same name.
@@ -203,7 +216,7 @@ function processReturnValue(func: FunctionNode)
   ref := makeRef "ret"
 
   let declaration
-  values.forEach (value) =>
+  for each value of values
     value.children = [ref]
 
     // Check whether return.value already declared within this function
@@ -214,14 +227,31 @@ function processReturnValue(func: FunctionNode)
     declaration ??= child if ancestor  // remember binding
 
   // Compute default return type
-  returnType .= func.returnType ?? func.signature?.returnType
+  returnType: ReturnTypeAnnotation? .= func.returnType ?? func.signature?.returnType
   if returnType
     { t } := returnType
     switch t.type
       "TypePredicate"
-        returnType = ": boolean"
-      "AssertsType"
+        token := {token: "boolean"} as ASTLeaf
+        literal: TypeLiteral :=
+          type: "TypeLiteral"
+          t: token
+          children: [token]
+        returnType =
+          type: "ReturnTypeAnnotation"
+          ts: true
+          t: literal
+          children: [": ", literal]
+      "TypeAsserts"
         returnType = undefined
+  if returnType
+    returnType = deepCopy returnType
+    addParentPointers returnType
+    if func.signature.modifier.async
+      replaceNode
+        returnType.t
+        makeNode wrapTypeInApplication returnType.t, "Awaited"
+        returnType
 
   // Modify existing declaration, or add declaration of return.value after {
   if declaration
@@ -230,11 +260,10 @@ function processReturnValue(func: FunctionNode)
   else
     block.expressions.unshift [
       getIndent block.expressions[0]
-    ,
-      type: "Declaration"
-      children: ["let ", ref, returnType]
-      names: []
-    ,
+      makeNode
+        type: "Declaration"
+        children: ["let ", ref, returnType]
+        names: []
       ";"
     ]
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -107,6 +107,7 @@ export type OtherNode =
   | Placeholder
   | PropertyAccess
   | RangeExpression
+  | ReturnTypeAnnotation
   | ReturnValue
   | SliceExpression
   | SpreadElement
@@ -1023,6 +1024,8 @@ export type TypeNode =
   | TypeElement
   | TypeFunction
   | TypeParenthesized
+  | TypeAsserts
+  | TypePredicate
 
 export type TypeIdentifier
   type: "TypeIdentifier"
@@ -1081,11 +1084,24 @@ export type TypeParenthesized
   children: Children
   parent?: Parent
 
-export type TypeLiteral =
+export type TypeLiteral
   type: "TypeLiteral"
   t: TypeLiteralNode
   children: Children
   parent?: Parent
+
+export type TypeAsserts
+  type: "TypeAsserts"
+  children: Children
+  parent?: Parent
+  t: TypeNode
+
+export type TypePredicate
+  type: "TypePredicate"
+  children: Children
+  parent?: Parent
+  lhs: ASTNode
+  rhs: ASTNode
 
 export type VoidType = ASTLeafWithType "VoidType"
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -419,23 +419,36 @@ function hasExportDeclaration(exp: ASTNode)
 /**
 * Copy an AST node deeply, including children.
 * Ref nodes maintain identity
+* Preserves aliasing
 */
-function deepCopy(node: ASTNode): ASTNode
-  if (node == null) return node
-  if (typeof node !== "object") return node
+function deepCopy<T extends ASTNode>(root: T): T
+  copied := new Map<ASTNode, ASTNode>
+  return recurse(root) as T
 
-  if Array.isArray node
-    return node.map deepCopy
+  function recurse(node: ASTNode): ASTNode
+    return node unless node? <? "object"
 
-  if node?.type is "Ref" return node
+    unless copied.has node
+      if Array.isArray node
+        array: ASTNode[] := new Array node#
+        copied.set node, array
+        for each item, i of node
+          array[i] = recurse item
+      else if node?.type is "Ref"
+        copied.set node, node
+      else
+        obj: any := {}
+        copied.set node, obj
+        for key in node
+          value := (node as any)[key]
+          if key is "parent"
+            // If parent is within deep copy, use that
+            // Otherwise, don't copy to avoid copying outside subtree
+            obj.parent = copied.get(value) ?? value
+          else
+            obj[key] = recurse value
 
-  // Use from entries to clone objects
-  // map the values to clone the children
-  return Object.fromEntries(
-    Object.entries(node).map [key, value] =>
-      return [key, deepCopy(value)]
-
-  ) as any
+    copied.get node
 
 /**
 * When cloning subtrees sometimes we need to remove hoistDecs
@@ -557,7 +570,7 @@ function spliceChild(node: ASTNode, child: ASTNode, del, ...replacements)
  * Convert type suffix of `?: T` to `: undefined | T`
  */
 function convertOptionalType(suffix: TypeSuffix | ReturnTypeAnnotation): void
-  if (suffix.t as ASTNodeBase).type is "AssertsType"
+  if (suffix.t as ASTNodeBase).type is "TypeAsserts"
     spliceChild suffix, suffix.optional, 1, suffix.optional =
       type: "Error"
       message: "Can't use optional ?: syntax with asserts type"

--- a/test/function.civet
+++ b/test/function.civet
@@ -2378,6 +2378,20 @@ describe "function", ->
     """
 
     testCase """
+      return.value typed async
+      ---
+      (): number =>
+        return = await 5
+      ---
+      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      async (): AutoPromise<number> => {
+        let ret:Awaited<AutoPromise<number>>;
+        ret = await 5
+        return ret
+      }
+    """
+
+    testCase """
       callable return.value
       ---
       function f


### PR DESCRIPTION
Fixes #1515

Also fix `deepCopy` to preserve aliasing, which is pretty important in our AST.