### PR TITLE
Fix #1637: prevent parser crash on blocks inside switch

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -421,7 +421,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       wrapIterationReturningResults exp, collect
       return
     when "BlockStatement"
-      return if node.expressions.some isExit
+      return if exp.expressions.some isExit
       assignResults(exp.expressions[exp.expressions.length - 1], collect)
       return
     when "IfStatement"
@@ -603,7 +603,7 @@ function processBreakContinueWith(statement: IterationStatement | ForStatement):
     .type is "BreakStatement" or .type is "ContinueStatement"
   )
     function controlName: string
-      switch control.type 
+      switch control.type
         when "BreakStatement"
           "break"
         when "ContinueStatement"

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1714,3 +1714,17 @@ describe "switch", ->
       ---
       ParseErrors: unknown:1:1 'continue switch' can only be used at end of 'when' clause
     """
+
+  testCase """
+    #1637
+    ---
+    nextLocation := switch direction
+      when Direction.Up
+        { location.y - 1 }
+    ---
+    let ref;switch(direction) {
+      case Direction.Up: {
+        { ref = location.y - 1 };break;
+      }
+    };const nextLocation =ref
+  """


### PR DESCRIPTION
`node` is sometimes the Statement tuple so using `exp` which is always the actual block. TS actually caught the error.

Note that this is being interpreted as a block statement not an object literal at present.