### PR TITLE
Fat pipe `||>` uses semicolons at statement level

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -451,6 +451,13 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       for each block of exp.blocks
         assignResults block, collect
       return
+    when "PipelineExpression"
+      // At statement level, pipeline generates semicolons between statements
+      // Return the last one
+      semi := exp.children.indexOf ";"
+      if 0 <= semi < exp.children# - 1
+        exp.children[semi+1..] = [collect exp.children[semi+1..]]
+        return
 
   // Don't push if there's a trailing semicolon
   return if node.-1?.type is "SemicolonDelimiter"
@@ -573,6 +580,13 @@ function insertReturn(node: ASTNode): void
         insertReturn block
       // NOTE: do not insert a return in the finally block
       return
+    when "PipelineExpression"
+      // At statement level, pipeline generates semicolons between statements
+      // Return the last one
+      semi := exp.children.indexOf ";"
+      if 0 <= semi < exp.children# - 1
+        exp.children[semi+1..] = [wrapWithReturn exp.children[semi+1..]]
+        return
 
   // Don't add return if there's a trailing semicolon
   return if node.-1?.type is "SemicolonDelimiter"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -583,7 +583,7 @@ function insertReturn(node: ASTNode): void
     when "PipelineExpression"
       // At statement level, pipeline generates semicolons between statements
       // Return the last one
-      semi := exp.children.indexOf ";"
+      semi := exp.children.lastIndexOf ";"
       if 0 <= semi < exp.children# - 1
         exp.children[semi+1..] = [wrapWithReturn exp.children[semi+1..]]
         return

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -20,6 +20,7 @@ type {
   needsRef
 } from ./ref.civet
 
+{ blockContainingStatement } from ./block.civet
 { processUnaryExpression } from ./unary.civet
 
 type ExprWithComments
@@ -128,12 +129,14 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
 function processPipelineExpressions(statements): void
   gatherRecursiveAll(statements, (n) => n.type is "PipelineExpression")
     .forEach (s) =>
-      const [ws, , body] = s.children
-      let [, arg] = s.children
+      [ws, , body] := s.children
+      [, arg] .= s.children
 
-      let i = 0, l = body.length
+      i .= 0
+      l := body.length
 
-      const children = [ws]
+      children := [ws]
+      comma := blockContainingStatement(s) ? ";" : ","
 
       let usingRef = null
 
@@ -161,7 +164,7 @@ function processPipelineExpressions(statements): void
                 usingRef = makeRef()
                 initRef = {
                   type: "AssignmentExpression"
-                  children: [usingRef, " = ", arg, ","]
+                  children: [usingRef, " = ", arg, comma]
                 }
 
                 arg = {
@@ -240,7 +243,7 @@ function processPipelineExpressions(statements): void
 
         if returning
           arg = returning
-          children.push(result, ",")
+          children.push(result, comma)
         else
           arg = result
 

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -53,7 +53,7 @@ describe "&. function block shorthand", ->
     class Foo {
       #name: string
       copy(foo: Foo) {
-        return (foo.#name = this.#name,foo)
+        foo.#name = this.#name;return foo
       }
     }
   """

--- a/test/function.civet
+++ b/test/function.civet
@@ -2465,7 +2465,7 @@ describe "function", ->
       () => {
         const ret = document.createElement('div')
 
-        let ref;((ref = document.createElement('input')).type = 'color',ret.appendChild(ref));return ret
+        let ref;(ref = document.createElement('input')).type = 'color';ret.appendChild(ref);return ret
       }
     """
 

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -482,6 +482,14 @@ describe "pipe", ->
     """
 
     testCase """
+      alternating pipes
+      ---
+      => a |> b ||> c |> d ||> e |> f
+      ---
+      () => { let ref;c((ref = b(a)));e((ref = d(ref)));return f(ref) }
+    """
+
+    testCase """
       return
       ---
       count |> &+1

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -183,7 +183,7 @@ describe "pipe", ->
     ---
     x |> throw ||> y
     ---
-    let ref;(y((ref = (()=>{throw x})())),ref)
+    let ref;y((ref = (()=>{throw x})()));ref
   """
 
   testCase """
@@ -422,7 +422,27 @@ describe "pipe", ->
       ---
       x ||> f
       ---
-      (f(x),x)
+      f(x);x
+    """
+
+    testCase """
+      basic in expression
+      ---
+      1 + (x ||> f)
+      ---
+      1 + ((f(x),x))
+    """
+
+    testCase """
+      basic in loop
+      ---
+      results :=
+        for x of y
+          x ||> f
+      ---
+      const results1=[];for (const x of y) {
+          f(x);results1.push(x)
+        };const results =results1
     """
 
     testCase """
@@ -430,7 +450,15 @@ describe "pipe", ->
       ---
       x ||> f |> g
       ---
-      (f(x),g(x))
+      f(x);g(x)
+    """
+
+    testCase """
+      thick pipe first in expression
+      ---
+      1 + (x ||> f |> g)
+      ---
+      1 + ((f(x),g(x)))
     """
 
     testCase """
@@ -440,7 +468,17 @@ describe "pipe", ->
       |> f
       ||> g
       ---
-      let ref;(g((ref = f(x))),ref)
+      let ref;g((ref = f(x)));ref
+    """
+
+    testCase """
+      thick pipe second in expression
+      ---
+      1 + (x
+      |> f
+      ||> g)
+      ---
+      let ref;1 + ((g((ref = f(x))),ref))
     """
 
     testCase """
@@ -466,7 +504,7 @@ describe "pipe", ->
       ---
       let ref;(({status}) => {
             return console.log(`Fetched ${url} with ${status}`)
-      })((ref = await fetch(url))),((json) => {
+      })((ref = await fetch(url)));((json) => {
             return console.log(`Parsed JSON ${json}`)
       })((ref = await ref.json()));return ref
     """, wrapper: """
@@ -482,7 +520,17 @@ describe "pipe", ->
       ||> f
       ||> g
       ---
-      (f(x),g(x),x)
+      f(x);g(x);x
+    """
+
+    testCase """
+      two thick pipes in expression
+      ---
+      1 + (x
+      ||> f
+      ||> g)
+      ---
+      1 + ((f(x),g(x),x))
     """
 
     testCase """
@@ -498,7 +546,7 @@ describe "pipe", ->
       ---
       array ||> .push(3) ||> .shift() ||> .sort()
       ---
-      (array.push(3),array.shift(),array.sort(),array)
+      array.push(3);array.shift();array.sort();array
     """
 
     testCase """
@@ -506,7 +554,7 @@ describe "pipe", ->
       ---
       array ||> .push 3 ||> .shift() ||> .sort()
       ---
-      (array.push(3),array.shift(),array.sort(),array)
+      array.push(3);array.shift();array.sort();array
     """
 
     testCase """
@@ -527,7 +575,7 @@ describe "pipe", ->
       ||> .shift()
       ||> .sort()
       ---
-      (array.push(3),array.shift(),array.sort(),array)
+      array.push(3);array.shift();array.sort();array
     """
 
     testCase """
@@ -537,7 +585,7 @@ describe "pipe", ->
       ||> .className = 'civet'
       ||> .appendChild document.createTextNode 'Civet'
       ---
-      let ref;((ref = document.createElement('div')).className = 'civet',ref.appendChild(document.createTextNode('Civet')),ref)
+      let ref;(ref = document.createElement('div')).className = 'civet';ref.appendChild(document.createTextNode('Civet'));ref
     """
 
     testCase """
@@ -547,7 +595,7 @@ describe "pipe", ->
         x + 1 ||> a.add
       ---
       (function() {
-        let ref;return (a.add((ref = x + 1)),ref)
+        let ref;a.add((ref = x + 1));return ref
       })
     """
 
@@ -556,7 +604,7 @@ describe "pipe", ->
       ---
       => import("../package.json") |> await ||> .init()
       ---
-      async () => { let ref;return ((ref = await import("../package.json")).init(),ref) }
+      async () => { let ref;(ref = await import("../package.json")).init();return ref }
     """
 
   describe "|>= assignment", ->
@@ -573,7 +621,7 @@ describe "pipe", ->
       ---
       document.app.title |>= &.toUpperCase()
       ---
-      let ref;ref = document.app,ref.title = ref.title.toUpperCase()
+      let ref;ref = document.app;ref.title = ref.title.toUpperCase()
     """
 
     testCase """
@@ -581,7 +629,7 @@ describe "pipe", ->
       ---
       f().b |>= foo
       ---
-      let ref;ref = f(),ref.b = foo(ref.b)
+      let ref;ref = f();ref.b = foo(ref.b)
     """
 
     // TODO: glob accessignment
@@ -640,7 +688,7 @@ describe "pipe", ->
       ---
       body.children[1] |>= .filter [, e] => !exps.includes e
       ---
-      let ref;ref = body.children,ref[1] = ref[1].filter(([, e]) => !exps.includes(e))
+      let ref;ref = body.children;ref[1] = ref[1].filter(([, e]) => !exps.includes(e))
     """
 
     testCase """
@@ -676,9 +724,9 @@ describe "pipe", ->
     fooResult := try
       foo() ||> bar
     ---
-    let ref;let ref1;try {
-      ref1 = (bar((ref = foo())),ref)
-    } catch(e) {ref1 = void 0;};const fooResult =ref1
+    let ref;try {
+      let ref1;bar((ref1 = foo()));ref = ref1
+    } catch(e) {ref = void 0;};const fooResult =ref
   """
 
   testCase.js """


### PR DESCRIPTION
Fixes #1339

Functionally equivalent, but good for linting. Also generates somewhat nicer looking code, because implicit `return`s get moved to the end of a chain.

It was a little trickier than the idea in https://github.com/DanielXMoore/Civet/issues/1339#issuecomment-2495547043 because of implicit returns.