### PR TITLE
Fix parenthesized `⧺` and `—` shorthands for `++` and `--`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2425,7 +2425,7 @@ FunctionExpression
       children: [ open, fn, close ],
       expression: fn,
     }
-  OpenParen:open __:ws1 !/\+\+|--|[\+\-&]\S/ !( Placeholder ( TypePostfix / BinaryOpRHS ) ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
+  OpenParen:open __:ws1 !/\+\+|--|⧺|—|[\+\-&]\S/ !( Placeholder ( TypePostfix / BinaryOpRHS ) ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
     const refA = makeRef("a")
     const fn = makeAmpersandFunction({
       ref: refA,

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -1083,6 +1083,20 @@ describe "operator sections", ->
   """
 
   testCase """
+    ++/-- without space isn't section
+    ---
+    (⧺a)
+    (—a)
+    (++a)
+    (--a)
+    ---
+    (++a);
+    (--a);
+    (++a);
+    (--a)
+  """
+
+  testCase """
     complex right section
     ---
     items.map ( + length * width)


### PR DESCRIPTION
Fixes #1583