### PR TITLE
Allow postfix in indented `if` conditions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5218,7 +5218,7 @@ Condition
     }
 
   # NOTE: Indented condition allows for further nested function application
-  PushIndent InsertOpenParen:open ( Nested Expression )?:expression InsertCloseParen:close PopIndent ->
+  PushIndent InsertOpenParen:open ( Nested PostfixedExpression )?:expression InsertCloseParen:close PopIndent ->
     if (!expression) return $skip
     return {
       type: "ParenthesizedExpression",
@@ -5229,7 +5229,7 @@ Condition
   # NOTE: Unindented condition forbids nested function application
   # to avoid ambiguity with 'then' clause
   InsertOpenParen:open ExpressionWithObjectApplicationForbidden:expression InsertCloseParen:close ->
-    // Don't double wrap parethesized expressions
+    // Don't double wrap parenthesized expressions
     if (expression.type === "ParenthesizedExpression") return expression
     expression = trimFirstSpace(expression)
     return {
@@ -5241,8 +5241,8 @@ Condition
 # Variation of Condition where there's a trailing token (e.g. `then`)
 # that is guaranteed afterward, so we can use indented application.
 BoundedCondition
-  InsertOpenParen:open Expression:expression InsertCloseParen:close ->
-    // Don't double wrap parethesized expressions
+  InsertOpenParen:open PostfixedExpression:expression InsertCloseParen:close ->
+    // Don't double wrap parenthesized expressions
     if (expression.type === "ParenthesizedExpression") return expression
     expression = trimFirstSpace(expression)
     return {

--- a/test/if.civet
+++ b/test/if.civet
@@ -230,6 +230,24 @@ describe "if", ->
   """
 
   testCase """
+    indented condition with postfix
+    ---
+    if
+      x.cond for some x of array
+      console.log 'yes'
+    else
+      console.log 'no'
+    ---
+    if(
+      (()=>{let results=false;for (const x of array) { if (x.cond) {results = true; break} }return results})()) {
+      console.log('yes')
+    }
+    else {
+      console.log('no')
+    }
+  """
+
+  testCase """
     condition with indentation and explicit then
     ---
     if (and)
@@ -247,6 +265,20 @@ describe "if", ->
     }
     else {
       console.log('no')
+    }
+  """
+
+  testCase """
+    condition with indentation, explicit then, and postfix
+    ---
+    if
+      x for every x in y
+    then
+      console.log 'yes'
+    ---
+    if((()=>{let results=true;for (const x in y) { if (!(
+      x)) {results = false; break} }return results})()) {
+      console.log('yes')
     }
   """
 


### PR DESCRIPTION
This example came up in Discord: (where `1` and `2` are placeholders for more complex expressions)

```js
if
  1 for every x in y
then
  2
```

Without this PR:

```js
if(
  1) (()=>{let results=true;for (const x in y)if (!(void 0)) {results = false; break};;return results})()(
  2)
```

With this PR:

```js
if((()=>{let results=true;for (const x in y) { if (!(
  1)) {results = false; break} }return results})()) {
  2
}
```