### PR TITLE
`array[i%]` modulo index shorthand

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -465,6 +465,17 @@ you can avoid `..` altogether:
 [left, right] = [x[<i], x[>=i]]
 </Playground>
 
+### Modulo Indexing
+
+You can use `a[i%]` to index into an array modulo its length:
+
+<Playground>
+for i of [0...a#]
+  drawAngle v[i-1%], v[i], v[i+1%]
+</Playground>
+
+See also [length shorthand](#length-shorthand).
+
 ## Strings
 
 Strings can span multiple lines:

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "unplugin": "^1.12.2"
   },
   "devDependencies": {
-    "@danielx/civet": "0.8.5",
+    "@danielx/civet": "0.8.11",
     "@danielx/hera": "^0.8.16",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1517,6 +1517,14 @@ MemberBracketContent
       children: $0,
       expression,
     }
+  # NOTE: `x[i%]` shorthand for `x[i %% x.length]`
+  OpenBracket:open PostfixedExpression:expression __:ws1 /%%?/ __:ws2 CloseBracket:close ->
+    return {
+      type: "Index",
+      children: [open, expression, ws1, ws2, close],
+      expression,
+      mod: true,
+    }
 
 SliceParameters
   Loc:ls Expression?:start __:ws RangeDots:dots Loc:le Expression?:end ->
@@ -3478,11 +3486,11 @@ PropertyDefinition
     const last = lastAccessInCallExpression(value)
     if (!last) return $skip
 
-    let name, hoistDec, ref, refAssignment
+    let name, ref, refAssignment
     const { expression, type } = last
     if (type === "Index") {
       // TODO: If `last` is a suitable string literal, could use it for `name`.
-      ({ ref, hoistDec, refAssignment } = maybeRefAssignment(expression))
+      ({ ref, refAssignment } = maybeRefAssignment(expression))
       if (refAssignment) {
         name = {
           type: "ComputedPropertyName",
@@ -3519,7 +3527,6 @@ PropertyDefinition
       name,
       names: [],
       value,
-      hoistDec,
     }
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -551,11 +551,11 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
     if glob?.type is "PropertyGlob"
       prefix .= children[...i]
       parts := []
-      let hoistDec, refAssignmentComma
+      let refAssignmentComma
       // add ref to ensure object base evaluated only once
       if prefix.length > 1
         ref := makeRef()
-        { hoistDec, refAssignmentComma } = makeRefAssignment ref, prefix
+        { refAssignmentComma } = makeRefAssignment ref, prefix
         prefix = [ref]
       prefix = prefix.concat(glob.dot)
 
@@ -613,7 +613,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
               part.delim // comma delimiter
             ]
           }
-      object .= {
+      object: ASTNodeObject .= {
         type: "ObjectExpression"
         children: [
           glob.object.children.0 // {
@@ -621,18 +621,16 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
           glob.object.children.-1 // whitespace and }
         ],
         properties: parts
-        hoistDec
       }
       if refAssignmentComma
-        object = {
+        object = makeNode
           type: "ParenthesizedExpression"
           children: ["(", ...refAssignmentComma, object, ")"]
           expression: object
-        }
       if (i is children.length - 1) return object
       return processCallMemberExpression({  // in case there are more
-        ...node,
-        children: [object, ...children.slice(i + 1)]
+        ...node
+        children: [object, ...children[i+1..]]
       })
     else if glob?.type is "PropertyBind"
       // TODO: add ref to ensure object base evaluated only once
@@ -654,6 +652,42 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
             ]
           }
           ...children[i+1..]
+        ]
+      })
+    else if glob is like {type: "Index", mod: true}
+      assert.notEqual i, 0, "Index modifier must be preceded by an expression"
+      prefix := i is 1 ? children[0] : children[<i]
+      { ref, refAssignment } .= maybeRefAssignment prefix
+      call := makeNode
+        type: "CallExpression"
+        children: [
+          getHelperRef "modulo"
+          makeNode
+            type: "Call"
+            children:  [
+              "("
+              ...glob.children[<..<] // between "[" and "]" tokens
+              ", "
+              ref
+              ".length"
+              ")"
+            ]
+        ]
+      return processCallMemberExpression({  // in case there are more
+        ...node
+        children: [
+          makeLeftHandSideExpression refAssignment ?? prefix
+          {
+            ...glob
+            mod: false
+            expression: call
+            children: [
+              glob.children[0] // "[" token
+              call
+              glob.children.-1 // "]" token
+            ]
+          }
+          ...children[>i]
         ]
       })
     else if glob is like {type: "SliceExpression", reversed: true}
@@ -1319,9 +1353,9 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
         throw new Error("Invalid parse tree for negative index access")
 
       if subexp
-        { hoistDec, refAssignment } := makeRefAssignment ref, subexp
-        exp.hoistDec = hoistDec
+        { refAssignment } := makeRefAssignment ref, subexp
         children.splice start, 0, makeLeftHandSideExpression refAssignment
+        refAssignment.parent = exp
 
       exp.len.children = [
         ref,

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -58,21 +58,19 @@ import {
 declare var ReservedWord: ParseRule
 
 function processPatternTest(lhs: ASTNode, patterns: PatternExpression[]): ASTNode
-  { ref, hoistDec, refAssignmentComma } := maybeRefAssignment lhs, "m"
+  { ref, refAssignmentComma } := maybeRefAssignment lhs, "m"
 
   conditionExpression := patterns
   .map getPatternConditions ., ref
   .map flatJoin ., " && "
   |> flatJoin ., " || "
 
-  makeLeftHandSideExpression {
+  makeLeftHandSideExpression makeNode
     type: "PatternTest"
-    hoistDec
     children: [
       ...refAssignmentComma
       conditionExpression
     ]
-  }
 
 function processPatternMatching(statements: ASTNode): void
   gatherRecursiveAll(statements, .type is "SwitchStatement")
@@ -106,7 +104,7 @@ function processPatternMatching(statements: ASTNode): void
         // Unwrap parenthesized expression
         condition = condition.expression as ParenthesizedExpression
 
-      { ref, hoistDec, refAssignmentComma } .= maybeRefAssignment condition, "m"
+      { ref, refAssignmentComma } .= maybeRefAssignment condition, "m"
       root: ASTNode[] := []
       prev .= root
       let e?: ElseClause
@@ -161,9 +159,7 @@ function processPatternMatching(statements: ASTNode): void
           children: ["if", condition, block, e]
           then: block
           else: e
-          hoistDec
         }]
-        hoistDec = undefined
         refAssignmentComma = []
         prev = e.block.expressions if e?
 

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -1,11 +1,12 @@
 import type {
   ASTNode
+  ASTNodeObject
   ASTRef
-  DeclarationStatement
 } from "./types.civet"
 
 import {
   isWhitespaceOrEmpty
+  makeNode
 } from "./util.civet"
 
 function makeRef(base = "ref", id = base): ASTRef
@@ -42,34 +43,43 @@ function needsRef(expression: ASTNode, base = "ref"): ASTRef | undefined
 function maybeRef(exp: ASTNode, base: string = "ref"): ASTNode
   needsRef(exp, base) or exp
 
+/**
+* Make an AssignmentExpression node that assigns `ref` to `exp`,
+* and hoists a `let ref` declaration. Returned in `refAssignment` property,
+* along with `refAssignmentComma` which is an array of the assignment
+* followed by a comma, for easy splicing into children.
+*/
 function makeRefAssignment(ref: ASTNode, exp: ASTNode): {
-  hoistDec: DeclarationStatement
-  refAssignment: ASTNode
+  refAssignment: ASTNodeObject
   refAssignmentComma: ASTNode[]
 }
-  refAssignment :=
+  refAssignment := makeNode
     type: "AssignmentExpression"
     children: [ref, " = ", exp]
-  {
     hoistDec:
       type: "Declaration"
       children: ["let ", ref]
       names: []
+  {
     refAssignment
-    refAssignmentComma:
-      if refAssignment
-        [refAssignment, ","]
-      else
-        []
+    refAssignmentComma: [refAssignment, ","]
   }
 
+/**
+* Returns `{ ref, refAssignment, refAssignmentComma }` where
+* * `ref` is a ref for `exp` if it's complex, otherwise `exp` itself
+* * `refAssignment` is an assignment expression that assigns `ref` to `exp`
+*   and hoists a `let ref` declaration, or if there a ref wasn't needed,
+*   `undefined` (actually lacking property)
+* * `refAssignmentComma` is an array of the assignment followed by a comma,
+*   or an empty array if there's no assignment, for easy splicing into children
+* Essentially `maybeRef` + `makeRefAssignment`.
+*/
 function maybeRefAssignment(exp: ASTNode, base: string = "ref"): {
   ref: ASTNode
-  hoistDec?: DeclarationStatement?
   refAssignment?: ASTNode
   refAssignmentComma: ASTNode[]
 }
-  let hoistDec, refAssignment
   ref := maybeRef exp, base
   if ref is exp
     { ref, refAssignmentComma: [] }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -208,7 +208,6 @@ export type PatternTest
   parent?: Parent
   special: true
   negated: boolean
-  hoistDec?: unknown
 
 export type ChainOp
   type: "ChainOp"
@@ -231,6 +230,7 @@ export type AssignmentExpression
   lhs: AssignmentExpressionLHS
   assigned: ASTNode
   expression: ExpressionNode
+  hoistDec?: ASTNode
 
 export type AssignmentExpressionLHS = [undefined, NonNullable<ASTNode>, [WSNode, [string, WSNode]], ASTLeaf][]
 
@@ -393,7 +393,7 @@ export type ForStatement
   parent?: Parent
   declaration: (DeclarationStatement | ForDeclaration)?
   block: BlockStatement
-  hoistDec: unknown
+  hoistDec: ASTNode
   generator?: ASTNode
   resultsRef: ASTRef?
   reduction?: ForReduction

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -510,3 +510,41 @@ describe "property access", ->
       ---
       ParseError
     """
+
+  describe "mod shorthand", ->
+    testCase """
+      simple
+      ---
+      x[i%]
+      x[i %]
+      x[i%%]
+      x[i %% ]
+      ---
+      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      x[modulo(i, x.length)]
+      x[modulo(i , x.length)]
+      x[modulo(i, x.length)]
+      x[modulo(i  , x.length)]
+    """
+
+    testCase """
+      complex
+      ---
+      x()[i+j%]
+      x.y[i+j%]
+      (x+y)[i+j%]
+      ---
+      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      let ref;(ref = x())[modulo(i+j, ref.length)]
+      let ref1;(ref1 = x.y)[modulo(i+j, ref1.length)]
+      let ref2;(ref2 = (x+y))[modulo(i+j, ref2.length)]
+    """
+
+    testCase """
+      assigned
+      ---
+      x()[i+j%] = rhs
+      ---
+      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      let ref;(ref = x())[modulo(i+j, ref.length)] = rhs
+    """

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,10 +150,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@danielx/civet@0.8.5":
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.8.5.tgz#158280904d8f60c5b2bd7c15dbe71ed137f0d2b7"
-  integrity sha512-nK7KAa+028ixciA/yGCVly4YNFFqTlKdrD/46BS0V93FBDGbbjt4T3lH3li0PSo4/ZUAE3hzUY8rGswukDDB2A==
+"@danielx/civet@0.8.11":
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/@danielx/civet/-/civet-0.8.11.tgz#82b172b909cdb6c4b1df006089affd876aeff3ce"
+  integrity sha512-jrIyenaKqaqSkcG/9L6sJXvz3LsYsdaUWUjCwbcDdnbqbBnM1kM0krFpw0eiWfw+uOdjH2Q0XOu28BJjyRuuTQ==
   dependencies:
     "@cspotcode/source-map-support" "^0.8.1"
     "@typescript/vfs" "^1.6.0"


### PR DESCRIPTION
Part of #909

Also simplify the use of `maybeRefAssignment` so that you don't need to include the `hoistDec` yourself; it's automatically included in the `AssignmentExpression` for the `ref`. So ref work should be a bit easier.