### PR TITLE
Non-end rest parameters support types

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -792,6 +792,7 @@ ArrowFunction
         modifier: {
           async: !!async.length,
         },
+        parameters,
         returnType,
       },
       parameters,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -48,6 +48,7 @@ import {
   modifyString,
   negateCondition,
   prepend,
+  preprocessParams,
   processAssignmentDeclaration,
   processBinaryOpExpression,
   processCallMemberExpression,
@@ -1842,87 +1843,7 @@ ArrowParameters
 
 NonEmptyParameters
   TypeParameters?:tp OpenParen:open ParameterList:params ( __ CloseParen ):close ->
-    // Categorize arguments to put any ThisType in front, and split remaining
-    // arguments into before and after the rest parameter.
-    let tt, before = [], rest, after = [], errors = []
-    function append(p) {
-      (rest ? after : before).push(p)
-    }
-    for (const param of params) {
-      switch (param.type) {
-        case "ThisType":
-          if (tt) {
-            append({
-              type: "Error",
-              message: "Only one typed this parameter is allowed",
-            })
-            append(param)
-          } else {
-            tt = trimFirstSpace(param)
-            if (before.length || rest) { // moving ThisType to front
-              let delim = tt.children.at(-1)
-              if (Array.isArray(delim)) delim = delim.at(-1)
-              if (delim?.token !== ",") {
-                tt = {
-                  ...tt,
-                  children: [...tt.children, ", "],
-                }
-              }
-            }
-          }
-          break
-        case "FunctionRestParameter":
-          if (rest) {
-            append({
-              type: "Error",
-              message: "Only one rest parameter is allowed",
-            })
-            append(param)
-          } else {
-            rest = param
-          }
-          break
-        default:
-          append(param)
-      }
-    }
-
-    const names = before.flatMap(p => p.names)
-    if (rest) {
-      const restIdentifier = rest.binding.ref || rest.binding
-      names.push(...rest.names || [])
-
-      let blockPrefix
-      if (after.length) {
-        blockPrefix = {
-          children: ["[", trimFirstSpace(after), "] = ", restIdentifier, ".splice(-", after.length.toString(), ")"],
-          names: after.flatMap(p => p.names)
-        }
-      }
-
-      return {
-        type: "Parameters",
-        children: [
-          tp,
-          open,
-          tt,
-          ...before,
-          // Remove delimiter
-          {...rest, children: rest.children.slice(0, -1)},
-          close,
-        ],
-        tp,
-        names,
-        blockPrefix,
-      }
-    }
-
-    return {
-      type: "Parameters",
-      children: [tp, open, tt, ...before, close],
-      names,
-      tp,
-    }
+    return preprocessParams(tp, open, params, close)
 
 ParameterList
   # Nested case: Allow for one line of parameters followed by a nested list
@@ -1957,12 +1878,13 @@ Parameter
 FunctionRestParameter
   # BindingRestElement has a leading _?
   # but also sometimes invokes __ via BindingIdentifier
-  !EOS BindingRestElement:id TypeSuffix? ParameterElementDelimiter ->
+  !EOS BindingRestElement:id TypeSuffix?:typeSuffix ParameterElementDelimiter ->
     return {
       type: "FunctionRestParameter",
       children: $0.slice(1),
       names: id.names,
       binding: id.binding,
+      typeSuffix,
     }
 
 # NOTE: Similar to BindingElement but appears in formal parameters list
@@ -7954,17 +7876,19 @@ TypeIndex
 # parse both (?!).  For simplicity, we allow either in all cases.
 # In some cases (e.g. let/const), we transpile them away later.
 TypeSuffix
-  _? QuestionMark?:optional _? Colon MaybeNestedType:t -> {
+  _? QuestionMark?:optional _? Colon:colon MaybeNestedType:t -> {
     type: "TypeSuffix",
     ts: true,
     optional,
     t,
+    colon,
     children: $0,
   }
   _? QuestionMark:optional _? -> {
     type: "TypeSuffix",
     ts: true,
     optional,
+    colon: undefined,
     children: $0,
   }
   # TypeScript has a special error for ! without : ("Declarations with definite
@@ -7977,6 +7901,7 @@ TypeSuffix
       ts: true,
       nonnull,
       t,
+      colon,
       children: [ $1, $2, colon, t ],
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1886,12 +1886,13 @@ Parameter
 FunctionRestParameter
   # BindingRestElement has a leading _?
   # but also sometimes invokes __ via BindingIdentifier
-  !EOS BindingRestElement:id TypeSuffix?:typeSuffix ParameterElementDelimiter ->
+  !EOS BindingRestElement:rest TypeSuffix?:typeSuffix ParameterElementDelimiter ->
     return {
       type: "FunctionRestParameter",
       children: $0.slice(1),
-      names: id.names,
-      binding: id.binding,
+      rest,
+      names: rest.names,
+      binding: rest.binding,
       typeSuffix,
     }
 
@@ -2216,7 +2217,7 @@ BindingRestElement
   _?:ws DotDotDot:dots ( BindingIdentifier / BindingPattern / EmptyBindingPattern ):binding BindingTypeSuffix?:typeSuffix ->
     return {
       type: "BindingRestElement",
-      children: [ws, [dots, binding]],
+      children: [ws, dots, binding],
       dots,
       binding,
       typeSuffix,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -48,7 +48,6 @@ import {
   modifyString,
   negateCondition,
   prepend,
-  preprocessParams,
   processAssignmentDeclaration,
   processBinaryOpExpression,
   processCallMemberExpression,
@@ -1812,10 +1811,12 @@ AfterReturnShorthand
 Parameters
   NonEmptyParameters
   TypeParameters?:tp Loc:p ->
+    const parameters = []
     return {
       type: "Parameters",
-      children: [tp, {$loc: p.$loc, token: "()"}],
+      children: [tp, {$loc: p.$loc, token: "("}, parameters, ")"],
       tp,
+      parameters,
       names: [],
       implicit: true,
     }
@@ -1834,16 +1835,22 @@ ShortArrowParameters
 
 ArrowParameters
   ShortArrowParameters ->
+    const parameters = [ $1 ]
     return {
       type: "Parameters",
-      children: ["(", $1, ")"],
-      names: $1.names,
+      children: ["(", parameters, ")"],
+      parameters,
     }
   Parameters
 
 NonEmptyParameters
-  TypeParameters?:tp OpenParen:open ParameterList:params ( __ CloseParen ):close ->
-    return preprocessParams(tp, open, params, close)
+  TypeParameters?:tp OpenParen:open ParameterList:parameters ( __ CloseParen ):close ->
+    return {
+      type: "Parameters",
+      children: [ tp, open, parameters, close ],
+      tp,
+      parameters,
+    }
 
 ParameterList
   # Nested case: Allow for one line of parameters followed by a nested list
@@ -2308,10 +2315,11 @@ FunctionExpression
         [[], op, [], refB] // BinaryOpRHS
       ]])
 
+    const parameterList = [ [ refA, "," ], refB ]
     const parameters = {
       type: "Parameters",
-      children: ["(", refA, ",", refB, ")"],
-      names: [],
+      children: ["(", parameterList, ")"],
+      parameters: parameterList
     }
 
     const block = {

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -1,5 +1,6 @@
 import type {
   ArrayBindingPattern
+  AtBinding
   ASTNode
   ASTNodeObject
   BindingPattern
@@ -111,28 +112,27 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
   splices: unknown[] := []
 
   function insertRestSplices(s, p: unknown[], thisAssignments: ThisAssignments): void
-    gatherRecursiveAll(s, (n) => n.blockPrefix or (opts?.injectParamProps and n.accessModifier) or n.type is "AtBinding")
-      .forEach (n) =>
-        // Insert `this` assignments
-        if n.type is "AtBinding"
-          { ref } := n as! AtBinding
-          { id } := ref
-          thisAssignments.push([`this.${id} = `, ref])
-          return
+    for each n of gatherRecursiveAll s, (n) => n.blockPrefix or (opts?.injectParamProps and n.accessModifier) or n.type is "AtBinding"
+      // Insert `this` assignments
+      if n.type is "AtBinding"
+        { ref } := n as! AtBinding
+        { id } := ref
+        thisAssignments.push([`this.${id} = `, ref])
+        continue
 
-        if opts?.injectParamProps and n.type is "Parameter" and n.accessModifier
-          for each id of n.names
-            thisAssignments.push
-              type: "AssignmentExpression"
-              children: [`this.${id} = `, id]
-              js: true
-          return
+      if opts?.injectParamProps and n.type is "Parameter" and n.accessModifier
+        for each id of n.names
+          thisAssignments.push
+            type: "AssignmentExpression"
+            children: [`this.${id} = `, id]
+            js: true
+        continue
 
-        { blockPrefix } := n
-        p.push(blockPrefix)
+      { blockPrefix } := n
+      p.push(blockPrefix)
 
-        // Search for any further nested splices, and at bindings
-        insertRestSplices(blockPrefix, p, thisAssignments)
+      // Search for any further nested splices, and at bindings
+      insertRestSplices(blockPrefix, p, thisAssignments)
 
   insertRestSplices(statements, splices, thisAssignments)
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -1,6 +1,5 @@
 import type {
   ArrayBindingPattern
-  AtBinding
   ASTNode
   ASTNodeObject
   BindingPattern
@@ -24,26 +23,22 @@ import {
  * see test/function.civet binding pattern
  */
 function adjustAtBindings(statements: ASTNode, asThis = false): void
-  gatherRecursiveAll(statements, .type is "AtBindingProperty")
-    .forEach((binding) => {
-      const { ref } = binding
+  for each binding of gatherRecursiveAll statements, .type is "AtBindingProperty"
+    { ref } := binding
 
-      if (asThis) {
-        // Convert from @x to x: this.x keeping any whitespace or initializer to the right
-        const atBinding = binding.binding
-        atBinding.children.pop()
-        atBinding.type = undefined
+    if asThis
+      // Convert from @x to x: this.x keeping any whitespace or initializer to the right
+      atBinding := binding.binding
+      atBinding.children.pop()
+      atBinding.type = undefined
 
-        binding.children.unshift(ref.id, ": this.", ref.base)
-        binding.type = "Property"
-        binding.ref = undefined
-        return
-      }
+      binding.children.unshift(ref.id, ": this.", ref.base)
+      binding.type = "Property"
+      binding.ref = undefined
+      return
 
-      if (ref.names[0] !== ref.base) {
-        binding.children.unshift(ref.base, ": ")
-      }
-    })
+    unless ref.names[0] is ref.base
+      binding.children.unshift(ref.base, ": ")
 
 function adjustBindingElements(elements: ASTNodeObject[])
   names := elements.flatMap .names or []
@@ -115,7 +110,7 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
     for each n of gatherRecursiveAll s, (n) => n.blockPrefix or (opts?.injectParamProps and n.accessModifier) or n.type is "AtBinding"
       // Insert `this` assignments
       if n.type is "AtBinding"
-        { ref } := n as! AtBinding
+        { ref } := n
         { id } := ref
         thisAssignments.push([`this.${id} = `, ref])
         continue

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -107,11 +107,8 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
   }
 
 function processDeclarations(statements: StatementTuple[]): void
-  // @ts-ignore
-  gatherRecursiveAll statements, .type is "Declaration"
-  // @ts-ignore
-  .forEach (statement: Declaration) =>
-    { bindings } := statement as Declaration
+  for each declaration of gatherRecursiveAll statements, .type is "Declaration"
+    { bindings } := declaration
     bindings?.forEach (binding) =>
       { typeSuffix } := binding
       if typeSuffix and typeSuffix.optional and typeSuffix.t
@@ -120,7 +117,7 @@ function processDeclarations(statements: StatementTuple[]): void
 
       { initializer } := binding
       if initializer
-        prependStatementExpressionBlock initializer, statement
+        prependStatementExpressionBlock initializer, declaration
 
 function prependStatementExpressionBlock(initializer: Initializer, statement: ASTNodeParent): ASTRef?
   {expression: exp} .= initializer

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,4 +1,5 @@
 import type {
+  ASTError
   ASTLeaf
   ASTNode
   ASTNodeObject
@@ -10,6 +11,8 @@ import type {
   Declaration
   ForStatement
   FunctionNode
+  FunctionParameter
+  FunctionRestParameter
   IterationExpression
   IterationFamily
   IterationStatement
@@ -18,11 +21,14 @@ import type {
   ReturnTypeAnnotation
   StatementTuple
   SwitchStatement
+  ThisType
   TypeArgument
   TypeArguments
   TypeIdentifier
   TypeLiteral
   TypeNode
+  TypeParameters
+  TypeSuffix
   Whitespace
 } from ./types.civet
 
@@ -812,6 +818,117 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
 
   return false
 
+function preprocessParams(tp: TypeParameters?, open: ASTNode, params: FunctionParameter[], close: ASTNode)
+  // Categorize arguments to put any ThisType in front, and split remaining
+  // arguments into before and after the rest parameter.
+  let tt, before: (FunctionParameter | ASTError)[] = [], rest: FunctionRestParameter?, after: (FunctionParameter | ASTError)[] = []
+  function append(p: FunctionParameter | ASTError): void
+    (rest ? after : before).push(p)
+  for each param of params
+    switch param.type
+      when "ThisType"
+        if tt
+          append
+            type: "Error"
+            message: "Only one typed this parameter is allowed"
+          append param
+        else
+          tt = trimFirstSpace(param) as ThisType
+          if before# or rest // moving ThisType to front
+            delim .= tt.children.-1
+            delim = delim.-1 if Array.isArray delim
+            unless delim is like {token: ","}
+              tt = {
+                ...tt
+                children: [...tt.children, ", "]
+              }
+      when "FunctionRestParameter"
+        if rest
+          append
+            type: "Error"
+            message: "Only one rest parameter is allowed"
+          append param
+        else
+          rest = param
+      else
+        append param
+
+  names := before.flatMap .names
+  if rest
+    restIdentifier := rest.binding.ref or rest.binding
+    names.push ...rest.names or []
+
+    let blockPrefix
+    if after#
+      blockPrefix = {
+        children: [
+          "[", trimFirstSpace(after), "] = ", restIdentifier
+          ".splice(-", after#.toString(), ")"
+        ]
+        names: after.flatMap .names
+      }
+      // Correct type of new rest parameter to tuple with `after` parameters
+      if rest.typeSuffix
+        // Handle imprecise typing of `splice`
+        blockPrefix.children.push
+          ts: true
+          children: [" as any"]
+        function optionalType(typeSuffix: TypeSuffix?, fallback: ASTNode): ASTNode
+          t := typeSuffix?.t ?? fallback
+          if typeSuffix?.optional
+            return
+              . t
+              . type: "Error"
+                message: "Optional parameter not allowed in/after rest parameter"
+          t
+        oldSuffix := rest.typeSuffix
+        colon := oldSuffix.colon ?? ": "
+        t :=
+          . "["
+          . "...", optionalType oldSuffix, "unknown[]"
+          . ...after.flatMap (p) =>
+              . ",", optionalType (p as Parameter).typeSuffix, " unknown"
+          . "]"
+        typeSuffix: TypeSuffix := {}
+          type: "TypeSuffix"
+          ts: true
+          colon
+          t
+          children:
+            . ...oldSuffix.children.filter (and) // spaces and colon
+                & is not oldSuffix.optional
+                & is not oldSuffix.t
+            . colon unless oldSuffix.colon
+            . t
+        rest = {
+          ...rest
+          typeSuffix
+          children: rest.children.map & is rest!.typeSuffix ? typeSuffix : &
+        }
+
+    return {
+      type: "Parameters",
+      children: [
+        tp,
+        open,
+        tt,
+        ...before,
+        // Remove delimiter
+        {...rest, children: rest.children.slice(0, -1)},
+        close,
+      ],
+      tp,
+      names,
+      blockPrefix,
+    }
+
+  return {
+    type: "Parameters",
+    children: [tp, open, tt, ...before, close],
+    names,
+    tp,
+  }
+
 function processParams(f): void
   { type, parameters, block } := f
   isConstructor := f.name is 'constructor'
@@ -1125,6 +1242,7 @@ export {
   assignResults
   insertReturn
   makeAmpersandFunction
+  preprocessParams
   processCoffeeDo
   processFunctions
   processIterationExpressions

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,9 +1,12 @@
 import type {
   AmpersandBlockBody
+  ArrayBindingPattern
   ASTError
   ASTLeaf
   ASTNode
   ASTNodeObject
+  Binding
+  BindingElement
   BindingIdentifier
   BlockStatement
   BreakStatement
@@ -19,6 +22,7 @@ import type {
   IterationStatement
   Parameter
   ParametersNode
+  PostRestBindingElements
   ReturnTypeAnnotation
   StatementTuple
   SwitchStatement
@@ -41,6 +45,7 @@ import {
 
 import {
   gatherBindingCode
+  gatherBindingPatternTypeSuffix
 } from ./binding.civet
 
 import {
@@ -818,7 +823,7 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
 
   return false
 
-function processParams(f): void
+function processParams(f: FunctionNode): void
   { type, parameters, block } := f
   isConstructor := f.name is 'constructor'
 
@@ -870,13 +875,35 @@ function processParams(f): void
     parameters.names.push ...rest.names or []
 
     if after#
-      parameters.blockPrefix = {
+      after = trimFirstSpace after
+      names := after.flatMap .names
+      elements := (after as (Parameter | ASTError)[]).map (p) =>
+        return p if p.type is "Error"
+        {
+          ...p
+          // omit individual argument types from output
+          children: p.children.filter (is not p.typeSuffix)
+          type: "BindingElement"
+        } satisfies BindingElement
+      pattern := makeNode {
+        type: "ArrayBindingPattern"
+        elements
+        length: after#
+        children: [ "[", elements, "]" ]
+        names
+      } satisfies ArrayBindingPattern
+      |> gatherBindingPatternTypeSuffix
+      |> as ArrayBindingPattern
+      { typeSuffix } := pattern
+      parameters.blockPrefix = makeNode {
+        type: "PostRestBindingElements"
         children: [
-          "[", trimFirstSpace(after), "] = ", restIdentifier
+          pattern, typeSuffix, " = ", restIdentifier
           ".splice(-", after#.toString(), ")"
         ]
-        names: after.flatMap .names
-      }
+        elements
+        names
+      } satisfies PostRestBindingElements
       // Correct type of new rest parameter to tuple with `after` parameters
       if rest.typeSuffix
         // Handle imprecise typing of `splice`
@@ -899,7 +926,7 @@ function processParams(f): void
           . ...after.flatMap (p) =>
               . ",", optionalType (p as Parameter).typeSuffix, " unknown"
           . "]"
-        typeSuffix: TypeSuffix := {}
+        typeSuffix: TypeSuffix := makeNode {}
           type: "TypeSuffix"
           ts: true
           colon
@@ -910,7 +937,7 @@ function processParams(f): void
                 & is not oldSuffix.t
             . colon unless oldSuffix.colon
             . t
-        rest = {
+        rest = makeNode {
           ...rest
           typeSuffix
           children: rest.children.map & is rest!.typeSuffix ? typeSuffix : &
@@ -923,7 +950,7 @@ function processParams(f): void
   { expressions } := block
   return unless expressions
 
-  let indent: string
+  let indent: ASTNode
   unless expressions#
     indent = ""
   else
@@ -976,17 +1003,25 @@ function processParams(f): void
     type: "SemicolonDelimiter"
     children: [";"]
 
-  prefix := splices
-    .map (s) => ["let ", s]
-    .concat(thisAssignments)
-    .map((s) => s.type
-      ? {
-        // TODO: figure out how to get JS only statement tuples
-        ...s,
-        children: [indent, ...s.children, delimiter]
-      }
-      : [indent, s, delimiter]
-    )
+  prefix: ASTNode[] .= []
+  for each binding of splices as Binding[]
+    assert.equal binding.type, "PostRestBindingElements", "splice should be of type Binding"
+    prefix.push makeNode {
+      type: "Declaration"
+      children: ["let ", binding]
+      names: binding.names
+      bindings: [] // avoid implicit return of any bindings
+      decl: "let"
+    } satisfies Declaration
+  prefix ++= thisAssignments
+  // Add indentation and delimiters
+  prefix = prefix.map (s) => s?.js
+    ? ["", makeNode {
+      // TODO: figure out how to get JS only statement tuples
+      ...s
+      children: [indent, ...s.children, delimiter]
+    }]
+    : [indent, s, delimiter]
 
   return unless prefix#
   // In constructor definition, insert prefix after first super() call
@@ -1001,6 +1036,7 @@ function processParams(f): void
       expressions.splice(index + 1, 0, ...prefix)
       return
   expressions.unshift(...prefix)
+  updateParentPointers block
   braceBlock block
 
 function processSignature(f: FunctionNode): void

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -905,8 +905,7 @@ function processParams(f: FunctionNode): void
       parameters.blockPrefix = makeNode {
         type: "PostRestBindingElements"
         children: [
-          pattern, typeSuffix, " = ", restIdentifier
-          ".splice(-", after#.toString(), ")"
+          pattern, " = ", restIdentifier, ".splice(-", after#.toString(), ")"
         ]
         elements
         names
@@ -914,18 +913,13 @@ function processParams(f: FunctionNode): void
 
       // Correct type of new rest parameter to tuple with `after` parameters
       if rest.typeSuffix
-        // Handle imprecise typing of `splice`
-        parameters.blockPrefix.children.push
-          ts: true
-          children: [" as any"]
-
         // In TypeScript, use ref for rest parameter to assign correct type
         ref := makeRef "rest"
         restRef := [
           { children: [ ref ], ts: true }
           { children: [ restIdentifier ], js: true }
         ]
-        parameters.blockPrefix.children[3..3] = restRef
+        parameters.blockPrefix.children[parameters.blockPrefix.children.indexOf restIdentifier] = restRef
         parameters.blockPrefix.children.push
           ts: true
           children: [
@@ -948,11 +942,12 @@ function processParams(f: FunctionNode): void
 
         oldSuffix := rest.typeSuffix
         colon := oldSuffix.colon ?? ": "
+        afterTypes := after.flatMap (p) =>
+          . ",", optionalType (p as Parameter).typeSuffix, " unknown"
         t :=
           . "["
           . "...", optionalType oldSuffix, "unknown[]"
-          . ...after.flatMap (p) =>
-              . ",", optionalType (p as Parameter).typeSuffix, " unknown"
+          . ...afterTypes
           . "]"
         typeSuffix: TypeSuffix := makeNode {}
           type: "TypeSuffix"
@@ -968,6 +963,11 @@ function processParams(f: FunctionNode): void
         suffixIndex := rest.children.indexOf rest.typeSuffix
         assert.notEqual suffixIndex, -1, "Could not find typeSuffix in rest parameter"
         rest.children[suffixIndex] = rest.typeSuffix = typeSuffix
+
+        // Handle imprecise typing of `splice`
+        parameters.blockPrefix.children.splice -1, 0,
+          ts: true
+          children: [" as [", afterTypes[1..], "]"]
 
     parameters.parameters.push rest
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,4 +1,5 @@
 import type {
+  AmpersandBlockBody
   ASTError
   ASTLeaf
   ASTNode
@@ -27,7 +28,6 @@ import type {
   TypeIdentifier
   TypeLiteral
   TypeNode
-  TypeParameters
   TypeSuffix
   Whitespace
 } from ./types.civet
@@ -818,13 +818,21 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
 
   return false
 
-function preprocessParams(tp: TypeParameters?, open: ASTNode, params: FunctionParameter[], close: ASTNode)
+function processParams(f): void
+  { type, parameters, block } := f
+  isConstructor := f.name is 'constructor'
+
+  // Check for singleton TypeParameters <Foo> before arrow function,
+  // which TypeScript (in tsx mode) treats like JSX; replace with <Foo,>
+  if type is "ArrowFunction" and parameters and parameters.tp and parameters.tp.parameters# is 1
+    parameters.tp.parameters.push(",")
+
   // Categorize arguments to put any ThisType in front, and split remaining
   // arguments into before and after the rest parameter.
   let tt, before: (FunctionParameter | ASTError)[] = [], rest: FunctionRestParameter?, after: (FunctionParameter | ASTError)[] = []
   function append(p: FunctionParameter | ASTError): void
     (rest ? after : before).push(p)
-  for each param of params
+  for each param of parameters.parameters
     switch param.type
       when "ThisType"
         if tt
@@ -853,14 +861,16 @@ function preprocessParams(tp: TypeParameters?, open: ASTNode, params: FunctionPa
       else
         append param
 
-  names := before.flatMap .names
+  parameters.names = before.flatMap .names
+  parameters.parameters[..] = []
+  parameters.parameters.push tt if tt
+  parameters.parameters.push ...before
   if rest
     restIdentifier := rest.binding.ref or rest.binding
-    names.push ...rest.names or []
+    parameters.names.push ...rest.names or []
 
-    let blockPrefix
     if after#
-      blockPrefix = {
+      parameters.blockPrefix = {
         children: [
           "[", trimFirstSpace(after), "] = ", restIdentifier
           ".splice(-", after#.toString(), ")"
@@ -870,7 +880,7 @@ function preprocessParams(tp: TypeParameters?, open: ASTNode, params: FunctionPa
       // Correct type of new rest parameter to tuple with `after` parameters
       if rest.typeSuffix
         // Handle imprecise typing of `splice`
-        blockPrefix.children.push
+        parameters.blockPrefix.children.push
           ts: true
           children: [" as any"]
         function optionalType(typeSuffix: TypeSuffix?, fallback: ASTNode): ASTNode
@@ -906,37 +916,8 @@ function preprocessParams(tp: TypeParameters?, open: ASTNode, params: FunctionPa
           children: rest.children.map & is rest!.typeSuffix ? typeSuffix : &
         }
 
-    return {
-      type: "Parameters",
-      children: [
-        tp,
-        open,
-        tt,
-        ...before,
-        // Remove delimiter
-        {...rest, children: rest.children.slice(0, -1)},
-        close,
-      ],
-      tp,
-      names,
-      blockPrefix,
-    }
-
-  return {
-    type: "Parameters",
-    children: [tp, open, tt, ...before, close],
-    names,
-    tp,
-  }
-
-function processParams(f): void
-  { type, parameters, block } := f
-  isConstructor := f.name is 'constructor'
-
-  // Check for singleton TypeParameters <Foo> before arrow function,
-  // which TypeScript (in tsx mode) treats like JSX; replace with <Foo,>
-  if type is "ArrowFunction" and parameters and parameters.tp and parameters.tp.parameters# is 1
-    parameters.tp.parameters.push(",")
+    rest.children.pop() // remove delimiter
+    parameters.parameters.push rest
 
   return unless block
   { expressions } := block
@@ -1149,10 +1130,11 @@ function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
   ws = trimFirstSpace(ws) as Whitespace
   args: ASTNode[] := []
   if expression is like {type: "ArrowFunction"}, {type: "FunctionExpression"}
-    { parameters } := expression
+    { parameters } .= expression
+    parameterList := parameters.parameters
     // Move initializers to arguments
-    newParameters := { ...parameters, children:
-      for each let parameter of parameters.children
+    newParameterList :=
+      for each let parameter of parameterList
         if parameter is like {type: "Parameter"}
           if initializer := parameter.initializer
             args.push initializer.expression, parameter.delim
@@ -1165,6 +1147,10 @@ function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
             args.push parameter.children.filter
               (is not (parameter as Parameter).typeSuffix)
         parameter
+    newParameters := {
+      ...parameters
+      parameters: newParameterList
+      children: parameters.children.map & is parameterList ? newParameterList : &
     }
     expression = {
       ...expression
@@ -1191,9 +1177,13 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
   if startsWithPredicate(body, .type is "ObjectExpression")
     body = makeLeftHandSideExpression body
 
+  parameterList := [
+    typeSuffix ? [ ref, typeSuffix ] as tuple : ref
+  ]
   parameters := makeNode {
     type: "Parameters"
-    children: typeSuffix ? ["(", ref, typeSuffix, ")"] : [ref]
+    children: typeSuffix ? ["(", parameterList, ")"] : [parameterList]
+    parameters: parameterList
     names: []
   } as ParametersNode
   expressions := [[' ', body]] satisfies StatementTuple[]
@@ -1242,7 +1232,6 @@ export {
   assignResults
   insertReturn
   makeAmpersandFunction
-  preprocessParams
   processCoffeeDo
   processFunctions
   processIterationExpressions

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -873,8 +873,15 @@ function processParams(f: FunctionNode): void
   if rest
     restIdentifier := rest.binding.ref or rest.binding
     parameters.names.push ...rest.names or []
+    rest.children.pop() // remove delimiter
 
-    if after#
+    if after#  // non-end rest
+      if rest.binding.type is "ArrayBindingPattern" or
+         rest.binding.type is "ObjectBindingPattern"
+        parameters.parameters.push
+          type: "Error"
+          message: "Non-end rest parameter cannot be binding pattern"
+
       after = trimFirstSpace after
       names := after.flatMap .names
       elements := (after as (Parameter | ASTError)[]).map (p) =>
@@ -904,12 +911,32 @@ function processParams(f: FunctionNode): void
         elements
         names
       } satisfies PostRestBindingElements
+
       // Correct type of new rest parameter to tuple with `after` parameters
       if rest.typeSuffix
         // Handle imprecise typing of `splice`
         parameters.blockPrefix.children.push
           ts: true
           children: [" as any"]
+
+        // In TypeScript, use ref for rest parameter to assign correct type
+        ref := makeRef "rest"
+        restRef := [
+          { children: [ ref ], ts: true }
+          { children: [ restIdentifier ], js: true }
+        ]
+        parameters.blockPrefix.children[3..3] = restRef
+        parameters.blockPrefix.children.push
+          ts: true
+          children: [
+            ", ", deepCopy(rest.binding), " = ", ref, " as "
+            trimFirstSpace rest.typeSuffix.t
+          ]
+        rest.rest.binding.js = true
+        rest.rest.children.push
+          children: [ ref ]
+          ts: true
+
         function optionalType(typeSuffix: TypeSuffix?, fallback: ASTNode): ASTNode
           t := typeSuffix?.t ?? fallback
           if typeSuffix?.optional
@@ -918,6 +945,7 @@ function processParams(f: FunctionNode): void
               . type: "Error"
                 message: "Optional parameter not allowed in/after rest parameter"
           t
+
         oldSuffix := rest.typeSuffix
         colon := oldSuffix.colon ?? ": "
         t :=
@@ -937,13 +965,10 @@ function processParams(f: FunctionNode): void
                 & is not oldSuffix.t
             . colon unless oldSuffix.colon
             . t
-        rest = makeNode {
-          ...rest
-          typeSuffix
-          children: rest.children.map & is rest!.typeSuffix ? typeSuffix : &
-        }
+        suffixIndex := rest.children.indexOf rest.typeSuffix
+        assert.notEqual suffixIndex, -1, "Could not find typeSuffix in rest parameter"
+        rest.children[suffixIndex] = rest.typeSuffix = typeSuffix
 
-    rest.children.pop() // remove delimiter
     parameters.parameters.push rest
 
   return unless block

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -902,7 +902,7 @@ function processParams(f: FunctionNode): void
       |> gatherBindingPatternTypeSuffix
       |> as ArrayBindingPattern
       { typeSuffix } := pattern
-      parameters.blockPrefix = makeNode {
+      blockPrefix := parameters.blockPrefix = makeNode {
         type: "PostRestBindingElements"
         children: [
           pattern, " = ", restIdentifier, ".splice(-", after#.toString(), ")"
@@ -919,15 +919,18 @@ function processParams(f: FunctionNode): void
           { children: [ ref ], ts: true }
           { children: [ restIdentifier ], js: true }
         ]
-        parameters.blockPrefix.children[parameters.blockPrefix.children.indexOf restIdentifier] = restRef
-        parameters.blockPrefix.children.push
+        blockPrefix.children[blockPrefix.children.indexOf restIdentifier] = restRef
+        blockPrefix.children.push
           ts: true
           children: [
-            ", ", deepCopy(rest.binding), " = ", ref, " as "
+            ", ", restIdentifier, " = ", ref, " as "
             trimFirstSpace rest.typeSuffix.t
           ]
-        rest.rest.binding.js = true
-        rest.rest.children.push
+        bindingIndex := rest.rest.children.indexOf rest.rest.binding
+        assert.notEqual bindingIndex, -1, "Could not find binding in rest parameter"
+        rest.rest.children[bindingIndex] = rest.rest.binding =
+          { ...rest.rest.binding, js: true }
+        rest.rest.children.splice bindingIndex+1, 0,
           children: [ ref ]
           ts: true
 
@@ -965,7 +968,7 @@ function processParams(f: FunctionNode): void
         rest.children[suffixIndex] = rest.typeSuffix = typeSuffix
 
         // Handle imprecise typing of `splice`
-        parameters.blockPrefix.children.splice -1, 0,
+        blockPrefix.children.splice -1, 0,
           ts: true
           children: [" as [", afterTypes[1..], "]"]
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -36,6 +36,7 @@ import type {
   MethodDefinition
   NormalCatchParameter
   ObjectExpression
+  ParametersNode
   ParenthesizedExpression
   Placeholder
   StatementNode
@@ -123,7 +124,6 @@ import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
   makeAmpersandFunction
-  preprocessParams
   processCoffeeDo
   processFunctions
   processIterationExpressions
@@ -883,16 +883,15 @@ function makeGetterMethod(name, ws, value, returnType, block?: BlockStatement, k
   { token } := kind
   ws = trimFirstSpace ws
   let setVal
-  parameters := token is "get" ?
+  parameterList: ASTRef[] := []
+  isGet := token is "get"
+  unless isGet
+    parameterList.push setVal = makeRef "value"
+  parameters: ParametersNode :=
     type: "Parameters"
-    children: ["()"]
-    names: []
-    implicit: true
-  :
-    type: "Parameters"
-    children: ["(", setVal = makeRef("value"), ")"]
-    names: []
-    implicit: false
+    children: ["(", parameterList, ")"]
+    parameters: parameterList
+    implicit: isGet
 
   let expressions: StatementTuple[]
   if block
@@ -909,7 +908,7 @@ function makeGetterMethod(name, ws, value, returnType, block?: BlockStatement, k
     }
 
   if autoReturn
-    finalStatement: StatementTuple := token is "get" ?
+    finalStatement: StatementTuple := isGet ?
       [ [expressions[0]?.[0] or "", ws], wrapWithReturn(value) ]
     :
       [ [expressions[0]?.[0] or "", ws], [ value, " = ", setVal ] ]
@@ -1922,7 +1921,6 @@ export {
   negateCondition
   precedenceStep
   prepend
-  preprocessParams
   processAssignmentDeclaration
   processBinaryOpExpression
   processCallMemberExpression

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -123,6 +123,7 @@ import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
   makeAmpersandFunction
+  preprocessParams
   processCoffeeDo
   processFunctions
   processIterationExpressions
@@ -1921,6 +1922,7 @@ export {
   negateCondition
   precedenceStep
   prepend
+  preprocessParams
   processAssignmentDeclaration
   processBinaryOpExpression
   processCallMemberExpression

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -289,7 +289,7 @@ function getPatternBlockPrefix(
   pattern: PatternExpression
   ref: ASTNode
   decl: ASTNode = "const "
-  suffix?: ASTNode
+  typeSuffix?: ASTNode
 ): StatementTuple[]?
   switch pattern.type
     when "ArrayBindingPattern"
@@ -311,7 +311,7 @@ function getPatternBlockPrefix(
   [
     ['', {
       type: "Declaration"
-      children: [decl, patternBindings, suffix, " = ", ref, ...splices]
+      children: [decl, patternBindings, typeSuffix, " = ", ref, ...splices]
       names: []
       bindings: [] // avoid implicit return of any bindings
     }, ";"]

--- a/source/parser/traversal.civet
+++ b/source/parser/traversal.civet
@@ -8,7 +8,18 @@ import { isFunction } from ./util.civet
 
 export type Predicate<T extends ASTNodeObject> = (arg: ASTNodeObject) => arg is T
 
-function gatherRecursiveWithinFunction<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>)
+function gatherRecursiveWithinFunction<T extends ASTNodeObject>(
+  node: ASTNode
+  predicate: Predicate<T>
+): T[]
+function gatherRecursiveWithinFunction(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+): ASTNodeObject[]
+function gatherRecursiveWithinFunction<T extends ASTNodeObject>(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+): (T | ASTNodeObject)[]
   gatherRecursive(node, predicate, isFunction)
 
 /**
@@ -40,15 +51,20 @@ function findChildIndex(parent: (ASTNodeObject | Children)?, child: ASTNode)
  * `{ancestor, child}` object.  If none are found, `ancestor` will be null.
  */
 function findAncestor<T extends ASTNodeParent>(
-  node: ASTNodeObject,
-  predicate: (parent: ASTNodeParent, child: ASTNodeObject) => parent is T,
+  node: ASTNodeObject
+  predicate: (parent: ASTNodeParent, child: ASTNodeObject) => parent is T
   stopPredicate?: (parent: ASTNodeParent, child: ASTNodeObject) => boolean
 ): { ancestor: T?, child: ASTNodeObject }
 function findAncestor(
+  node: ASTNodeObject
+  predicate: (parent: ASTNodeParent, child: ASTNodeObject) => boolean
+  stopPredicate?: (parent: ASTNodeParent, child: ASTNodeObject) => boolean
+): { ancestor: ASTNodeObject?, child: ASTNodeObject }
+function findAncestor<T extends ASTNodeParent>(
   node: ASTNodeObject,
   predicate: (parent: ASTNodeParent, child: ASTNodeObject) => boolean,
   stopPredicate?: (parent: ASTNodeParent, child: ASTNodeObject) => boolean
-): { ancestor: ASTNodeObject?, child: ASTNodeObject }
+): { ancestor: (T | ASTNodeObject)?, child: ASTNodeObject }
   { parent } .= node
   while parent and not stopPredicate?(parent, node)
     if predicate(parent, node)
@@ -61,7 +77,18 @@ function findAncestor(
 // while recursing into nested expressions
 // without recursing into nested blocks/for loops
 
-function gatherNodes<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>): T[]
+function gatherNodes<T extends ASTNodeObject>(
+  node: ASTNode
+  predicate: Predicate<T>
+): T[]
+function gatherNodes(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+): ASTNodeObject[]
+function gatherNodes<T extends ASTNodeObject>(
+  node: ASTNode,
+  predicate: (arg: ASTNodeObject) => boolean
+): (T | ASTNodeObject)[]
   return [] if not node? or node <? "string"
 
   if Array.isArray(node)
@@ -83,13 +110,26 @@ function gatherNodes<T extends ASTNodeObject>(node: ASTNode, predicate: Predicat
           gatherNodes(n, predicate)
     else
       return gatherNodes
-        //@ts-ignore
         node.children
         predicate
 
 // Gather nodes that match a predicate recursing into all unmatched children
 // i.e. if the predicate matches a node it is not recursed into further
-function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = never>(node: ASTNode, predicate: Predicate<T>, skipPredicate?: Predicate<S>): Exclude<T, S>[]
+function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = never>(
+  node: ASTNode
+  predicate: Predicate<T>
+  skipPredicate?: Predicate<S>
+): Exclude<T, S>[]
+function gatherRecursive(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+  skipPredicate?: (arg: ASTNodeObject) => boolean
+): ASTNodeObject[]
+function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = never>(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+  skipPredicate?: (arg: ASTNodeObject) => boolean
+): (ASTNodeObject | Exclude<T, S>)[]
   return [] if not node? or node <? "string"
 
   if Array.isArray node
@@ -98,22 +138,31 @@ function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = neve
   return [] if skipPredicate? node
 
   if predicate node
-    return [node as Exclude<T, S>]
+    return [node]
 
   return gatherRecursive
-    //@ts-ignore
     node.children
     predicate
     skipPredicate
 
-function gatherRecursiveAll<T extends ASTNodeObject>(node: ASTNode, predicate: Predicate<T>): T[]
+function gatherRecursiveAll<T extends ASTNodeObject>(
+  node: ASTNode
+  predicate: Predicate<T>
+): T[]
+function gatherRecursiveAll(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+): ASTNodeObject[]
+function gatherRecursiveAll<T extends ASTNodeObject>(
+  node: ASTNode
+  predicate: (arg: ASTNodeObject) => boolean
+): (T | ASTNodeObject)[]
   return [] if not node? or node <? "string"
 
   if Array.isArray node
     return node.flatMap (n) => gatherRecursiveAll n, predicate
 
   nodes := gatherRecursiveAll
-    //@ts-ignore
     node.children
     predicate
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -650,7 +650,7 @@ export type Identifier =
   type: "Identifier"
   name: string
   names: string[]
-  children: Children & [ ASTLeaf ]
+  children: Children & [ ASTLeaf | ASTString ]
   parent?: Parent
 
 export type ReturnValue =
@@ -1031,8 +1031,10 @@ export type ParametersNode =
   type: "Parameters"
   children: Children
   parent?: Parent
-  names: string[]
+  parameters: FunctionParameter[]
+  names?: string[] // set eventually by processParams
   tp?: TypeParameters?
+  implicit?: boolean // makeGetterMethod
 
 export type Parameter
   type: "Parameter"
@@ -1059,7 +1061,13 @@ export type ThisType
   children: Children
   parent?: Parent
 
-export type FunctionParameter = Parameter | FunctionRestParameter | ThisType
+export type FunctionParameter =
+  | Parameter
+  | FunctionRestParameter
+  | ThisType
+  // for & blocks:
+  | ASTRef
+  | [ ASTRef, ASTNode ] // ASTRef + delimiter or type suffix
 
 type AccessModifier = ASTNode
 type ParameterElementDelimiter = ASTNode

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -101,6 +101,7 @@ export type OtherNode =
   | FieldDefinition
   | FinallyClause
   | ForDeclaration
+  | FunctionRestParameter
   | ImportAssertion
   | Index
   | Initializer
@@ -124,6 +125,7 @@ export type OtherNode =
   | ReturnValue
   | SliceExpression
   | SpreadElement
+  | ThisType
   | TypeArgument
   | TypeArguments
   | TypeSuffix
@@ -1004,6 +1006,7 @@ export type TypeSuffix =
   type: "TypeSuffix"
   ts: true
   optional?: ASTNode
+  colon?: ASTNode
   nonnull?: ASTNode
   t?: ASTNode
   children: Children
@@ -1023,6 +1026,7 @@ export type MethodModifier =
   async?: boolean
   generator?: boolean
 
+// Avoiding conflict with Parameters<FunctionType> TypeScript helper
 export type ParametersNode =
   type: "Parameters"
   children: Children
@@ -1040,6 +1044,22 @@ export type Parameter
   initializer?: Initializer?
   delim?: ParameterElementDelimiter?
   binding: BindingIdentifier | BindingPattern
+
+export type FunctionRestParameter
+  type: "FunctionRestParameter"
+  children: Children
+  parent?: Parent
+  names: string[]
+  typeSuffix?: TypeSuffix?
+  binding: BindingIdentifier | BindingPattern
+
+export type ThisType
+  type: "ThisType"
+  ts: true
+  children: Children
+  parent?: Parent
+
+export type FunctionParameter = Parameter | FunctionRestParameter | ThisType
 
 type AccessModifier = ASTNode
 type ParameterElementDelimiter = ASTNode

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -635,15 +635,15 @@ export type Binding =
   parent?: Parent
   names: string[]
   pattern: BindingIdentifier | BindingPattern
-  typeSuffix: TypeSuffix?
-  initializer: Initializer?
+  typeSuffix?: TypeSuffix?
+  initializer?: Initializer?
   splices: unknown[]
   thisAssignments: unknown[]
 
 export type Initializer =
   type: "Initializer"
   expression: ASTNode
-  children: Children & [ASTNode, ASTNode, ASTNode]
+  children: Children
   parent?: Parent
 
 export type Identifier =
@@ -771,7 +771,7 @@ export type ArrayBindingPattern =
   typeSuffix?: TypeSuffix?
 
 export type ArrayBindingPatternContent =
-  (BindingElement | BindingRestElement | ElisionElement)[]
+  (BindingElement | BindingRestElement | ElisionElement | ASTError)[]
 
 export type PostRestBindingElements
   type: "PostRestBindingElements"
@@ -786,7 +786,7 @@ export type BindingElement =
   names: string[]
   binding: BindingIdentifier | BindingPattern
   typeSuffix?: TypeSuffix?
-  delim: ASTNode
+  delim?: ASTNode
 
 export type BindingRestElement =
   type: "BindingRestElement"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -995,9 +995,9 @@ export type FunctionSignature =
   type: "MethodSignature" | "FunctionSignature"
   children: Children
   parent?: Parent
-  name: string
-  id: Identifier
-  optional: unknown
+  // undefined means anonymous (e.g. arrow function)
+  name?: string?
+  id?: Identifier?
   modifier: MethodModifier
   returnType: ReturnTypeAnnotation?
   parameters: ParametersNode

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -3,10 +3,11 @@ export type ASTNode =
   | Children
   | StatementNode
   | OtherNode
+  | UntypedNode
   | undefined
 
 // OtherNode includes BinaryOp which includes certain strings
-export type ASTNodeObject = Exclude<StatementNode | OtherNode, string>
+export type ASTNodeObject = Exclude<StatementNode | OtherNode | UntypedNode, string>
 
 /**
 * Nodes that represent statements.
@@ -138,6 +139,14 @@ export type ASTNodeParent = ASTNodeObject & IsParent
 export type Parent = (ASTNodeObject & IsParent)?
 export type Children = ASTNode[] & (type?: undefined) & (token?: undefined) & (children?: undefined)
 export type ASTString = string & (type?: undefined) & (token?: undefined) & (children?: undefined)
+
+// These nodes are hacks like Arrays but only appear in JS or TS mode
+export type UntypedNode =
+  type?: never
+  js?: boolean
+  ts?: boolean
+  children: Children
+  parent?: Parent
 
 // Wrapper nodes are just for making non-object nodes into objects
 // so that they have a parent, needed for e.g. `replaceNode`.
@@ -1035,6 +1044,7 @@ export type ParametersNode =
   names?: string[] // set eventually by processParams
   tp?: TypeParameters?
   implicit?: boolean // makeGetterMethod
+  blockPrefix?: PostRestBindingElements
 
 export type Parameter
   type: "Parameter"
@@ -1054,6 +1064,7 @@ export type FunctionRestParameter
   names: string[]
   typeSuffix?: TypeSuffix?
   binding: BindingIdentifier | BindingPattern
+  rest: BindingRestElement
 
 export type ThisType
   type: "ThisType"
@@ -1065,6 +1076,7 @@ export type FunctionParameter =
   | Parameter
   | FunctionRestParameter
   | ThisType
+  | ASTError
   // for & blocks:
   | ASTRef
   | [ ASTRef, ASTNode ] // ASTRef + delimiter or type suffix

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -5,6 +5,7 @@ import type {
   ASTNodeParent
   Children
   FunctionNode
+  FunctionSignature
   Identifier
   IsParent
   IsToken
@@ -732,8 +733,9 @@ function parenthesizeType(type: ASTNode)
  * Uses function* instead of arrow function if given generator star.
  * Returns an Array suitable for `children`.
  */
-function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?: ASTNode): ASTNode
+function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorStar?: ASTNode): ASTNode
   let awaitPrefix: ASTNode?
+  generator := generatorStar ? [ generatorStar ] : []
 
   async := []
   if asyncFlag
@@ -745,9 +747,9 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
       children: ["await "]
 
   yieldWrap .= false
-  unless generator
+  unless generator#
     if hasYield expressions
-      generator = "*"
+      generator.push "*"
       yieldWrap = true
 
   block := makeNode {
@@ -765,14 +767,19 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
     parameters: parameterList
     names: []
 
-  signature :=
+  signature: FunctionSignature := {}
+    type: "FunctionSignature"
     modifier:
-      async: !!async.length
-      generator: !!generator
+      async: !!async#
+      generator: !!generator#
+    parameters
     returnType: undefined
+    children:
+      generator# ? [ async, "function", generator, parameters ]
+                 : [ async, parameters ]
 
   let fn
-  if generator
+  if generator#
     fn = makeNode {
       type: "FunctionExpression"
       signature
@@ -782,7 +789,7 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
       async
       block
       generator
-      children: [async, "function", generator, parameters, block]
+      children: [ ...signature.children, block ]
     }
   else
     fn = makeNode {
@@ -793,7 +800,7 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
       ts: false
       async
       block
-      children: [async, parameters, "=>", block]
+      children: [ ...signature.children, "=>", block ]
     }
 
   children := [ makeLeftHandSideExpression(fn), "()" ]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -5,10 +5,13 @@ import type {
   ASTNodeParent
   Children
   FunctionNode
+  Identifier
   IsParent
   IsToken
   IterationStatement
   Literal
+  Parameter
+  ParametersNode
   Parent
   StatementNode
   TypeSuffix
@@ -755,9 +758,11 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
     root: false
   }
 
-  parameters :=
+  parameterList: Parameter[] := []
+  parameters: ParametersNode :=
     type: "Parameters"
-    children: ["()"]
+    children: ["(", parameterList, ")"]
+    parameters: parameterList
     names: []
 
   signature :=
@@ -797,7 +802,17 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generator?
     if gatherRecursiveWithinFunction(block, (is like { token: "this" }))#
       children.splice 1, 0, ".bind(this)"
     if gatherRecursiveWithinFunction(block, (is like { token: "arguments" }))#
-      children.-1 = parameters.children.-1 = "(arguments)"
+      binding: Identifier :=
+        type: "Identifier"
+        name: "arguments"
+        names: ["arguments"]
+        children: ["arguments"]
+      parameterList.push {}
+        type: "Parameter"
+        children: [binding]
+        names: ["arguments"]
+        binding
+      children.-1 = "(arguments)"
 
   exp: ASTNode .= makeNode {
     type: "CallExpression"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -785,7 +785,6 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
       signature
       parameters
       returnType: undefined
-      ts: false
       async
       block
       generator
@@ -797,7 +796,6 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
       signature
       parameters
       returnType: undefined
-      ts: false
       async
       block
       children: [ ...signature.children, "=>", block ]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -270,7 +270,7 @@ function hasTrailingComment(node: ASTNode): boolean
  * Inserts string `c` in the first position.
  * maintains $loc for source maps
  */
-function insertTrimmingSpace(target: ASTNode, c: string): ASTNode
+function insertTrimmingSpace<T extends ASTNode>(target: T, c: string): T
   return target unless target?
 
   if Array.isArray target
@@ -307,7 +307,7 @@ function insertTrimmingSpace(target: ASTNode, c: string): ASTNode
  * Trims the first single space from the spacing array or node's children if present
  * maintains $loc for source maps
  */
-function trimFirstSpace(target: ASTNode): ASTNode
+function trimFirstSpace<T extends ASTNode>(target: T): T
   insertTrimmingSpace target, ""
 
 function inplaceInsertTrimmingSpace(target: ASTNode, c: string): void

--- a/test/function.civet
+++ b/test/function.civet
@@ -691,6 +691,15 @@ describe "function", ->
     })
   """
 
+  throws """
+    non-end destructuring rest parameter
+    ---
+    (a, ...[b, c], d) ->
+      d
+    ---
+    ParseErrors: unknown:1:4 Non-end rest parameter cannot be binding pattern
+  """
+
   testCase """
     non-end @ rest parameter
     ---

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -520,6 +520,30 @@ describe "[TS] function", ->
       ParseErrors: unknown:1:19 Only one typed this parameter is allowed
     """
 
+  describe "typing of rest parameters", ->
+    testCase """
+      final rest
+      ---
+      function f(a, b, ...c: number[])
+        [a, b, c]
+      ---
+      function f(a, b, ...c: number[]) {
+        return [a, b, c]
+      }
+    """
+
+    testCase """
+      middle rest
+      ---
+      function f(a, ...rest: number[], x: string, y)
+        [a, rest, x, y]
+      ---
+      function f(a, ...rest:[... number[], string, unknown]) {
+        let [x, y]: [ string,unknown] = rest.splice(-2) as any;
+        return [a, rest, x, y]
+      }
+    """
+
   describe ":: typing of parameters", ->
     testCase """
       binding array pattern params with types

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -539,7 +539,7 @@ describe "[TS] function", ->
         [a, rest, x, y]
       ---
       function f(a, ...rest1:[... number[], string, unknown]) {
-        let [x, y]: [ string,unknown] = rest1.splice(-2) as any, rest = rest1 as number[];
+        let [x, y] = rest1.splice(-2) as [ string, unknown], rest = rest1 as number[];
         return [a, rest, x, y]
       }
     """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -556,6 +556,19 @@ describe "[TS] function", ->
       }
     """
 
+    testCase """
+      non-end rest ref
+      ---
+      function f(a, ...@rest: number[], x: string, y)
+        [a, @rest, x, y]
+      ---
+      function f(a, ...rest1:[... number[], string, unknown]) {
+        let [x, y] = rest1.splice(-2) as [ string, unknown], rest = rest1 as number[];
+        this.rest = rest;
+        return [a, this.rest, x, y]
+      }
+    """
+
   describe ":: typing of parameters", ->
     testCase """
       binding array pattern params with types

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -522,7 +522,7 @@ describe "[TS] function", ->
 
   describe "typing of rest parameters", ->
     testCase """
-      final rest
+      end rest
       ---
       function f(a, b, ...c: number[])
         [a, b, c]
@@ -533,13 +533,25 @@ describe "[TS] function", ->
     """
 
     testCase """
-      middle rest
+      non-end rest
       ---
       function f(a, ...rest: number[], x: string, y)
         [a, rest, x, y]
       ---
-      function f(a, ...rest:[... number[], string, unknown]) {
-        let [x, y]: [ string,unknown] = rest.splice(-2) as any;
+      function f(a, ...rest1:[... number[], string, unknown]) {
+        let [x, y]: [ string,unknown] = rest1.splice(-2) as any, rest = rest1 as number[];
+        return [a, rest, x, y]
+      }
+    """
+
+    testCase.js """
+      non-end rest JS
+      ---
+      function f(a, ...rest: number[], x: string, y)
+        [a, rest, x, y]
+      ---
+      function f(a, ...rest) {
+        let [x, y] = rest.splice(-2);
         return [a, rest, x, y]
       }
     """


### PR DESCRIPTION
Fixes #929 by
* Typing new end rest parameter as tuple type
* Add type casting of `splice` return value
* Add ref to type cast remaining array, but only for TypeScript output

Lots of other internal cleanup along the way:

* Fix traversal functions to allow non-`Predicate` arguments instead of erroring. In this case, they just don't filter.
* Move `NonEmptyParameters` handler into `processParams`
* Uniform use of `PostRestBindingElements` in `blockPrefix`
* `Parameters` node now has `parameters` property with array of actual parameters
* Internal type fixes