### PR TITLE
Fix automatic `Promise` wrapping of async return types

### DIFF
--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -146,7 +146,7 @@ declareHelper := {
     ], ";\n"]
   AutoPromise(ref): void
     state.prelude.push ["",
-      ts [ "type ", ref, "<T> = T extends Promise<unknown> ? T : Promise<T>" ]
+      ts [ "type ", ref, "<T> = Promise<Awaited<T>>" ]
       ";\n"
     ]
   JSX(jsxRef): void

--- a/test/function.civet
+++ b/test/function.civet
@@ -2416,7 +2416,7 @@ describe "function", ->
       (): number =>
         return = await 5
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       async (): AutoPromise<number> => {
         let ret:Awaited<AutoPromise<number>>;
         ret = await 5

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -559,7 +559,7 @@ describe "[TS] function", ->
       ---
       async :void ->
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       (async function():AutoPromise<void> {})
     """
 
@@ -568,7 +568,7 @@ describe "[TS] function", ->
       ---
       async :void =>
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       async ():AutoPromise<void> => {}
     """
 
@@ -577,7 +577,7 @@ describe "[TS] function", ->
       ---
       async function f(): void {}
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       async function f(): AutoPromise<void> {}
     """
 
@@ -586,7 +586,7 @@ describe "[TS] function", ->
       ---
       f := :number -> await Promise.resolve 5
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       const f = async function():AutoPromise<number> { return await Promise.resolve(5) }
     """
 
@@ -595,7 +595,7 @@ describe "[TS] function", ->
       ---
       f := :number => await Promise.resolve 5
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       const f = async ():AutoPromise<number> => await Promise.resolve(5)
     """
 
@@ -605,7 +605,7 @@ describe "[TS] function", ->
       function f(): number
         await Promise.resolve 5
       ---
-      type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+      type AutoPromise<T> = Promise<Awaited<T>>;
       async function f(): AutoPromise<number> {
         return await Promise.resolve(5)
       }

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -161,7 +161,7 @@ describe "[TS] type declaration", ->
     type X = async (message: string) => Promise<void>
     type Z = async (message: string) => A | B | C
     ---
-    type AutoPromise<T> = T extends Promise<unknown> ? T : Promise<T>;
+    type AutoPromise<T> = Promise<Awaited<T>>;
     type X = (message: string) => AutoPromise<void>
     type Y = (message: string) =>AutoPromise<void>
     type X = (message: string) => Promise<void>


### PR DESCRIPTION
Our current `AutoPromise` wrapper is [broken in many cases](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAggrsA9gBQE6ILYEsDOEA8AKgHxQC8UhUEAHsBAHYAmOUamuBcDA1g4gHcGpAPyUoALjbpseIsQDcAWABQq0JCgARcrAQoZnfFoCG9YqqhWA9NYB6I1SZwgGAYygAzbm+BZEDFBMABQAlFLwSOyyBKbmUADellCoEMBwqIEmAiZYwFAMEALaZhDKKgC+qurg0FoAqrqRBhxycdAAPlDcTBCeWIVMFipWULYOTi7uXj5+AUFwYRH60UbtUF09fQMQQ4nJqemZUNm5+YXF7eVVaioa0DBNK4ZyJgwgw6PjjirOrh7edxzLJLPRRF4EN4ffYjFJpDJZHJ5ApFEr0a6qIA). TS seems to be splitting up `AutoPromise<A | B>` into `AutoPromise<A> | AutoPromise<B>` which fails the check for a single `Promise<...>` wrapper.

But the arguably simpler `Promise<Awaited<T>>` wrapper [seems to work great](https://www.typescriptlang.org/play/?ssl=1&ssc=23&pln=1&pc=43#code/C4TwDgpgBAggrsA9gBQE6ILYEsDOEA8AKgHxQC8UamuBMA7gIZbAQAmRxxA3ALABQ-UJCgARcrAQp02PPhEMWxflBUB6VQD0A-PwY4QAOwDGUAGZxjwLIgNRWACgCUALglIqMgvMVQA3sqhUCGA4VFsGRmYoAwg6UQUIXj4AX35BcGgRAFVxeHdpGjkEqAAfKAtWCFMsGNYlPhUodW1dfWMzCyMrGzs4J1c8qWpZb2gyiqqatlJ-BsDg0PDI4GjY+JYk1IE+IWgYXMkPQoYDEHrG5p0+PUMTc0trcP63Ic98E7O-AKCQsKgIpgrGJxUabNI7DKUMQUQZHWRwrwJTgBJqaK67KE5GGHArw3GIlilcoGSrVWrIuaoloQ4TIfbY-LDAgI96nCkXNH8IA)!

This shouldn't affect help hovers; the user will still see `AutoPromise<their type>` just as before (that's why we gave it a name in the first place).