### PR TITLE
`coffeeClasses` improved compatibility: private static class fields via `=`, bound methods via `=>` , `constructor` shouldn't `return`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3359,10 +3359,12 @@ loop
 ### CoffeeScript Classes
 
 <Playground>
-"civet coffeeClasses"
+"civet coffeeClasses autoVar"
 class X
+  privateVar = 5
   constructor: (@x) ->
   get: -> @x
+  bound: => @x
 </Playground>
 
 ### IIFE Wrapper

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -12,6 +12,7 @@ import {
   attachPostfixStatementAsExpression,
   append,
   blockWithPrefix,
+  braceBlock,
   convertNamedImportsToObject,
   convertObjectToJSXAttributes,
   convertWithClause,
@@ -1248,8 +1249,7 @@ FieldDefinition
   # name: (param1, param2) ->
   CoffeeClassesEnabled ClassElementName:id _? Colon __ AssignmentExpression:exp ->
     switch (exp.type) {
-      // TODO: => functions
-      case "FunctionExpression":
+      case "FunctionExpression": {
         const fnTokenIndex = exp.children.findIndex(c => c?.token?.startsWith("function"))
         // copy
         const children = exp.children.slice()
@@ -1264,6 +1264,18 @@ FieldDefinition
           ...exp,
           children,
         }
+      }
+      case "ArrowFunction": {
+        const block = {...exp.block} // prepare for bracing
+        const children = exp.children
+        .filter(c => !(Array.isArray(c) && c[c.length-1]?.token?.includes("=>")))
+        .map(c => c === exp.block ? block : c)
+        children.unshift(id)
+        exp = { ...exp, block, children }
+        block.parent = exp // needed by braceBlock
+        braceBlock(block)
+        return exp
+      }
       default:
         return {
           type: "FieldDefinition",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1245,8 +1245,8 @@ AccessModifier
 
 # https://262.ecma-international.org/#prod-FieldDefinition
 FieldDefinition
-  # TODO: CoffeeCompat class method fields
   # name: (param1, param2) ->
+  # name: (param1, param2) => which gets wrapped in bind in constructor
   CoffeeClassesEnabled ClassElementName:id _? Colon __ AssignmentExpression:exp ->
     switch (exp.type) {
       case "FunctionExpression": {
@@ -1262,6 +1262,9 @@ FieldDefinition
         }
         return {
           ...exp,
+          type: "MethodDefinition",
+          name: id.name,
+          signature: { ...exp.signature, id, name: id.name },
           children,
         }
       }
@@ -1271,7 +1274,15 @@ FieldDefinition
         .filter(c => !(Array.isArray(c) && c[c.length-1]?.token?.includes("=>")))
         .map(c => c === exp.block ? block : c)
         children.unshift(id)
-        exp = { ...exp, block, children }
+        exp = {
+          ...exp,
+          type: "MethodDefinition",
+          name: id.name,
+          signature: { ...exp.signature, id, name: id.name },
+          block,
+          children,
+          autoBind: true
+        }
         block.parent = exp // needed by braceBlock
         braceBlock(block)
         return exp

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1285,9 +1285,9 @@ FieldDefinition
     }
 
   # NOTE: Added readonly semantic equivalent of const field assignment
-  InsertReadonly:r ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedExpression ->
+  InsertReadonly:readonly ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedExpression ->
     // Adjust position to space before assignment to make TypeScript remapping happier
-    r.children[0].$loc = {
+    readonly.children[0].$loc = {
       pos: ca.$loc.pos - 1,
       length: ca.$loc.length + 1,
     }
@@ -1296,15 +1296,28 @@ FieldDefinition
       id,
       typeSuffix,
       children: $0,
+      readonly,
     }
 
-  ( Abstract _? )? ( Readonly _? )? ClassElementName:id TypeSuffix?:typeSuffix Initializer? ->
+  # In a CoffeeScript class, `x = y` makes a private variable x visible
+  # only within the class scope only
+  CoffeeClassesEnabled ActualAssignment:assignment ->
+    return {
+      type: "CoffeeClassPrivate",
+      children: [ assignment ],
+      assignment,
+    }
+
+  ( Abstract _? )?:abstract ( Readonly _? )?:readonly ClassElementName:id TypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "FieldDefinition",
       children: $0,
-      ts: $1 ? true : undefined,
+      ts: abstract ? true : undefined,
       id,
       typeSuffix,
+      abstract,
+      readonly,
+      initializer,
     }
 
 ThisLiteral

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -145,12 +145,9 @@ function createVarDecs(block: BlockStatement, scopes, pushVar?): void
     assignmentStatements
 
   // Let descendent blocks add the var at the outer enclosing function scope
-  if (!pushVar) {
-    pushVar = function (name) {
-      varIds.push(name)
-      decs.add(name)
-    }
-  }
+  pushVar ?= (name: string) =>
+    varIds.push(name)
+    decs.add(name)
 
   { expressions: statements } := block
   decs := findDecs statements

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1053,19 +1053,26 @@ function processParams(f: FunctionNode): void
 
   return unless prefix#
   // In constructor definition, insert prefix after first super() call
+  index .= -1
   if isConstructor
-    superCalls := gatherNodes expressions,
-      (is like {type: "CallExpression", children: [ {token: "super"}, ... ]}) as Predicate<CallExpression>
-    if superCalls#
-      {child} := findAncestor superCalls[0], (is block)
-      index := findChildIndex expressions, child
-      if index < 0
-        throw new Error("Could not find super call within top-level expressions")
-      expressions.splice(index + 1, 0, ...prefix)
-      return
-  expressions.unshift(...prefix)
+    index = findSuperCall block
+  expressions.splice(index + 1, 0, ...prefix)
   updateParentPointers block
   braceBlock block
+
+/** Returns index of (first) super call expression in block, if there's one */
+function findSuperCall(block: BlockStatement): number
+  { expressions } := block
+  superCalls := gatherNodes expressions,
+    (is like {type: "CallExpression", children: [ {token: "super"}, ... ]}) as Predicate<CallExpression>
+  if superCalls#
+    {child} := findAncestor superCalls[0], (is block)
+    index := findChildIndex expressions, child
+    if index < 0
+      throw new Error("Could not find super call within top-level expressions")
+    index
+  else
+    -1
 
 function processSignature(f: FunctionNode): void
   {block, signature} := f
@@ -1294,6 +1301,7 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
 
 export {
   assignResults
+  findSuperCall
   insertReturn
   makeAmpersandFunction
   processCoffeeDo

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1462,6 +1462,42 @@ function processBreaksContinues(statements: StatementTuple[]): void
     label.children.push label.name = parent.label.name
     delete label.special
 
+/**
+In a CoffeeScript class, `x = y` makes a private variable x visible
+only within the class scope only, implemented via IIFE wrapper
+*/
+function processCoffeeClasses(statements: StatementTuple[]): void
+  for each ce of gatherRecursiveAll statements, .type is "ClassExpression"
+    { expressions } := ce.body
+    privates := expressions.filter &[1]?.type is "CoffeeClassPrivate"
+    continue unless privates#
+
+    { parent } := ce
+    indent := expressions[0][0]
+
+    // Remove privates from class body, in place
+    for i of [expressions# >.. 0]
+      if expressions[i][1]?.type is "CoffeeClassPrivate"
+        expressions.splice i, 1
+
+    wrapped .= wrapIIFE
+      . ...privates
+      . [indent, wrapWithReturn ce]
+
+    // Outer assignment
+    if { binding } .= ce
+      binding = trimFirstSpace binding
+      wrapped = makeNode {
+        type: "AssignmentExpression"
+        children: [binding, " = ", wrapped]
+        lhs: binding as any // TODO: incorrect shape
+        assigned: binding
+        expression: wrapped as CallExpression
+        names: [ce.name]
+      }
+
+    replaceNode ce, wrapped, parent
+
 function processProgram(root: BlockStatement): void
   state := getState()
   config := getConfig()
@@ -1510,16 +1546,17 @@ function processProgram(root: BlockStatement): void
   // so their target node can be found in the block without being inside a return
   processFunctions(statements, config)
 
+  processCoffeeClasses(statements) if config.coffeeClasses
+
   // Insert prelude
   statements.unshift(...state.prelude)
 
-  if (config.autoLet) {
+  if config.autoLet
     createConstLetDecs(statements, [], "let")
-  } else if(config.autoConst) {
+  else if config.autoConst
     createConstLetDecs(statements, [], "const")
-  } else if (config.autoVar) {
+  else if config.autoVar
     createVarDecs(root, [])
-  }
 
   // REPL wants all top-level variables hoisted to outermost scope
   processRepl root, rootIIFE if config.repl

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -27,6 +27,7 @@ import type {
   ElseClause
   FinallyClause
   ForStatement
+  FunctionSignature
   IfStatement
   Initializer
   IterationStatement
@@ -124,6 +125,7 @@ import {
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
+  findSuperCall
   makeAmpersandFunction
   processCoffeeDo
   processFunctions
@@ -1462,18 +1464,51 @@ function processBreaksContinues(statements: StatementTuple[]): void
     label.children.push label.name = parent.label.name
     delete label.special
 
-/**
-In a CoffeeScript class, `x = y` makes a private variable x visible
-only within the class scope only, implemented via IIFE wrapper
-*/
 function processCoffeeClasses(statements: StatementTuple[]): void
   for each ce of gatherRecursiveAll statements, .type is "ClassExpression"
     { expressions } := ce.body
+    indent := expressions[0]?[0] ?? '\n'
+
+    autoBinds := expressions.filter (&[1] as MethodDefinition?)?.autoBind
+    if autoBinds#
+      let construct: MethodDefinition?
+      for [, c] of expressions
+        if c is like {type: "MethodDefinition", name: "constructor"} and c.block
+          construct = c
+          break
+      unless construct
+        parametersList: never[] := []
+        parameters: ParametersNode :=
+          type: "Parameters"
+          children: [parametersList]
+          parameters: parametersList
+          names: []
+        signature: FunctionSignature := {}
+          type: "MethodSignature"
+          children: [ "constructor(", parameters, ")" ]
+          parameters
+          modifier: {}
+          returnType: undefined
+        block := makeEmptyBlock()
+        construct = {}
+          ...signature
+          type: "MethodDefinition"
+          name: "constructor"
+          block
+          signature
+          children: [ ...signature.children, block ]
+        expressions.unshift [indent, construct]
+      index := findSuperCall construct.block
+      construct.block.expressions.splice index+1, 0,
+        ...for each [, a] of autoBinds
+          [indent, ["this.", a.name, " = this.", a.name, ".bind(this)"], ";"]
+
+    // In a CoffeeScript class, `x = y` makes a private variable x visible
+    // only within the class scope only, implemented via IIFE wrapper
     privates := expressions.filter &[1]?.type is "CoffeeClassPrivate"
     continue unless privates#
 
     { parent } := ce
-    indent := expressions[0][0]
 
     // Remove privates from class body, in place
     for i of [expressions# >.. 0]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -103,6 +103,7 @@ import {
 import {
   blockContainingStatement
   blockWithPrefix
+  braceBlock
   duplicateBlock
   hoistRefDecs
   makeBlockFragment
@@ -1878,6 +1879,7 @@ export {
   append
   attachPostfixStatementAsExpression
   blockWithPrefix
+  braceBlock
   convertNamedImportsToObject
   convertObjectToJSXAttributes
   convertWithClause

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -92,6 +92,7 @@ export type OtherNode =
   | CatchPattern
   | CaseBlock
   | CaseClause
+  | CoffeeClassPrivate
   | CommentNode
   | ComputedPropertyName
   | ConditionFragment
@@ -248,7 +249,7 @@ export type AssignmentExpression
   type: "AssignmentExpression"
   children: Children
   parent?: Parent
-  names: null
+  names: string[] | null
   lhs: AssignmentExpressionLHS
   assigned: ASTNode
   expression: ExpressionNode
@@ -1084,7 +1085,7 @@ export type FunctionParameter =
 type AccessModifier = ASTNode
 type ParameterElementDelimiter = ASTNode
 
-export type TypeParameters = unknown
+export type TypeParameters = ASTNode
 
 export type FunctionNode = FunctionExpression | ArrowFunction | MethodDefinition
 
@@ -1096,6 +1097,7 @@ export type ClassExpression
   id: Identifier
   heritage: ASTNode
   body: ClassBody
+  binding: [BindingIdentifier, TypeParameters]
 
 export type ClassBody = BlockStatement & { subtype: "ClassBody" }
 
@@ -1106,6 +1108,17 @@ export type FieldDefinition
   ts?: boolean?
   id: ASTNode
   typeSuffix?: TypeSuffix?
+  abstract?: ASTNode
+  "readonly"?: ASTNode
+  initializer?: Initializer
+
+export type CoffeeClassPrivate
+  type: "CoffeeClassPrivate"
+  children: Children
+  parent?: Parent
+  id: ASTNode
+  typeSuffix?: TypeSuffix?
+  initializer: Initializer
 
 export type Literal =
   type: "Literal"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -953,8 +953,8 @@ export type FunctionExpression
   parent?: Parent
   name: string
   id: Identifier
-  async: ASTNode[]
-  generator: ASTNode[]
+  async?: ASTNode[]
+  generator?: ASTNode[]
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
@@ -983,11 +983,12 @@ export type MethodDefinition =
   children: Children
   parent?: Parent
   name: string
-  async: ASTNode[]
-  generator: ASTNode[]
+  async?: ASTNode[]
+  generator?: ASTNode[]
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
+  autoBind?: boolean // CoffeeScript => bound methods
 
 export type ArrowFunction =
   type: "ArrowFunction"

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -62,3 +62,27 @@ describe "coffeeClasses", ->
       }
     }
   """
+
+  testCase """
+    private static class fields
+    ---
+    "civet coffeeCompat"
+    class API
+      HTTP_GET = 'GET'
+      HTTP_HEAD = 'HEAD'
+      HTTP_VERBS = [HTTP_GET, HTTP_HEAD]
+      callApi: ->
+        console.log HTTP_VERBS[0]
+    ---
+    var API;
+    API = (()=>{
+      var HTTP_GET, HTTP_HEAD, HTTP_VERBS;
+      HTTP_GET = 'GET'
+      HTTP_HEAD = 'HEAD'
+      HTTP_VERBS = [HTTP_GET, HTTP_HEAD]
+      return class API {
+      callApi() {
+        return console.log(HTTP_VERBS[0]);
+      }
+    }})()
+  """

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -26,10 +26,36 @@ describe "coffeeClasses", ->
       lit: => @literate
     ---
     exports.Lexer = class Lexer {
+      constructor(){
+      this.tokenize = this.tokenize.bind(this);
+      this.lit = this.lit.bind(this);}
       tokenize(code, opts = {}) {
         return this.literate = opts.literate
-      };
+      }
       lit() {return  this.literate}
+    }
+  """
+
+  testCase """
+    colon fat arrow function with super constructor
+    ---
+    "civet coffeeClasses"
+    class Foo extends Bar
+      constructor: ->
+        super()
+        @count = 0
+      inc: => @count++
+      dec: => @count--
+    ---
+    class Foo extends Bar {
+      constructor() {
+        super()
+      this.inc = this.inc.bind(this);
+      this.dec = this.dec.bind(this);
+        this.count = 0
+      }
+      inc() {return  this.count++}
+      dec() {return  this.count--}
     }
   """
 
@@ -82,7 +108,7 @@ describe "coffeeClasses", ->
       HTTP_VERBS = [HTTP_GET, HTTP_HEAD]
       return class API {
       callApi() {
-        return console.log(HTTP_VERBS[0]);
+        return console.log(HTTP_VERBS[0])
       }
     }})()
   """

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -17,6 +17,23 @@ describe "coffeeClasses", ->
   """
 
   testCase """
+    colon fat arrow function
+    ---
+    "civet coffeeClasses"
+    exports.Lexer = class Lexer
+      tokenize: (code, opts = {}) =>
+        @literate = opts.literate
+      lit: => @literate
+    ---
+    exports.Lexer = class Lexer {
+      tokenize(code, opts = {}) {
+        return this.literate = opts.literate
+      };
+      lit() {return  this.literate}
+    }
+  """
+
+  testCase """
     implicit async
     ---
     "civet coffeeClasses"


### PR DESCRIPTION
Improved compatibility with CoffeeScript under `coffeeClasses` mode:

* Private static classic fields via `x = y` within a class body, by wrapping body in an IIFE and adding some local variables. Probably only works with `autoVar` enabled (like various other `coffeeCompat` features). Fixes #457
* Bound methods via `f: =>` within a class body, by adding to the constructor (after `super` call if there is one). Also rewrite into method, similar to `f: ->`. Fixes #55.
* Fix `constructor` getting an automatically inserted return [in most cases](https://civet.dev/playground?code=ImNpdmV0IGNvZmZlZUNsYXNzZXMiCmNsYXNzIFgKICBjb25zdHJ1Y3RvcjogKHgpIC0%2BCiAgICB4KCk%3D). (Recent regression perhaps? This would make `coffeeClasses` pretty unusable.)

Compilations should match CoffeeScript's compilations.