### PR TITLE
Fix parenthesized `&` followed by binary op

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2425,7 +2425,7 @@ FunctionExpression
       children: [ open, fn, close ],
       expression: fn,
     }
-  OpenParen:open __:ws1 !/\+\+|--|[\+\-&]\S/ !( Placeholder TypePostfix ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
+  OpenParen:open __:ws1 !/\+\+|--|[\+\-&]\S/ !( Placeholder ( TypePostfix / BinaryOpRHS ) ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
     const refA = makeRef("a")
     const fn = makeAmpersandFunction({
       ref: refA,

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -1107,9 +1107,19 @@ describe "operator sections", ->
   """
 
   testCase """
-    & not left section
+    & as not left section
     ---
     (& as number) + 1
     ---
     $ => ($ as number) + 1
+  """
+
+  testCase """
+    & binary not left section
+    ---
+    operator foo
+    (& foo 5) + 1
+    ---
+    ;
+    $ => (foo($, 5)) + 1
   """


### PR DESCRIPTION
Follow up to #1574

> Placeholders followed by binary operators seem to already be correctly handled (because they're not valid expressions)

Turns out I was wrong about this. Custom binary operators are at least one example.