### PR TITLE
Restart LSP when `package.json` or Civet config file changes

### DIFF
--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -64,8 +64,8 @@ function activateClient(context: ExtensionContext)
   // Start the client. This will also launch the server
   client.start()
 
-  // Watch for changes to tsconfig.json and restart the server
-  workspace.createFileSystemWatcher("**/tsconfig.json").onDidChange =>
+  // Watch for changes to tsconfig.json, package.json, and civetconfig and restart the server
+  workspace.createFileSystemWatcher("**/{tsconfig,package,🐈,civetconfig,civet.config}.{json,yaml,yml,civet,js}").onDidChange =>
     await client?.stop()
     await client.start()
 


### PR DESCRIPTION
Useful for when installing packages, or changing Civet parse options, or e.g. changing to `"type": "module"` (as reported in Discord)