### PR TITLE
Robust parsing of `foo.` with error node

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1681,6 +1681,18 @@ PropertyAccess
       children: [ dot, ...comments, ...id.children ],
     }
 
+  # NOTE: For LSP completion / robustness, parse `foo.` but with an error node
+  ExplicitAccessStart:dot &EOS ->
+    return {
+      type: "PropertyAccess",
+      name: "",
+      dot,
+      children: [ dot, {
+        type: "Error",
+        message: "Missing property name after '.'",
+      }]
+    }
+
   ImplicitAccessStart:dot ( PrivateIdentifier / LengthShorthand ):id ->
     return {
       type: "PropertyAccess",


### PR DESCRIPTION
@NWYLZW Can you make use of this for completions after typing `.`? I still couldn't get completions to work in this case, but at least I get other TypeScript errors after typing a `.`...