### PR TITLE
Multiple items and spreads in array comprehensions

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1861,6 +1861,13 @@ function flatJoin<T>(list: T[][], sep: T): T[]
       ...sublist
 </Playground>
 
+<Playground>
+flatImage :=
+  for x of [0...nx]
+    ...for y of [0...ny]
+      image.get x, y
+</Playground>
+
 If you don't specify a body, `for` loops list the item being iterated over:
 
 <Playground>

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1818,7 +1818,7 @@ for key: keyof typeof object, value in object
 
 ### Loop Expressions
 
-If needed, loops automatically assemble an Array of the last value
+If needed, loops automatically assemble an array of the last value
 within the body of the loop for each completed iteration.
 
 <Playground>
@@ -1849,6 +1849,17 @@ When not at the top level, loop expressions wrap in an
 so you cannot use `return` inside such a loop,
 nor can you `break` or `continue` any outer loop.
 :::
+
+You can also accumulate multiple items and/or spreads:
+
+<Playground>
+function flatJoin<T>(list: T[][], sep: T): T[]
+  for sublist, i of list
+    if i
+      sep, ...sublist
+    else
+      ...sublist
+</Playground>
 
 If you don't specify a body, `for` loops list the item being iterated over:
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -326,6 +326,30 @@ CommaExpression
     if($2.length == 0) return $1
     return $0
 
+# Variation on CommaExpression that allows ... spreads,
+# which we allow in statements for the sake of expressionized iterations
+CommaExpressionSpread
+  AssignmentExpressionSpread ( CommaDelimiter AssignmentExpressionSpread )* ->
+    if($2.length == 0) return $1
+    return $0
+
+AssignmentExpressionSpread
+  _? DotDotDot AssignmentExpression:expression ->
+    return {
+      type: "SpreadElement",
+      children: $0,
+      expression,
+      names: expression.names,
+    }
+  AssignmentExpression:expression ( _? DotDotDot )? ->
+    if (!$2) return $1
+    return {
+      type: "SpreadElement",
+      children: [ ...$2, $1 ],
+      expression,
+      names: expression.names,
+    }
+
 # https://262.ecma-international.org/#prod-Arguments
 Arguments
   ExplicitArguments
@@ -5397,7 +5421,9 @@ CommaExpressionStatement
   # NOTE: semi-colons are being handled elsewhere
   # NOTE: Shouldn't need negative lookahead if shadowed in the proper order
   # NOTE: CommaExpression allows , operator
-  CommaExpression ->
+  # NOTE: CommaExpressionSpread allows ... spreads,
+  # which are useful within expressionized iterations
+  CommaExpressionSpread ->
     // Wrap object literal with parens to disambiguate from block statements.
     // Also wrap nameless functions from `->` expressions with parens
     // as needed in JS.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -329,11 +329,37 @@ CommaExpression
 # Variation on CommaExpression that allows ... spreads,
 # which we allow in statements for the sake of expressionized iterations
 CommaExpressionSpread
+  _?:ws DotDotDot _?:ws2 IterationActualStatement:iteration ->
+    if (iteration.subtype === "do" || iteration.subtype === "comptime") return $skip
+    if (ws2) {
+      if (ws) {
+        ws = [ws, ws2]
+      } else {
+        ws = ws2
+      }
+    }
+    iteration = { ...iteration, resultsParent: true }
+    return prepend(ws, iteration)
   AssignmentExpressionSpread ( CommaDelimiter AssignmentExpressionSpread )* ->
     if($2.length == 0) return $1
     return $0
 
 AssignmentExpressionSpread
+  _? DotDotDot AssignmentExpression:expression ->
+    return {
+      type: "SpreadElement",
+      children: $0,
+      expression,
+      names: expression.names,
+    }
+  AssignmentExpression:expression ( _? DotDotDot )? ->
+    if (!$2) return $1
+    return {
+      type: "SpreadElement",
+      children: [ ...$2, $1 ],
+      expression,
+      names: expression.names,
+    }
   _? DotDotDot AssignmentExpression:expression ->
     return {
       type: "SpreadElement",
@@ -4386,12 +4412,7 @@ Statement
   KeywordStatement
   VariableStatement
   IfStatement !ShouldExpressionize -> $1
-  IterationStatement !ShouldExpressionize ->
-    // Leave generator forms for IterationExpression
-    if ($1.generator) return $skip
-    // Leave `for` reductions for IterationExpression
-    if ($1.reduction) return $skip
-    return $1
+  IterationActualStatement
   SwitchStatement !ShouldExpressionize -> $1
   TryStatement !ShouldExpressionize -> $1
   FinallyClause
@@ -4406,6 +4427,14 @@ Statement
   BlockStatement
 
   # NOTE: no WithStatement
+
+IterationActualStatement
+  IterationStatement !ShouldExpressionize ->
+    // Leave generator forms for IterationExpression
+    if ($1.generator) return $skip
+    // Leave `for` reductions for IterationExpression
+    if ($1.reduction) return $skip
+    return $1
 
 # NOTE: Leave statement with trailing call expressions or pipe operator
 # to be expressionized by

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2699,7 +2699,14 @@ BareBlock
   EmptyBareBlock
 
 ThenClause
-  Then SingleLineStatements -> $2
+  Then ThenBlock -> $2
+
+# `then` can be followed by nested block (unlike CoffeeScript)
+# or same-line statements separated by `;`, or empty
+ThenBlock
+  NoBlock EmptyBlock -> $2
+  ImplicitNestedBlock
+  SingleLineStatements
 
 BracedThenClause
   &Then InsertOpenBrace:open ThenClause:exp InsertCloseBrace:close ->
@@ -4526,7 +4533,7 @@ LabelledItem
 # https://262.ecma-international.org/#prod-IfStatement
 IfStatement
   # NOTE: Allow indentation in condition when there's an explicit `then` clause
-  ( If / Unless ):kind _?:ws BoundedCondition:condition Then BlockOrEmpty:block ElseClause?:e ->
+  ( If / Unless ):kind _?:ws BoundedCondition:condition ThenClause:block ElseClause?:e ->
     if (kind.negated) {
       kind = { ...kind, token: "if" }
       condition = negateCondition(condition)

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -156,7 +156,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
     ws = exp[0]
     exp = exp[1]!
 
-  return unless exp?.type is "StatementExpression"
+  return unless exp is like {type: "StatementExpression"}, {type: "SpreadElement", expression: {type: "StatementExpression"}}
 
   pre: ASTNode[] := []
   statementExp := exp.statement

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -677,7 +677,24 @@ function wrapIterationReturningResults(
   // to implement `implicitlyReturned`
   return if statement.resultsRef?
 
-  resultsRef := statement.resultsRef = makeRef "results"
+  // Inherit parent's resultsRef if requested
+  if statement.resultsParent
+    { ancestor } := findAncestor statement,
+      .type is "ForStatement" or .type is "IterationStatement"
+      isFunction
+    unless ancestor
+      statement.children.unshift
+        type: "Error"
+        message: "Could not find ancestor of spread iteration"
+      return
+    resultsRef := statement.resultsRef = ancestor.resultsRef
+    iterationDefaultBody statement
+    { block } := statement
+    unless block.empty
+      assignResults block, (node) => [ resultsRef, ".push(", node, ")" ]
+    return
+
+  resultsRef := statement.resultsRef ?= makeRef "results"
 
   declaration := iterationDeclaration statement
   { ancestor, child } := findAncestor statement, .type is "BlockStatement"
@@ -1145,6 +1162,7 @@ function expressionizeIteration(exp: IterationExpression): void
 
     statements =
       . ["", statement]
+
   else
     resultsRef := statement.resultsRef ??= makeRef "results"
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -754,7 +754,7 @@ function makeExpressionStatement(expression: ASTNode): ASTNode
   if Array.isArray(expression) and expression[1]?[0]?[0]?[1]?.token is "," // CommaExpression
     [
       makeExpressionStatement expression[0]
-      expression[1].map ([comma, exp]) => // CommaDelimiter AssignmentExpression
+      expression[1].map [comma, exp] => // CommaDelimiter AssignmentExpression
         [comma, makeExpressionStatement exp]
     ]
   else if expression?.type is "ObjectExpression" or

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1002,7 +1002,7 @@ function processAssignments(statements): void
 
     let block?: BlockStatement
     // Extract StatementExpression as block
-    if exp.parent?.type is "BlockStatement" and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
+    if blockContainingStatement(exp) and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
       block = makeBlockFragment()
       if ref := prependStatementExpressionBlock(
         {type: "Initializer", expression: $2, children: [undefined, undefined, $2]}

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -382,6 +382,7 @@ export type IterationStatement
   generator?: ASTNode
   object?: boolean
   resultsRef: ASTRef?
+  resultsParent?: boolean // inherit resultsRef from parent loop
 
 export type BreakStatement
   type: "BreakStatement"
@@ -425,6 +426,7 @@ export type ForStatement
   hoistDec: ASTNode
   generator?: ASTNode
   resultsRef: ASTRef?
+  resultsParent?: boolean // inherit resultsRef from parent loop
   reduction?: ForReduction
   object?: boolean
 

--- a/test/for.civet
+++ b/test/for.civet
@@ -1527,3 +1527,58 @@ describe "for", ->
       ---
       if (!(()=>{let results=true;for (const f of facesHit) {results = false; break}return results})()) { return false }
     """
+
+  describe "spreads", ->
+    testCase """
+      comma in body
+      ---
+      function concatPairs(pairs)
+        for [x, y] of pairs
+          x, y
+      ---
+      function concatPairs(pairs) {
+        const results=[];for (const [x, y] of pairs) {
+          results.push(x, y)
+        };return results;
+      }
+    """
+
+    testCase """
+      spread in body
+      ---
+      function concat(arrays)
+        for array of arrays
+          ...array
+      ---
+      function concat(arrays) {
+        const results=[];for (const array of arrays) {
+          results.push(...array)
+        };return results;
+      }
+    """
+
+    testCase """
+      reverse spread in body
+      ---
+      function concat(arrays)
+        for array of arrays
+          array ...
+      ---
+      function concat(arrays) {
+        const results=[];for (const array of arrays) {
+          results.push( ...array)
+        };return results;
+      }
+    """
+
+    testCase """
+      multiple spreads in body
+      ---
+      result :=
+        for item of items
+          item.pre, ...item.mid, item.post, ... item.tail
+      ---
+      const results=[];for (const item of items) {
+          results.push(item.pre, ...item.mid, item.post, ... item.tail)
+        };const result =results
+    """

--- a/test/for.civet
+++ b/test/for.civet
@@ -1582,3 +1582,30 @@ describe "for", ->
           results.push(item.pre, ...item.mid, item.post, ... item.tail)
         };const result =results
     """
+
+    testCase """
+      spread iteration
+      ---
+      function flatSquare(arrays)
+        for array of arrays
+          ... for item of array
+            item * item
+      ---
+      function flatSquare(arrays) {
+        const results=[];for (const array of arrays) {
+           for (const item of array) {
+            results.push(item * item)
+          }
+        };return results;
+      }
+    """
+
+    throws """
+      spread iteration without parent
+      ---
+      function flatSquare(arrays)
+        ... for item of array
+          item * item
+      ---
+      ParseErrors: unknown:2:3 Could not find ancestor of spread iteration
+    """

--- a/test/if.civet
+++ b/test/if.civet
@@ -276,8 +276,8 @@ describe "if", ->
     then
       console.log 'yes'
     ---
-    if((()=>{let results=true;for (const x in y) { if (!(
-      x)) {results = false; break} }return results})()) {
+    if(
+      (()=>{let results=true;for (const x in y) { if (!x) {results = false; break} }return results})()) {
       console.log('yes')
     }
   """
@@ -343,6 +343,14 @@ describe "if", ->
     if x then y
     ---
     if (x) y
+  """
+
+  testCase """
+    if then with braces
+    ---
+    if x then {y}
+    ---
+    if (x) ({y})
   """
 
   testCase """
@@ -953,6 +961,14 @@ describe "if", ->
       x = (if y then "a" else "b")
       ---
       x = ((y? "a" : "b"))
+    """
+
+    testCase """
+      parenthesized expression with then and braces
+      ---
+      x = (if y then {z})
+      ---
+      x = ((y? ({z}):void 0))
     """
 
     testCase """


### PR DESCRIPTION
Fixes #439 

Includes optimization for `...for` inside `for`, as suggested by @bbrk24 

During self-test, I also found that `z = (if x then {y})` was incorrectly compiled to `z = ((x?y:void 0))` (note missing braces). That's fixed here too.