### PR TITLE
`for` reduction implicit body can destructure, fix implicitly returned patterns in some cases

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1970,6 +1970,18 @@ all := for join item of array
   `[${item.type}] ${item.title}`
 </Playground>
 
+Implicit bodies in `for sum/product/min/max/join` reductions
+can use a single destructuring:
+
+<Playground>
+xMin := for min {x} of points
+</Playground>
+
+<Playground>
+xMin := for min [x] of points
+yMin := for min [, y] of points
+</Playground>
+
 ### Object Comprehensions
 
 Loops can also accumulate their body values into an object.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2239,22 +2239,13 @@ BindingElement
 
   # NOTE: Merged in SingleNameBinding
   _?:ws ( BindingIdentifier / BindingPattern ):binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
-    // NOTE: RegExpLiteral doesn't have children so it will lose the initializer
-    // for now
-    if (binding.children) {
-      binding = {
-        ...binding,
-        initializer,
-        children: [...binding.children, initializer],
-      }
-    }
-
     return {
       type: "BindingElement",
       names: binding.names,
       typeSuffix,
       binding,
-      children: [ws, binding],
+      children: [ws, binding, initializer],
+      initializer,
     }
 
   # NOTE: Merged in ElisionElement

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -4,6 +4,7 @@ import type {
   ASTNodeObject
   AtBinding
   BindingPattern
+  BindingRestElement
   Children
   ObjectBindingPattern
   ThisAssignments
@@ -65,8 +66,8 @@ function adjustBindingElements(elements: ASTNodeObject[])
       length
     }
   else if restCount is 1
-    rest := elements[restIndex]
-    after := elements.slice(restIndex + 1)
+    rest := elements[restIndex] as BindingRestElement
+    after := elements[restIndex + 1..]
 
     restIdentifier := rest.binding.ref or rest.binding
     names.push ...rest.names or []
@@ -77,9 +78,11 @@ function adjustBindingElements(elements: ASTNodeObject[])
       // increment l if trailing comma
       if (arrayElementHasTrailingComma(after[l - 1])) l++
 
+      elements := trimFirstSpace after
       blockPrefix = {
         type: "PostRestBindingElements"
-        children: ["[", trimFirstSpace(after), "] = ", restIdentifier, ".splice(-", l.toString(), ")"]
+        elements
+        children: ["[", elements, "] = ", restIdentifier, ".splice(-", l.toString(), ")"]
         names: after.flatMap((p) => p.names)
       }
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -3,6 +3,7 @@ import type {
   ASTNode
   ASTNodeObject
   AtBinding
+  BindingPattern
   Children
   ObjectBindingPattern
   ThisAssignments

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -339,28 +339,30 @@ function patternAsValue(pattern: ASTNodeObject): ASTNode
       pattern
 
 /**
-Find the first bound variable in a pattern
-Example: {x: [y]} -> y
+Find all bound variables in a pattern and return as an array
+Example: {x: [, y], z} -> [y, z]
 */
-function patternFirstBinding(pattern: ASTNodeObject): BindingIdentifier
-  switch pattern.type
-    when "ArrayBindingPattern"
-      for each element of pattern.elements
-        if value? := patternFirstBinding element
-          return value
-    when "BindingElement"
-      return patternFirstBinding pattern.binding
-    when "ObjectBindingPattern"
-      for each property of pattern.properties
-        if value? := patternFirstBinding property
-          return value
-    when "BindingProperty"
-      return patternFirstBinding pattern.value
-    when "Binding"
-      return patternFirstBinding pattern.pattern
-    when "Identifier"
-      return pattern.name
-  return
+function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
+  bindings: BindingIdentifier[] := []
+  recurse pattern
+  return bindings
+
+  function recurse(pattern: ASTNodeObject): void
+    switch pattern.type
+      when "ArrayBindingPattern"
+        for each element of pattern.elements
+          recurse element
+      when "ObjectBindingPattern"
+        for each property of pattern.properties
+          recurse property
+      when "BindingElement"
+        recurse pattern.binding
+      when "BindingProperty"
+        recurse pattern.value ?? pattern.name
+      when "Binding"
+        recurse pattern.pattern
+      when "Identifier", "AtBinding"
+        bindings.push pattern
 
 // NOTE: this is almost the same as insertReturn but doesn't remove `breaks` in `when` and
 // does construct an else clause pushing undefined in if statements that lack them
@@ -784,10 +786,22 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
      statement.declaration?.type is "ForDeclaration"
     // For regular loops and object comprehensions, use entire pattern
     // For reductions, use the first binding
-    value := reduction
-      ? patternFirstBinding statement.declaration.binding
-      : patternAsValue statement.declaration.binding
-    fillBlock [ "", value ]
+    if reduction
+      bindings := patternBindings statement.declaration.binding.pattern
+      if bindings#
+        fillBlock [ "", bindings[0] ]
+        for binding of bindings[1..]
+          binding.children.unshift
+            type: "Error"
+            subtype: "Warning"
+            message: "Ignored binding in reduction loop with implicit body"
+      else
+        fillBlock [ "",
+          type: "Error"
+          message: "Empty binding pattern in reduction loop with implicit body"
+        ]
+    else
+      fillBlock [ "", patternAsValue statement.declaration.binding.pattern ]
     block.empty = false
 
   return false

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -3,7 +3,6 @@ import type {
   ASTNode
   ASTNodeObject
   BindingIdentifier
-  BindingPatternComponent
   BlockStatement
   BreakStatement
   CallExpression
@@ -287,22 +286,20 @@ function processReturnValue(func: FunctionNode)
 
   return true
 
-function patternAsValue(pattern: BindingPatternComponent): ASTNode
+function patternAsValue(pattern: ASTNodeObject): ASTNode
   switch pattern.type
     when "ArrayBindingPattern"
       children := [...pattern.children]
-      index := children.indexOf(pattern.elements)
+      index := children.indexOf pattern.elements
       if (index < 0) throw new Error("failed to find elements in ArrayBindingPattern")
-      children[index] = for each el of pattern.elements
-        [ws, e, delim] := el.children
-        { ...el, children: [ws, patternAsValue(e), delim] }
-      { ...pattern, children }
+      elements := children[index] = pattern.elements.map patternAsValue
+      { ...pattern, elements, children }
     when "ObjectBindingPattern"
-      const children = [...pattern.children]
-      const index = children.indexOf(pattern.properties)
+      children := [...pattern.children]
+      index := children.indexOf pattern.properties
       if (index < 0) throw new Error("failed to find properties in ArrayBindingPattern")
-      children[index] = pattern.properties.map patternAsValue
-      { ...pattern, children }
+      properties := children[index] = pattern.properties.map patternAsValue
+      { ...pattern, properties, children }
     when "BindingProperty"
       let children: Children
       // { name: value } = ... declares value, not name
@@ -312,10 +309,31 @@ function patternAsValue(pattern: BindingPatternComponent): ASTNode
         if isWhitespaceOrEmpty pattern.children[0]
           children.unshift pattern.children[0]
       else
-        children = pattern.children
+        children = [...pattern.children]
+        if pattern.initializer?
+          index := children.indexOf pattern.initializer
+          assert.notEqual index, -1, "failed to find initializer in BindingElement"
+          children.splice index, 1
         if pattern.value?
           children = children.map & is pattern.value ?
             patternAsValue pattern.value : &
+      { ...pattern, children }
+    when "AtBindingProperty"
+      children := [...pattern.children]
+      if pattern.initializer?
+        index := children.indexOf pattern.initializer
+        assert.notEqual index, -1, "failed to find initializer in AtBindingProperty"
+        children.splice index, 1
+      { ...pattern, children }
+    when "BindingElement"
+      children := [...pattern.children]
+      if pattern.initializer?
+        index := children.indexOf pattern.initializer
+        assert.notEqual index, -1, "failed to find initializer in BindingElement"
+        children.splice index, 1
+      index := children.indexOf pattern.binding
+      assert.notEqual index, -1, "failed to find binding in BindingElement"
+      children[index] = patternAsValue pattern.binding
       { ...pattern, children }
     else
       pattern
@@ -324,7 +342,7 @@ function patternAsValue(pattern: BindingPatternComponent): ASTNode
 Find the first bound variable in a pattern
 Example: {x: [y]} -> y
 */
-function patternFirstBinding(pattern: BindingPatternComponent): BindingIdentifier
+function patternFirstBinding(pattern: ASTNodeObject): BindingIdentifier
   switch pattern.type
     when "ArrayBindingPattern"
       for each element of pattern.elements

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -2,9 +2,12 @@ import type {
   ASTLeaf
   ASTNode
   ASTNodeObject
+  BindingIdentifier
+  BindingPatternComponent
   BlockStatement
   BreakStatement
   CallExpression
+  Children
   Declaration
   ForStatement
   FunctionNode
@@ -284,7 +287,7 @@ function processReturnValue(func: FunctionNode)
 
   return true
 
-function patternAsValue(pattern: ASTNodeObject): ASTNode
+function patternAsValue(pattern: BindingPatternComponent): ASTNode
   switch pattern.type
     when "ArrayBindingPattern"
       children := [...pattern.children]
@@ -300,15 +303,19 @@ function patternAsValue(pattern: ASTNodeObject): ASTNode
       if (index < 0) throw new Error("failed to find properties in ArrayBindingPattern")
       children[index] = pattern.properties.map patternAsValue
       { ...pattern, children }
-    when "Identifier", "BindingProperty"
-      const children = [
-        // { name: value } = ... declares value, not name
-        pattern.value ?? pattern.name
-        pattern.delim
-      ]
-      // Check for leading whitespace
-      if isWhitespaceOrEmpty pattern.children[0]
-        children.unshift(pattern.children[0])
+    when "BindingProperty"
+      let children: Children
+      // { name: value } = ... declares value, not name
+      if pattern.value?.type is "Identifier"
+        children = [ pattern.value, pattern.delim ]
+        // Check for leading whitespace
+        if isWhitespaceOrEmpty pattern.children[0]
+          children.unshift pattern.children[0]
+      else
+        children = pattern.children
+        if pattern.value?
+          children = children.map & is pattern.value ?
+            patternAsValue pattern.value : &
       { ...pattern, children }
     else
       pattern
@@ -317,7 +324,7 @@ function patternAsValue(pattern: ASTNodeObject): ASTNode
 Find the first bound variable in a pattern
 Example: {x: [y]} -> y
 */
-function patternFirstBinding(pattern: ASTNodeObject): ASTNode
+function patternFirstBinding(pattern: BindingPatternComponent): BindingIdentifier
   switch pattern.type
     when "ArrayBindingPattern"
       for each element of pattern.elements

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -284,41 +284,58 @@ function processReturnValue(func: FunctionNode)
 
   return true
 
-function patternAsValue(pattern): ASTNode
-  switch (pattern.type) {
-    case "ArrayBindingPattern": {
-      const children = [...pattern.children]
-      const index = children.indexOf(pattern.elements)
+function patternAsValue(pattern: ASTNodeObject): ASTNode
+  switch pattern.type
+    when "ArrayBindingPattern"
+      children := [...pattern.children]
+      index := children.indexOf(pattern.elements)
       if (index < 0) throw new Error("failed to find elements in ArrayBindingPattern")
-      children[index] = pattern.elements.map((el) => {
-        const [ws, e, delim] = el.children
-        return { ...el, children: [ws, patternAsValue(e), delim] }
-      })
-      return { ...pattern, children }
-    }
-    case "ObjectBindingPattern": {
+      children[index] = for each el of pattern.elements
+        [ws, e, delim] := el.children
+        { ...el, children: [ws, patternAsValue(e), delim] }
+      { ...pattern, children }
+    when "ObjectBindingPattern"
       const children = [...pattern.children]
       const index = children.indexOf(pattern.properties)
       if (index < 0) throw new Error("failed to find properties in ArrayBindingPattern")
       children[index] = pattern.properties.map patternAsValue
-      return { ...pattern, children }
-    }
-    case "Identifier":
-    case "BindingProperty": {
+      { ...pattern, children }
+    when "Identifier", "BindingProperty"
       const children = [
         // { name: value } = ... declares value, not name
         pattern.value ?? pattern.name
         pattern.delim
       ]
       // Check for leading whitespace
-      if (isWhitespaceOrEmpty(pattern.children[0])) {
+      if isWhitespaceOrEmpty pattern.children[0]
         children.unshift(pattern.children[0])
-      }
-      return { ...pattern, children }
-    }
-    default:
-      return pattern
-  }
+      { ...pattern, children }
+    else
+      pattern
+
+/**
+Find the first bound variable in a pattern
+Example: {x: [y]} -> y
+*/
+function patternFirstBinding(pattern: ASTNodeObject): ASTNode
+  switch pattern.type
+    when "ArrayBindingPattern"
+      for each element of pattern.elements
+        if value? := patternFirstBinding element
+          return value
+    when "BindingElement"
+      return patternFirstBinding pattern.binding
+    when "ObjectBindingPattern"
+      for each property of pattern.properties
+        if value? := patternFirstBinding property
+          return value
+    when "BindingProperty"
+      return patternFirstBinding pattern.value
+    when "Binding"
+      return patternFirstBinding pattern.pattern
+    when "Identifier"
+      return pattern.name
+  return
 
 // NOTE: this is almost the same as insertReturn but doesn't remove `breaks` in `when` and
 // does construct an else clause pushing undefined in if statements that lack them
@@ -740,7 +757,12 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
 
   if statement.type is "ForStatement" and
      statement.declaration?.type is "ForDeclaration"
-    fillBlock [ "", patternAsValue statement.declaration.binding ]
+    // For regular loops and object comprehensions, use entire pattern
+    // For reductions, use the first binding
+    value := reduction
+      ? patternFirstBinding statement.declaration.binding
+      : patternAsValue statement.declaration.binding
+    fillBlock [ "", value ]
     block.empty = false
 
   return false

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -1,11 +1,16 @@
 import type {
+  ArrayBindingPatternContent
   ASTNode
   ASTNodeObject
   ASTRef
+  BindingProperty
+  BindingRestElement
+  BindingRestProperty
   BlockStatement
   Condition
   ContinueStatement
   ElseClause
+  Identifier
   ParenthesizedExpression
   ParseRule
   PatternClause
@@ -314,24 +319,23 @@ function getPatternBlockPrefix(
     ...duplicateDeclarations.map ['', &, ";"]
   ]
 
-function elideMatchersFromArrayBindings(elements) {
-  return elements.map((el) => {
-    // TODO: this isn't unified with the element [ws, e, sep] tuple yet
-    if (el.type is "BindingRestElement") {
-      return ["", el, undefined]
-    }
-    const { children: [ws, e, delim] } = el
-    switch (e.type) {
-      case "Literal":
-      case "RegularExpressionLiteral":
-      case "StringLiteral":
-      case "PinPattern":
-        return delim
-      default:
-        return [ws, nonMatcherBindings(e), delim]
-    }
-  })
-}
+function elideMatchersFromArrayBindings(elements: ArrayBindingPatternContent): ASTNode[]
+  for each element of elements
+    switch element.type
+      when "BindingRestElement", "ElisionElement"
+        element
+      when "BindingElement"
+        switch element.binding.type
+          when "Literal", "RegularExpressionLiteral", "StringLiteral", "PinPattern"
+            element.delim
+          else
+            binding := nonMatcherBindings element.binding
+            makeNode {
+              ...element
+              binding
+              children: element.children.map (c) =>
+                c is element.binding ? binding : c
+            }
 
 function elideMatchersFromPropertyBindings(properties) {
   return properties.map((p) => {
@@ -373,28 +377,18 @@ function elideMatchersFromPropertyBindings(properties) {
   })
 }
 
-function nonMatcherBindings(pattern)
+function nonMatcherBindings(pattern: ASTNodeObject)
   switch pattern.type
-    when "ArrayBindingPattern"
-      elements := elideMatchersFromArrayBindings(pattern.elements)
-      {
+    when "ArrayBindingPattern", "PostRestBindingElements"
+      elements := elideMatchersFromArrayBindings pattern.elements
+      makeNode {
         ...pattern
         elements
         children: pattern.children.map & is pattern.elements ? elements : &
       }
-    when "PostRestBindingElements"
-      const els = elideMatchersFromArrayBindings(pattern.children[1])
-      {
-        ...pattern,
-        children: [
-          pattern.children[0],
-          els,
-          ...pattern.children.slice(2),
-        ],
-      }
     when "ObjectBindingPattern"
-      properties := elideMatchersFromPropertyBindings(pattern.properties)
-      {
+      properties := elideMatchersFromPropertyBindings pattern.properties
+      makeNode {
         ...pattern
         properties
         children: pattern.children.map & is pattern.properties ? properties : &
@@ -403,21 +397,18 @@ function nonMatcherBindings(pattern)
       pattern
 
 function aggregateDuplicateBindings(bindings)
-  props := gatherRecursiveAll bindings, .type is "BindingProperty"
-  arrayBindings := gatherRecursiveAll bindings, .type is "ArrayBindingPattern"
-
-  for each { elements } of arrayBindings
-    for each element of elements
-      if Array.isArray element
-        [, e] := element
-        if e.type is "Identifier"
-          props.push e
-        else if e.type is "BindingRestElement"
-          props.push e
+  props := gatherRecursiveAll bindings,
+    ($): $ is BindingProperty | BindingRestProperty | Identifier | BindingRestElement => (or)
+      $.type is "BindingProperty"
+      // Don't deduplicate ...rest properties; user should do so manually
+      // because ...rest can be named arbitrarily
+      //$.type is "BindingRestProperty"
+      $.type is "Identifier" and $.parent?.type is "BindingElement"
+      $.type is "BindingRestElement"
 
   declarations: ASTNode[] := []
 
-  propsGroupedByName: Map<string, ASTNodeObject[]> := new Map
+  propsGroupedByName := new Map<string, ASTNodeObject[]>
 
   for each p of props
     { name, value } := p
@@ -475,7 +466,7 @@ function aggregateDuplicateBindings(bindings)
  * Adjust the alias of a binding property, adding an alias if one doesn't exist or
  * replacing an existing alias. This mutates the property in place.
  */
-function aliasBinding(p, ref: ASTRef): void
+function aliasBinding(p: ASTNodeObject, ref: ASTRef): void
   if p.type is "Identifier"
     // Array element binding
     // TODO: This ignores `name` and `names` properties of Identifier and

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -96,6 +96,7 @@ export type OtherNode =
   | DefaultClause
   | ElisionElement
   | ElseClause
+  | EmptyBinding
   | FieldDefinition
   | FinallyClause
   | ForDeclaration
@@ -113,6 +114,7 @@ export type OtherNode =
   | PinPattern
   | PinProperty
   | Placeholder
+  | PostRestBindingElements
   | PropertyAccess
   | PropertyBind
   | PropertyGlob
@@ -726,7 +728,7 @@ export type BindingPattern = BindingIdentifier | ObjectBindingPattern | ArrayBin
 
 // Includes things that appear inside BindingPatterns (when recursing)
 // but aren't patterns by themselves
-export type BindingPatternComponent = BindingProperty | BindingRestProperty | BindingElement | BindingRestElement | BindingPattern
+export type BindingPatternComponent = BindingProperty | AtBindingProperty | BindingRestProperty | BindingElement | BindingRestElement | BindingPattern
 
 export type PatternExpression = BindingPattern | ConditionFragment
 
@@ -754,6 +756,13 @@ export type ArrayBindingPattern =
 export type ArrayBindingPatternContent =
   (BindingElement | BindingRestElement | ElisionElement)[]
 
+export type PostRestBindingElements
+  type: "PostRestBindingElements"
+  children: Children
+  parent?: Parent
+  elements: ArrayBindingPatternContent
+  names: string[]
+
 export type BindingElement =
   type: "BindingElement"
   children: Children
@@ -771,6 +780,14 @@ export type BindingRestElement =
   names: string[]
   rest: true
   typeSuffix?: TypeSuffix?
+  binding: BindingIdentifier | BindingPattern | EmptyBinding
+
+export type EmptyBinding
+  type: "EmptyBinding"
+  children: Children
+  parent?: Parent
+  names: string[]
+  ref: ASTRef
 
 export type ElisionElement =
   type: "ElisionElement"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -722,7 +722,11 @@ export type FinallyToken = "finally " | { $loc: Loc, token: "finally" }
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 
-export type BindingPattern = BindingRestElement | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral
+export type BindingPattern = BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | Literal | RegularExpressionLiteral
+
+// Includes things that appear inside BindingPatterns (when recursing)
+// but aren't patterns by themselves
+export type BindingPatternComponent = BindingProperty | BindingRestProperty | BindingElement | BindingRestElement | BindingPattern
 
 export type PatternExpression = BindingPattern | ConditionFragment
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -80,7 +80,10 @@ export type OtherNode =
   | ArrayElement
   | Await
   | Binding
+  | BindingElement
+  | BindingProperty
   | BindingRestElement
+  | BindingRestProperty
   | Call
   | CatchBinding
   | CatchClause
@@ -91,6 +94,7 @@ export type OtherNode =
   | ComputedPropertyName
   | ConditionFragment
   | DefaultClause
+  | ElisionElement
   | ElseClause
   | FieldDefinition
   | FinallyClause

--- a/test/for.civet
+++ b/test/for.civet
@@ -1451,6 +1451,31 @@ describe "for", ->
     """
 
     testCase """
+      implicit body array destructuring
+      ---
+      total := for sum [,x] of y
+      ---
+      let results=0;for (const [,x] of y) {results += x};const total =results
+    """
+
+    testCase """
+      implicit body object destructuring
+      ---
+      total := for sum {x: {y}} of z
+      ---
+      let results=0;for (const {x: {y}} of z) {results += y};const total =results
+    """
+
+    throws """
+      implicit body multiple destructuring
+      ---
+      total := for sum [x, y, z] of w
+      ---
+      ParseErrors: unknown:1:22 Ignored binding in reduction loop with implicit body
+      unknown:1:25 Ignored binding in reduction loop with implicit body
+    """
+
+    testCase """
       for in
       ---
       nonEmpty = for some x in y

--- a/test/function.civet
+++ b/test/function.civet
@@ -1113,6 +1113,28 @@ describe "function", ->
     """
 
     testCase """
+      expanded property declaration
+      ---
+      ->
+        {x: [y]} := obj
+      ---
+      (function() {
+        const {x: [y]} = obj;return {x: [y]}
+      })
+    """
+
+    testCase """
+      initialized property declaration
+      ---
+      ->
+        {x = 5, @y = 10, z: zz = 15} := obj
+      ---
+      (function() {
+        const {x = 5, y = 10, z: zz = 15} = obj;this.y = y;;return {x, y, zz}
+      })
+    """
+
+    testCase """
       complex declaration
       ---
       ->
@@ -1757,6 +1779,17 @@ describe "function", ->
       ---
       (function(x) {
         let a = 3, b = 4;return b
+      })
+    """
+
+    testCase """
+      destructuring declaration
+      ---
+      (x) ->
+        {a, b: c, d: [,e]} := x
+      ---
+      (function(x) {
+        const {a, b: c, d: [,e]} = x;return {a, c, d: [,e]}
       })
     """
 

--- a/test/object-comprehensions.civet
+++ b/test/object-comprehensions.civet
@@ -188,18 +188,17 @@ describe "object comprehensions", ->
   testCase """
     single line
     ---
-    o := {for x of [1] [x]: 2 * x }
+    o := {for x of [1] then [x]: 2 * x }
     ---
-    const o = {...(()=>{const results={};for (const x of [1]({[x]: 2 * x})) {Object.assign(results,x)}return results})() }
+    const o = {...(()=>{const results={};for (const x of [1]) Object.assign(results,({[x]: 2 * x}));return results})() }
   """
 
   testCase """
-
     non-comprehension loop
     ---
-    o := {...for x of [1] [x]: 2 * x }
+    o := {...for x of [1] then [x]: 2 * x }
     ---
-    const o = {...(()=>{const results=[];for (const x of [1]({[x]: 2 * x})) {results.push(x)}return results})() }
+    const o = {...(()=>{const results=[];for (const x of [1]) results.push(({[x]: 2 * x}));return results})() }
   """
 
   testCase """


### PR DESCRIPTION
My initial goal was to make `for sum [x] of y` use an implicit body of `x` instead of `[x]`.

Along the way, I ran into some bugs in `patternAsValue`, which led to cleaning up of some pattern matching code to correctly handle the previous addition of `BindingElement`.