### PR TITLE
Fix `& &` disambiguation (placeholder vs. bitwise and)

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -370,8 +370,9 @@ ForbiddenImplicitCalls
   # NOTE: Don't allow non-heregex regexes that begin with a space as first argument without parens
   "/ "
   # NOTE: Exclude binary & operator with argument
-  # (which could otherwise be interpreted as an ampersand function)
-  &( /&(?=\s)/ !( NotDedented ( Ampersand / ReservedBinary ) ) ( IndentedFurther / !EOS ) ) BinaryOpRHS
+  # (which could otherwise be interpreted as an ampersand function),
+  # unless the argument starts with & that itself looks like a binary operator
+  &( /&(?=\s)/ !( NotDedented ReservedBinary ) !( &( NotDedented Ampersand ( IndentedFurther / !EOS ) ) BinaryOpRHS ) ( IndentedFurther / !EOS ) ) BinaryOpRHS
   # Don't treat @@decorator @@decorator class ... as implicit calls
   ClassImplicitCallForbidden ( Class / AtAt )
   Identifier "=" Whitespace

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -213,8 +213,20 @@ describe "&. function block shorthand", ->
     bitwise and
     ---
     x.map & & 1
+    x.map & &
+      1
+    x.map 1 & &
+    x.map 1 &
+      &
+    x.map 1 & &.x
     ---
     x.map($ => $ & 1)
+    x.map($1 => $1 &
+      1)
+    x.map($2 => 1 & $2)
+    x.map($3 => 1 &
+      $3)
+    x.map($4 => 1 & $4.x)
   """
 
   testCase """


### PR DESCRIPTION
Fixes #1541

I'm not sure this is perfect in all cases (or even that we can be), but it seems to better handle `1 & &` vs. `& & 1`.

Previously, we forbid an implicit call starting with a `&` that could be interpreted as a binary operator, unless the right-hand side started with a `&`. This correctly handled `& & 1`, but didn't correctly handle `1 & &`. Now the "unless" case further requires that the second `&` can also be interpreted as a binary operator (i.e. has a right-hand side).

(There's many nested levels of negation here, making it very confusing...)