### PR TITLE
Fix `await` step vs. expression detection in pipeline

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -886,7 +886,7 @@ PipelineHeadItem
   ParenthesizedExpression
 
 PipelineTailItem
-  ( AwaitOp / Yield / Return / Throw ) !AccessStart !MaybeNestedExpression -> $1
+  ( AwaitOp / Yield / Return / Throw ) !AccessStart !MaybeParenNestedExpression -> $1
   "import" !AccessStart ->
     return {
       type: "Identifier",
@@ -5384,6 +5384,7 @@ NestedExpression
 # MaybeNestedExpression but where expression needs to be output with
 # parentheses if indented, so that the expression starts on the same line.
 # (e.g. for `return` or `yield`)
+# This also doesn't allow initial __ (whereas MaybeNestedExpression does)
 MaybeParenNestedExpression
   # Skip if there's a postfix if/etc.
   &( _? PostfixStatement NoBlock ) -> ""

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -324,6 +324,23 @@ describe "pipe", ->
     await Promise.all(x)
   """
 
+  // #1525
+  testCase """
+    complex pipe to await op
+    ---
+    await.all
+      . async do
+          f()
+              |> await.all
+      . build
+    ---
+    await Promise.all( [
+        (async ()=>{{
+          return await Promise.all(f())
+      }})(),
+        build])
+  """
+
   testCase """
     // @ts-expect-error comment
     ---


### PR DESCRIPTION
Fixes #1525

#1520 introduced some extra situations to not trigger an `await` step, which unfortunately included (via `MaybeNestedExpression`) an arbitrary `Expression` following the `await`, but `Expression` allows starting with `__`. 😱 

This PR instead uses `MaybeParenNestedExpression`, which is what e.g. `throw` actually uses. Despite the similar name, this rule is much more careful about initial newline, and seems to work. 🤞 