### PR TITLE
Fix trailing member/call behavior

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -370,7 +370,7 @@ ExplicitArguments
 ApplicationStart
   # Indented argument cannot start with a binary operator or a
   # trailing member expression
-  IndentedApplicationAllowed &( IndentedFurther !IdentifierBinaryOp !ReservedBinary ) !IndentedTrailingMemberExpressions
+  IndentedApplicationAllowed &( IndentedFurther !IdentifierBinaryOp !ReservedBinary ) !IndentedTrailingCallExpressions
   !EOS &( _ ( BracedApplicationAllowed / !"{" ) !ForbiddenImplicitCalls )
 
 ForbiddenImplicitCalls
@@ -401,41 +401,16 @@ ForbiddenImplicitCalls
 ReservedBinary
   /(as|of|by|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
 
-ArgumentsWithTrailingMemberExpressions
-  Arguments:args AllowedTrailingMemberExpressions:trailing ->
-    return [ args, ...trailing ]
-
-# Matches in the empty case
-TrailingMemberExpressions
-  MemberExpressionRest* IndentedTrailingMemberExpressions? ->
-    if (!$2) return $1
-    return [...$1, ...$2]
-
-# Does not match in the empty case
-IndentedTrailingMemberExpressions
-  # All trailing member expressions should be at the same indentation level:
-  # either strictly indented, or at the same indentation level
-  PushIndent NestedTrailingMemberExpression* PopIndent ->
-    if (!$2.length) return $skip
-    return $2.flat()
-  NestedTrailingMemberExpression+ ->
-    return $1.flat()
-
-NestedTrailingMemberExpression
-  # NOTE: Assert "." to not match "?" or "!" as a member expression on the following line
-  Nested:ws &( "?"? "." ![0-9] ) MemberExpressionRest+:rests ->
-    const [ first, ...rest ] = rests
-    return [ prepend(ws, first), ...rest ]
-
-AllowedTrailingMemberExpressions
-  TrailingMemberPropertyAllowed TrailingMemberExpressions -> $2
-  MemberExpressionRest*
+ArgumentsWithTrailingCallExpressions
+  Arguments:args AllowedTrailingCallExpressions?:trailing ->
+    return [ args, ...trailing ?? [] ]
 
 # Does not match in the empty case
 TrailingCallExpressions
   # NOTE: Assert "." to not match "?" or "!" or string literal
   # as a call expression on the following line
   CallExpressionRest* IndentedTrailingCallExpressions? ->
+    $1 = $1.flat()
     if (!$1.length && !$2) return $skip
     if (!$2) return $1
     return [...$1, ...$2]
@@ -1418,7 +1393,7 @@ LeftHandSideExpression
 # https://262.ecma-international.org/#prod-CallExpression
 CallExpression
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
-  Super ArgumentsWithTrailingMemberExpressions CallExpressionRest*:rest ->
+  Super ArgumentsWithTrailingCallExpressions CallExpressionRest*:rest ->
     return processCallMemberExpression({
       type: "CallExpression",
       children: [$1, ...$2, ...rest.flat()],
@@ -1430,7 +1405,7 @@ CallExpression
     return dynamizeImportDeclarationExpression([i, iws, imports, fws, from])
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
-  "import" ArgumentsWithTrailingMemberExpressions CallExpressionRest*:rest ->
+  "import" ArgumentsWithTrailingCallExpressions CallExpressionRest*:rest ->
     return processCallMemberExpression({
       type: "CallExpression",
       children: [$1, ...$2, ...rest.flat()],
@@ -1460,10 +1435,10 @@ CallExpressionRest
     }
     return literal
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
-  OptionalShorthand?:optional ArgumentsWithTrailingMemberExpressions:argsWithTrailing ->
+  OptionalShorthand?:optional ArgumentsWithTrailingCallExpressions:argsWithTrailing ->
     if (!optional) return argsWithTrailing
 
-    const call = argsWithTrailing[0];
+    const call = argsWithTrailing[0]
     return [ {
       ...call,
       children: [optional, ...call.children],
@@ -3667,7 +3642,6 @@ PropertyDefinition
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->
   #  return prepend(ws, id)
-
 
 NamedProperty
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -593,3 +593,27 @@ describe "function application", ->
       x
       .y)
   """
+
+  testCase """
+    mix of trailing members
+    ---
+    argv := yargs process.argv[2...]
+        .positional 'filename',
+            type: 'string'
+            normalize: true
+            describe: 'input file'
+        .options
+            encoding: {}
+        .argv
+    ---
+    const argv = yargs(process.argv.slice(2))
+        .positional('filename', {
+            type: 'string',
+            normalize: true,
+            describe: 'input file',
+        })
+        .options({
+            encoding: {},
+        })
+        .argv
+  """


### PR DESCRIPTION
Fixes @bbrk24's reported regression (which is now a test).
* Call arguments now check for trailing call expressions instead of trailing member expressions.
* I never understood why we had both trailing member and trailing call rules. We no longer use the member ones, so the grammar got a bunch simpler.
* Missing `.flat()` in handling trailing call expressions (else a JSX test would fail).