### PR TITLE
Fix modulo access with placeholders: `x[& %]`

### DIFF
--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -33,8 +33,8 @@ declareHelper := {
       ts ": <T>(object: T, prop: PropertyKey) => boolean"
       " = ({}.constructor"
       asAny
-      ").hasOwn;\n"
-    ]]
+      ").hasOwn"
+    ], ";\n"]
   is(isRef): void
     // Thanks to @thetarnav for help with this TypeScript magic.
     // If the second argument is more general, narrow it.
@@ -49,8 +49,7 @@ declareHelper := {
       ts ": { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B }"
       " = Object.is"
       asAny
-      ";\n"
-    ]]
+    ], ";\n"]
   /**
    * Array length check with type guard.
    * From tlgreg https://discord.com/channels/933472021310996512/1012166187196629113/1157386582546976873
@@ -66,8 +65,10 @@ declareHelper := {
     ]]
   rslice(rsliceRef): void
     RSliceable := makeRef "RSliceable"
-    state.prelude.push ["", [
+    state.prelude.push ["",
       ts [ "type ", RSliceable, "<R> = string | {length: number; slice(start: number, end: number): {reverse(): R}}\n" ]
+    ]
+    state.prelude.push ["", [
       preludeVar
       rsliceRef
       ts [ ": <R, T extends string | ", RSliceable, "<R>>(a: T, start?: number, end?: number) => T extends string ? string : T extends ", RSliceable, "<infer R> ? R : never" ]
@@ -84,25 +85,26 @@ declareHelper := {
       "  } else {\n"
       "    return a.slice(end, start + 1).reverse()\n"
       "  }\n"
-      "});\n"
-    ]]
+      "})"
+    ], ";\n"]
   div(divRef): void
     state.prelude.push ["", [ // [indent, statement]
       preludeVar
       divRef
       ts ": (a: number, b: number) => number"
-      " = (a, b) => Math.floor(a / b);\n"
-    ]]
+      " = (a, b) => Math.floor(a / b)"
+    ], ";\n"]
   modulo(moduloRef): void
     state.prelude.push ["", [ // [indent, statement]
       preludeVar
       moduloRef
       ts ": (a: number, b: number) => number"
-      " = (a, b) => (a % b + b) % b;\n"
-    ]]
+      " = (a, b) => (a % b + b) % b"
+    ], ";\n"]
   Falsy(FalsyRef): void
     state.prelude.push ["", // [indent, statement]
-      ts ["type ", FalsyRef, " = false | 0 | '' | 0n | null | undefined;\n"]
+      ts ["type ", FalsyRef, " = false | 0 | '' | 0n | null | undefined"]
+      ";\n"
     ]
   xor(xorRef): void
     Falsy := getHelperRef "Falsy"
@@ -118,8 +120,7 @@ declareHelper := {
       ]
       " = (a, b) => (a ? !b && a : b)"
       asAny
-      ";\n"
-    ]]
+    ], ";\n"]
   xnor(xnorRef): void
     Falsy := getHelperRef "Falsy"
     state.prelude.push ["", [ // [indent, statement]
@@ -133,8 +134,7 @@ declareHelper := {
       ]
       " = (a, b) => (a ? b : !b || a)"
       asAny
-      ";\n"
-    ]]
+    ], ";\n"]
   concatAssign(ref): void
     state.prelude.push ["", [ // [indent, statement]
       preludeVar
@@ -142,10 +142,10 @@ declareHelper := {
       ts [
         ": <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A"
       ]
-      " = (lhs, rhs) => (((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs);\n"
-    ]]
+      " = (lhs, rhs) => (((rhs", asAny, ")?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs", asAny, ").push.apply(lhs, rhs", asAny, ") : (lhs", asAny, ").push(rhs), lhs)"
+    ], ";\n"]
   AutoPromise(ref): void
-    state.prelude.push [""
+    state.prelude.push ["",
       ts [ "type ", ref, "<T> = T extends Promise<unknown> ? T : Promise<T>" ]
       ";\n"
     ]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -660,26 +660,31 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
       assert.notEqual i, 0, "Index access must be preceded by an expression"
       prefix := i is 1 ? children[0] : children[<i]
       { ref, refAssignment } := maybeRefAssignment prefix
+      args := [
+        glob.children[<..<] // between "[" and "]" tokens
+        ","
+        [ " ", ref, ".length" ]
+      ]
       call := makeNode
         type: "CallExpression"
+        implicit: true
         children: [
           getHelperRef "modulo"
-          makeNode
+          makeNode {
             type: "Call"
+            args
             children:  [
               "("
-              ...glob.children[<..<] // between "[" and "]" tokens
-              ", "
-              ref
-              ".length"
+              args
               ")"
             ]
+          }
         ]
       return processCallMemberExpression({  // in case there are more
         ...node
         children: [
           makeLeftHandSideExpression refAssignment ?? prefix
-          {
+          makeNode {
             ...glob
             mod: false
             expression: call

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -148,6 +148,15 @@ describe "&. function block shorthand", ->
   """
 
   testCase """
+    modulo access
+    ---
+    'abc'[&%]
+    ---
+    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    $ => 'abc'[modulo($, 'abc'.length)]
+  """
+
+  testCase """
     kitchen sink
     ---
     x.map &.profile?.name?[0..2]

--- a/test/slice.civet
+++ b/test/slice.civet
@@ -247,7 +247,7 @@ describe "slice", ->
       ---
       x[a..>b] = c
       ---
-      ParseErrors: unknown:16:8 Call expression ending with Call is not a valid left-hand side
+      ParseErrors: unknown:16:7 Call expression ending with Call is not a valid left-hand side
       unknown:1:9 Slice range cannot be decreasing in assignment
     """
 


### PR DESCRIPTION
Fixes #1568

Also cleanup helpers' delimiters in statement tuples, to avoid unneeded ASI in some cases (including the added test).