### PR TITLE
Fix implicit `async` and `*` in methods

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3727,60 +3727,22 @@ MethodDefinition
       abstract: true,
       signature,
       parameters: signature.parameters,
-      ts: true
+      async: signature.async,
+      generator: signature.generator,
+      ts: true,
     }
   # NOTE: Not adding extra validation using PropertySetParameterList
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
   MethodSignature:signature !(PropertyAccess / ExplicitPropertyGlob / UnaryPostfix / NonNullAssertion) BracedBlock?:block ->
-    let children = $0
-    let generatorPos = 0
-    let { modifier } = signature
-
-    if (hasAwait(block)) {
-      generatorPos++
-      children = children.slice()
-      // get or set
-      if (modifier?.get || modifier?.set) {
-        children.push({
-          type: "Error",
-          message: "Getters and setters cannot be async",
-        })
-      } else if(modifier?.async) {
-        // Do nothing, already async
-      } else {
-        // Insert implicit async
-        children.unshift("async ")
-        modifier = { ...modifier, async: true }
-        signature = { ...signature, modifier }
-      }
-    }
-
-    if (hasYield(block)) {
-      if (children === $0) children = children.slice()
-
-      // get or set
-      if (modifier?.get || modifier?.set) {
-        children.push({
-          type: "Error",
-          message: "Getters and setters cannot be generators",
-        })
-      } else if(modifier?.generator) {
-        // Do nothing, already generator
-      } else {
-        // Insert implicit generator
-        children.splice(generatorPos, 0, "*")
-        modifier = { ...modifier, generator: true }
-        signature = { ...signature, modifier }
-      }
-    }
-
     return {
       type: "MethodDefinition",
-      children,
+      children: $0,
       name: signature.name,
       signature,
       block,
       parameters: signature.parameters,
+      async: signature.async,
+      generator: signature.generator,
     }
 
   # shorthand get method definition
@@ -3863,33 +3825,31 @@ MethodDefinition
 
 MethodModifier
   # NOTE: Merged get/set definitions
-  GetOrSet:kind _? &ClassElementName ->
+  GetOrSet:kind _?:ws &ClassElementName ->
     return {
-      type: "MethodModifier",
-      async: false,
-      generator: false,
-      get: kind.token === "get",
-      set: kind.token === "set",
-      children: $0,
+      // no async or generator, because getters and setters can't be
+      modifier: {
+        async: false,
+        generator: false,
+        get: kind.token === "get",
+        set: kind.token === "set",
+      },
+      children: [ kind, ws ],
     }
   # NOTE: Merged async and generator into MethodModifier
-  ( Async __ ) ( Star __ )? ->
+  ( Async __ )?:async ( Star __ )?:generator ->
+    if (!async) async = []
+    if (!generator) generator = []
     return {
-      type: "MethodModifier",
-      async: true,
-      get: false,
-      set: false,
-      generator: !!$2,
-      children: $0,
-    }
-  Star __ ->
-    return {
-      type: "MethodModifier",
-      async: false,
-      get: false,
-      set: false,
-      generator: true,
-      children: $0,
+      async,
+      generator,
+      modifier: {
+        async: !!async.length,
+        get: false,
+        set: false,
+        generator: !!generator.length,
+      },
+      children: [ async, generator ],
     }
 
 # TypeScript method signature
@@ -3905,8 +3865,8 @@ MethodSignature
     }
 
   # NOTE: If this node layout changes, be sure to update
-  # `convertMethodToFunction` and `[3]` in code below
-  MethodModifier?:modifier ClassElementName:name _? QuestionMark?:optional _? NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ->
+  # `convertMethodToFunction`
+  MethodModifier:modifier ClassElementName:name _?:ws1 QuestionMark?:optional _?:ws2 NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ->
     // Normalize name so we can check if it is `constructor`
     if (name.name) {
       name = name.name
@@ -3915,16 +3875,16 @@ MethodSignature
     }
 
     // TypeScript supports optional methods with bodies; remove ? from JS output
-    if (optional) $0[3] = optional = { ...optional, ts: true }
-
-    modifier = modifier || {}
+    if (optional) optional = { ...optional, ts: true }
 
     return {
       type: "MethodSignature",
-      children: $0,
+      children: [ ...modifier.children, name, ws1, optional, ws2, parameters, returnType ],
+      async: modifier.async,
+      generator: modifier.generator,
       name,
       optional,
-      modifier, // get/set/async/generator
+      modifier: modifier.modifier, // get/set/async/generator
       returnType,
       parameters,
     }

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -897,36 +897,38 @@ function processSignature(f: FunctionNode): void
   {block, signature} := f
 
   if not f.async?# and hasAwait(block)
-    f.async.push "async "
-    signature.modifier.async = true
+    if f.async?
+      f.async.push "async "
+      signature.modifier.async = true
+    else
+      for each a of gatherRecursiveWithinFunction block, .type is "Await"
+        i := findChildIndex a.parent, a
+        // i+1 because after "await" we have a consistent location in sourcemap
+        a.parent!.children.splice i+1, 0,
+          type: "Error"
+          message: `await invalid in ${signature.modifier.get ? "getter" : signature.modifier.set ? "setter" : signature.name}` // name likely constructor
 
   if not f.generator?# and hasYield(block)
-    if f.type is "ArrowFunction"
-      gatherRecursiveWithinFunction block, .type is "YieldExpression"
-      .forEach (y) =>
+    if f.generator?
+      f.generator.push "*"
+      signature.modifier.generator = true
+    else
+      for each y of gatherRecursiveWithinFunction block, .type is "YieldExpression"
         i := y.children.findIndex .type is "Yield"
         // i+1 because after "yield" we have a consistent location in sourcemap
         y.children.splice i+1, 0,
           type: "Error"
-          message: "Can't use yield inside of => arrow function"
-    else
-      f.generator.push "*"
-      signature.modifier.generator = true
+          message: `yield invalid in ${f.type is "ArrowFunction" ? "=> arrow function" : signature.modifier.get ? "getter" : signature.modifier.set ? "setter" : signature.name}` // name likely constructor
 
   if signature.modifier.async and not signature.modifier.generator and
      signature.returnType and not isPromiseType signature.returnType.t
     replaceNode signature.returnType.t, wrapTypeInPromise signature.returnType.t
 
 function processFunctions(statements, config): void
-  for each f of gatherRecursiveAll statements, .type is "FunctionExpression" or .type is "ArrowFunction"
-    if f.type is "FunctionExpression"
+  for each f of gatherRecursiveAll statements, .type is "FunctionExpression" or .type is "ArrowFunction" or .type is "MethodDefinition"
+    if f.type is "FunctionExpression" or f.type is "MethodDefinition"
       implicitFunctionBlock(f)
     processSignature(f)
-    processParams(f)
-    processReturn(f, config.implicitReturns)
-
-  for each f of gatherRecursiveAll statements, .type is "MethodDefinition"
-    implicitFunctionBlock(f)
     processParams(f)
     processReturn(f, config.implicitReturns)
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -783,34 +783,29 @@ function lastAccessInCallExpression(exp)
 
 // Given a MethodDefinition, convert into a FunctionExpression.
 // Returns undefined if the method is a getter or setter.
-function convertMethodToFunction(method) {
-  const { signature, block } = method
-  let { modifier, optional } = signature
-  if (optional) return
-  if (modifier) {
-    if (modifier.get or modifier.set) {
-      return
-    } else if (modifier.async) {
-      // put function after async
-      modifier = [modifier.children[0][0], " function ", ...modifier.children.slice(1)]
-    } else {
-      modifier = ["function ", ...(modifier.children or [])]
-    }
-  } else {
-    modifier = "function ";
-  }
+function convertMethodToFunction(method)
+  { signature, block } := method
+  { async, modifier, optional } := signature
+  return if optional
+  return if modifier?.get or modifier?.set
+  func := ["function "]
+  if async?
+    // put `function` after `async`
+    func.unshift async
+    // ensure space after `async` (absent in e.g. `async* f()`)
+    if async# and not async.-1?.#
+      async.push " "
   return {
-    ...signature,
-    id: signature.name,
-    signature,
-    type: "FunctionExpression",
+    ...signature
+    id: signature.name
+    signature
+    type: "FunctionExpression"
     children: [
-      [modifier, ...signature.children.slice(1)],
-      block,
-    ],
-    block,
+      [...func, ...signature.children.slice(1)]
+      block
+    ]
+    block
   }
-}
 
 // Convert NamedImports into equivalent ObjectExpression or ObjectBindingPattern
 function convertNamedImportsToObject(node, pattern?: boolean)
@@ -906,6 +901,7 @@ function makeGetterMethod(name, ws, value, returnType, block?: BlockStatement, k
       type: "BlockStatement"
       expressions
       children: ["{ ", expressions, " }"]
+      bare: false
     }
 
   if autoReturn
@@ -919,21 +915,21 @@ function makeGetterMethod(name, ws, value, returnType, block?: BlockStatement, k
   children := [kind, " ", name, parameters, returnType, block]
 
   return {
-    type: "MethodDefinition",
-    children,
-    name,
+    type: "MethodDefinition"
+    children
+    name
     signature: {
       type: "MethodSignature"
       modifier: {
         get: token is "get"
         set: token is "set"
         async: false
-      },
-      name,
-      returnType,
-    },
-    block,
-    parameters,
+      }
+      name
+      returnType
+    }
+    block
+    parameters
   }
 
 function processBindingPatternLHS(lhs, tail): void

--- a/test/class.civet
+++ b/test/class.civet
@@ -1058,6 +1058,23 @@ describe "class", ->
       }
     """
 
+    testCase """
+      async do shields await
+      ---
+      class A
+        f()
+          async do
+            await 3
+      ---
+      class A {
+        f() {
+          return (async ()=>{{
+            return await 3
+          }})()
+        }
+      }
+    """
+
   describe "implicit generator", ->
     testCase """
       implicit generator
@@ -1083,6 +1100,23 @@ describe "class", ->
       class A {
         *f() {
           yield 3
+        }
+      }
+    """
+
+    testCase """
+      do* shields yield
+      ---
+      class A
+        f()
+          do*
+            yield 3
+      ---
+      class A {
+        f() {
+          return (function*(){{
+            yield 3
+          }})()
         }
       }
     """

--- a/test/function.civet
+++ b/test/function.civet
@@ -238,7 +238,7 @@ describe "function", ->
       ---
       => yield 5
       ---
-      ParseErrors: unknown:1:9 Can't use yield inside of => arrow function
+      ParseErrors: unknown:1:9 yield invalid in => arrow function
     """
 
     throws """
@@ -246,7 +246,7 @@ describe "function", ->
       ---
       => yield 5
       ---
-      ParseErrors: unknown:1:9 Can't use yield inside of => arrow function
+      ParseErrors: unknown:1:9 yield invalid in => arrow function
     """, inlineMap: true
 
     throws """
@@ -256,8 +256,8 @@ describe "function", ->
         yield 1
         yield 2
       ---
-      ParseErrors: unknown:2:8 Can't use yield inside of => arrow function
-      unknown:3:8 Can't use yield inside of => arrow function
+      ParseErrors: unknown:2:8 yield invalid in => arrow function
+      unknown:3:8 yield invalid in => arrow function
     """
 
     testCase """


### PR DESCRIPTION
Fixes #1621 by unifying implicit async/generator handling in methods with functions. Previously, methods did the implicit additions too early, during the grammar which is before `async do` and `do*` gain wrappers.