### PR TITLE
Fix object literals and bulleted lists in JSX indented attributes, fix indentation detection

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5472,30 +5472,37 @@ Debugger
 
 MaybeNestedNonPipelineExpression
   NestedBulletedArray
-  PushIndent ( Nested NonPipelineExpression )? PopIndent ->
-    if ($3) return $3
-    return $skip
+  NestedImplicitObjectLiteral
+  PushIndent ( Nested NonPipelineExpression )? PopIndent AllowedTrailingCallExpressions? ->
+    if (!$2) return $skip
+    if (!$4) return $2
+    return [ $2, $4 ]
   NonPipelineExpression
 
 MaybeNestedPostfixedExpression
   NestedBulletedArray
-  PushIndent ( Nested PostfixedExpression )? PopIndent ->
-    if ($3) return $3
-    return $skip
+  NestedImplicitObjectLiteral
+  PushIndent ( Nested PostfixedExpression )? PopIndent AllowedTrailingCallExpressions? ->
+    if (!$2) return $skip
+    if (!$4) return $2
+    return [ $2, $4 ]
   PostfixedExpression
+
+NestedPostfixedExpressionNoTrailing
+  NestedBulletedArray
+  NestedImplicitObjectLiteral
+  PushIndent ( Nested PostfixedExpression )? PopIndent ->
+    if (!$2) return $skip
+    return $2
 
 MaybeNestedExpression
   NestedBulletedArray
-  PushIndent ( Nested Expression )? PopIndent ->
-    if ($3) return $3
-    return $skip
+  NestedImplicitObjectLiteral
+  PushIndent ( Nested Expression )? PopIndent AllowedTrailingCallExpressions? ->
+    if (!$2) return $skip
+    if (!$4) return $2
+    return [ $2, $4 ]
   Expression
-
-NestedExpression
-  NestedBulletedArray
-  PushIndent ( Nested Expression )? PopIndent ->
-    if ($3) return $3
-    return $skip
 
 # MaybeNestedExpression but where expression needs to be output with
 # parentheses if indented, so that the expression starts on the same line.
@@ -5510,7 +5517,7 @@ MaybeParenNestedExpression
   &EOS ( ArrayLiteral / ObjectLiteral ) -> $2
   # Value after `return` needs to be wrapped in parentheses
   # if it starts on another line.
-  &EOS InsertSpace InsertOpenParen PushIndent ( Nested Expression ):exp PopIndent InsertNewline InsertIndent InsertCloseParen ->
+  &EOS InsertSpace InsertOpenParen PushIndent ( Nested Expression ):exp PopIndent AllowedTrailingCallExpressions? InsertNewline InsertIndent InsertCloseParen ->
     if (!exp) return $skip
     return $0.slice(1)
 
@@ -7196,9 +7203,8 @@ JSXAttributeName
 JSXAttributeInitializer
   # Outside CoffeeScript compatibility mode,
   # allow attribute value to be an indented expression
-  !CoffeeJSXEnabled Whitespace?:ws1 Equals:equals &( NonNewlineWhitespace* EOL ):ws2 InsertInlineOpenBrace:open PushIndent:indent PostfixedExpression?:expression PopIndent InsertCloseBrace:close ->
-    if (!expression) return $skip
-    return [ ws1, equals, ws2, open, indent, expression, close ]
+  !CoffeeJSXEnabled Whitespace?:ws1 Equals:equals &( NonNewlineWhitespace* EOL ) InsertInlineOpenBrace:open NestedPostfixedExpressionNoTrailing:expression InsertCloseBrace:close ->
+    return [ ws1, equals, open, trimFirstSpace(expression), close ]
   Whitespace? Equals Whitespace? JSXAttributeValue
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeValue

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -408,9 +408,8 @@ ArgumentsWithTrailingCallExpressions
 
 # Does not match in the empty case
 TrailingCallExpressions
-  # NOTE: Assert "." to not match "?" or "!" or string literal
-  # as a call expression on the following line
-  CallExpressionRest* IndentedTrailingCallExpressions? ->
+  # NOTE: Forbid nested implicit calls because trailing calls are dedented
+  ExplicitCallExpressionRest* IndentedTrailingCallExpressions? ->
     $1 = $1.flat()
     if (!$1.length && !$2) return $skip
     if (!$2) return $1
@@ -1445,6 +1444,27 @@ CallExpressionRest
       children: [optional, ...call.children],
       optional,
     }, ...argsWithTrailing.slice(1) ]
+
+ExplicitCallExpressionRest
+  MemberExpressionRest
+  # NOTE: TypeScript instantiation expressions
+  # https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#instantiation-expressions
+  # But x<y>z and x<y>0 is a comparison chain.
+  TypeArguments !( IdentifierName / NumericLiteral ) -> $1
+  # perf: assertion to exit early
+  /(?=['"`])/ ( TemplateLiteral / StringLiteral ):literal ->
+    if (literal.type === "StringLiteral") {
+      literal = "`" + literal.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
+    }
+    return literal
+  OptionalShorthand?:optional ExplicitArguments:call ->
+    if (!optional) return call
+
+    return {
+      ...call,
+      children: [optional, ...call.children],
+      optional,
+    }
 
 # NOTE: Added shorthand x?(3) -> x?.(3)
 OptionalShorthand
@@ -7203,6 +7223,7 @@ JSXAttributeName
 JSXAttributeInitializer
   # Outside CoffeeScript compatibility mode,
   # allow attribute value to be an indented expression
+  # Forbid trailing expressions outside the indentation, as that should be JSX
   !CoffeeJSXEnabled Whitespace?:ws1 Equals:equals &( NonNewlineWhitespace* EOL ) InsertInlineOpenBrace:open NestedPostfixedExpressionNoTrailing:expression InsertCloseBrace:close ->
     return [ ws1, equals, open, trimFirstSpace(expression), close ]
   Whitespace? Equals Whitespace? JSXAttributeValue

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5493,35 +5493,35 @@ Debugger
 MaybeNestedNonPipelineExpression
   NestedBulletedArray
   NestedImplicitObjectLiteral
-  PushIndent ( Nested NonPipelineExpression )? PopIndent AllowedTrailingCallExpressions? ->
-    if (!$2) return $skip
-    if (!$4) return $2
-    return [ $2, $4 ]
+  PushIndent ( Nested NonPipelineExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+    if (!expression) return $skip
+    if (!trailing) return expression
+    return [ expression, trailing ]
   NonPipelineExpression
 
 MaybeNestedPostfixedExpression
   NestedBulletedArray
   NestedImplicitObjectLiteral
-  PushIndent ( Nested PostfixedExpression )? PopIndent AllowedTrailingCallExpressions? ->
-    if (!$2) return $skip
-    if (!$4) return $2
-    return [ $2, $4 ]
+  PushIndent ( Nested PostfixedExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+    if (!expression) return $skip
+    if (!trailing) return expression
+    return [ expression, trailing ]
   PostfixedExpression
 
 NestedPostfixedExpressionNoTrailing
   NestedBulletedArray
   NestedImplicitObjectLiteral
-  PushIndent ( Nested PostfixedExpression )? PopIndent ->
-    if (!$2) return $skip
-    return $2
+  PushIndent ( Nested PostfixedExpression )?:expression PopIndent ->
+    if (!expression) return $skip
+    return expression
 
 MaybeNestedExpression
   NestedBulletedArray
   NestedImplicitObjectLiteral
-  PushIndent ( Nested Expression )? PopIndent AllowedTrailingCallExpressions? ->
-    if (!$2) return $skip
-    if (!$4) return $2
-    return [ $2, $4 ]
+  PushIndent ( Nested Expression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+    if (!expression) return $skip
+    if (!trailing) return expression
+    return [ expression, trailing ]
   Expression
 
 # MaybeNestedExpression but where expression needs to be output with

--- a/test/call-expression.civet
+++ b/test/call-expression.civet
@@ -1,4 +1,4 @@
-{ testCase } from ./helper.civet
+{ testCase, throws } from ./helper.civet
 
 describe "call-expression", ->
   testCase """
@@ -193,6 +193,16 @@ describe "call-expression", ->
           'ready',
           (bot) => {}) // TODO
         .login(config.bot.token)
+    """
+
+    throws """
+      dedent doesn't count as indented call
+      ---
+      x =
+          a
+        b
+      ---
+      ParseError
     """
 
   describe "insert semicolons to prevent accidental calls", ->

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -609,3 +609,29 @@ describe "JSX object literal shorthand", ->
           </>}
        />
     """
+
+    testCase """
+      multiline literals
+      ---
+      <For each=
+        . 1
+        . 2
+        . 3
+      >
+        <div style=
+          background: "white"
+          color: "black"
+        >
+      ---
+      <For each={[
+          1,
+          2,
+          3]}
+      >
+        <div style={{
+          background: "white",
+          color: "black",
+        }}
+         />
+      </For>
+    """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -363,7 +363,8 @@ describe "pipe", ->
     ---
     x; // c
     // @ts-expect-error
-    let ref;foo ??=(baz((ref = \n  bar())),qux(ref),ref)
+    let ref;foo ??=
+      (baz((ref = bar())),qux(ref),ref)
   """
 
   describe "ampersand", ->
@@ -711,8 +712,8 @@ describe "pipe", ->
       foo()
       |> await
     ---
-    ({foo:await (
-      foo())})
+    ({foo:
+      await foo()})
   """
 
   testCase """


### PR DESCRIPTION
The `MaybeNested...Expression` rules were surprisingly quite broken. Can you spot the bug?

```js
MaybeNestedExpression
  NestedBulletedArray
  PushIndent ( Nested Expression )? PopIndent ->
    if ($3) return $3
    return $skip
  Expression
```

"Luckily" `PopIndent` was always false, so the indented rule never applied. But we weren't correctly tracking indentation in this case.

With this fixed, we no longer supported dedented trailing call expressions after a nested expression. So I added `AllowedTrailingCallExpression?` after `PopIndent` in the rule above (and its friends).

But adding that revealed a different bug.  In particular, the following was treated as a call before:

```js
x =
    a
  b
```

So I modified `AllowedTrailingCallExpression` to not check for implicit calls; they shouldn't be relevant for trailing call expressions.

With all that fixed, it was relatively easy to fix #1622 JSX indented attributes to use something like this. I couldn't use the exact mechanism because (1) it didn't want the `Maybe` and (2) I didn't want to allow for dedented trailing call expressions in JSX, because e.g. a dedented `.foo` should be treated as JSX `class` shorthand, not a trailing member access.