### PR TITLE
Ensure space after `for..of/in`

### DIFF
--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -1,7 +1,7 @@
 import type {
   ArrayBindingPattern
   ASTNode
-  ASTString
+  ASTNodeObject
   AtBinding
   Children
   ObjectBindingPattern
@@ -43,7 +43,7 @@ function adjustAtBindings(statements: ASTNode, asThis = false): void
       }
     })
 
-function adjustBindingElements(elements: ASTNodeBase[])
+function adjustBindingElements(elements: ASTNodeObject[])
   names := elements.flatMap .names or []
   { length } := elements
 

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -1,6 +1,6 @@
 import type {
   ASTNode
-  ASTNodeBase
+  ASTNodeObject
   ASTLeaf
   ASTError
   Children
@@ -16,6 +16,7 @@ import {
   makeLeftHandSideExpression
   makeNumericLiteral
   prepend
+  startsWith
   trimFirstSpace
 } from ./util.civet
 
@@ -241,11 +242,15 @@ function processForInOf($0: [
   declaration2: [ws1: ASTNode, comma: ASTLeaf, ws2: ASTNode, decl2: ASTNode]
   ws: ASTNode
   inOf: ASTLeaf
-  exp: ASTNodeBase
+  exp: ASTNodeObject
   step: [Whitespace, ASTLeaf, ASTNode]
   close: ASTLeaf
 ])
   [awaits, eachOwn, open, declaration, declaration2, ws, inOf, exp, step, close] .= $0
+
+  // ensure space after in/of
+  unless startsWith exp, /^\s/
+    exp = prepend(" ", exp) as ASTNodeObject
 
   if exp.type is "RangeExpression" and inOf.token is "of" and !declaration2
     // TODO: add support for `declaration2` to efficient `forRange`

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -117,11 +117,6 @@ export type OtherNode =
   | WhenClause
   | Yield
 
-/** @deprecated */
-export type ASTNodeBase = ASTNode &
-  parent: ASTNodeBase?
-  children: Children
-
 export type IsToken = { token: string }
 export type IsParent = { children: Children }
 export type ASTNodeParent = ASTNodeObject & IsParent

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -1,7 +1,6 @@
 import type {
   ASTLeaf
   ASTNode
-  ASTNodeBase
   ASTNodeObject
   ASTNodeParent
   FunctionNode
@@ -372,6 +371,10 @@ function makeNumericLiteral(n: number): Literal
     } as NumericLiteral // missing $loc
   ]
 
+/**
+* Detect whether the first nontrivial string/token matches a given regular
+* expression. You probably want the RegExp to start with `^`.
+*/
 function startsWith(target: ASTNode, value: RegExp)
   if (!target) return
   if Array.isArray target
@@ -570,7 +573,7 @@ function spliceChild(node: ASTNode, child: ASTNode, del, ...replacements)
  * Convert type suffix of `?: T` to `: undefined | T`
  */
 function convertOptionalType(suffix: TypeSuffix | ReturnTypeAnnotation): void
-  if (suffix.t as ASTNodeBase).type is "TypeAsserts"
+  if suffix.t?.type is "TypeAsserts"
     spliceChild suffix, suffix.optional, 1, suffix.optional =
       type: "Error"
       message: "Can't use optional ?: syntax with asserts type"

--- a/test/for.civet
+++ b/test/for.civet
@@ -82,6 +82,14 @@ describe "for", ->
     for (const x of y);
   """
 
+  testCase """
+    no space after of
+    ---
+    for x of$
+    ---
+    for (const x of $);
+  """
+
   // TODO: This is dubious
   testCase """
     optional parens inline


### PR DESCRIPTION
Fixes #1527

Also finished off the last of `ASTNodeBase` → `ASTNodeObject` transition.