### PR TITLE
Extension bug fix for unplugin on webpack; cleanup old bug workarounds

### DIFF
--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -142,7 +142,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
 
   cache := new Map<string, CacheEntry> unless options.cache is false
 
-  plugin: ReturnType<typeof rawPlugin> & { __virtualModulePrefix?: string } := {
+  plugin: ReturnType<typeof rawPlugin> := {
     name: 'unplugin-civet'
     enforce: 'pre'
 
@@ -369,15 +369,6 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
                   compilerOptions.outDir ?? process.cwd()
                   filePath
 
-                // Work around unplugin+esbuild bug where it only creates the
-                // root output directory, not any subdirectories.
-                if meta.framework is 'esbuild'
-                  fs.mkdirSync
-                    path.dirname(
-                      path.resolve(esbuildOptions.outdir!, pathFromDistDir)
-                    )
-                    recursive: true
-
                 this.emitFile
                   source: content
                   fileName: pathFromDistDir
@@ -391,15 +382,6 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
     resolveId(id, importer, options)
       id = aliasResolver id if aliasResolver?
       if (/\0/.test(id)) return null
-
-      // unplugin webpack virtualizes our resolved paths, by prepending
-      // plugin.__virtualModulePrefix and then encodeURIComponent.
-      // [https://github.com/unjs/unplugin/blob/f6ceb5092715b8047eeb069b249b919f3ef2bcfb/src/webpack/index.ts#L131]
-      // Undo this transformation on the `importer` path
-      // so we can correctly resolve its directory.
-      if plugin.__virtualModulePrefix and
-         importer?.startsWith plugin.__virtualModulePrefix
-        importer = decodeURIComponent importer[plugin.__virtualModulePrefix#..]
 
       let postfix: string
       {id, postfix} = cleanCivetId(id)
@@ -598,7 +580,12 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
     }
 
     webpack(compiler)
-      compiler.options.resolve.extensions.unshift ".civet" if implicitExtension
+      if implicitExtension
+        compiler.options ?= {}
+        compiler.options.resolve ?= {}
+        // Default from https://webpack.js.org/configuration/resolve/#resolveextensions
+        compiler.options.resolve.extensions ?= ['', '.js', '.json', '.wasm']
+        compiler.options.resolve.extensions.unshift ".civet"
       aliasResolver = (id) =>
         // Based on normalizeAlias from
         // https://github.com/webpack/enhanced-resolve/blob/72999caf002f6f7bb4624e65fdeb7ba980b11e24/lib/ResolverFactory.js#L158


### PR DESCRIPTION
I noticed some old code that worked around unplugin bugs that have since been fixed (https://github.com/unjs/unplugin/pull/362 and https://github.com/unjs/unplugin/pull/430), and removed that.

But webpack also wasn't building because of some assumptions in automatic extensions. Should be fixed now (with a hard-coded default).