### PR TITLE
Playground buttons to copy input or output

### DIFF
--- a/civet.dev/.vitepress/components/PlaygroundFull.vue
+++ b/civet.dev/.vitepress/components/PlaygroundFull.vue
@@ -137,7 +137,7 @@ function clear() {
 <style scoped>
 .buttons {
   display: flex;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: center;
   flex-wrap: wrap;
   margin: 15px 0;


### PR DESCRIPTION
Follow up to #1569 to
* Buttons for copying both input or output to clipboard
* Show buttons in all cases, not just when it's long
* Improve looks somewhat: `copy` text wasn't obviously a button; now it's a clipboard icon, with feedback via a green checkmark or a red X

![image](https://github.com/user-attachments/assets/e8456a4e-0083-4601-b260-afabacb7d6bb)
