### PR TITLE
"civet strict" directive to enable JS strict mode

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -46,6 +46,7 @@ and following ESM, require importing files with the correct extension.
 | [`jsxCodeSameLine`](reference#automatic-code-children) | treat same-line JSX children as Civet code |
 | [`objectIs`](reference#object-is) | implement the `is` operator via `Object.is` |
 | [`repl`](reference#iife-wrapper) | wrap the program in an IIFE that exposes globals |
+| [`strict`](reference#strict) | enable JavaScript strict mode (equivalent to `"use strict"`) |
 
 ## ECMAScript Compatibility
 
@@ -56,7 +57,7 @@ For now, we have the following related options:
 
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
-| `-implicit-returns` | turn off implicit return of last value in functions |
+| [`-implicit-returns`](reference#no-implicit-returns) | turn off implicit return of last value in functions |
 
 ## CoffeeScript Compatibility
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -989,8 +989,8 @@ function circle(degrees: number): {x: number, y: number}
 ::: info
 Implicit return of the last value in a function can be avoided by
 specifying a `void` return type (or `Promise<void>` for async functions),
-adding a final semicolon or explicit `return`,
-or globally using the directive `"civet -implicitReturns"`.
+adding a final semicolon or explicit `return`, or globally using
+[the directive `"civet -implicitReturns"`](#no-implicit-returns).
 Generators also don't implicitly `return`
 (use explicit `return` to return a special final value).
 :::
@@ -3253,3 +3253,37 @@ This behavior is usually helpful in a REPL context: it lets you attempt to
 correct a previous declaration.
 It also matches Chrome's console behavior (but not NodeJS's CLI behavior).
 :::
+
+## JavaScript Compatibility
+
+Civet aims to be mostly compatible with JavaScript and TypeScript,
+so that most JavaScript/TypeScript code is valid Civet code.
+See [comparison](comparison) for the few exceptions.
+You can increase JavaScript compatibility with the following options:
+
+### No Implicit Returns
+
+To disable [implicit returns from functions](#function),
+use the directive `"civet -implicitReturns"`:
+
+<Playground>
+"civet -implicitReturns"
+function processAll(array)
+  for item of array
+    process item
+</Playground>
+
+### Strict Mode
+
+Output from Civet runs by default in JavaScript's sloppy mode,
+unless it is loaded as an ECMAScript module.
+To turn on
+[JavaScript's strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode),
+add the directive `"use strict"` as usual, or the Civet directive
+`"civet strict"`. The latter is useful because it can be specified in
+[Civet configuration files](config).
+
+<Playground>
+"civet strict"
+x = 5 // invalid
+</Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8712,6 +8712,7 @@ Reset
       repl: false,
       rewriteTsImports: true,
       server: false,
+      strict: false,
       symbols: wellKnownSymbols,
       tab: undefined, // default behavior = same as space
       verbose: false,
@@ -8775,6 +8776,10 @@ Init
         Object.assign(config, directive.config)
       }
     })
+
+    if (config.strict) {
+      $0 = [...$0, '"use strict";\n']
+    }
 
     return $0
 

--- a/test/prologues.civet
+++ b/test/prologues.civet
@@ -20,6 +20,16 @@ describe "prologues", ->
     .x
   """
 
+  testCase """
+    strict mode
+    ---
+    "civet strict"
+    x = 1
+    ---
+    "use strict";
+    x = 1
+  """
+
 describe "shebang", ->
   testCase """
     keeps it at the top

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -30,6 +30,7 @@ declare module "@danielx/civet" {
     rewriteCivetImports: string
     rewriteTsImports: boolean
     server: boolean
+    strict: boolean
     symbols: string[]
     tab: number
     verbose: boolean


### PR DESCRIPTION
Fixes #1481

If we ever want a "Civet strict mode", we might want to call this `jsStrict` instead of `strict`. But maybe two "strict" modes would be confusing, so in this hypothetical scenario, it might be better to call our thing something else (like "stern mode").