### PR TITLE
Type's postfix `if` must be on the same line

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8304,7 +8304,7 @@ TypeBullet
     return list
 
 TypeWithPostfix
-  TypeConditional:t ( SameLineOrIndentedFurther TypeIfClause )?:postfix ->
+  TypeConditional:t ( _? TypeIfClause )?:postfix ->
     if (!postfix) return t
     return prepend(postfix[0],
       expressionizeTypeIf([ ...postfix[1], $1, undefined ]))

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -414,6 +414,26 @@ describe "[TS] function", ->
     }
   """
 
+  // #1590
+  testCase """
+    not postfix if
+    ---
+    function fn(i: number): string
+      if i < 10
+        "a"
+      else
+        "b"
+    ---
+    function fn(i: number): string {
+      if (i < 10) {
+        return "a"
+      }
+      else {
+        return "b"
+      }
+    }
+  """
+
   describe "application", ->
     testCase """
       type arguments

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -653,14 +653,13 @@ describe "[TS] type declaration", ->
       type Example1 = (Dog extends Animal?never: number)
     """
 
-    testCase """
+    throws """
       indented postfix if
       ---
       type Example1 = number
         if Dog extends Animal
       ---
-      type Example1 =
-        (Dog extends Animal? number:never)
+      ParseError
     """
 
   testCase """


### PR DESCRIPTION
Require postfix `if`/`unless` in a type context to be on the same line, not a following indented line. Fixes #1590

Allowing indentation seems terribly ambiguous with implicit type arguments. This is also how postfix `if` already behaves in expression context: the following example [fails to parse](https://civet.dev/playground?code=Zm9vCiAgaWYgY29uZGl0aW9u):

```js
foo
  if condition
```