### PR TITLE
Fix `for key: T, value in` loop to define `value` using typed `key`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1758,9 +1758,8 @@ for own key in object
 You can add types to the declarations (unlike TypeScript):
 
 <Playground>
-for var key: string, value: unknown in object
-  console.log key, JSON.stringify value
-key ?= "no last key"
+for key: keyof typeof object, value in object
+  process key, value
 </Playground>
 
 ### Loop Expressions

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -338,17 +338,18 @@ function processForInOf($0: [
       children: [declaration, " = ", itemRef]
       names: declaration.names
     }, ";"]
-    pattern = itemRef
     declaration =
       type: "ForDeclaration"
       binding: {
         type: "Binding"
-        pattern
-        children: [ pattern ]
+        pattern: itemRef
+        children: [ itemRef ]
         names: []
       }
       children: ["const ", itemRef]
       names: []
+    unless pattern.type is "Identifier"
+      pattern = itemRef
 
   unless declaration2 or own
     return {
@@ -392,7 +393,12 @@ function processForInOf($0: [
       if decl2
         blockPrefix.push ["", {
           type: "Declaration"
-          children: [trimFirstSpace(ws2), decl2, " = ", trimFirstSpace(expRef), "[", trimFirstSpace(pattern), "]"]
+          children: [
+            trimFirstSpace(ws2), decl2, " = "
+            trimFirstSpace(expRef)
+            "[", trimFirstSpace(pattern), "]"
+          ]
+          decl: decl2
           names: decl2.names
         }, ";"]
 

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -51,8 +51,19 @@ describe "[TS] for", ->
     for x: T, y in z
       console.log x, y
     ---
-    for (const key in z) {const x: T = key;const y = z[key];
+    for (const key in z) {const x: T = key;const y = z[x];
       console.log(x, y)
+    }
+  """
+
+  testCase """
+    destructuring for..in with two declarations
+    ---
+    for [a, b]: T, value in z
+      console.log x
+    ---
+    for (const key in z) {const [a, b]: T = key;const value = z[key];
+      console.log(x)
     }
   """
 


### PR DESCRIPTION
Helps with #1562

Before:

```js
for x: T, y in z
  console.log x, y
---
for (const key in z) {const x: T = key;const y = z[key];
  console.log(x, y)
}
```

After:

```js
for x: T, y in z
  console.log x, y
---
for (const key in z) {const x: T = key;const y = z[x];
  console.log(x, y)
}
```

This allows us to manually fix the type of the key to `keyof typeof z`, for example, which helps get the right type for `y`.