### PR TITLE
`let x?` allows initial `undefined` value + type inference; `let x? = y` for simple `y`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2548,7 +2548,7 @@ function f(x?: string)?: string
   x
 </Playground>
 
-More generally, `T?` allows for `undefined` and
+More generally, type `T?` allows for `undefined` and
 `T??` additionally allows for `null`:
 
 <Playground>
@@ -2560,6 +2560,14 @@ To allow for type inference and the initial `undefined` value:
 
 <Playground>
 let x?
+</Playground>
+
+To allow for later assignment of `undefined` while specifying an initial value
+(currently limited to a literal or member expression):
+
+<Playground>
+let x? = 5
+let y? = x
 </Playground>
 
 ### Non-Null Types

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2556,6 +2556,12 @@ let i: number?
 let x: string??
 </Playground>
 
+To allow for type inference and the initial `undefined` value:
+
+<Playground>
+let x?
+</Playground>
+
 ### Non-Null Types
 
 `T!` removes `undefined` and `null` from the type:

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6150,8 +6150,12 @@ CoffeeDoubleQuotedStringCharacters
 # https://262.ecma-international.org/#prod-RegularExpressionLiteral
 RegularExpressionLiteral
   HeregexLiteral
-  $("/" RegularExpressionBody "/" RegularExpressionFlags) ->
-    return { type: "RegularExpressionLiteral", $loc, token: $1 }
+  $("/" RegularExpressionBody "/" RegularExpressionFlags):raw ->
+    return {
+      type: "RegularExpressionLiteral",
+      raw,
+      children: [ { $loc, token: raw } ]
+    }
 
 RegularExpressionClass
   $(OpenBracket RegularExpressionClassCharacters CloseBracket) ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2878,7 +2878,7 @@ LiteralContent
 # https://262.ecma-international.org/#prod-NullLiteral
 NullLiteral
   "null" NonIdContinue ->
-    return { $loc, token: $1 }
+    return { type: "NullLiteral", $loc, token: $1 }
 
 # https://262.ecma-international.org/#prod-BooleanLiteral
 BooleanLiteral
@@ -2888,13 +2888,13 @@ BooleanLiteral
 _BooleanLiteral
   CoffeeBooleansEnabled CoffeeScriptBooleanLiteral -> $2
   ( "true" / "false" ) NonIdContinue ->
-    return { $loc, token: $1 }
+    return { type: "BooleanLiteral", $loc, token: $1 }
 
 CoffeeScriptBooleanLiteral
   ( "yes" / "on" ) NonIdContinue ->
-    return { $loc, token: "true" }
+    return { type: "BooleanLiteral", $loc, token: "true" }
   ( "no" / "off" ) NonIdContinue ->
-    return { $loc, token: "false" }
+    return { type: "BooleanLiteral", $loc, token: "false" }
 
 # NOTE: Added :symbol shorthand for Symbol.symbol or Symbol.for("symbol")
 SymbolLiteral
@@ -8101,10 +8101,11 @@ TypePrimary
   # NOTE: typeof takes a unary expression, as in
   # https://github.com/microsoft/TypeScript/blob/ae27e55b027c66bf5b80f596da866f8485ac491d/src/compiler/parser.ts#L5666-L5669
   # (binary expression can accidentally grab closing ">" of type arguments)
-  _? Typeof _? UnaryExpression ->
+  _? Typeof _? UnaryExpression:expression ->
     return {
-      type: "TypeofType",
+      type: "TypeTypeof",
       children: $0,
+      expression,
     }
   _? TypeTuple ->
     return prepend($1, $2)

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -124,7 +124,9 @@ function processDeclarations(statements: StatementTuple[]): void
               type: "TypeTypeof"
               children: ["typeof ", expression]
               expression
-          else if expression.type is "Literal"
+          else if expression.type is "Literal" or
+                  expression.type is "RegularExpressionLiteral" or
+                  expression.type is "TemplateLiteral"
             typeSuffix.children.push ": ", typeSuffix.t = literalType expression
           else
             spliceChild binding, typeSuffix, 1,

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -40,6 +40,7 @@ import {
   convertOptionalType
   insertTrimmingSpace
   isExit
+  literalType
   makeLeftHandSideExpression
   makeNode
   spliceChild
@@ -115,17 +116,31 @@ function processDeclarations(statements: StatementTuple[]): void
       { typeSuffix, initializer } .= binding
 
       if typeSuffix and typeSuffix.optional
+        // Convert `let x? = y` to `let x: undefined | typeof y = y`
+        if initializer and not typeSuffix.t
+          expression := trimFirstSpace initializer.expression!
+          if expression.type is like "Identifier", "MemberExpression"
+            typeSuffix.children.push ": ", typeSuffix.t = {}
+              type: "TypeTypeof"
+              children: ["typeof ", expression]
+              expression
+          else if expression.type is "Literal"
+            typeSuffix.children.push ": ", typeSuffix.t = literalType expression
+          else
+            spliceChild binding, typeSuffix, 1,
+              type: "Error"
+              message: `Optional type can only be inferred from literals or member expressions, not ${expression.type}`
+            continue
         if typeSuffix.t
           // Convert `let x?: T` to `let x: undefined | T`
           convertOptionalType typeSuffix
         else
           // Convert `let x?` to `let x = undefined`
           spliceChild binding, typeSuffix, 1
-          unless initializer
-            binding.children.push initializer = binding.initializer =
-              type: "Initializer"
-              expression: "undefined"
-              children: [" = ", "undefined"]
+          binding.children.push initializer = binding.initializer =
+            type: "Initializer"
+            expression: "undefined"
+            children: [" = ", "undefined"]
 
       if initializer
         prependStatementExpressionBlock initializer, declaration

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -42,6 +42,7 @@ import {
   isExit
   makeLeftHandSideExpression
   makeNode
+  spliceChild
   trimFirstSpace
   updateParentPointers
 } from ./util.civet
@@ -109,13 +110,23 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
 function processDeclarations(statements: StatementTuple[]): void
   for each declaration of gatherRecursiveAll statements, .type is "Declaration"
     { bindings } := declaration
-    bindings?.forEach (binding) =>
-      { typeSuffix } := binding
-      if typeSuffix and typeSuffix.optional and typeSuffix.t
-        // Convert `let x?: T` to `let x: undefined | T`
-        convertOptionalType typeSuffix
+    continue unless bindings?
+    for each binding of bindings
+      { typeSuffix, initializer } .= binding
 
-      { initializer } := binding
+      if typeSuffix and typeSuffix.optional
+        if typeSuffix.t
+          // Convert `let x?: T` to `let x: undefined | T`
+          convertOptionalType typeSuffix
+        else
+          // Convert `let x?` to `let x = undefined`
+          spliceChild binding, typeSuffix, 1
+          unless initializer
+            binding.children.push initializer = binding.initializer =
+              type: "Initializer"
+              expression: "undefined"
+              children: [" = ", "undefined"]
+
       if initializer
         prependStatementExpressionBlock initializer, declaration
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -60,6 +60,7 @@ export type ExpressionNode =
   | PipelineExpression
   | RegularExpressionLiteral
   | StatementExpression
+  | TemplateLiteral
   | TypeNode
   | UnaryExpression
   | UnwrappedExpression
@@ -766,10 +767,14 @@ export type ConditionFragment =
 
 export type RegularExpressionLiteral =
   type: "RegularExpressionLiteral"
-  $loc: Loc
-  token: string
+  children: Children
   parent?: Parent
-  children?: never
+  raw: string
+
+export type TemplateLiteral
+  type: "TemplateLiteral"
+  children: Children
+  parent?: Parent
 
 export type ArrayBindingPattern =
   type: "ArrayBindingPattern"
@@ -1124,7 +1129,7 @@ export type CoffeeClassPrivate
 
 export type Literal =
   type: "Literal"
-  subtype: "NullLiteral" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral"
+  subtype: "NullLiteral" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral" | "RegularExpressionLiteral"
   children: Children & LiteralContentNode[]
   parent?: Parent
   raw: string

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1124,7 +1124,7 @@ export type CoffeeClassPrivate
 
 export type Literal =
   type: "Literal"
-  subtype?: "NumericLiteral" | "StringLiteral"
+  subtype: "NullLiteral" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral"
   children: Children & LiteralContentNode[]
   parent?: Parent
   raw: string
@@ -1171,6 +1171,7 @@ export type ParseRule = (context: {fail: () => void}, state: {pos: number, input
 export type TypeNode =
   | TypeIdentifier
   | TypeLiteral
+  | TypeTypeof
   | TypeUnary
   | TypeTuple
   | TypeElement
@@ -1242,6 +1243,12 @@ export type TypeLiteral
   children: Children
   parent?: Parent
 
+export type TypeTypeof
+  type: "TypeTypeof"
+  children: Children
+  parent?: Parent
+  expression: ASTNode
+
 export type TypeAsserts
   type: "TypeAsserts"
   children: Children
@@ -1257,7 +1264,7 @@ export type TypePredicate
 
 export type VoidType = ASTLeafWithType "VoidType"
 
-export type TypeLiteralNode = ASTLeaf | VoidType
+export type TypeLiteralNode = ASTLeaf | ASTString | VoidType
 
 export type ThisAssignments = ([string, ASTRef] | AssignmentExpression)[]
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -680,8 +680,8 @@ function skipIfOnlyWS(target)
  * Splice child from children/array, similar to Array.prototype.splice,
  * but specifying a child instead of an index.  Throw if child not found.
  */
-function spliceChild(node: ASTNode, child: ASTNode, del, ...replacements)
-  children := node?.children ?? node
+function spliceChild(node: ASTNodeObject | ASTNode[], child: ASTNode, del: number, ...replacements: ASTNode[])
+  children := Array.isArray(node) ? node : node.children
   unless Array.isArray children
     throw new Error "spliceChild: non-array node has no children field"
   index := children.indexOf child
@@ -900,6 +900,7 @@ export {
   replaceNode
   replaceNodes
   skipIfOnlyWS
+  spliceChild
   startsWith
   startsWithPredicate
   stripTrailingImplicitComma

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -3,6 +3,7 @@ import type {
   ASTNode
   ASTNodeObject
   ASTNodeParent
+  ASTString
   Children
   FunctionNode
   FunctionSignature
@@ -14,10 +15,11 @@ import type {
   Parameter
   ParametersNode
   Parent
-  StatementNode
-  TypeSuffix
   ReturnTypeAnnotation
+  StatementNode
   StatementTuple
+  TypeNode
+  TypeSuffix
 } from ./types.civet
 
 import {
@@ -396,6 +398,28 @@ function literalValue(literal: Literal)
       return parseInt(raw, 10)
     else
       throw new Error("Unrecognized literal " + JSON.stringify(literal))
+
+/** TypeScript type for given literal */
+function literalType(literal: Literal): TypeNode
+  let t: ASTString
+  switch literal.subtype
+    when "NullLiteral"
+      t = "null"
+    when "BooleanLiteral"
+      t = "boolean"
+    when "NumericLiteral"
+      if literal.raw.endsWith 'n'
+        t = "bigint"
+      else
+        t = "number"
+    when "StringLiteral"
+      t = "string"
+    else
+      throw new Error `unknown literal subtype ${literal.subtype}`
+  {}
+    type: "TypeLiteral"
+    t
+    children: [t]
 
 function makeNumericLiteral(n: number): Literal
   s := n.toString()
@@ -887,6 +911,7 @@ export {
   isToken
   isWhitespaceOrEmpty
   literalValue
+  literalType
   makeLeftHandSideExpression
   makeNode
   makeNumericLiteral

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -15,9 +15,11 @@ import type {
   Parameter
   ParametersNode
   Parent
+  RegularExpressionLiteral
   ReturnTypeAnnotation
   StatementNode
   StatementTuple
+  TemplateLiteral
   TypeNode
   TypeSuffix
 } from ./types.civet
@@ -400,22 +402,30 @@ function literalValue(literal: Literal)
       throw new Error("Unrecognized literal " + JSON.stringify(literal))
 
 /** TypeScript type for given literal */
-function literalType(literal: Literal): TypeNode
+function literalType(literal: Literal | RegularExpressionLiteral | TemplateLiteral): TypeNode
   let t: ASTString
-  switch literal.subtype
-    when "NullLiteral"
-      t = "null"
-    when "BooleanLiteral"
-      t = "boolean"
-    when "NumericLiteral"
-      if literal.raw.endsWith 'n'
-        t = "bigint"
-      else
-        t = "number"
-    when "StringLiteral"
+  switch literal.type
+    when "RegularExpressionLiteral"
+      t = "RegExp"
+    when "TemplateLiteral"
       t = "string"
+    when "Literal"
+      switch literal.subtype
+        when "NullLiteral"
+          t = "null"
+        when "BooleanLiteral"
+          t = "boolean"
+        when "NumericLiteral"
+          if literal.raw.endsWith 'n'
+            t = "bigint"
+          else
+            t = "number"
+        when "StringLiteral"
+          t = "string"
+        else
+          throw new Error `unknown literal subtype ${literal.subtype}`
     else
-      throw new Error `unknown literal subtype ${literal.subtype}`
+      throw new Error `unknown literal type ${literal.type}`
   {}
     type: "TypeLiteral"
     t

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -48,6 +48,22 @@ describe "[TS] let declaration", ->
   """
 
   testCase """
+    let ? sets to undefined
+    ---
+    let n?
+    ---
+    let n = undefined
+  """
+
+  testCase """
+    let ? ignored with initializer
+    ---
+    let n? = 5
+    ---
+    let n= 5
+  """
+
+  testCase """
     let ?: allows for undefined
     ---
     let n?: number

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -56,11 +56,31 @@ describe "[TS] let declaration", ->
   """
 
   testCase """
-    let ? ignored with initializer
+    let ? with initializer
     ---
-    let n? = 5
+    let a? = null
+    let b? = true
+    let c? = 5
+    let d? = 5n
+    let e? = "hello"
+    let f? = x
+    let g? = x.y[z]
     ---
-    let n= 5
+    let a : undefined | null= null
+    let b : undefined | boolean= true
+    let c : undefined | number= 5
+    let d : undefined | bigint= 5n
+    let e : undefined | string= "hello"
+    let f : undefined | (typeof x)= x
+    let g : undefined | (typeof x.y[z])= x.y[z]
+  """
+
+  throws """
+    let ? with complex initializer
+    ---
+    let c? = x.y()
+    ---
+    ParseErrors: unknown:1:6 Optional type can only be inferred from literals or member expressions, not CallExpression
   """
 
   testCase """

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -63,16 +63,20 @@ describe "[TS] let declaration", ->
     let c? = 5
     let d? = 5n
     let e? = "hello"
-    let f? = x
-    let g? = x.y[z]
+    let f? = `hello`
+    let g? = /hello/
+    let h? = x
+    let i? = x.y[z]
     ---
     let a : undefined | null= null
     let b : undefined | boolean= true
     let c : undefined | number= 5
     let d : undefined | bigint= 5n
     let e : undefined | string= "hello"
-    let f : undefined | (typeof x)= x
-    let g : undefined | (typeof x.y[z])= x.y[z]
+    let f : undefined | string= `hello`
+    let g : undefined | RegExp= /hello/
+    let h : undefined | (typeof x)= x
+    let i : undefined | (typeof x.y[z])= x.y[z]
   """
 
   throws """


### PR DESCRIPTION
Previously, `let x?` compiled to the invalid TypeScript `let x?`. Now it compiles to `let x = undefined`. As [this playground shows](https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEA3W8wHsB2wBc8BGaaEIUGAsAFDEAu8AHvALzwCuWIAZgJYYjCXoMAZyIgAdBDQBzABR0AlJXjKVqgPRqAegH5KXDvBmDg8+AG8l9JvACslhgGpmARgAMlAL4DMI4hOlyihSqIfAaOkA), this seems to allow for the initial `undefined` value (no error about access before initialized) as well as type inference.

This PR also makes `let x? = 5` compile to `let x = 5` (instead of leaving the invalid `?` in there). I wanted to compile it to `let x: undefined | typeof 5 = 5`, but sadly this [isn't valid TypeScript](https://www.typescriptlang.org/docs/handbook/2/typeof-types.html#limitations):

> TypeScript intentionally limits the sorts of expressions you can use `typeof` on. Specifically, it’s only legal to use `typeof` on identifiers (i.e. variable names) or their properties. 