### PR TITLE
Fix wrapping of braced objects in parentheses

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -820,9 +820,7 @@ FatArrowBody
   # NOTE: Skip expressionized statements, so they get braced instead
   !EOS !( _? ExpressionizedStatement ) NonPipelineExpression:exp !TrailingDeclaration !TrailingPipe !TrailingPostfix !SemicolonDelimiter ->
     // Ensure object literal is wrapped in parens
-    if (exp.type === "ObjectExpression") {
-      exp = makeLeftHandSideExpression(exp)
-    }
+    exp = makeExpressionStatement(exp)
     const expressions = [["", exp]]
     return {
       type: "BlockStatement",

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -274,7 +274,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   { expression } .= condition
 
   // Support for negated conditions built by unless/until
-  if {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression', expression: expression2}]} := expression
+  if {type: 'UnaryExpression', children: [['!'], {type: 'ParenthesizedExpression', expression: expression2}]} := expression
     expression = expression2
 
   processDeclarationCondition expression, condition.expression, s
@@ -298,7 +298,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
       children .= condition.children
       // For negated conditions, put conditions inside the negation
       if s.negated
-        unless condition.expression is like {type: 'UnaryExpression', children: ['!', {type: 'ParenthesizedExpression'}]}
+        unless condition.expression is like {type: 'UnaryExpression', children: [['!'], {type: 'ParenthesizedExpression'}]}
           throw new Error "Unsupported negated condition"
         { children } = condition.expression.children[1] as ParenthesizedExpression
       children.unshift "("

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -5,7 +5,7 @@ import type {
   ASTRef
   Binding
   BlockStatement
-  DeclarationStatement
+  Declaration
   ExpressionNode
   IfStatement
   Initializer
@@ -110,8 +110,8 @@ function processDeclarations(statements: StatementTuple[]): void
   // @ts-ignore
   gatherRecursiveAll statements, .type is "Declaration"
   // @ts-ignore
-  .forEach (statement: DeclarationStatement) =>
-    { bindings } := statement as DeclarationStatement
+  .forEach (statement: Declaration) =>
+    { bindings } := statement as Declaration
     bindings?.forEach (binding) =>
       { typeSuffix } := binding
       if typeSuffix and typeSuffix.optional and typeSuffix.t
@@ -194,7 +194,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
 function processDeclarationCondition(condition, rootCondition, parent: ASTNodeParent): void
   return unless condition.type is "DeclarationCondition"
 
-  { decl, bindings } := condition.declaration as DeclarationStatement
+  { decl, bindings } := condition.declaration as Declaration
   // TODO: Add support for `let` and `const` declarations with multiple bindings in conditions
   binding := bindings[0]
   { pattern, typeSuffix, initializer } .= binding

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -5,7 +5,7 @@ import type {
   BlockStatement
   BreakStatement
   CallExpression
-  DeclarationStatement
+  Declaration
   ForStatement
   FunctionNode
   IterationExpression
@@ -653,7 +653,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
       (s): s is BreakStatement => s.type is "BreakStatement" and not s.with,
       (s) => isFunction(s) or s.type is "IterationStatement")# is 0
 
-  declaration: DeclarationStatement := {
+  declaration: Declaration := {
     type: "Declaration"
     children: [decl, " ", resultsRef]
     decl

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -203,12 +203,17 @@ function negateCondition(condition)
   i := children.indexOf(expression)
   if i < 0
     throw new Error `Could not find expression in condition`
-  children[i] = expression =
+  pre := ["!"]
+  expression = makeLeftHandSideExpression expression
+  children[i] = expression = {
     type: "UnaryExpression"
     children: [
-      "!"
-      makeLeftHandSideExpression expression
+      pre
+      expression
     ]
+    pre
+    expression
+  }
   { ...condition, expression, children }
 
 /**
@@ -740,6 +745,8 @@ function makeExpressionStatement(expression: ASTNode): ASTNode
         [comma, makeExpressionStatement exp]
     ]
   else if expression?.type is "ObjectExpression" or
+          (expression?.type is "UnaryExpression" and not expression.pre?# and
+           expression.expression?.type is "ObjectExpression") or
           (expression?.type is "FunctionExpression" and not expression.id)
     makeLeftHandSideExpression expression
   else

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -20,7 +20,7 @@ import type {
   CatchClause
   ComptimeStatement
   Condition
-  DeclarationStatement
+  Declaration
   DoStatement
   ElseClause
   FinallyClause
@@ -459,7 +459,7 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
       block: emptyCatchBlock
 
   // else clause support
-  let hoistDec: DeclarationStatement?
+  let hoistDec: Declaration?
   if e
     c = c!  // absent catch clause would have been created above
     // `let ok = true` before try
@@ -1421,13 +1421,14 @@ function processProgram(root: BlockStatement): void
     createVarDecs(root, [])
   }
 
+  // REPL wants all top-level variables hoisted to outermost scope
+  processRepl root, rootIIFE if config.repl
+
+  // Automatic semicolon insertion
   processBlocks(statements)
 
   populateRefs(statements)
   adjustAtBindings(statements)
-
-  // REPL wants all top-level variables hoisted to outermost scope
-  processRepl root, rootIIFE if config.repl
 
   // Run synchronous versions of async steps in case we're in sync mode
   if getSync()
@@ -1447,7 +1448,11 @@ function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
     continue unless decl.names?# // skip 'let ref'
     if decl.parent is topBlock or decl.decl is "var"
       decl.children.shift() // remove const/let/var
-      root.expressions.splice i++, 0, ["", `var ${decl.names.join ','};`]
+      if decl.bindings.0?.pattern?.type is "ObjectBindingPattern"
+        // If first pattern is braced, need to wrap in parens
+        decl.children.unshift "("
+        decl.children.push ")"
+      root.expressions.splice i++, 0, ["", `var ${decl.names.join ','}`, ";"]
   // Hoist all function declarations, and hoist values when top-level
   for each func of gatherRecursive topBlock, .type is "FunctionExpression"
     if func.name and func.parent?.type is "BlockStatement" // declaration
@@ -1458,12 +1463,12 @@ function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
         func.parent = root
       else
         func.children.unshift func.name, "="
-        root.expressions.splice i++, 0, ["", `var ${func.name};`]
+        root.expressions.splice i++, 0, ["", `var ${func.name}`, ";"]
   // Hoist top-level class declarations (like `let`)
   for each classExp of gatherRecursiveWithinFunction topBlock, .type is "ClassExpression"
     if classExp.name and classExp.parent is topBlock or classExp.parent is like {type: "ReturnStatement", parent: ^topBlock}
       classExp.children.unshift classExp.name, "="
-      root.expressions.splice i++, 0, ["", `var ${classExp.name};`]
+      root.expressions.splice i++, 0, ["", `var ${classExp.name}`, ";"]
 
 function populateRefs(statements: ASTNode): void {
   const refNodes = gatherRecursive(statements, .type is "Ref")

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -736,6 +736,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
 // Wrap expression in parentheses to make into a statement when:
 // * object literal expression
 // * anonymous function expression
+// * unary suffix applied to above
 // * comma operators applied to above
 function makeExpressionStatement(expression: ASTNode): ASTNode
   if Array.isArray(expression) and expression[1]?[0]?[0]?[1]?.token is "," // CommaExpression
@@ -745,9 +746,10 @@ function makeExpressionStatement(expression: ASTNode): ASTNode
         [comma, makeExpressionStatement exp]
     ]
   else if expression?.type is "ObjectExpression" or
+          (expression?.type is "FunctionExpression" and not expression.id) or
           (expression?.type is "UnaryExpression" and not expression.pre?# and
-           expression.expression?.type is "ObjectExpression") or
-          (expression?.type is "FunctionExpression" and not expression.id)
+           expression.expression is not
+           makeExpressionStatement expression.expression)
     makeLeftHandSideExpression expression
   else
     expression

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -258,6 +258,9 @@ export type UnaryExpression
   type: "UnaryExpression"
   children: Children
   parent?: Parent
+  pre?: ASTNode[]
+  expression: ASTNode
+  post?: ASTNode
 
 export type Await
   type: "Await"
@@ -309,7 +312,7 @@ export type ParenthesizedExpression
   type: "ParenthesizedExpression"
   children: Children
   parent?: Parent
-  expression: ASTNode
+  expression: ASTNode!
   implicit?: boolean
 
 export type IfStatement

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -18,7 +18,7 @@ export type StatementNode =
   | ComptimeStatement
   | ContinueStatement
   | DebuggerStatement
-  | DeclarationStatement
+  | Declaration
   | DoStatement
   | EmptyStatement
   | ExportDeclaration
@@ -394,7 +394,7 @@ export type ForStatement
   type: "ForStatement"
   children: Children
   parent?: Parent
-  declaration: (DeclarationStatement | ForDeclaration)?
+  declaration: (Declaration | ForDeclaration)?
   block: BlockStatement
   hoistDec: ASTNode
   generator?: ASTNode
@@ -583,7 +583,7 @@ export type ImportAssertion
   keyword: "with" | "assert"
   object: ASTNode
 
-export type DeclarationStatement =
+export type Declaration =
   type: "Declaration"
   children: Children
   names: string[]

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -42,7 +42,9 @@ function processUnaryExpression(pre: ASTNode[], exp: ASTNode, post?: ASTNode[]):
     if pre.length
       return {
         type: "UnaryExpression"
-        children: [...pre, exp]
+        children: [pre, exp]
+        pre
+        expression: exp
       }
     return exp
 
@@ -83,7 +85,10 @@ function processUnaryExpression(pre: ASTNode[], exp: ASTNode, post?: ASTNode[]):
 
   return {
     type: "UnaryExpression"
-    children: [...pre, exp, post]
+    children: [ pre, exp, post ]
+    pre
+    expression: exp
+    post
   }
 
 function processUnaryNestedExpression(pre: ASTNode[], args: ArrayExpression | ASTNode[], post: ASTNode[])

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -94,7 +94,7 @@ describe "repl directive", ->
     ---
     function f() {
       var x = 5;return x
-    }(()=>{
+    };(()=>{
     return () => { var y = f();return y }})()
   """
 
@@ -105,7 +105,7 @@ describe "repl directive", ->
     f()
     function f() console.log 'hi'
     ---
-    function f() { return console.log('hi') }(()=>{f()
+    function f() { return console.log('hi') };(()=>{f()
     ;return f})()
   """
 
@@ -184,4 +184,17 @@ describe "repl directive", ->
     primes := [...smallPrimes] ||> .# = n
     ---
     var primes;(()=>{let ref;primes =( (ref = [...smallPrimes]).length = n,ref);return primes})()
+  """
+
+  testCase """
+    object destructuring
+    ---
+    "civet repl"
+    import { create } from 'qrcode'
+    const { foo } = bar, a = 5
+    const {x} = y
+    ---
+    var create;var foo,a;var x;(async ()=>{( {create} = await import('qrcode'));
+    ( { foo } = bar, a = 5);
+    ( {x} = y);return  {x}})()
   """

--- a/test/object.civet
+++ b/test/object.civet
@@ -18,6 +18,14 @@ describe "object", ->
   """
 
   testCase """
+    function returning empty literal with suffix
+    ---
+    => {} as object
+    ---
+    () =>( {} as object)
+  """
+
+  testCase """
     comma-separated literals
     ---
     {},{},{}

--- a/test/object.civet
+++ b/test/object.civet
@@ -10,6 +10,14 @@ describe "object", ->
   """
 
   testCase """
+    empty literal with suffix
+    ---
+    {} as object
+    ---
+    ({} as object)
+  """
+
+  testCase """
     comma-separated literals
     ---
     {},{},{}


### PR DESCRIPTION
* REPL wrapping of object destructuring assignments (#1581)
* Object literals with unary suffixes, in general and in fat arrow bodies (#1582)