### PR TITLE
Bun docs: improve getting started guidance

### DIFF
--- a/source/bun-civet.civet
+++ b/source/bun-civet.civet
@@ -4,6 +4,8 @@ Bun plugin for Civet files. Simply follow the steps below:
 1. Create bunfig.toml if it doesn't exist
 2. Add the following line:
 preload = ["@danielx/civet/bun-civet"]
+3. Get plugin from npm:
+bun add -D @danielx/civet
 
 After that, you can use .civet files with the Bun cli, like:
 $ bun file.civet


### PR DESCRIPTION
Added a step to load plugin, without executing which the user gets an unobvious error