### PR TITLE
Fix fallthrough in implicitly returned switch with semicolon, improve `hasExit` heuristic

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2807,7 +2807,7 @@ SingleLineStatements
       maybeComment?.type === "Comment" && maybeComment.token.startsWith("//")
 
     const children = [expressions]
-    if (hasTrailingComment) children.push("\n")
+    if (hasTrailingComment) children.push(["\n"])
 
     return {
       type: "BlockStatement",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -30,6 +30,7 @@ import {
   getPrecedence,
   getTrimmingSpace,
   hasAwait,
+  hasTrailingComment,
   hasYield,
   insertTrimmingSpace,
   isComma,
@@ -2801,13 +2802,8 @@ SingleLineStatements
     const expressions = [...stmts]
     if (last) expressions.push(last)
 
-    // check for trailing comment
-    const maybeComment = expressions.at(-1)?.[2]?.children?.[2]?.at(-1)
-    const hasTrailingComment =
-      maybeComment?.type === "Comment" && maybeComment.token.startsWith("//")
-
     const children = [expressions]
-    if (hasTrailingComment) children.push(["\n"])
+    if (hasTrailingComment(expressions)) children.push(["\n"])
 
     return {
       type: "BlockStatement",

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -441,13 +441,15 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       return
     when "SwitchStatement"
       // insert a results.push in each case block
-      assignResults(exp.children[2], collect)
+      for each clause of exp.caseBlock.clauses
+        assignResults clause, collect
       return
     when "TryStatement"
       // NOTE: CoffeeScript doesn't add a push to an empty catch block but does add if there is any statement in the catch block
       // we always add a push to the catch block
       // NOTE: does not insert a push in the finally block
-      exp.blocks.forEach((block) => assignResults(block, collect))
+      for each block of exp.blocks
+        assignResults block, collect
       return
 
   // Don't push if there's a trailing semicolon
@@ -561,7 +563,10 @@ function insertReturn(node: ASTNode): void
       insertReturn exp.children[0]
       return
     when "SwitchStatement"
-      insertSwitchReturns(exp)
+      // insert a return in each when/else/default block
+      // case blocks don't get implicit returns
+      for each clause of exp.caseBlock.clauses
+        insertReturn clause
       return
     when "TryStatement"
       for each block of exp.blocks
@@ -574,13 +579,6 @@ function insertReturn(node: ASTNode): void
 
   // Insert return after indentation and before expression
   node[1] = wrapWithReturn node[1]
-
-// insert a return in each when/else/default block
-// case blocks don't get implicit returns
-// maybe default blocks shouldn't either?
-function insertSwitchReturns(exp: SwitchStatement): void
-  for each clause of exp.caseBlock.clauses
-    insertReturn clause
 
 // Process `break with` and `continue with` within a loop statement
 // that already has a resultsRef attribute.

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -62,6 +62,7 @@ import {
   deepCopy
   getTrimmingSpace
   hasAwait
+  hasTrailingComment
   hasYield
   inplacePrepend
   isEmptyBareBlock
@@ -481,7 +482,11 @@ function insertReturn(node: ASTNode): void
       // Then try to add implicit return
       insertReturn node.block
       unless isExit node.block
-        node.block.expressions.push ["", wrapWithReturn(undefined, node, true)]
+        comment := hasTrailingComment node.block.expressions
+        node.block.expressions.push [
+          comment ? node.block.expressions.-1.0 or "\n" : ""
+          wrapWithReturn undefined, node, not comment
+        ]
       return
     when "DefaultClause"
       insertReturn(node.block)

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -275,13 +275,10 @@ function processReturnValue(func: FunctionNode)
 
   // Implicit return before }
   unless block.children.-2?.type is "ReturnStatement"
-    indent := getIndent(block.expressions.-1) or ";"
+    indent := getIndent block.expressions.-1
     block.expressions.push [
-      [indent]
-    ,
-      type: "ReturnStatement",
-      expression: ref,
-      children: ["return ", ref]
+      indent
+      wrapWithReturn ref, block, not indent
     ]
 
   return true
@@ -464,23 +461,27 @@ function insertReturn(node: ASTNode): void
   // TODO: unify this with the `exp` switch
   switch node.type
     when "BlockStatement"
-      if node.expressions.length
+      if node.expressions#
         return if node.expressions.some ([, exp]) => isExit exp
         last := node.expressions[node.expressions.length - 1]
         insertReturn(last)
       else
         // NOTE: Kind of hacky but I'm too much of a coward to make `->` add an implicit return
-        if node.parent.type is "CatchClause"
-          node.expressions.push(["return"])
+        if node.parent?.type is like "CatchClause", "WhenClause"
+          node.expressions.push ["", wrapWithReturn(undefined, node)]
       return
     // NOTE: "CaseClause"s don't get a return statement inserted
     when "WhenClause"
       // Remove inserted `break;` if it hasn't already been removed
-      node.children.splice node.children.indexOf(node.break), 1 if node.break
-      if node.block.expressions.length
-        insertReturn(node.block)
-      else
-        node.block.expressions.push(wrapWithReturn())
+      if node.break
+        breakIndex := node.children.indexOf node.break
+        assert.notEqual breakIndex, -1, "Could not find break in when clause"
+        node.children.splice breakIndex, 1
+        node.break = undefined
+      // Then try to add implicit return
+      insertReturn node.block
+      unless isExit node.block
+        node.block.expressions.push ["", wrapWithReturn(undefined, node, true)]
       return
     when "DefaultClause"
       insertReturn(node.block)
@@ -507,7 +508,7 @@ function insertReturn(node: ASTNode): void
       parent := outer.parent as BlockStatement?
       index := findChildIndex parent?.expressions, outer
       assert.notEqual index, -1, "Could not find declaration in parent"
-      parent!.expressions.splice index+1, 0, ["", {
+      parent!.expressions.splice index+1, 0, ["",
         type: "ReturnStatement"
         expression: value
         children: [
@@ -516,7 +517,7 @@ function insertReturn(node: ASTNode): void
           value
         ]
         parent: exp
-      }]
+      ]
       braceBlock parent!
       return
     when "FunctionExpression"
@@ -526,10 +527,7 @@ function insertReturn(node: ASTNode): void
         index := findChildIndex parent?.expressions, outer
         assert.notEqual index, -1, "Could not find function declaration in parent"
         parent!.expressions.splice index+1, 0, ["",
-          type: "ReturnStatement"
-          expression: exp.id
-          children: [";return ", exp.id]
-          parent: exp
+          wrapWithReturn exp.id, exp, true
         ]
         braceBlock parent!
         return
@@ -549,21 +547,20 @@ function insertReturn(node: ASTNode): void
       // else block
       if (exp.else) insertReturn(exp.else.block)
       // Add explicit return after if block if no else block
-      else exp.children.push ["", {
-        type: "ReturnStatement"
-        // NOTE: add a prefixed semi-colon because the if block may not be braced
-        children: [";return"]
-        parent: exp
-      }]
+      else exp.children.push ["",
+        // NOTE: add a prefixed semicolon because the if block may not be braced
+        wrapWithReturn undefined, exp, true
+      ]
       return
     when "PatternMatchingStatement"
-      insertReturn(exp.children[0])
+      insertReturn exp.children[0]
       return
     when "SwitchStatement"
       insertSwitchReturns(exp)
       return
     when "TryStatement"
-      exp.blocks.forEach((block) => insertReturn(block))
+      for each block of exp.blocks
+        insertReturn block
       // NOTE: do not insert a return in the finally block
       return
 
@@ -571,14 +568,13 @@ function insertReturn(node: ASTNode): void
   return if node.-1?.type is "SemicolonDelimiter"
 
   // Insert return after indentation and before expression
-  const returnStatement = wrapWithReturn(node[1])
-  node.splice(1, 1, returnStatement)
+  node[1] = wrapWithReturn node[1]
 
 // insert a return in each when/else/default block
 // case blocks don't get implicit returns
 // maybe default blocks shouldn't either?
-function insertSwitchReturns(exp): void
-  exp.caseBlock.clauses.forEach (clause) =>
+function insertSwitchReturns(exp: SwitchStatement): void
+  for each clause of exp.caseBlock.clauses
     insertReturn clause
 
 // Process `break with` and `continue with` within a loop statement

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -61,6 +61,7 @@ import {
   hasAwait
   hasExportDeclaration
   hasImportDeclaration
+  hasTrailingComment
   hasYield
   inplaceInsertTrimmingSpace
   inplacePrepend
@@ -1797,6 +1798,7 @@ export {
   hasAwait
   hasExportDeclaration
   hasImportDeclaration
+  hasTrailingComment
   hasYield
   insertTrimmingSpace
   isComma

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -28,6 +28,7 @@ export type StatementNode =
   | ImportDeclaration
   | IterationStatement
   | LabelledStatement
+  | PatternMatchingStatement
   | ReturnStatement
   | SwitchStatement
   | ThrowStatement
@@ -451,6 +452,13 @@ export type CaseClause
   parent?: Parent
   cases: ASTNode[]
   block: BlockStatement
+
+export type PatternMatchingStatement
+  type: "PatternMatchingStatement"
+  children: Children & [StatementTuple]
+  parent?: Parent
+  condition: Condition
+  caseBlock: CaseBlock
 
 export type WhenClause
   type: "WhenClause"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -3,12 +3,12 @@ import type {
   ASTNode
   ASTNodeObject
   ASTNodeParent
-  Children
   FunctionNode
   IsParent
   IsToken
   IterationStatement
   Literal
+  Parent
   StatementNode
   TypeSuffix
   ReturnTypeAnnotation
@@ -192,9 +192,16 @@ function isExit(node: ASTNode): boolean
       true
     // if checks then and else clause
     when "IfStatement"
-      (and)
-        isExit node.then
-        isExit node.else?.block
+      (or)
+        // `insertReturn` for IfStatement adds a return to children
+        // when there's no else block
+        node.children.-1?.type is "ReturnStatement"
+        (node.children.-1 as StatementTuple)?[1]?.type is "ReturnStatement"
+        (and)
+          isExit node.then
+          isExit node.else?.block
+    when "PatternMatchingStatement"
+      isExit node.children[0][1]
     when "BlockStatement"
       // [1] extracts statement from [indent, statement, delim]
       node.expressions.some (s) => isExit s[1]
@@ -788,14 +795,15 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
 
   return exp
 
-function wrapWithReturn(expression?: ASTNode): ASTNode
-  const children = expression ? ["return ", expression] : ["return"]
+function wrapWithReturn(expression?: ASTNode, parent: Parent = expression?.parent, semi = false): ASTNode
+  children := expression ? ["return ", expression] : ["return"]
+  children.unshift ";" if semi
 
   return makeNode {
     type: "ReturnStatement"
     children
     expression
-    parent: expression?.parent
+    parent
   }
 
 function flatJoin<T, S>(array: T[][], separator: S): (T | S)[]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -3,6 +3,7 @@ import type {
   ASTNode
   ASTNodeObject
   ASTNodeParent
+  Children
   FunctionNode
   IsParent
   IsToken
@@ -241,6 +242,15 @@ function stripTrailingImplicitComma(children: ASTNode[])
     children[...-1]
   else
     children
+
+function hasTrailingComment(node: ASTNode): boolean
+  return false unless node?
+  return true if node.type is "Comment"
+  if Array.isArray node
+    return hasTrailingComment node.-1
+  if "children" in node
+    return hasTrailingComment (node.children as Children).-1
+  false
 
 /**
  * Trims the first single space from the spacing array or node's children if present
@@ -827,6 +837,7 @@ export {
   hasAwait
   hasExportDeclaration
   hasImportDeclaration
+  hasTrailingComment
   hasYield
   inplaceInsertTrimmingSpace
   inplacePrepend

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -203,6 +203,15 @@ function isExit(node: ASTNode): boolean
           isExit node.else?.block
     when "PatternMatchingStatement"
       isExit node.children[0][1]
+    when "SwitchStatement"
+      (and)
+        // Ensure exhaustive by requiring an else/default clause
+        node.caseBlock.clauses.some .type is "DefaultClause"
+        // Every clause should exit
+        node.caseBlock.clauses.every isExit
+    when "TryStatement"
+      // Require all non-finally blocks to exit
+      node.blocks.every isExit
     when "BlockStatement"
       // [1] extracts statement from [indent, statement, delim]
       node.expressions.some (s) => isExit s[1]

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -470,7 +470,9 @@ describe "switch", ->
         when 'value'
           1
         when 'semi'
-          ; // omitted `return`, keep `break`
+          ; // omitted `return`
+        when 'multi'
+          a;b; // omitted `return`
         else
           0
     ---
@@ -482,8 +484,12 @@ describe "switch", ->
           return 1
         }
         case 'semi': {
-          ; // omitted `return`, keep `break`
+          ; // omitted `return`
           return
+        }
+        case 'multi': {
+          a;b; // omitted `return`
+    return
         }
         default: {
           return 0

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -461,6 +461,37 @@ describe "switch", ->
     }
   """
 
+  testCase """
+    don't fall through after omitted implicit return
+    ---
+    =>
+      switch foo
+        when 'empty'
+        when 'value'
+          1
+        when 'semi'
+          ; // omitted `return`, keep `break`
+        else
+          0
+    ---
+    () => {
+      switch(foo) {
+        case 'empty': {return
+        }
+        case 'value': {
+          return 1
+        }
+        case 'semi': {
+          ; // omitted `return`, keep `break`
+          return
+        }
+        default: {
+          return 0
+        }
+      }
+    }
+  """
+
   // #1118
   testCase """
     break after pattern matching statement


### PR DESCRIPTION
Fixes #1602

This was trickier than expected. One fun issue is that SemicolonDelimiter can end with a trailing Comment. This hasn't been an issue in the past because we avoid adding `return` in such scenarios. But now we need to, so I added a `hasTrailingComment` helper for this.