### PR TITLE
`:label` supports Civet reserved words (but not JS reserved words)

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2102,7 +2102,9 @@ while item?
 
 ::: info
 Labels have the colon on the left to avoid conflict with implicit object
-literals.  The colons are optional in `break` and `continue`.
+literals.  The colons are optional in `break` and `continue`,
+except for Civet reserved words (e.g. `and`) where a colon is required.
+JavaScript reserved words are invalid as labels.
 :::
 
 ### Controlling Loop Value

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4460,7 +4460,10 @@ LabelledStatement
 
 Label
   # NOTE: `:label` instead of `label:` to not clash with implicit object literal
-  Colon:colon Identifier:id Whitespace:w ->
+  Colon:colon IdentifierName:id Whitespace:w ->
+    // If `id` is a JavaScript reserved word, JS or TS will output an error.
+    // `:void` is sometimes useful as a return-type annotation, so leave that.
+    if (id.name === "void") return $skip
     return {
       type: "Label",
       name: id.name,
@@ -4469,8 +4472,13 @@ Label
 
 # Argument to break/continue, which can include colon or not in input,
 # but should not have colon in output
+# Colon is required if the identifier is a Civet keyword,
+# except for 'loop' which we special-case
 LabelIdentifier
-  Colon? Identifier:id -> id
+  Colon IdentifierName:id -> id
+  # Infinite loop of break/continue isn't helpful, so treat as label
+  &Loop IdentifierName:id -> id
+  Identifier
 
 LabelledItem
   Statement

--- a/test/label.civet
+++ b/test/label.civet
@@ -1,4 +1,4 @@
-{testCase, wrapper} from ./helper.civet
+{testCase, throws, wrapper} from ./helper.civet
 
 describe "labels", ->
   testCase """
@@ -105,5 +105,36 @@ describe "labels", ->
       default: {
         label: a = 1
       }
+    }
+  """
+
+  testCase """
+    reserved word label
+    ---
+    :and while x
+      break :and
+    ---
+    and: while (x) {
+      break and
+    }
+  """
+
+  throws """
+    reserved word label without colon
+    ---
+    :and while x
+      break and
+    ---
+    ParseError
+  """
+
+  testCase """
+    loop label
+    ---
+    :loop while x
+      break loop
+    ---
+    loop: while (x) {
+      break loop
     }
   """


### PR DESCRIPTION
Fixes #1638

* Allow reserved words in `:label`
  * JavaScript reserved words will fail on output
  * Civet reserved words like `loop` and `and` are useful
  * `:void` remains untouched for possible return type annotation...
* `break :label` can also use a reserved word, with the same caveats
* `break loop` also works like `break :loop`, because it's "natural" meaning `while (true) break` isn't useful.

It's debatable to me whether `:void` should be allowed as a return-type annotation. It's extremely fragile; for example, `:number` doesn't work as a return-type annotation at the beginning of a line (it's treated as a label). UPDATE: But I guess `:void` is common enough to be worth keeping.

We could allow JavaScript reserved words in `:label` (possibly excepting `:void`) by transpiling them to `_label:` (though we need to avoid conflicts here, and can't exactly use refs). I'm not sure how useful this would be. But it might be nice e.g. to write

```js
:while while cond()
  ...
  break :while
```