### PR TITLE
`for` reduction fixes: `each` supports implicit body, `for*` is an error

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4730,16 +4730,23 @@ ForStatement
 
 ForClause
   For ( _? Star )?:generator __ ForStatementControlWithWhen:c  ->
-    const {children, declaration} = c
+    let {children, declaration, reduction, hoistDec, blockPrefix} = c
+    if (generator && reduction) {
+      // TODO: `for* concat` might make sense
+      children = [{
+        type: "Error",
+        message: `Cannot use reduction (${reduction.subtype}) with generators`,
+      }, ...children]
+    }
 
     return {
       type: "ForStatement",
       children: [$1, ...$3, ...children],
       declaration,
       block: null,
-      blockPrefix: c.blockPrefix,
-      hoistDec: c.hoistDec,
-      reduction: c.reduction,
+      blockPrefix,
+      hoistDec,
+      reduction,
       generator,
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4730,7 +4730,7 @@ ForStatement
 
 ForClause
   For ( _? Star )?:generator __ ForStatementControlWithWhen:c  ->
-    let {children, declaration, reduction, hoistDec, blockPrefix} = c
+    let {children, reduction} = c
     if (generator && reduction) {
       // TODO: `for* concat` might make sense
       children = [{
@@ -4740,13 +4740,10 @@ ForClause
     }
 
     return {
+      ...c,
       type: "ForStatement",
       children: [$1, ...$3, ...children],
-      declaration,
       block: null,
-      blockPrefix,
-      hoistDec,
-      reduction,
       generator,
     }
 

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -304,6 +304,7 @@ function processForInOf($0: [
         implicitLift: true
       }, ";"]
 
+      eachDeclaration := declaration
       declaration =
         type: "Declaration"
         children: ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", trimFirstSpace(expRef), ".length"]
@@ -311,7 +312,7 @@ function processForInOf($0: [
 
       condition := [counterRef, " < ", lenRef, "; "]
       children := [open, declaration, "; ", condition, counterRef, increment, close]
-      return { declaration, children, blockPrefix }
+      return { declaration, eachDeclaration, children, blockPrefix }
     else
       eachOwnError =
         type: "Error",

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1139,7 +1139,7 @@ function processFunctions(statements, config): void
 
 function expressionizeIteration(exp: IterationExpression): void
   { async, generator, block, children, statement } .= exp
-  i := children.indexOf statement
+  i .= children.indexOf statement
   if i < 0
     throw new Error "Could not find iteration statement in iteration expression"
 
@@ -1151,11 +1151,6 @@ function expressionizeIteration(exp: IterationExpression): void
 
   let statements: StatementTuple[]
   if generator
-    if (statement as ForStatement).reduction
-      children.unshift
-        type: "Error"
-        message: `Cannot use reduction (${(statement as ForStatement).reduction!.subtype}) with generators`
-
     iterationDefaultBody statement
 
     assignResults block, (node) =>

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -822,27 +822,28 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
         braceBlock block
         return true
 
-  if statement.type is "ForStatement" and
-     statement.declaration?.type is "ForDeclaration"
-    // For regular loops and object comprehensions, use entire pattern
-    // For reductions, use the first binding
-    if reduction
-      bindings := patternBindings statement.declaration.binding.pattern
-      if bindings#
-        fillBlock [ "", bindings[0] ]
-        for binding of bindings[1..]
-          binding.children.unshift
+  if statement.type is "ForStatement"
+    declaration := statement.eachDeclaration ?? statement.declaration
+    if declaration?.type is "ForDeclaration"
+      // For regular loops and object comprehensions, use entire pattern
+      // For reductions, use the first binding
+      if reduction
+        bindings := patternBindings declaration.binding.pattern
+        if bindings#
+          fillBlock [ "", bindings[0] ]
+          for binding of bindings[1..]
+            binding.children.unshift
+              type: "Error"
+              subtype: "Warning"
+              message: "Ignored binding in reduction loop with implicit body"
+        else
+          fillBlock [ "",
             type: "Error"
-            subtype: "Warning"
-            message: "Ignored binding in reduction loop with implicit body"
+            message: "Empty binding pattern in reduction loop with implicit body"
+          ]
       else
-        fillBlock [ "",
-          type: "Error"
-          message: "Empty binding pattern in reduction loop with implicit body"
-        ]
-    else
-      fillBlock [ "", patternAsValue statement.declaration.binding.pattern ]
-    block.empty = false
+        fillBlock [ "", patternAsValue declaration.binding.pattern ]
+      block.empty = false
 
   return false
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -422,6 +422,9 @@ export type ForStatement
   children: Children
   parent?: Parent
   declaration: (Declaration | ForDeclaration)?
+  /** Original declaration that got rewritten by `for each`
+  (used for implicit body) */
+  eachDeclaration?: (Declaration | ForDeclaration)?
   block: BlockStatement
   hoistDec: ASTNode
   generator?: ASTNode

--- a/test/for.civet
+++ b/test/for.civet
@@ -1559,6 +1559,22 @@ describe "for", ->
       if (!(()=>{let results=true;for (const f of facesHit) {results = false; break}return results})()) { return false }
     """
 
+    throws """
+      for* with reduction
+      ---
+      for* sum x of y
+      ---
+      ParseErrors: unknown:1:6 Cannot use reduction (sum) with generators
+    """
+
+    throws """
+      assigned for* with reduction
+      ---
+      z := for* sum x of y
+      ---
+      ParseErrors: unknown:1:11 Cannot use reduction (sum) with generators
+    """
+
   describe "spreads", ->
     testCase """
       comma in body

--- a/test/for.civet
+++ b/test/for.civet
@@ -1462,6 +1462,28 @@ describe "for", ->
     """
 
     testCase """
+      each, implicit body
+      ---
+      a := for some each x of y
+      b := for every each x of y
+      c := for count each x of y
+      d := for sum each x of y
+      e := for product each x of y
+      f := for min each x of y
+      g := for max each x of y
+      h := for join each x of y
+      ---
+      let results=false;for (let i = 0, len = y.length; i < len; i++) {const x = y[i];results = true; break};const a =results
+      let results1=true;for (let i1 = 0, len1 = y.length; i1 < len1; i1++) {const x = y[i1];results1 = false; break};const b =results1
+      let results2=0;for (let i2 = 0, len2 = y.length; i2 < len2; i2++) {const x = y[i2];++results2};const c =results2
+      let results3=0;for (let i3 = 0, len3 = y.length; i3 < len3; i3++) {const x = y[i3];results3 += x};const d =results3
+      let results4=1;for (let i4 = 0, len4 = y.length; i4 < len4; i4++) {const x = y[i4];results4 *= x};const e =results4
+      let results5=Infinity;for (let i5 = 0, len5 = y.length; i5 < len5; i5++) {const x = y[i5];results5 = Math.min(results5, x)};const f =results5
+      let results6=-Infinity;for (let i6 = 0, len6 = y.length; i6 < len6; i6++) {const x = y[i6];results6 = Math.max(results6, x)};const g =results6
+      let results7="";for (let i7 = 0, len7 = y.length; i7 < len7; i7++) {const x = y[i7];results7 += x};const h =results7
+    """
+
+    testCase """
       for concat
       ---
       flat := for concat x of y


### PR DESCRIPTION
Fixes two `for` reduction bugs

TODO: `for* concat` could make sense, but we'd need to detect whether the item is an array or `isConcatSpreadable` and either `yield*` or `yield` accordingly. Worth adding?