### PR TITLE
Range literal `[a..b]` defaults to increasing; adaptive behavior behind `"civet coffeeRange"` directive

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -80,6 +80,7 @@ For now, we have the following related options:
 | [`coffeeNot`](reference#coffeescript-operators) | `not` → `!`, disabling Civet extensions like [`is not`](reference#humanized-operators) |
 | [`coffeeOf`](reference#coffeescript-operators) | `a of b` → `a in b`, `a not of b` → `!(a in b)`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
 | [`coffeePrototype`](reference#coffeescript-operators) | `x::` -> `x.prototype`, `x::y` -> `x.prototype.y` |
+| [`coffeeRange`](reference#coffeescript-range-literals) | `[a..b]` increases or decreases depending on whether `a < b` or `a > b` |
 
 ## Environment Options
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -437,27 +437,32 @@ You can also omit the name of the rest component:
 <Playground>
 letters := ['a'..'f']
 numbers := [1..10]
-reversed := [10..1]
 indices := [0...array.length]
 </Playground>
 
 An infinite range `[x..]` is supported when [looping](#range-loop).
 
-Alternatively, `..` can explicitly exclude endpoints with `<` or `>`,
-or include endpoints with `<=` or `>=`. These also control loop direction,
-whereas `[a..b]` determines direction based on whether `a <= b`.
+Alternatively, `..` can exclude an endpoint with `<`,
+or explicitly include an endpoint with `<=` (or `≤`):
 
 <Playground>
 indices := [0..<array.length]
+strict := [a<..<b]
+// [a<=..≤b] same as [a..b]
 </Playground>
 
-<Playground>
-reversed := [array.length>..0]
-</Playground>
+You can construct a reverse (decreasing) range by specifying `>` (exclusive)
+or `>=` (inclusive) on at least one endpoint:
 
 <Playground>
-increasing := [a..<=b]
+reversed := [10..>=1]
+reversedIndices := [array.length>..0]
 </Playground>
+
+If you'd rather `[a..b]` and `[a...b]` construct an increasing or decreasing
+range depending on whether `a < b` or `a > b` (unless you specify an explicit
+direction via `<`/`>`/`<=`/`>=`), use the
+[`"civet coffeeRange"` directive](#coffeescript-ranges).
 
 ### Array/String Slicing
 
@@ -3281,6 +3286,15 @@ on
 off
 yes
 no
+</Playground>
+
+### CoffeeScript Ranges
+
+<Playground>
+"civet coffeeRange"
+[10..1]
+[a..b]
+[a...b]
 </Playground>
 
 ### CoffeeScript Comments

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -40,6 +40,7 @@ Things Kept from CoffeeScript
 - `for ... when <condition>`
 - `for ... by <step>` when looping over range literals
 - Range literals `[0...10]`, `[a..b]`, `[x - 2 .. x + 2]`
+  (with some [changes](#things-changed-from-coffeescript))
 - Array slices `list[0...2]` → `list.slice(0, 2)`
 - Slice assignment `numbers[3..6] = [-3, -4, -5, -6]` → `numbers.splice(3, 4, ...[-3, -4, -5, -6])`
 - Implicit returns
@@ -69,6 +70,10 @@ Civet.
 - `for from` (use JS `for of`, `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for in` (use `for each of`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
 - `for own of` (use `for own in`, or `"civet coffeeCompat"`, or `"civet coffeeForLoops"`)
+- Range literals `[a..b]` and `[a...b]` are increasing by default
+  (same as Civet and CoffeeScript slices): if `a > b`, then `[a..b]` is empty.
+  To get a decreasing range, use `[a..>=b]` or `[a..>b]`,
+  or use `"civet coffeeCompat"` or `"civet coffeeRange"`.
 - `a ? b` (use `a ?? b`, though it doesn't check for undeclared variables; `"civet coffeeCompat"`, or `"civet coffeeBinaryExistential"` enables `a ? b` at the cost of losing JS ternary operator)
 - `a of b` (use `a in b` as in JS, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)
 - `a not of b` (use `a not in b`, or `"civet coffeeCompat"`, or `"civet coffeeOf"`)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3056,13 +3056,16 @@ RangeDots
       type: "RangeDots",
       left: { inclusive: true, raw: "" },
       right: { inclusive: false, raw: "." },
-      increasing: undefined,
+      // Ranges are increasing by default, but adaptive in coffeeCompat mode
+      increasing: config.coffeeRange ? undefined : true,
       triple: true,
       children: [],
     }
   OptionalRangeEnd:left _?:ws1 DotDot:dots _?:ws2 OptionalRangeEnd:right ->
     // Inherit increasing flag from either side
-    const increasing = left.increasing ?? right.increasing
+    // Ranges are increasing by default, but adaptive in coffeeCompat mode
+    const increasing = left.increasing ?? right.increasing ??
+      (config.coffeeRange ? undefined : true)
     if (left.increasing != null && right.increasing != null &&
         left.increasing !== right.increasing) {
       const error = {
@@ -8860,6 +8863,7 @@ Reset
       coffeeNot: false,
       coffeeOf: false,
       coffeePrototype: false,
+      coffeeRange: false,
       defaultElement: "div",
       globals: [],
       iife: false,
@@ -8906,6 +8910,7 @@ Reset
           "coffeeNot",
           "coffeeOf",
           "coffeePrototype",
+          "coffeeRange",
         ]) {
           config[option] = b
         }

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -131,7 +131,7 @@ function forRange(
   stepExp: ASTNode
   close: ASTLeaf
 )
-  { start, end, left, right, increasing } := range
+  { start, end, left, right, increasing } .= range
 
   counterRef := makeRef("i")
 
@@ -162,27 +162,32 @@ function forRange(
   startRefDec := (startRef !== start) ? [startRef, " = ", start, ", "] : []
   endRefDec := (endRef !== end) ? [endRef, " = ", end, ", "] : []
 
-  unless left.inclusive
-    startRef =
-      . makeLeftHandSideExpression(start)
-      . " + "
-      . stepRef
-
   let ascDec: ASTNode[] = [], ascRef
   if stepExp
     unless stepRef is stepExp
       ascDec = [", ", stepRef, " = ", stepExp]
 
-  else if start?.type is "Literal" is end?.type
+  if start?.type is "Literal" is end?.type
     // @ts-ignore Allow comparison of any literal values, as in JS
     asc = literalValue(start) <= literalValue(end)
     if "StringLiteral" is start.subtype is end.subtype
-      startRef = (literalValue(start) as string).charCodeAt(0).toString()
+      startChar := (literalValue(start) as string).charCodeAt(0).toString()
+      startRef =
+        type: "Literal"
+        subtype: "NumericLiteral"
+        raw: startChar
+        children: [startChar]
       endRef = (literalValue(end) as string).charCodeAt(0).toString()
 
-  else
+  else unless stepExp
     ascRef = makeRef("asc")
     ascDec = [", ", ascRef, " = ", startRef, " <= ", endRef]
+
+  unless left.inclusive
+    startRef =
+      . makeLeftHandSideExpression startRef
+      . " + "
+      . stepRef
 
   let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
   let names: string[] = forDeclaration?.names ?? []
@@ -195,7 +200,7 @@ function forRange(
       varAssign = [...trimFirstSpace(varName) as ASTNode[], " = "]
       varLet = [",", ...varName, " = ", counterRef]
     else // const or var or assignment like `for x[y] of z`: put inside loop
-      value := "StringLiteral" is start.subtype ? ["String.fromCharCode(", counterRef, ")"] : counterRef
+      value := "StringLiteral" is start?.subtype ? ["String.fromCharCode(", counterRef, ")"] : counterRef
       blockPrefix = [
         ["", [forDeclaration, " = ", value], ";"]
       ]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1074,6 +1074,7 @@ export type Literal =
 export type LiteralContentNode =
   | ASTLeaf
   | ASTLeafWithType "NumericLiteral" | "StringLiteral"
+  | string
 
 export type NumericLiteral = ASTLeafWithType "NumericLiteral"
 export type StringLiteral = ASTLeafWithType "StringLiteral"

--- a/test/compat/coffee-range.civet
+++ b/test/compat/coffee-range.civet
@@ -1,0 +1,131 @@
+{ testCase } from "../helper.civet"
+
+describe "coffeeRange", ->
+  testCase """
+    [0..10]
+    ---
+    "civet coffeeRange"
+    [0..10]
+    ---
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  """
+
+  testCase """
+    [0...10]
+    ---
+    "civet coffeeRange"
+    [0...10]
+    ---
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  """
+
+  testCase """
+    [0..-10]
+    ---
+    "civet coffeeRange"
+    [0..-10]
+    ---
+    [0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]
+  """
+
+  testCase """
+    [0...256]
+    ---
+    "civet coffeeRange"
+    [0...256]
+    ---
+    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)}, (_, i) => s + i * step)})(0,256)
+  """
+
+  testCase """
+    [0..255]
+    ---
+    "civet coffeeRange"
+    [0..255]
+    ---
+    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => s + i * step)})(0,255)
+  """
+
+  testCase """
+    hex
+    ---
+    [0..0xa]
+    ---
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  """
+
+  testCase """
+    negative hex
+    ---
+    "civet coffeeRange"
+    [0..-0xa]
+    ---
+    [0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]
+  """
+
+  testCase """
+    [x - 5 .. x + 5]
+    ---
+    "civet coffeeRange"
+    [x - 5 .. x + 5]
+    ---
+    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => s + i * step)})(x - 5 , x + 5)
+  """
+
+  testCase """
+    ['a' .. 'f']
+    ---
+    "civet coffeeRange"
+    ['a' .. 'f']
+    ---
+    ["a", "b", "c", "d", "e", "f"]
+  """
+
+  testCase """
+    ["f" .. "a"]
+    ---
+    "civet coffeeRange"
+    ["f" .. "a"]
+    ---
+    ["f", "e", "d", "c", "b", "a"]
+  """
+
+  testCase """
+    ["Z".."A"]
+    ---
+    "civet coffeeRange"
+    ["Z".."A"]
+    ---
+    ["Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"]
+  """
+
+  testCase """
+    ..< with numbers
+    ---
+    "civet coffeeRange"
+    [0..<10]
+    [10..<0]
+    ---
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    []
+  """
+
+  testCase """
+    ..< with strings
+    ---
+    "civet coffeeRange"
+    ['a'..<'g']
+    ['g'..<'a']
+    ---
+    ["a", "b", "c", "d", "e", "f"];
+    []
+  """
+
+  testCase """
+    ..< with variables
+    ---
+    "civet coffeeRange"
+    [a..<b]
+    ---
+    ((s) => Array.from({length: b - s}, (_, i) => s + i))(a)
+  """

--- a/test/for.civet
+++ b/test/for.civet
@@ -253,6 +253,17 @@ describe "for", ->
   """
 
   testCase """
+    for of character range with inequality
+    ---
+    for letter of ['a'<..<'z']
+      letter
+    ---
+    for (let i = 97 + 1; i < 122; ++i) {const letter = String.fromCharCode(i);
+      letter
+    }
+  """
+
+  testCase """
     for each of character range
     ---
     for each letter of ['a'..'z']

--- a/test/range.civet
+++ b/test/range.civet
@@ -38,15 +38,17 @@ describe "range", ->
     ---
     [0..-10]
     ---
-    [0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]
+    []
   """
 
   testCase """
     [97524..97520]
     ---
+    [97520..97524]
     [97524..97520]
     ---
-    [97524, 97523, 97522, 97521, 97520]
+    [97520, 97521, 97522, 97523, 97524];
+    []
   """
 
   testCase """
@@ -54,7 +56,7 @@ describe "range", ->
     ---
     [0...256]
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)}, (_, i) => s + i * step)})(0,256)
+    ((s) => Array.from({length: 256 - s}, (_, i) => s + i))(0)
   """
 
   testCase """
@@ -62,7 +64,7 @@ describe "range", ->
     ---
     [0..255]
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => s + i * step)})(0,255)
+    ((s) => Array.from({length: 255 - s + 1}, (_, i) => s + i))(0)
   """
 
   testCase """
@@ -110,7 +112,7 @@ describe "range", ->
     ---
     [0..-0xa]
     ---
-    [0, -1, -2, -3, -4, -5, -6, -7, -8, -9, -10]
+    []
   """
 
   testCase """
@@ -135,7 +137,7 @@ describe "range", ->
     ---
     [x - 5 .. x + 5]
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => s + i * step)})(x - 5 , x + 5)
+    ((s) => Array.from({length:  (x + 5) - s + 1}, (_, i) => s + i))(x - 5 )
   """
 
   testCase """
@@ -159,7 +161,7 @@ describe "range", ->
     ---
     ["f" .. "a"]
     ---
-    ["f", "e", "d", "c", "b", "a"]
+    []
   """
 
   testCase """
@@ -175,7 +177,7 @@ describe "range", ->
     ---
     ["Z".."A"]
     ---
-    ["Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"]
+    []
   """
 
   testCase """
@@ -203,7 +205,7 @@ describe "range", ->
     ---
     f();
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)}, (_, i) => s + i * step)})(0,n)
+    ((s) => Array.from({length: n - s}, (_, i) => s + i))(0)
   """
 
   describe "inequalities on range", ->

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -19,6 +19,7 @@ declare module "@danielx/civet" {
     coffeeNot: boolean
     coffeeOf: boolean
     coffeePrototype: boolean
+    coffeeRange: boolean
     defaultElement: string
     globals: string[]
     implicitReturns: boolean


### PR DESCRIPTION
Now that we have the ability to change the range literal direction via `<`/`>`/`<=`/`>=` modifiers, change the default behavior to `<=`. Old behavior available via `"civet coffeeCompat"` or `"civet coffeeRange"`.

Arguments for this change in default behavior from Discord:
* Brings range literal `[a..b]` into alignment with slices `x[a..b]` (which were already increasing by default, unless you explicitly write `>` or `>=`)
* Avoids bugs where you write e.g. `[1...n]` and fail to consider the case `n = 0`, so you end up with `[1, 0]` whereas you meant `[]`.

BREAKING CHANGE: `[a..b]` and `[a...b]` no longer creates a decreasing range without an explicit `>` or `>=`; add one where needed.

~~TODO: fix tests~~
~~TODO: some character loops are breaking~~