### PR TITLE
Fix REPL support for `ref`s created by Civet

### DIFF
--- a/civet.dev/.vitepress/components/PlaygroundFull.vue
+++ b/civet.dev/.vitepress/components/PlaygroundFull.vue
@@ -79,6 +79,9 @@ function runInBrowser() {
     }
   } catch (err) {
     console.error(err);
+    if (err instanceof SyntaxError) {
+      console.log('Attempted to eval:', code)
+    }
     evalOutput.value += `[THROWN] ${err.toString()}\n`
   }
   evalComplete.value = true

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1408,6 +1408,7 @@ function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
   i .= 0
   // Hoist top-level declarations and all var declarations
   for each decl of gatherRecursiveWithinFunction topBlock, .type is "Declaration"
+    continue unless decl.names?# // skip 'let ref'
     if decl.parent is topBlock or decl.decl is "var"
       decl.children.shift() // remove const/let/var
       root.expressions.splice i++, 0, ["", `var ${decl.names.join ','};`]

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -151,7 +151,7 @@ describe "repl directive", ->
   """
 
   testCase """
-    inner classesj
+    inner classes
     ---
     "civet repl"
     if true
@@ -175,4 +175,13 @@ describe "repl directive", ->
       }
       return new C
     }})()
+  """
+
+  testCase """
+    skip let ref
+    ---
+    "civet repl"
+    primes := [...smallPrimes] ||> .# = n
+    ---
+    var primes;(()=>{let ref;primes =( (ref = [...smallPrimes]).length = n,ref);return primes})()
   """


### PR DESCRIPTION
Fixes #1550

It turns out the input caused a `let ref` which had an empty `names` field, which let to `"civet repl"` creating an invalid statement `var ;`. Now such declarations are skipped from hoisting, so the `ref`s don't get exposed and they don't cause a crash.

Also, future `SyntaxError` crashes will cause the code to be output to console, for easier diagnosis.