### PR TITLE
`%%` operator types support `bigint` in addition to `number`

### DIFF
--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -98,8 +98,10 @@ declareHelper := {
     state.prelude.push ["", [ // [indent, statement]
       preludeVar
       moduloRef
-      ts ": (a: number, b: number) => number"
-      " = (a, b) => (a % b + b) % b"
+      " = "
+      ts "("
+      "(a", ts(": number"), ", b", ts(": number"), ") => (a % b + b) % b",
+      ts ") as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint)"
     ], ";\n"]
   Falsy(FalsyRef): void
     state.prelude.push ["", // [indent, statement]

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -486,7 +486,7 @@ describe "assignment", ->
     a %/= b
     a ÷= b
     ---
-    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
     var div: (a: number, b: number) => number = (a, b) => Math.floor(a / b);
     a = modulo(a, b)
     a = div(a, b)
@@ -701,7 +701,7 @@ describe "assignment", ->
     ---
     index = (@index + 1) %% 8
     ---
-    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
     index = modulo((this.index + 1), 8)
   """
 

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -30,7 +30,16 @@ describe "binary operations", ->
     ---
     a %% b
     ---
-    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
+    modulo(a, b)
+  """
+
+  testCase.js """
+    positive modulo JS
+    ---
+    a %% b
+    ---
+    var modulo = (a, b) => (a % b + b) % b;
     modulo(a, b)
   """
 
@@ -39,7 +48,7 @@ describe "binary operations", ->
     ---
     a %% b %% c
     ---
-    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
     modulo(modulo(a, b), c)
   """
 
@@ -48,7 +57,7 @@ describe "binary operations", ->
     ---
     x + a %% b
     ---
-    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
     x + modulo(a, b)
   """
 

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -152,7 +152,7 @@ describe "&. function block shorthand", ->
     ---
     'abc'[&%]
     ---
-    var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
     $ => 'abc'[modulo($, 'abc'.length)]
   """
 

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -519,7 +519,7 @@ describe "property access", ->
       x[i%%]
       x[i %% ]
       ---
-      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
       x[modulo(i, x.length)]
       x[modulo(i , x.length)]
       x[modulo(i, x.length)]
@@ -533,7 +533,7 @@ describe "property access", ->
       x.y[i+j%]
       (x+y)[i+j%]
       ---
-      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
       let ref;(ref = x())[modulo(i+j, ref.length)]
       let ref1;(ref1 = x.y)[modulo(i+j, ref1.length)]
       let ref2;(ref2 = (x+y))[modulo(i+j, ref2.length)]
@@ -544,6 +544,6 @@ describe "property access", ->
       ---
       x()[i+j%] = rhs
       ---
-      var modulo: (a: number, b: number) => number = (a, b) => (a % b + b) % b;
+      var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
       let ref;(ref = x())[modulo(i+j, ref.length)] = rhs
     """


### PR DESCRIPTION
Fixes #1600