### PR TITLE
Scientific numeric literals take priority over access

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6029,7 +6029,7 @@ DecimalBigIntegerLiteral
 # https://262.ecma-international.org/#prod-DecimalLiteral
 DecimalLiteral
   # NOTE: Not matching the dot as part of a number if it is followed by a valid JS identifier so that it will match as a property access
-  $( /(?:0|[1-9](?:_[0-9]|[0-9])*)(?=\.(?:\p{ID_Start}|[_$]))/ ) ->
+  $( /(?:0|[1-9](?:_[0-9]|[0-9])*)(?=\.(?:\p{ID_Start}|[_$]))/ ) !( "." ExponentPart ) ->
     // Insert an extra dot to make property access work
     return $1 + "."
   $( /(?:0|[1-9](?:_[0-9]|[0-9])*)(?:\.(?:[0-9](?:_[0-9]|[0-9])*))?/ ExponentPart? )

--- a/test/numbers.civet
+++ b/test/numbers.civet
@@ -103,10 +103,14 @@ describe "numbers", ->
     x = 1e2
     y = 1e-2
     z = 1e+2
+    w = 1.e2
+    n = 1.e-2
     ---
     x = 1e2
     y = 1e-2
     z = 1e+2
+    w = 1.e2
+    n = 1.e-2
   """
 
   testCase """


### PR DESCRIPTION
Fix the equivalent of https://github.com/jashkenas/coffeescript/issues/5469 by giving priority to `1.e1` as a number, not an access (`(1).e1`), as suggested by @STRd6.

Improves JavaScript compatibility.

Technically this is a breaking change, but it's also reasonably a bug fix.