### PR TITLE
Check for valid left-hand sides, forbidding lone placeholder

### DIFF
--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -12,6 +12,7 @@ import type {
 
 import {
   assert
+  checkValidLHS
   literalValue
   makeLeftHandSideExpression
   makeNumericLiteral
@@ -248,11 +249,18 @@ function processForInOf($0: [
 ])
   [awaits, eachOwn, open, declaration, declaration2, ws, inOf, exp, step, close] .= $0
 
+  // ForInOfDeclaration is either ForDeclaration or LeftHandSideExpression
+  // In the latter case, check valid LHS
+  for each decl of [declaration, declaration2?.-1]
+    continue unless decl?
+    unless decl.type is "ForDeclaration"
+      checkValidLHS decl
+
   // ensure space after in/of
   unless startsWith exp, /^\s/
     exp = prepend(" ", exp) as ASTNodeObject
 
-  if exp.type is "RangeExpression" and inOf.token is "of" and !declaration2
+  if exp.type is "RangeExpression" and inOf.token is "of" and not declaration2
     // TODO: add support for `declaration2` to efficient `forRange`
     return forRange
       open, declaration, exp

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -52,6 +52,7 @@ import {
   addParentPointers
   append
   assert
+  checkValidLHS
   deepCopy
   flatJoin
   getTrimmingSpace
@@ -921,6 +922,8 @@ function processAssignments(statements): void
   // Move assignments/updates within LHS of assignments/updates
   // to run earlier via comma operator
   for each exp of gatherRecursiveAll statements, .type is "AssignmentExpression" or .type is "UpdateExpression"
+    checkValidLHS exp.assigned
+
     function extractAssignment(lhs)
       expr .= lhs
       while expr.type is "ParenthesizedExpression"
@@ -940,7 +943,7 @@ function processAssignments(statements): void
     switch exp.type
       when "AssignmentExpression"
         continue unless exp.lhs
-        exp.lhs.forEach (lhsPart, i) =>
+        for each lhsPart of exp.lhs
           if newLhs := extractAssignment(lhsPart[1])
             lhsPart[1] = newLhs
       when "UpdateExpression"
@@ -1451,9 +1454,7 @@ function processPlaceholders(statements: StatementTuple[]): void
   placeholderMap := new Map<ASTNodeObject, (Placeholder)[]>()
   liftedIfs := new Set<IfStatement>()
 
-  gatherRecursiveAll statements, .type is "Placeholder"
-  .forEach (_exp) =>
-    exp := _exp as! Placeholder
+  for each exp of gatherRecursiveAll statements, .type is "Placeholder"
     let ancestor: ASTNodeObject?
     if exp.subtype is "."
       // Partial placeholder . lifts to the nearest call expression,

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -4,6 +4,7 @@ type {
 { gatherRecursiveAll } from ./traversal.civet
 {
   addParentPointers
+  checkValidLHS
   clone
   makeLeftHandSideExpression
   makeNode
@@ -99,9 +100,9 @@ function constructPipeStep(fn, arg, returning)
 // head: expr
 // body: [ws, pipe, ws, expr][]
 
-function processPipelineExpressions(statements): void {
+function processPipelineExpressions(statements): void
   gatherRecursiveAll(statements, (n) => n.type is "PipelineExpression")
-    .forEach((s) => {
+    .forEach (s) =>
       const [ws, , body] = s.children
       let [, arg] = s.children
 
@@ -111,51 +112,39 @@ function processPipelineExpressions(statements): void {
 
       let usingRef = null
 
-      for (i = 0; i < l; i++) {
+      for (i = 0; i < l; i++)
         const step = body[i]
         const [leadingComment, pipe, trailingComment, expr] = step
         const returns = pipe.token is "||>"
         let ref, result,
           returning = returns ? arg : null
 
-        if (pipe.token is "|>=") {
+        if pipe.token is "|>="
           let initRef
-          if (i is 0) {
-            :outer switch (arg.type) {
+          if i is 0
+            checkValidLHS arg
+
+            :outer switch arg.type
               case "MemberExpression":
                 // If there is only a single access then we don't need a ref
                 if (arg.children.length <= 2) break
               case "CallExpression":
                 const access = arg.children.pop()
-
-                switch (access.type) {
-                  case "PropertyAccess":
-                  case "SliceExpression":
-                  case "Index":
-                    break
-                  default:
-                    children.unshift({
-                      type: "Error",
-                      $loc: pipe.token.$loc,
-                      message: `Can't assign to ${access.type}`,
-                    })
-                    arg.children.push(access)
-                    break outer
-                }
+                // processAssignments will check that this is a valid
+                // last access to assign to
 
                 usingRef = makeRef()
                 initRef = {
-                  type: "AssignmentExpression",
-                  children: [usingRef, " = ", arg, ","],
+                  type: "AssignmentExpression"
+                  children: [usingRef, " = ", arg, ","]
                 }
 
                 arg = {
-                  type: "MemberExpression",
+                  type: "MemberExpression"
                   children: [usingRef, access]
                 }
 
-                break;
-            }
+                break
 
             // assignment node
             const lhs = [[
@@ -180,22 +169,19 @@ function processPipelineExpressions(statements): void {
             removeHoistDecs arg
 
             // except keep the ref the same
-            if (arg.children[0].type is "Ref") {
+            if arg.children[0].type is "Ref"
               arg.children[0] = usingRef
-            }
 
-          } else {
+          else
             children.unshift({
               type: "Error",
               $loc: pipe.token.$loc,
               message: "Can't use |>= in the middle of a pipeline",
             })
-          }
-        } else {
+        else
           if (i is 0) s.children = children
-        }
 
-        if (returns and (ref = needsRef(arg))) {
+        if returns and (ref = needsRef(arg))
           // Use the existing ref if present
           usingRef = usingRef or ref
           arg = {
@@ -206,49 +192,41 @@ function processPipelineExpressions(statements): void {
             }, ")"],
           }
           returning = usingRef
-        }
 
-        [result, returning] = constructPipeStep(
+        [result, returning] = constructPipeStep
           {
             leadingComment: skipIfOnlyWS(leadingComment),
             trailingComment: skipIfOnlyWS(trailingComment),
             expr
-          },
-          arg,
-          returning,
-        )
+          }
+          arg
+          returning
 
-        if (result.type is "ReturnStatement") {
+        if result.type is "ReturnStatement"
           // Attach errors/warnings if there are more steps
-          if (i < l - 1) {
+          if i < l - 1
             result.children.push({
               type: "Error",
               message: "Can't continue a pipeline after returning",
             })
-          }
           arg = result
-          if (children[children.length - 1] is ",") {
+          if children[children.length - 1] is ","
             children.pop()
             children.push(";")
-          }
           break
-        }
 
-        if (returning) {
+        if returning
           arg = returning
           children.push(result, ",")
-        } else {
+        else
           arg = result
-        }
-      }
 
-      if (usingRef) {
+      if usingRef
         s.hoistDec = {
           type: "Declaration",
           children: ["let ", usingRef],
           names: [],
         }
-      }
 
       children.push(arg)
 
@@ -263,8 +241,6 @@ function processPipelineExpressions(statements): void {
 
       // Update parent pointers
       addParentPointers(s, s.parent)
-    })
-}
 
 export {
   processPipelineExpressions

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -60,6 +60,7 @@ export type ExpressionNode =
   | TypeNode
   | UnaryExpression
   | UnwrappedExpression
+  | UpdateExpression
   | YieldExpression
 
 /**
@@ -215,13 +216,19 @@ export type ChainOp
   children?: never
   parent?: never
 
+export type UpdateExpression
+  type: "UpdateExpression"
+  children: Children
+  parent?: Parent
+  assigned: ASTNode
+
 export type AssignmentExpression
   type: "AssignmentExpression"
   children: Children
   parent?: Parent
   names: null
   lhs: AssignmentExpressionLHS
-  assigned: ???
+  assigned: ASTNode
   expression: ExpressionNode
 
 export type AssignmentExpressionLHS = [undefined, NonNullable<ASTNode>, [WSNode, [string, WSNode]], ASTLeaf][]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -15,6 +15,10 @@ import type {
 } from ./types.civet
 
 import {
+  replaceNode
+} from ./lib.civet
+
+import {
   gatherRecursiveWithinFunction
   type Predicate
 } from ./traversal.civet
@@ -512,6 +516,32 @@ function parenthesizeExpression(expression: ASTNode)
     implicit: true
   }
 
+// If the expression is not a valid left-hand side for assignment,
+// add an Error node to it and return true.
+// TOMAYBE: Static semantics https://262.ecma-international.org/#sec-static-semantics-assignmenttargettype
+function checkValidLHS(node: ASTNode): boolean
+  switch node?.type
+    when "UnaryExpression"
+      node.children.unshift
+        type: "Error"
+        message: "Unary expression is not a valid left-hand side"
+      return true
+    when "CallExpression"
+      lastType := node.children.-1?.type
+      switch lastType
+        when "PropertyAccess", "SliceExpression", "Index"
+        else
+          node.children.splice -1, 0,
+            type: "Error"
+            message: `Call expression ending with ${lastType} is not a valid left-hand side`
+          return true
+    when "Placeholder"
+      node.children.unshift
+        type: "Error"
+        message: `Lone placeholder (${node.subtype}) is not a valid left-hand side`
+      return true
+  return false
+
 /**
  * Just update parent pointers for the children of a node,
  * recursing into arrays but not objects.  More efficient version of
@@ -722,6 +752,7 @@ export {
   addParentPointers
   append
   assert
+  checkValidLHS
   clone
   convertOptionalType
   deepCopy

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -509,14 +509,22 @@ describe "assignment", ->
     a ??= b
   """
 
-  // TOMAYBE: Static semantics https://262.ecma-international.org/#sec-static-semantics-assignmenttargettype
-  testCase """
-    illegal assignment with function call
-    ---
-    a() = b
-    ---
-    a() = b
-  """, wrapper: ''
+  describe "invalid LHS", ->
+    throws """
+      +++
+      ---
+      +++x
+      ---
+      ParseErrors: unknown:1:3 Unary expression is not a valid left-hand side
+    """
+
+    throws """
+      function call
+      ---
+      a() = b
+      ---
+      ParseErrors: unknown:1:2 Call expression ending with Call is not a valid left-hand side
+    """
 
   describe "inner assignment operators", ->
     testCase """
@@ -594,8 +602,10 @@ describe "assignment", ->
     testCase """
       double ++
       ---
+      ++++x
       ++x++
       ---
+      (++x, ++x);
       (++x, x++)
     """
 

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -148,6 +148,14 @@ describe "&. function block shorthand", ->
     x.map($ => $.name = name += "foo")
   """
 
+  throws """
+    placeholder assignment
+    ---
+    & = "hello"
+    ---
+    ParseErrors: unknown:1:6 Lone placeholder (&) is not a valid left-hand side
+  """
+
   testCase """
     addition
     ---
@@ -684,6 +692,14 @@ describe "&. function block shorthand", ->
     $1 => { const results1=[];for (const x of $1) {
       results1.push(x*x)
     };return results1;}
+  """
+
+  throws """
+    assignment position in for..of
+    ---
+    for & of &
+    ---
+    ParseErrors: unknown:1:6 Lone placeholder (&) is not a valid left-hand side
   """
 
   describe "multiple &", ->

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -603,7 +603,7 @@ describe "pipe", ->
       ---
       f() |>= foo
       ---
-      ParseErrors: unknown:1:7 Can't assign to Call
+      ParseErrors: unknown:1:2 Call expression ending with Call is not a valid left-hand side
     """
 
     testCase """


### PR DESCRIPTION
Fixes #1528

Consolidated some pipe-specific code that did some checks, and fixed one existing test case that said we ought to fix this.

I'm slightly worried that we're modifying in-place during `processForInOf`, which could affect the cache, but I think these error cases would be consistent... I wasn't sure how else to structure `checkValidLHS`.