### PR TITLE
Fix placeholders in `for each` loops

### DIFF
--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -296,6 +296,7 @@ function processForInOf($0: [
         type: "Declaration"
         children: [declaration, " = ", trimFirstSpace(expRef), "[", counterRef, "]"]
         names: assignmentNames
+        implicitLift: true
       }, ";"]
 
       declaration =

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1574,7 +1574,13 @@ function processPlaceholders(statements: StatementTuple[]): void
       // Ampersand placeholder & lifts to nearest call expression,
       // excluding the call itself, or else to the nearest block statement.
       let child
+      let implicitLift: boolean?
       { ancestor, child } = findAncestor exp, (ancestor, child) =>
+        // Skip this node of its child told us to
+        prevImplicitLift := implicitLift
+        {implicitLift} = ancestor as Declaration
+        return if prevImplicitLift
+
         {type} := ancestor
         if type is "IfStatement"
           liftedIfs.add ancestor
@@ -1646,7 +1652,7 @@ function processPlaceholders(statements: StatementTuple[]): void
       typeSuffix ??= placeholder.typeSuffix
       // NOTE: Replace last child instead of placeholder itself
       // so that we preserve any whitespace that's been glommed as a prefix
-      replaceNode placeholder.children.-1, ref
+      placeholder.children.-1 = ref
 
     // Function wrapping can change parent; use original for replaceNode
     {parent} := ancestor

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -619,6 +619,9 @@ export type Declaration =
   decl: "let" | "const" | "var"
   splices?: unknown
   thisAssignments?: ThisAssignments
+  // Should placeholders in contents be lifted above the parent block,
+  // because they actual came from code outside the block?
+  implicitLift?: boolean
 
 export type Binding =
   type: "Binding"

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -746,6 +746,17 @@ describe "&. function block shorthand", ->
     ParseErrors: unknown:1:6 Lone placeholder (&) is not a valid left-hand side
   """
 
+  testCase """
+    for each
+    ---
+    for each bit of &
+      Number bit
+    ---
+    $ => { const results=[];for (let i = 0, len = $.length; i < len; i++) {const bit = $[i];
+      results.push(Number(bit))
+    };return results;}
+  """
+
   describe "multiple &", ->
     testCase """
       self-addition


### PR DESCRIPTION
Fixes #1603

There might be other situations where we need to `implicitLift` (and maybe it will need to be a number instead of just 1 or 0) but at least we have a mechanism now.

(also open to better names than "`implicitLift`")