### PR TITLE
Object comprehensions via loops in braces

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1937,6 +1937,31 @@ min := for min item of array
 max := for max item of array
 </Playground>
 
+### Object Comprehensions
+
+Loops can also accumulate their body values into an object.
+When any loop is found is found within an object expression,
+its body value is spread into the containing object.
+
+<Playground>
+object  := {a: 1, b: 2, c: 3}
+doubled := {
+  for key in object
+    [key]: 2 * object[key]
+}
+</Playground>
+
+The loop can exist anywhere a property is expected.
+It can be freely mixed with other object properties.
+
+<Playground>
+rateLimits := {
+  admin: Infinity,
+  for user of users:
+    [user.name]: getRemainingLimit(user)
+}
+</Playground>
+
 ### Infinite Loop
 
 <Playground>

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1940,7 +1940,7 @@ max := for max item of array
 ### Object Comprehensions
 
 Loops can also accumulate their body values into an object.
-When any loop is found is found within an object expression,
+When any loop is found is found within a braced object expression,
 its body value is spread into the containing object.
 
 <Playground>
@@ -1951,13 +1951,22 @@ doubled := {
 }
 </Playground>
 
+<Playground>
+i .= 1
+squares := {
+  do
+    [i]: i * i
+  while i++ < 10
+}
+</Playground>
+
 The loop can exist anywhere a property is expected.
 It can be freely mixed with other object properties.
 
 <Playground>
 rateLimits := {
   admin: Infinity,
-  for user of users:
+  for user of users
     [user.name]: getRemainingLimit(user)
 }
 </Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3284,20 +3284,6 @@ ObjectLiteral
   BracedObjectLiteral
   NestedImplicitObjectLiteral
   InlineObjectLiteral
-  ObjectComprehension
-
-ObjectComprehension
-  OpenBrace __ "for" _ Identifier:id _ "of" _ Expression:exp __ ObjectComprehensionProps:props __ CloseBrace ->
-    return ["(()=>{const _results = {};\n",
-             "for (const ", id, " of ", exp, ") {\n",
-             "Object.assign(_results, {\n",
-             props, "\n",
-             "})}; return _results})()"
-           ]
-
-ObjectComprehensionProps
-  (ComputedPropertyName __ ":" __ Expression __)+ ->
-    return $0.map(entry => entry.concat([","]))
 
 BracedObjectLiteral
   OpenBrace:open AllowAll ( BracedObjectLiteralContent __ CloseBrace )? RestoreAll ->
@@ -3314,7 +3300,7 @@ BracedObjectLiteral
 BracedObjectLiteralContent
   # Allow unnested comma-separated properties on first line, optionally
   # followed by nested comma-separated properties on further lines
-  ( PropertyDefinition ObjectPropertyDelimiter )*:line NestedPropertyDefinitions?:nested ->
+  ( ObjectPropLine )*:line NestedPropertyDefinitions?:nested ->
     line = line.flatMap(([prop, delim]) => {
       // Allow each prop to be a single Property object or an array of such
       prop = Array.isArray(prop) ? prop : [prop]
@@ -3329,7 +3315,7 @@ BracedObjectLiteralContent
     })
     return line.concat(nested || [])
   # As a backup, allow for arbitrary untracked indentation
-  ( __ PropertyDefinition ObjectPropertyDelimiter )+ ->
+  ( __ ObjectPropLine )+ ->
     return $0.flatMap(([ws, prop, delim]) => {
       // Allow each prop to be a single Property object or an array of such
       prop = Array.isArray(prop) ? prop : [prop]
@@ -3343,6 +3329,14 @@ BracedObjectLiteralContent
       }
       return [...prop.slice(0, prop.length-1), last]
     })
+
+
+ObjectPropLine
+  PropertyDefinition ObjectPropertyDelimiter
+
+InsertSpread
+  "" ->
+    return { $loc, token: "..." }
 
 # NOTE: Nested implicit object literal starts with an indentation.
 # All properties can be spaced out and must have a colon.
@@ -3377,7 +3371,7 @@ NestedPropertyDefinitions
 
 NestedPropertyDefinition
   # TODO: This may be a little weird/ambiguous with single identifier shorthand
-  Nested:ws ( PropertyDefinition ObjectPropertyDelimiter )+:inlineProps ->
+  Nested:ws ( ObjectPropLine )+:inlineProps ->
     return inlineProps.flatMap( ([prop, delim], i) => {
       // Allow each prop to be a single Property object or an array of such
       if (!Array.isArray(prop)) prop = [prop]
@@ -3553,6 +3547,15 @@ PropertyDefinition
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->
   #  return prepend(ws, id)
+  InsertSpread:dots IterationExpression:exp ->
+    exp.statement.object = true
+    return {
+      type: "SpreadProperty",
+      children: [dots, exp],
+      names: exp.names,
+      dots,
+      value: exp,
+    }
 
 NamedProperty
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3424,7 +3424,6 @@ ObjectPropertyDelimiter
 PropertyDefinition
   # Safe to prioritize this over others as it's unlikely that a loop is matched unless the user intended to put the loop there. This is also required for giving braceless-do loop priority over interpreting do as a PropertyName
   _?:ws InsertDotDotDot:dots IterationExpression:exp ->
-    debugger
     let { statement } = exp
 
     // immutably set exp.statement.object = true

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3284,6 +3284,20 @@ ObjectLiteral
   BracedObjectLiteral
   NestedImplicitObjectLiteral
   InlineObjectLiteral
+  ObjectComprehension
+
+ObjectComprehension
+  OpenBrace __ "for" _ Identifier:id _ "of" _ Expression:exp __ ObjectComprehensionProps:props __ CloseBrace ->
+    return ["(()=>{const _results = {};\n",
+             "for (const ", id, " of ", exp, ") {\n",
+             "Object.assign(_results, {\n",
+             props, "\n",
+             "})}; return _results})()"
+           ]
+
+ObjectComprehensionProps
+  (ComputedPropertyName __ ":" __ Expression __)+ ->
+    return $0.map(entry => entry.concat([","]))
 
 BracedObjectLiteral
   OpenBrace:open AllowAll ( BracedObjectLiteralContent __ CloseBrace )? RestoreAll ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3300,7 +3300,7 @@ BracedObjectLiteral
 BracedObjectLiteralContent
   # Allow unnested comma-separated properties on first line, optionally
   # followed by nested comma-separated properties on further lines
-  ( ObjectPropLine )*:line NestedPropertyDefinitions?:nested ->
+  ( PropertyDefinition ObjectPropertyDelimiter )*:line NestedPropertyDefinitions?:nested ->
     line = line.flatMap(([prop, delim]) => {
       // Allow each prop to be a single Property object or an array of such
       prop = Array.isArray(prop) ? prop : [prop]
@@ -3315,7 +3315,7 @@ BracedObjectLiteralContent
     })
     return line.concat(nested || [])
   # As a backup, allow for arbitrary untracked indentation
-  ( __ ObjectPropLine )+ ->
+  ( __ PropertyDefinition ObjectPropertyDelimiter )+ ->
     return $0.flatMap(([ws, prop, delim]) => {
       // Allow each prop to be a single Property object or an array of such
       prop = Array.isArray(prop) ? prop : [prop]
@@ -3329,14 +3329,6 @@ BracedObjectLiteralContent
       }
       return [...prop.slice(0, prop.length-1), last]
     })
-
-
-ObjectPropLine
-  PropertyDefinition ObjectPropertyDelimiter
-
-InsertSpread
-  "" ->
-    return { $loc, token: "..." }
 
 # NOTE: Nested implicit object literal starts with an indentation.
 # All properties can be spaced out and must have a colon.
@@ -3371,7 +3363,7 @@ NestedPropertyDefinitions
 
 NestedPropertyDefinition
   # TODO: This may be a little weird/ambiguous with single identifier shorthand
-  Nested:ws ( ObjectPropLine )+:inlineProps ->
+  Nested:ws ( PropertyDefinition ObjectPropertyDelimiter )+:inlineProps ->
     return inlineProps.flatMap( ([prop, delim], i) => {
       // Allow each prop to be a single Property object or an array of such
       if (!Array.isArray(prop)) prop = [prop]
@@ -3547,7 +3539,7 @@ PropertyDefinition
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->
   #  return prepend(ws, id)
-  InsertSpread:dots IterationExpression:exp ->
+  InsertDotDotDot:dots IterationExpression:exp ->
     exp.statement.object = true
     return {
       type: "SpreadProperty",
@@ -6468,6 +6460,10 @@ DotDotDot
   "..." ->
     return { $loc, token: $1 }
   "…" ->
+    return { $loc, token: "..." }
+
+InsertDotDotDot
+  "" ->
     return { $loc, token: "..." }
 
 DoubleColon

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3422,6 +3422,34 @@ ObjectPropertyDelimiter
 # https://262.ecma-international.org/#prod-PropertyDefinition
 # NOTE: Must start on same line
 PropertyDefinition
+  # Safe to prioritize this over others as it's unlikely that a loop is matched unless the user intended to put the loop there. This is also required for giving braceless-do loop priority over interpreting do as a PropertyName
+  _?:ws InsertDotDotDot:dots IterationExpression:exp ->
+    debugger
+    let { statement } = exp
+
+    // immutably set exp.statement.object = true
+    statement = { ...statement, object: true }
+    exp = {
+      ...exp,
+      statement,
+      children: exp.children.map(($) => $ === exp.statement ? statement : $),
+    }
+
+    const children = [ws, dots, exp]
+    if (statement.reduction) {
+      children.unshift({
+        type: "Error",
+        message: "Reduction loops are forbidden in object literals",
+      })
+    }
+
+    return {
+      type: "SpreadProperty",
+      children,
+      names: exp.names,
+      dots,
+      value: exp,
+    }
   _?:ws NamedProperty:prop ->
     return prepend(ws, prop)
 
@@ -3539,32 +3567,6 @@ PropertyDefinition
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->
   #  return prepend(ws, id)
-  _?:ws InsertDotDotDot:dots IterationExpression:exp ->
-    let { statement } = exp
-
-    // immutably set exp.statement.object = true
-    statement = { ...statement, object: true }
-    exp = {
-      ...exp,
-      statement,
-      children: exp.children.map(($) => $ === exp.statement ? statement : $),
-    }
-
-    const children = [ws, dots, exp]
-    if (statement.reduction) {
-      children.unshift({
-        type: "Error",
-        message: "Reduction loops are forbidden in object literals",
-      })
-    }
-
-    return {
-      type: "SpreadProperty",
-      children,
-      names: exp.names,
-      dots,
-      value: exp,
-    }
 
 
 NamedProperty

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3539,7 +3539,7 @@ PropertyDefinition
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->
   #  return prepend(ws, id)
-  InsertDotDotDot:dots IterationExpression:exp ->
+  _?:ws InsertDotDotDot:dots IterationExpression:exp ->
     let { statement } = exp
 
     // immutably set exp.statement.object = true
@@ -3550,7 +3550,7 @@ PropertyDefinition
       children: exp.children.map(($) => $ === exp.statement ? statement : $),
     }
 
-    const children = [dots, exp]
+    const children = [ws, dots, exp]
     if (statement.reduction) {
       children.unshift({
         type: "Error",
@@ -3565,6 +3565,7 @@ PropertyDefinition
       dots,
       value: exp,
     }
+
 
 NamedProperty
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3422,9 +3422,16 @@ ObjectPropertyDelimiter
 # https://262.ecma-international.org/#prod-PropertyDefinition
 # NOTE: Must start on same line
 PropertyDefinition
-  # Safe to prioritize this over others as it's unlikely that a loop is matched unless the user intended to put the loop there. This is also required for giving braceless-do loop priority over interpreting do as a PropertyName
+  # NOTE: This needs to be above NamedProperty so that
+  # a `do` block doesn't get treated as {do} property
   _?:ws InsertDotDotDot:dots IterationExpression:exp ->
     let { statement } = exp
+    // Treat empty-bodied `do` and `loop` (which require no expression)
+    // as keys instead of iterations
+    if (exp.block.implicit &&
+        (statement.type === "DoStatement" || statement.subtype === "loop")) {
+      return $skip
+    }
 
     // immutably set exp.statement.object = true
     statement = { ...statement, object: true }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3540,10 +3540,27 @@ PropertyDefinition
   #_?:ws IdentifierReference:id ->
   #  return prepend(ws, id)
   InsertDotDotDot:dots IterationExpression:exp ->
-    exp.statement.object = true
+    let { statement } = exp
+
+    // immutably set exp.statement.object = true
+    statement = { ...statement, object: true }
+    exp = {
+      ...exp,
+      statement,
+      children: exp.children.map(($) => $ === exp.statement ? statement : $),
+    }
+
+    const children = [dots, exp]
+    if (statement.reduction) {
+      children.unshift({
+        type: "Error",
+        message: "Reduction loops are forbidden in object literals",
+      })
+    }
+
     return {
       type: "SpreadProperty",
-      children: [dots, exp],
+      children,
       names: exp.names,
       dots,
       value: exp,

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -640,6 +640,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
   { resultsRef, block } := statement
 
   reduction := statement.type is "ForStatement" and statement.reduction
+
   decl: "const" | "let" .= reduction ? "let" : "const"
   if statement.type is "IterationStatement" or statement.type is "ForStatement"
     if processBreakContinueWith statement
@@ -661,6 +662,8 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
     bindings: []
   }
 
+  object := statement.type is "ForStatement" and statement.object
+
   if reduction
     declaration.children.push "=" +
       switch reduction.subtype
@@ -670,6 +673,8 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
         when "max" then "-Infinity"
         when "product" then "1"
         else "0"
+  else if object
+    declaration.children.push "={}"
   else
     // Assign [] directly only in const case, so TypeScript can better infer
     if decl is "const"
@@ -684,6 +689,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
       return declaration
     unless block.empty
       assignResults block, (node) =>
+        return [ "Object.assign(", resultsRef, ",", node, ")" ] if object
         return [ resultsRef, ".push(", node, ")" ] unless reduction
         switch reduction.subtype
           when "some"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -640,7 +640,6 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
   { resultsRef, block } := statement
 
   reduction := statement.type is "ForStatement" and statement.reduction
-
   decl: "const" | "let" .= reduction ? "let" : "const"
   if statement.type is "IterationStatement" or statement.type is "ForStatement"
     if processBreakContinueWith statement
@@ -663,7 +662,6 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
   }
 
   object := statement.type is "ForStatement" and statement.object
-
   if reduction
     declaration.children.push "=" +
       switch reduction.subtype

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -661,7 +661,6 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
     bindings: []
   }
 
-  object := statement.type is "ForStatement" and statement.object
   if reduction
     declaration.children.push "=" +
       switch reduction.subtype
@@ -671,7 +670,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
         when "max" then "-Infinity"
         when "product" then "1"
         else "0"
-  else if object
+  else if statement.object
     declaration.children.push "={}"
   else
     // Assign [] directly only in const case, so TypeScript can better infer
@@ -687,7 +686,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
       return declaration
     unless block.empty
       assignResults block, (node) =>
-        return [ "Object.assign(", resultsRef, ",", node, ")" ] if object
+        return [ "Object.assign(", resultsRef, ",", node, ")" ] if statement.object
         return [ resultsRef, ".push(", node, ")" ] unless reduction
         switch reduction.subtype
           when "some"

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -2,71 +2,117 @@
 
 describe "object comprehensions", ->
   testCase """
-    1
+    basic
     ---
-    { 
-    for x of [1, 2, 3]
-    [x]:  2 * x
-    [x * 2]: 4 * x
+    {
+      for x of [1, 2, 3]
+        [x]:  2 * x
+        [x * 2]: 4 * x
     }
     ---
-    (()=>{const _results = {};
-    for (const x of [1, 2, 3]) {
-    Object.assign(_results, {
-    [x]:  2 * x
-    ,[x * 2]: 4 * x
-    ,
-    })}; return _results})()
+    ({
+      ...(()=>{const results={};for (const x of [1, 2, 3]) {
+        Object.assign(results,({[x]:  2 * x,
+        [x * 2]: 4 * x}))
+      }return results})()
+    })
+  """
+
+  testCase """
+    with other props
+    ---
+    {
+      a: 'a prop'
+      for x of [1, 2, 3]
+        [x]:  2 * x
+        [x * 2]: 4 * x
+      b: 'b prop'
+    }
+    ---
+    ({
+      a: 'a prop',
+      ...(()=>{const results={};for (const x of [1, 2, 3]) {
+        Object.assign(results,({[x]:  2 * x,
+        [x * 2]: 4 * x}))
+      }return results})(),
+      b: 'b prop'
+    })
+  """
+
+  testCase """
+    mixed trailing commas
+    ---
+    {
+      a1: 'a1 prop'
+      a2: 'a2 prop',
+      for x of [1, 2, 3]
+        [x]:  2 * x
+        [x * 2]: 4 * x,
+      b1: 'b1 prop'
+      b2: 'b2 prop'
+    }
+    ---
+    ({
+      a1: 'a1 prop',
+      a2: 'a2 prop',
+      ...(()=>{const results={};for (const x of [1, 2, 3]) {
+        Object.assign(results,({[x]:  2 * x,
+        [x * 2]: 4 * x,}))
+      }return results})(),
+      b1: 'b1 prop',
+      b2: 'b2 prop'
+    })
+  """
+
+  testCase """
+    indentation separates comprehension props from object props
+    ---
+    {
+      [a]: 'a computed prop'
+      for x of [1, 2, 3]
+        [x]:  2 * x
+        [x * 2]: 4 * x
+      [b]: 'b computed prop'
+    }
+    ---
+    ({
+      [a]: 'a computed prop',
+      ...(()=>{const results={};for (const x of [1, 2, 3]) {
+        Object.assign(results,({[x]:  2 * x,
+        [x * 2]: 4 * x}))
+      }return results})(),
+      [b]: 'b computed prop'
+    })
   """
 
   testCase """
     scoping
     ---
-    { 
-    for _results of [1]
-    [_results]:  2 * _results
-    [_results * 2]: 4 * _results
+    {
+      for results of [1]
+        [results]:  2 * x
     }
     ---
-    (()=>{const _results = {};
-    for (const _results of [1]) {
-    Object.assign(_results, {
-    [_results]:  2 * _results
-    ,[_results * 2]: 4 * _results
-    ,
-    })}; return _results})()
+    ({
+      ...(()=>{const results1={};for (const results of [1]) {
+        Object.assign(results1,({[results]:  2 * x}))
+      }return results1})()
+    })
   """
 
   testCase """
-    spacing 1
+    loop body with additional statements
     ---
-    { for x of [1]
-    [x]:  2 * x
-    [x * 2]: 4 * x
+    {
+      for x of [1]
+        foo bar
+        [x]:  2 * x
     }
     ---
-    (()=>{const _results = {};
-    for (const x of [1]) {
-    Object.assign(_results, {
-    [x]:  2 * x
-    ,[x * 2]: 4 * x
-    ,
-    })}; return _results})()
-  """
-
-  testCase """
-    spacing 2: indentation
-    ---
-    { for x of [1]
-      [x]:  2 * x
-      [x * 2]: 4 * x
-    }
-    ---
-    (()=>{const _results = {};
-    for (const x of [1]) {
-    Object.assign(_results, {
-    [x]:  2 * x
-    ,[x * 2]: 4 * x
-    ,
-    })}; return _results})()
+    ({
+      ...(()=>{const results={};for (const x of [1]) {
+        foo(bar)
+        Object.assign(results,({[x]:  2 * x}))
+      }return results})()
+    })
   """

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -1,4 +1,4 @@
-{ testCase } from ./helper.civet
+{ testCase, throws } from ./helper.civet
 
 describe "object comprehensions", ->
   testCase """
@@ -224,4 +224,43 @@ describe "object comprehensions", ->
     o := {do [x]: f(x) while(predicate(x)) }
     ---
     const o = {...(()=>{const results={};do { Object.assign(results,({[x]: f(x)})) } while(predicate(x))return results})() }
+  """
+
+  testCase """
+    empty loop is allowed
+    ---
+    {
+      for x of [{a: b}, {c:d}]
+    }
+    ---
+    ({
+      ...(()=>{const results={};for (const x of [{a: b}, {c:d}]) {Object.assign(results,x)}return results})()
+    })
+  """
+
+  testCase """
+    simple expressionization is allowed
+    ---
+    {
+      for x of [1, 2, 3]
+        f(x)
+    }
+    ---
+    ({
+      ...(()=>{const results={};for (const x of [1, 2, 3]) {
+        Object.assign(results,f(x))
+      }return results})()
+    })
+  """
+
+  throws """
+    for reductions are disallowed
+    ---
+    {
+      a: b,
+      for count x of [1, 2, 3]
+        x % 2 == 0
+    }
+    ---
+    ParseErrors: unknown:3:3 Reduction loops are forbidden in object literals
   """

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -1,0 +1,72 @@
+{ testCase } from ./helper.civet
+
+describe "object comprehensions", ->
+  testCase """
+    1
+    ---
+    { 
+    for x of [1, 2, 3]
+    [x]:  2 * x
+    [x * 2]: 4 * x
+    }
+    ---
+    (()=>{const _results = {};
+    for (const x of [1, 2, 3]) {
+    Object.assign(_results, {
+    [x]:  2 * x
+    ,[x * 2]: 4 * x
+    ,
+    })}; return _results})()
+  """
+
+  testCase """
+    scoping
+    ---
+    { 
+    for _results of [1]
+    [_results]:  2 * _results
+    [_results * 2]: 4 * _results
+    }
+    ---
+    (()=>{const _results = {};
+    for (const _results of [1]) {
+    Object.assign(_results, {
+    [_results]:  2 * _results
+    ,[_results * 2]: 4 * _results
+    ,
+    })}; return _results})()
+  """
+
+  testCase """
+    spacing 1
+    ---
+    { for x of [1]
+    [x]:  2 * x
+    [x * 2]: 4 * x
+    }
+    ---
+    (()=>{const _results = {};
+    for (const x of [1]) {
+    Object.assign(_results, {
+    [x]:  2 * x
+    ,[x * 2]: 4 * x
+    ,
+    })}; return _results})()
+  """
+
+  testCase """
+    spacing 2: indentation
+    ---
+    { for x of [1]
+      [x]:  2 * x
+      [x * 2]: 4 * x
+    }
+    ---
+    (()=>{const _results = {};
+    for (const x of [1]) {
+    Object.assign(_results, {
+    [x]:  2 * x
+    ,[x * 2]: 4 * x
+    ,
+    })}; return _results})()
+  """

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -219,11 +219,50 @@ describe "object comprehensions", ->
   """
 
   testCase """
-    do while object comprehension
+    do...while object comprehension
     ---
     o := {do [x]: f(x) while(predicate(x)) }
     ---
     const o = {...(()=>{const results={};do { Object.assign(results,({[x]: f(x)})) } while(predicate(x))return results})() }
+  """
+
+  testCase """
+    do...while multi-line
+    ---
+    i .= 1
+    squares := {
+      do {
+        [i]: i * i
+      } while i++ < 10
+    }
+    ---
+    let i = 1
+    const squares = {
+      ...(()=>{const results={};do {
+        Object.assign(results,({[i]: i * i}))
+      } while (i++ < 10)return results})()
+    }
+  """
+
+  testCase """
+    "loop"
+    ---
+    o := {
+      a: "a prop",
+      loop
+        break if predicate(i)
+        i++
+        [i]: f(i)
+    }
+    ---
+    const o = {
+      a: "a prop",
+      ...(()=>{const results={};while(true) {
+        if (predicate(i)) { break }
+        i++
+        Object.assign(results,({[i]: f(i)}))
+      }return results})()
+    }
   """
 
   testCase """

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -101,7 +101,7 @@ describe "object comprehensions", ->
   """
 
   testCase """
-    loop body with additional statements
+    loop body with additional statements: single prop
     ---
     {
       for x of [1]
@@ -115,4 +115,113 @@ describe "object comprehensions", ->
         Object.assign(results,({[x]:  2 * x}))
       }return results})()
     })
+  """
+
+  testCase """
+    loop body with additional statements: multi prop style 1
+    ---
+    {
+      for x of [1]
+        foo bar
+        {
+          [x]:  2 * x
+          [2*x]: 4 * x
+        }
+    }
+    ---
+    ({
+      ...(()=>{const results={};for (const x of [1]) {
+        foo(bar)
+        Object.assign(results,({
+          [x]:  2 * x,
+          [2*x]: 4 * x
+        }))
+      }return results})()
+    })
+  """
+
+  testCase """
+    loop body with additional statements: multi prop style 2
+    ---
+    {
+      for x of [1]
+        foo bar
+        [x]:  2 * x
+        [2*x]: 4 * x
+    }
+    ---
+    ({
+      ...(()=>{const results={};for (const x of [1]) {
+        foo(bar)
+        Object.assign(results,({[x]:  2 * x,
+        [2*x]: 4 * x}))
+      }return results})()
+    })
+  """
+
+  testCase """
+    on first line
+    ---
+    {for x of [1]
+      [x]:  2 * x
+      [2*x]: 4 * x }
+    ---
+    ({...(()=>{const results={};for (const x of [1]) {
+      Object.assign(results,({[x]:  2 * x,
+      [2*x]: 4 * x}))
+    }return results})() })
+  """
+
+  testCase """
+    on first line with other props
+    ---
+    {a: "a prop",for x of [1]
+      [x]:  2 * x
+      [2*x]: 4 * x }
+    ---
+    ({a: "a prop",...(()=>{const results={};for (const x of [1]) {
+      Object.assign(results,({[x]:  2 * x,
+      [2*x]: 4 * x}))
+    }return results})() })
+  """
+
+  testCase """
+    single line
+    ---
+    o := {for x of [1] [x]: 2 * x }
+    ---
+    const o = {...(()=>{const results={};for (const x of [1]({[x]: 2 * x})) {Object.assign(results,x)}return results})() }
+  """
+
+  testCase """
+
+    non-comprehension loop
+    ---
+    o := {...for x of [1] [x]: 2 * x }
+    ---
+    const o = {...(()=>{const results=[];for (const x of [1]({[x]: 2 * x})) {results.push(x)}return results})() }
+  """
+
+  testCase """
+    while object comprehension
+    ---
+    o := {while(predicate(x)) [x]: f(x)}
+    ---
+    const o = {...(()=>{const results={};while(predicate(x)) Object.assign(results,({[x]: f(x)}));return results})()}
+  """
+
+  testCase """
+    non-comprehension while loop
+    ---
+    o := {...while(predicate(x)) [x]: f(x)}
+    ---
+    const o = {...(()=>{const results=[];while(predicate(x)) results.push(({[x]: f(x)}));return results})()}
+  """
+
+  testCase """
+    do while object comprehension
+    ---
+    o := {do [x]: f(x) while(predicate(x)) }
+    ---
+    const o = {...(()=>{const results={};do { Object.assign(results,({[x]: f(x)})) } while(predicate(x))return results})() }
   """

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -175,11 +175,11 @@ describe "object comprehensions", ->
   testCase """
     on first line with other props
     ---
-    {a: "a prop",for x of [1]
+    { a: "a prop", for x of [1]
       [x]:  2 * x
       [2*x]: 4 * x }
     ---
-    ({a: "a prop",...(()=>{const results={};for (const x of [1]) {
+    ({ a: "a prop", ...(()=>{const results={};for (const x of [1]) {
       Object.assign(results,({[x]:  2 * x,
       [2*x]: 4 * x}))
     }return results})() })
@@ -205,9 +205,9 @@ describe "object comprehensions", ->
   testCase """
     while object comprehension
     ---
-    o := {while(predicate(x)) [x]: f(x)}
+    o := { while(predicate(x)) [x]: f(x)}
     ---
-    const o = {...(()=>{const results={};while(predicate(x)) Object.assign(results,({[x]: f(x)}));return results})()}
+    const o = { ...(()=>{const results={};while(predicate(x)) Object.assign(results,({[x]: f(x)}));return results})()}
   """
 
   testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -1408,9 +1408,9 @@ describe "object", ->
     testCase """
       with reserved word keys
       ---
-      state.{and,await,break,case,catch,class,const,continue,debugger,default,delete,else,enum,export,extends}
+      state.{and,await,break,case,catch,class,const,continue,debugger,default,delete,do,else,enum,export,extends}
       ---
-      ({and:state.and,await:state.await,break:state.break,case:state.case,catch:state.catch,class:state.class,const:state.const,continue:state.continue,debugger:state.debugger,default:state.default,delete:state.delete,else:state.else,enum:state.enum,export:state.export,extends:state.extends})
+      ({and:state.and,await:state.await,break:state.break,case:state.case,catch:state.catch,class:state.class,const:state.const,continue:state.continue,debugger:state.debugger,default:state.default,delete:state.delete,do:state.do,else:state.else,enum:state.enum,export:state.export,extends:state.extends})
     """
 
     testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -1408,9 +1408,9 @@ describe "object", ->
     testCase """
       with reserved word keys
       ---
-      state.{and,await,break,case,catch,class,const,continue,debugger,default,delete,do,else,enum,export,extends}
+      state.{and,await,break,case,catch,class,const,continue,debugger,default,delete,else,enum,export,extends}
       ---
-      ({and:state.and,await:state.await,break:state.break,case:state.case,catch:state.catch,class:state.class,const:state.const,continue:state.continue,debugger:state.debugger,default:state.default,delete:state.delete,do:state.do,else:state.else,enum:state.enum,export:state.export,extends:state.extends})
+      ({and:state.and,await:state.await,break:state.break,case:state.case,catch:state.catch,class:state.class,const:state.const,continue:state.continue,debugger:state.debugger,default:state.default,delete:state.delete,else:state.else,enum:state.enum,export:state.export,extends:state.extends})
     """
 
     testCase """


### PR DESCRIPTION
Work-in-progress to address the "object comprehension" part of issue #439.

Implementation rationale is that whenever  the following is seen:
```
{ 
  for identifier of expression 
    [a] : b
    [c]:  d
    //...
}
```

Then it should be recognized as object comprehension (instead of being recognized as a block containing a ForOf statement).

This works because `for identifier of expression` being followed by a computed property key-value pair is invalid syntax in js.

I need some guidance:

### 1

My rules recognize the syntax but it isn't prioritized over "block containing a for-of" rule when the [a] : b are indented. This results in the following input-output pair:

```
{ for x of [1, 2, 3]
  [x]:  2 * x
  [x * 2]: 4 * x
}
// Becomes:
 for (const x of [1, 2, 3]) {
  ({[x]:  2 * x,
  [x * 2]: 4 * x})
}
}

```

This is also a test (last one) which fails. If I remove the leading whitespace, then it works fine

```
{ for x of [1, 2, 3]
  [x]:  2 * x
  [x * 2]: 4 * x
}
// Becomes:
(()=>{const _results = {};
  for (const x of [1, 2, 3]) {
    Object.assign(_results, {
      [x]:  2 * x,
      [x * 2]: 4 * x
  })}; 
  return _results
})()
```

Which provides the output `{ '1': 2, '2': 4, '3': 6, '4': 8, '6': 12 }` if you run it. Note that the indentation in this output has been done by me manually for readability.

### 2

How should I deal with the indentation in output? I'm introduce an IIFE, a for loop, and an `Object.assign`. That's 3 extra levels of nesting. Should I just add two spaces for each level?

### 3

The second test case transpiles but it's incorrect because the inner `_results` shadows the outer `_results` and I need to use the variable I introduce in the inner scope. How do I create a variable that's guaranteed to not conflict with the inner scope? 

### 4

I've noticed that my code differs from the existing code in following ways:

1. Most rules return an object with `type`
2. There's some way to deal with source locations so that it's useful for source mapping

I'll address these in future commits. Tell me if there are other conventions that I should learn about!