### PR TITLE
Fix parenthesized `&` followed by type postfix

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2425,7 +2425,7 @@ FunctionExpression
       children: [ open, fn, close ],
       expression: fn,
     }
-  OpenParen:open __:ws1 !/\+\+|--|[\+\-&]\S/ BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
+  OpenParen:open __:ws1 !/\+\+|--|[\+\-&]\S/ !( Placeholder TypePostfix ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
     const refA = makeRef("a")
     const fn = makeAmpersandFunction({
       ref: refA,

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -1105,3 +1105,11 @@ describe "operator sections", ->
     ---
     const callback = (b => sum += /*num*/b)
   """
+
+  testCase """
+    & not left section
+    ---
+    (& as number) + 1
+    ---
+    $ => ($ as number) + 1
+  """


### PR DESCRIPTION
Fixes #1570

Placeholders followed by binary operators seem to already be correctly handled (because they're not valid expressions)