### PR TITLE
Fix `sum`/`count`/`each`/`own`/etc. as loop iteration variables

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4549,8 +4549,7 @@ ForClause
     }
 
 ForStatementControlWithWhen
-  ForReduction?:reduction ForStatementControl:control WhenCondition?:condition ->
-    if (reduction) control = { ...control, reduction }
+  ForStatementControlWithReduction:control WhenCondition?:condition ->
     if (!condition) return control
     const expressions = [["", {
       type: "ContinueStatement",
@@ -4572,6 +4571,12 @@ ForStatementControlWithWhen
         }, ";"]
       ],
     }
+
+ForStatementControlWithReduction
+  # Try without reduction first, to allow sum/count/etc as variables
+  ForStatementControl
+  ForReduction:reduction ForStatementControl:control ->
+    return { ...control, reduction }
 
 ForReduction
   ( "some" / "every" / "count" / "sum" / "product" / "min" / "max" ):subtype NonIdContinue __:ws ->
@@ -4739,9 +4744,17 @@ ForStatementParameters
   # https://262.ecma-international.org/#prod-ForInOfStatement
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
+  # NOTE: &OpenParen is to fill the spot normally taken by each/own
+  ( Await __ )? &OpenParen ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
+    return processForInOf($0)
+  # NOTE: Added optional each/own modifiers,
+  # which are tried second to allow them to still work as identifiers
   ( Await __ )? ( (Each / Own) __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
     return processForInOf($0)
   # NOTE: Added optional parens
+  # NOTE: &ForInOfDeclaration is to fill the spot normally taken by each/own
+  ( Await __ )? &ForInOfDeclaration InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
+    return processForInOf($0)
   ( Await __ )? ( (Each / Own) __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
     return processForInOf($0)
   ForRangeParameters

--- a/test/for.civet
+++ b/test/for.civet
@@ -496,6 +496,22 @@ describe "for", ->
 
   describe "each..of", ->
     testCase """
+      each still works as variable
+      ---
+      for each of array
+        console.log each
+      for each in object
+        console.log each
+      ---
+      for (const each of array) {
+        console.log(each)
+      }
+      for (const each in object) {
+        console.log(each)
+      }
+    """
+
+    testCase """
       each..of
       ---
       for each item of array
@@ -1207,6 +1223,26 @@ describe "for", ->
     """
 
   describe "reductions", ->
+    testCase """
+      still work as variables
+      ---
+      z = for some of y
+      z = for every of y
+      z = for count of y
+      z = for sum of y
+      z = for product of y
+      z = for min of y
+      z = for max of y
+      ---
+      const results=[];for (const some of y) {results.push(some)};z = results
+      const results1=[];for (const every of y) {results1.push(every)};z = results1
+      const results2=[];for (const count of y) {results2.push(count)};z = results2
+      const results3=[];for (const sum of y) {results3.push(sum)};z = results3
+      const results4=[];for (const product of y) {results4.push(product)};z = results4
+      const results5=[];for (const min of y) {results5.push(min)};z = results5
+      const results6=[];for (const max of y) {results6.push(max)};z = results6
+    """
+
     testCase """
       empty body
       ---

--- a/test/for.civet
+++ b/test/for.civet
@@ -598,6 +598,22 @@ describe "for", ->
 
   describe "own..in", ->
     testCase """
+      own still works as variable
+      ---
+      for own of array
+        console.log own
+      for own in object
+        console.log own
+      ---
+      for (const own of array) {
+        console.log(own)
+      }
+      for (const own in object) {
+        console.log(own)
+      }
+    """
+
+    testCase """
       own..in
       ---
       for own key in object


### PR DESCRIPTION
Fixes #1529

`each` is a long-standing issue. All fixed by trying to parse without the new syntax first.