### PR TITLE
`"""` interpolations require `coffeeInterpolation`, `///` respects `coffeeInterpolation`, `coffeeComment`, `coffeeDiv`

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -69,11 +69,11 @@ For now, we have the following related options:
 | [`coffeeBooleans`](reference#coffeescript-booleans) | `yes`, `no`, `on`, `off` |
 | [`coffeeClasses`](reference#coffeescript-classes) | CoffeeScript-style `class` methods via `->` functions |
 | [`coffeeComment`](reference#coffeescript-comments) | `# single line comments` |
-| [`coffeeDiv`](reference#coffeescript-comments) | `x // y` integer division |
+| [`coffeeDiv`](reference#coffeescript-comments) | `x // y` integer division instead of JS comment |
 | [`coffeeDo`](reference#coffeescript-do) | `do ->`; disables [ES6 `do...while` loops](reference#do-while-until-loop) and [Civet `do` blocks](reference#do-blocks) |
 | [`coffeeEq`](reference#coffeescript-operators) | `==` → `===`, `!=` → `!==` |
 | [`coffeeForLoops`](reference#coffeescript-for-loops) | `for in`/`of`/`from` loops behave like they do in CoffeeScript (like Civet's `for each of`/`in`/`of` respectively) |
-| [`coffeeInterpolation`](reference#double-quoted-strings) | `"a string with #{myVar}"` |
+| [`coffeeInterpolation`](reference#double-quoted-strings) | `"a string with #{myVar}"`, `///regex #{myVar}///` |
 | [`coffeeIsnt`](reference#coffeescript-operators) | `isnt` → `!==` |
 | [`coffeeJSX`](reference#indentation) | JSX children ignore indentation; tags need to be explicitly closed |
 | [`coffeeLineContinuation`](reference#coffeescript-line-continuations) | `\` at end of line continues to next line |

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -531,7 +531,7 @@ console.log '''
 <Playground>
 console.log """
   <div>
-    Civet #{version}
+    Civet
   </div>
 """
 </Playground>
@@ -552,7 +552,8 @@ first slash is not immediately followed by a space.  Instead of `/ x /`
 write `/\ x /` or `/[ ]x /` (or more escaped forms like `/[ ]x[ ]/`).
 
 In addition, you can use `///...///` to write multi-line regular expressions
-that ignore top-level whitespace and single-line comments:
+that ignore top-level whitespace and single-line comments, and interpolates
+`${expression}` like in template literals:
 
 <Playground>
 phoneNumber := ///
@@ -562,6 +563,10 @@ phoneNumber := ///
   (?=\d) [\d-. ]+ \d    // start and end with digit
   $
 ///
+</Playground>
+
+<Playground>
+r := /// ${prefix} \s+ ${suffix} ///
 </Playground>
 
 :::info
@@ -3231,11 +3236,19 @@ do (url) ->
   await fetch url
 </Playground>
 
-### Double-Quoted Strings
+### CoffeeScript Interpolation
 
 <Playground>
 "civet coffeeInterpolation"
 console.log "Hello #{name}!"
+console.log """
+  Goodbye #{name}!
+"""
+</Playground>
+
+<Playground>
+"civet coffeeInterpolation"
+r = /// #{prefix} \s+ #{suffix} ///
 </Playground>
 
 ### CoffeeScript Operators
@@ -3306,6 +3319,13 @@ you can enable `#` for single-line comments:
 <Playground>
 "civet coffeeComment"
 # one-line comment
+</Playground>
+
+<Playground>
+"civet coffeeComment"
+r = ///
+  \s+ # whitespace
+///
 </Playground>
 
 [`###...###` block comments](#block-comments) are always available.

--- a/notes/Comparison-to-CoffeeScript.md
+++ b/notes/Comparison-to-CoffeeScript.md
@@ -33,7 +33,6 @@ Things Kept from CoffeeScript
 - Chained comparisons: `a < b < c` → `a < b && b < c`
 - Postfix `if/unless/while/until/for`
 - Block Strings `"""` / `'''`
-  - `#{exp}` interpolation in `"""` strings
 - `when` inside `switch` automatically breaks
 - Multiple `,` separated `case`/`when` expressions
 - `else` → `default` in `switch`
@@ -109,7 +108,7 @@ Things Changed from CoffeeScript
 - Generators don't implicitly return the last value (as this is rarely useful)
 - Backtick embedded JS has been replaced with JS template literals.
 - No longer allowing multiple postfix `if/unless` on the same line (use `&&` or `and` to combine conditions).
-- `#{}` interpolation in `""` strings only when `"civet coffeeCompat"` or `"civet coffeeInterpolation"`
+- `#{}` interpolation in `"..."` and `"""..."""` strings only when `"civet coffeeCompat"` or `"civet coffeeInterpolation"`
 - Expanded chained comparisons to work on more operators `a in b instanceof C` → `a in b && b instanceof C`
 - Postfix iteration/conditionals always wrap the statement [#5431](https://github.com/jashkenas/coffeescript/issues/5431):
   `try x() if y` → `if (y) try x()`
@@ -117,12 +116,12 @@ Things Changed from CoffeeScript
   In Coffee `(x)` → `x;` but in Civet `(x)` → `(x)`. Spacing and comments are also preserved as much as possible.
 - Heregex / re.X
   - Stay closer to the [Python spec](https://docs.python.org/3/library/re.html#re.X)
-  - Allows both kinds of substitutions `#{..}`, `${..}`.
-  - Also allows both kinds of single line comments `//`, `#`.
+  - Allows JS-style substitutions `${..}`. For Coffee-style substitutions `#{..}`, use `"civet coffeeCompat"` or `"civet coffeeInterpolation"`.
+  - Allows JS-style comments `//` unless `"civet coffeeDiv"` is set (including by `"civet coffeeCompat"`). For Coffee-style comments `#`, use `"civet coffeeCompat"` or `"civet coffeeInterpolation"`.
+  - With `coffeeComment` on, `#` is always the start of a comment outside of character classes regardless of leading space (CoffeeScript treats
+  `\s+#` as comment starts inside and outside of character classes).
   - Keeps non-newline whitespace inside of character classes.
   - Doesn't require escaping `#` after space inside of character classes.
-  - `#` is always the start of a comment outside of character classes regardless of leading space (CoffeeScript treats
-  `\s+#` as comment starts inside and outside of character classes).
   - Might later add a compat flag to get more CoffeeScript compatibility.
   - Might also later add a compat flag to only use ES interpolations and comments inside Heregexes.
 - JSX children need to be properly indented
@@ -167,15 +166,17 @@ Civet provides a compatibility prologue directive that aims to be 97+% compatibl
 | coffeeBooleans      | `yes`, `no`, `on`, `off` |
 | coffeeClasses       | CoffeeScript-style `class` methods via `->` functions |
 | coffeeComment       | `# single line comments` |
+| coffeeDiv           | `x // y` integer division instead of JS comment |
 | coffeeDo            | `do ->`, disables ES6 do/while |
 | coffeeEq            | `==` → `===`, `!=` → `!==` |
 | coffeeForLoops      | for in, of, from loops behave like they do in CoffeeScript |
-| coffeeInterpolation | `"a string with #{myVar}"` |
+| coffeeInterpolation | `"a string with #{myVar}"`, `///regex #{myVar}///` |
 | coffeeIsnt          | `isnt` → `!==` |
 | coffeeLineContinuation | `\` at end of line continues to next line |
 | coffeeNot           | `not` → `!`, disabling Civet extensions like `is not` |
 | coffeeOf            | `a of b` → `a in b`, `a not of b` → `!(a in b)`, `a in b` → `b.indexOf(a) >= 0`, `a not in b` → `b.indexOf(a) < 0` |
 | coffeePrototype     | `x::` -> `x.prototype`, `x::y` -> `x.prototype.y` |
+| coffeeRange         | `[a..b]` increases or decreases depending on whether `a < b` or `a > b` |
 
 You can use these with `"civet coffeeCompat"` to opt in to all or use them bit by bit with `"civet coffeeComment coffeeEq coffeeInterpolation"`.
 Another possibility is to slowly remove them to provide a way to migrate files a little at a time `"civet coffeeCompat -coffeeBooleans -coffeeComment -coffeeEq"`.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6123,8 +6123,16 @@ SingleStringCharacters
   /(?:\\.|[^'])*/ ->
     return { $loc, token: $0 }
 
-TripleDoubleStringCharacters
+TripleDoubleStringContents
+  CoffeeInterpolationEnabled ( CoffeeTripleDoubleStringCharacters / CoffeeStringSubstitution )* -> $2
+  !CoffeeInterpolationEnabled TripleDoubleStringCharacters -> [$2]
+
+CoffeeTripleDoubleStringCharacters
   /(?:"(?!"")|#(?!\{)|\\.|[^#"])+/ ->
+    return { $loc, token: $0 }
+
+TripleDoubleStringCharacters
+  /(?:"(?!"")|\\.|[^"])+/ ->
     return { $loc, token: $0 }
 
 TripleSingleStringCharacters
@@ -6200,7 +6208,7 @@ HeregexBody
 HeregexPart
   RegularExpressionClass
 
-  CoffeeStringSubstitution -> { type: "Substitution", children: $1 }
+  CoffeeInterpolationEnabled CoffeeStringSubstitution -> { type: "Substitution", children: $2 }
   TemplateSubstitution -> { type: "Substitution", children: $1 }
 
   /(?:\\.)/ ->
@@ -6223,14 +6231,16 @@ HeregexPart
   # Escape forward slashes (that aren't part of a triple slash)
   /\/(?!\/\/)/ ->
     return { $loc, token: "\\/" }
-  /[^[\/\s#\\]+/ ->
+  # Don't swallow up # and $ which might be interpolations,
+  # but handle them as single characters if they're not
+  /[^[\/\s#$\\]+|[#$]/ ->
     return { $loc, token: $0 }
 
 HeregexComment
   # NOTE: CoffeeScript doesn't treat JS comments as regex comments
-  # TODO: this behavior should be toggled by a coffeeCompat directive
-  JSSingleLineComment
-  CoffeeSingleLineComment
+  # We disable them when coffeeDiv flag (// operator) is enabled
+  !CoffeeDivEnabled JSSingleLineComment
+  CoffeeCommentEnabled CoffeeSingleLineComment -> $2
 
 # https://262.ecma-international.org/#prod-RegularExpressionBody
 # NOTE: Simplified a little from the spec, ignoring <PS>, <LS>
@@ -6265,7 +6275,7 @@ _TemplateLiteral
     }
 
   # NOTE: actual CoffeeScript """ string behaviors are pretty weird, this is simplified
-  TripleDoubleQuote ( TripleDoubleStringCharacters / CoffeeStringSubstitution )* TripleDoubleQuote ->
+  TripleDoubleQuote TripleDoubleStringContents TripleDoubleQuote ->
     return dedentBlockSubstitutions($0, config.tab)
 
   # NOTE: ''' don't have interpolation so could be converted into a regular

--- a/source/parser/string.civet
+++ b/source/parser/string.civet
@@ -61,7 +61,7 @@ function getIndentOfBlockString(str: string, tab: TabConfig)
 
   minLevel
 
-function dedentBlockString({ $loc, token: str }: ASTLeaf, tab: TabConfig, dedent: number | undefined, trimStart = true, trimEnd = true)
+function dedentBlockString({ $loc, token: str }: ASTLeaf, tab: TabConfig, dedent: number?, trimStart = true, trimEnd = true)
   // If string begins with a newline then indentation assume that it should be removed for all lines
   if not dedent? and /^[ \t]*\r?\n/.test str
     // Remove remaining shared indentation

--- a/test/block-strings.civet
+++ b/test/block-strings.civet
@@ -68,27 +68,13 @@ describe "block strings", ->
   '''
 
   testCase '''
-    CoffeeScript compatible interpolation
+    attempted CoffeeScript interpolation
     ---
     x = """
       Ahoy #{name}
     """
     ---
-    x = `Ahoy ${name}`
-  '''
-
-  testCase '''
-    CoffeeScript compatible interpolation
-    ---
-    x = """
-      Hi
-      Ahoy #{name}
-
-      Hello
-      Mr. #{surname}
-    """
-    ---
-    x = `Hi\nAhoy ${name}\n\nHello\nMr. ${surname}`
+    x = `Ahoy #{name}`
   '''
 
   describe "single quoted", ->

--- a/test/helper.civet
+++ b/test/helper.civet
@@ -13,18 +13,18 @@ compare := (src: string, result: string, compilerOpts: CompilerOptionsWithWrappe
     ...compilerOpts
   })
 
-  assert.equal compileResult, result, """
-    #{filename}
+  assert.equal compileResult, result, ```
+    ${filename}
     --- Source   ---
-    #{src}
+    ${src}
 
     --- Expected ---
-    #{result}
+    ${result}
 
     --- Got      ---
-    #{compileResult}
+    ${compileResult}
 
-  """
+  ```
 
   jsCode .= compileResult
   wrapper := compilerOpts.wrapper ?? wrappers.-1
@@ -39,15 +39,15 @@ compare := (src: string, result: string, compilerOpts: CompilerOptionsWithWrappe
       loader: if compilerOpts.js then 'jsx' else 'tsx'
       jsx: 'preserve'
   catch e
-    assert.fail """
-      Failed to parse #{if compilerOpts.js then 'JavaScript' else 'TypeScript'}
+    assert.fail ```
+      Failed to parse ${if compilerOpts.js then 'JavaScript' else 'TypeScript'}
 
       --- Code ---
-      #{jsCode}
+      ${jsCode}
 
       --- Error    ---
-      #{e}
-    """
+      ${e}
+    ```
 
 /**
  * Pass a string with the following format:
@@ -111,15 +111,15 @@ throws := (text: string, compilerOpts?: CompilerOptions, opt?: "only" | "skip") 
     assert.throws
       => e && throw e
       undefined as any
-      """
+      ```
 
         --- Source   ---
-        #{src}
+        ${src}
 
         --- Got      ---
-        #{result!}
+        ${result!}
 
-        """
+      ```
     // Then check against desired error message
     if error
       {name} := e! as {name: string}
@@ -131,18 +131,18 @@ throws := (text: string, compilerOpts?: CompilerOptions, opt?: "only" | "skip") 
           s = s.replace /\nExpected:[^]*$/, ''
       else // just name
         s = name
-      assert.equal s, error, """
+      assert.equal s, error, ```
 
         --- Source         ---
-        #{src}
+        ${src}
 
         --- Expected Error ---
-        #{error}
+        ${error}
 
         --- Got Error      ---
-        #{e!.toString()}
+        ${e!.toString()}
 
-      """
+      ```
 
 throws.only = (text: string, compilerOpts?: CompilerOptions) -> throws text, compilerOpts, "only"
 throws.skip = (text: string, compilerOpts?: CompilerOptions) -> throws text, compilerOpts, "skip"
@@ -152,18 +152,18 @@ evalsTo := (src: string, value: any) ->
     js: true
     sync: true  // TODO: consider wrapping in `it` so we can use async API
   }
-  assert.deepEqual result, value, """
+  assert.deepEqual result, value, ```
 
     --- Source   ---
-    #{src}
+    ${src}
 
     --- Expected ---
-    #{value}
+    ${value}
 
     --- Got      ---
-    #{result}
+    ${result}
 
-  """
+  ```
 
 wrapper := (wrap: string) ->
   before => wrappers.push wrap

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -50,4 +50,6 @@ describe "integration", ->
     it `should sourcemap correctly, ${mode} mode`, ->
       {err, stderr} := await execCmdError `bash -c "(cd integration/example && ../../dist/civet --no-config error-${mode}.civet)"`
       assert.match err.message, /Command failed/
-      assert.match stderr, ///error-#{mode}.civet:6:7///
+      // The newline in this /// block is to avoid a bug in Civet <0.9:
+      assert.match stderr, ///error-
+      ${mode}.civet:6:7///

--- a/test/object.civet
+++ b/test/object.civet
@@ -988,6 +988,7 @@ describe "object", ->
   testCase '''
     triple-quoted template literal key shorthand
     ---
+    "civet coffeeInterpolation"
     {"""x#{y}z""": value}
     ---
     ({[`x${y}z`]: value})

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -174,15 +174,16 @@ describe "regexp", ->
       comment in character class
       ---
       ;
-      ///[/*]///
+      ///[//*]///
       ---
       ;
-      /[/*]/
+      /[//*]/
     """
 
     testCase """
       coffee comment in character class
       ---
+      "civet coffeeComment"
       ;
       ///[ # hey ]///
       ---
@@ -212,9 +213,68 @@ describe "regexp", ->
       /abb/
     """
 
+    testCase """
+      no JS comment
+      ---
+      "civet coffeeDiv"
+      ;
+      ///
+        abb // hey
+      ///
+      ---
+      ;
+      /abb\\/\\/hey/
+    """
+
+    testCase """
+      no coffee comment
+      ---
+      ;
+      ///
+        abb # hey
+      ///
+      ---
+      ;
+      /abb#hey/
+    """
+
+    testCase """
+      coffee comment
+      ---
+      "civet coffeeComment"
+      ;
+      ///
+        abb # hey
+      ///
+      ---
+      ;
+      /abb/
+    """
+
     testCase '''
       substitutions
       ---
+      ;
+      ///${a}///
+      ---
+      ;
+      RegExp(`${a}`)
+    '''
+
+    testCase '''
+      no coffee substitutions
+      ---
+      ;
+      ///#{a}///
+      ---
+      ;
+      /#{a}/
+    '''
+
+    testCase '''
+      coffee substitutions
+      ---
+      "civet coffeeInterpolation"
       ;
       ///#{a}///
       ---
@@ -227,7 +287,7 @@ describe "regexp", ->
       ---
       ;
       ///
-       `#{a}
+       `${a}
       ///
       ---
       ;
@@ -237,6 +297,7 @@ describe "regexp", ->
     testCase '''
       allows both kinds of substitutions
       ---
+      "civet coffeeInterpolation"
       ;
       ///
         ${yo}
@@ -265,7 +326,7 @@ describe "regexp", ->
       ---
       ;
       ///
-        \\[#{a}]
+        \\[${a}]
       ///
       ---
       ;
@@ -277,7 +338,7 @@ describe "regexp", ->
       ---
       ;
       ///
-        x#{a}
+        x${a}
       ///g
       ---
       ;
@@ -288,6 +349,7 @@ describe "regexp", ->
     testCase '''
       coffee script's heregex
       ---
+      "civet coffeeCompat"
       ;
       /// ^
         (?:

--- a/test/strings.civet
+++ b/test/strings.civet
@@ -96,79 +96,9 @@ describe "strings", ->
     b"
   """
 
-  // NOTE: the `a` variable is only to make the string not be interpereted as a directive prologue
-
   testCase '''
-    coffee compat string interpolation
+    tagged template literal with string
     ---
-    "civet coffee-compat"
-    a
-    "a#{b}c"
-    ---
-    a;
-    `a${b}c`
-  '''
-
-  testCase '''
-    coffee compat string interpolation with ${}
-    ---
-    "civet coffee-compat"
-    a
-    "a#{b}c${d}"
-    ---
-    a;
-    `a${b}c\\${d}`
-  '''
-
-  testCase '''
-    coffee compat string interpolation with escaped octothorpe
-    ---
-    "civet coffee-compat"
-    a
-    "a\\#{b}c"
-    ---
-    a
-    "a\\#{b}c"
-  '''
-
-  testCase '''
-    coffee compat string interpolation with newlines
-    ---
-    "civet coffee-compat"
-    a
-    "a
-    #{b}c"
-    ---
-    a;
-    `a\\n${b}c`
-  '''
-
-  testCase '''
-    coffee compat string interpolation restore indented
-    ---
-    "civet coffee-compat"
-    f (a, b) => "#{[a, b]
-      .join 'x'
-    }"
-    ---
-    f((a, b) => `${[a, b]
-      .join('x')
-    }`)
-  '''
-
-  testCase '''
-    coffee compat tagged template literal
-    ---
-    "civet coffee-compat"
-    tag"a#{b}c"
-    ---
-    tag`a${b}c`
-  '''
-
-  testCase '''
-    coffee compat tagged template literal without interpolation
-    ---
-    "civet coffee-compat"
     tag"a"
     ---
     tag`a`
@@ -179,17 +109,5 @@ describe "strings", ->
     ---
     tag"""a#{b}c"""
     ---
-    tag`a${b}c`
-  '''
-
-  testCase '''
-    multi-line function call in """
-    ---
-    """
-      #{func 1,
-      2}
-    """
-    ---
-    `${func(1,
-      2)}`
+    tag`a#{b}c`
   '''


### PR DESCRIPTION
* Bring `"""` strings into alignment with `"` strings: `#{expr}` interpolation is supported only when `coffeeInterpolation` is set. Use ` ``` ` and `${expr}` to interpolate
* Bring `///` regexes into alignment with this: `#{expr}` interpolation is supported only when `coffeeInterpolation` is set. Use `${expr}` interpolation instead.
* Fix a bug where `///foo${expr}///` did not interpolate
* Change comment behavior in `///`:
  * `#` is a comment only when `coffeeComment` is enabled
  * `//` is a comment only when `coffeeDiv` is disabled (the idea is that `coffeeDiv` sacrifices `//` working as a comment)

BREAKING CHANGE: `"""` and `///` no longer support `#{expr}` interpolation unless you set `coffeeInterpolation`; `///` no longer supports `#` comments without `coffeeComment`; `///` no longer supports `//` comments with `coffeeDiv`