### PR TITLE
`for concat` reduction for concatenating arrays, `for first` reduction for finding elements

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1964,6 +1964,19 @@ numEven := for count item of array
 numKeys := for count key in object
 </Playground>
 
+`for first` returns the first body value.
+If there is no body, it uses the item being looped over.
+Combined with a `when` condition, this can act like
+[`Array.prototype.find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
+
+<Playground>
+firstEven :=
+  for first item of array when item % 2 === 0
+firstEvenSquare :=
+  for first item of array when item % 2 === 0
+    item * item
+</Playground>
+
 `for sum` adds up the body values with `+`, starting from `0`.
 If there is no body, it adds the item being looped over.
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1995,10 +1995,19 @@ It's like `for sum` but starting from `""` instead of `0`.
 
 <Playground>
 all := for join item of array
-  `[${item.type}] ${item.title}`
+  `[${item.type}] ${item.title}\n`
 </Playground>
 
-Implicit bodies in `for sum/product/min/max/join` reductions
+`for concat` concatenates the body values as arrays,
+using the [concat operator `++`](#concat-operator).
+If there is no body, it uses the item being looped over.
+
+<Playground>
+function flat1<T>(arrays: T[][]): T[]
+  for concat array of arrays
+</Playground>
+
+Implicit bodies in `for sum/product/min/max/join/concat` reductions
 can use a single destructuring:
 
 <Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4714,7 +4714,7 @@ ForStatementControlWithReduction
     return { ...control, reduction }
 
 ForReduction
-  ( "some" / "every" / "count" / "sum" / "product" / "min" / "max" / "join" / "concat" ):subtype NonIdContinue __:ws ->
+  ( "some" / "every" / "count" / "first" / "sum" / "product" / "min" / "max" / "join" / "concat" ):subtype NonIdContinue __:ws ->
     return {
       type: "ForReduction",
       subtype,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4714,7 +4714,7 @@ ForStatementControlWithReduction
     return { ...control, reduction }
 
 ForReduction
-  ( "some" / "every" / "count" / "sum" / "product" / "min" / "max" / "join" ):subtype NonIdContinue __:ws ->
+  ( "some" / "every" / "count" / "sum" / "product" / "min" / "max" / "join" / "concat" ):subtype NonIdContinue __:ws ->
     return {
       type: "ForReduction",
       subtype,

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -731,6 +731,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
         when "max" then "-Infinity"
         when "product" then "1"
         when "join" then '""'
+        when "concat" then "[]"
         else "0"
   else if statement.object
     declaration.children.push "={}"
@@ -759,6 +760,8 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
           when "count"
             [ "if (", node, ") ++", resultsRef ]
           when "sum", "join" then [ resultsRef, " += ", node ]
+          when "concat"
+            [ getHelperRef("concatAssign"), "(", resultsRef, ", ", node, ")" ]
           when "product" then [ resultsRef, " *= ", node ]
           when "min" then [ resultsRef, " = Math.min(", resultsRef, ", ", node, ")" ]
           when "max" then [ resultsRef, " = Math.max(", resultsRef, ", ", node, ")" ]

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -727,6 +727,7 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
       switch reduction.subtype
         when "some" then "false"
         when "every" then "true"
+        when "first" then "undefined"
         when "min" then "Infinity"
         when "max" then "-Infinity"
         when "product" then "1"
@@ -759,6 +760,8 @@ function iterationDeclaration(statement: IterationStatement | ForStatement)
               resultsRef, " = false; break}" ]
           when "count"
             [ "if (", node, ") ++", resultsRef ]
+          when "first"
+            [ resultsRef, " = ", node, "; break" ]
           when "sum", "join" then [ resultsRef, " += ", node ]
           when "concat"
             [ getHelperRef("concatAssign"), "(", resultsRef, ", ", node, ")" ]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -438,7 +438,7 @@ export type ForDeclaration
 
 export type ForReduction
   type: "ForReduction"
-  subtype: "some" | "every" | "count" | "sum" | "product" | "min" | "max" | "join"
+  subtype: "some" | "every" | "count" | "sum" | "product" | "min" | "max" | "join" | "concat"
 
 export type SwitchStatement
   type: "SwitchStatement"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -438,7 +438,7 @@ export type ForDeclaration
 
 export type ForReduction
   type: "ForReduction"
-  subtype: "some" | "every" | "count" | "sum" | "product" | "min" | "max" | "join" | "concat"
+  subtype: "some" | "every" | "count" | "find" | "sum" | "product" | "min" | "max" | "first" | "concat"
 
 export type SwitchStatement
   type: "SwitchStatement"

--- a/test/for.civet
+++ b/test/for.civet
@@ -1462,6 +1462,20 @@ describe "for", ->
     """
 
     testCase """
+      for concat
+      ---
+      flat := for concat x of y
+      numbers := for concat x of y
+        [x, x+1]
+      ---
+      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
+      let results=[];for (const x of y) {concatAssign(results, x)};const flat =results
+      let results1=[];for (const x of y) {
+        concatAssign(results1, [x, x+1])
+      };const numbers =results1
+    """
+
+    testCase """
       implicit body array destructuring
       ---
       total := for sum [,x] of y

--- a/test/for.civet
+++ b/test/for.civet
@@ -1476,6 +1476,23 @@ describe "for", ->
     """
 
     testCase """
+      for first
+      ---
+      first := for first x of y
+      positive := for first x of y when x > 0
+      complex := for first x of y
+        continue unless x > 0
+        x * x
+      ---
+      let results=undefined;for (const x of y) {results = x; break};const first =results
+      let results1=undefined;for (const x of y) {if (!(x > 0)) continue;results1 = x; break};const positive =results1
+      let results2=undefined;for (const x of y) {
+        if (!(x > 0)) { continue }
+        results2 = x * x; break
+      };const complex =results2
+    """
+
+    testCase """
       implicit body array destructuring
       ---
       total := for sum [,x] of y


### PR DESCRIPTION
`for concat` concatenates using `++`. Like #1656, this is another approach to flattening, which I imagine would be useful in some cases. For example, `array.flat(1)` is equivalent to

```js
for concat subarray of array
```

---

`for first` returns the first body, as suggested in #1649, or else `undefined`. For example, this can simulate `Array.prototype.find`: `array.find(cond)` is equivalent to

```js
for first item of array when cond(item)
```

If `cond` isn't already a function, though, it can make nicer code (no function wrapper necessary).
`for first` also lets you choose *what* to return when found. For example, you can simulate `array.findIndex(cond)` like so:

```js
for first item, i of array when cond(item)
  i
```

I wasn't sure whether to return the first *truthy* body. This would behave more like `for some`, just changing the return value. But I think just returning the first body offers more consistent behavior (maybe you want to return a falsey value), and you can add truthy checking via `when`. But this is partly why it's called `for first`, not `for find`.