### PR TITLE
Fix top-level `await`/`yield` in `iife` mode (including REPL and Playground)

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -222,6 +222,7 @@ Program
       bare: true,
       root: true,
       topLevelAwait: hasAwait(statements),
+      topLevelYield: hasYield(statements),
     }
     processProgram(program)
     return program

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -221,8 +221,6 @@ Program
       children: [reset, init, ws1, statements, ws2],
       bare: true,
       root: true,
-      topLevelAwait: hasAwait(statements),
-      topLevelYield: hasYield(statements),
     }
     processProgram(program)
     return program

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1546,20 +1546,9 @@ function processProgram(root: BlockStatement): void
   assert.equal state.forbidTrailingMemberProperty#, 1, "forbidTrailingMemberProperty"
   assert.equal state.JSXTagStack#, 1, "JSXTagStack"
 
-  let rootIIFE: ASTNode
-  if config.iife or config.repl
-    // Avoid top-level await if code is async (same as CoffeeScript),
-    // and avoid top-level yield* if code is a generator,
-    // so that code works in CommonJS environment and so REPL can eval it
-    rootIIFE = wrapIIFE root.expressions, root.topLevelAwait,
-      if root.topLevelYield then "*"
-    newExpressions: StatementTuple[] := [['', rootIIFE]]
-    root.children = root.children.map & is root.expressions ? newExpressions : &
-    root.expressions = newExpressions
-
   addParentPointers(root)
 
-  { expressions: statements } := root
+  { expressions: statements } .= root
 
   processPlaceholders(statements)
   processNegativeIndexAccess(statements)
@@ -1574,6 +1563,21 @@ function processProgram(root: BlockStatement): void
   processFinallyClauses(statements)
   processBreaksContinues(statements)
 
+  // Now that e.g. `do*` and `async do` have been processed
+  // (processIterationExpressions), we can detect top-level await/yield
+  root.topLevelAwait = hasAwait statements
+  root.topLevelYield = hasYield statements
+  let rootIIFE: ASTNode
+  if config.iife or config.repl
+    // Avoid top-level await if code is async (same as CoffeeScript),
+    // and avoid top-level yield* if code is a generator,
+    // so that code works in CommonJS environment and so REPL can eval it
+    rootIIFE = wrapIIFE root.expressions, root.topLevelAwait,
+      if root.topLevelYield then "*"
+    statements = [['', rootIIFE]]
+    root.children = root.children.map & is root.expressions ? statements : &
+    root.expressions = statements
+
   // Hoist hoistDec attributes to actual declarations.
   // NOTE: This should come after iteration expressions get processed
   // into IIFEs.
@@ -1581,6 +1585,7 @@ function processProgram(root: BlockStatement): void
 
   // Adding implicit returns should happen after hoisting any ref declarations
   // so their target node can be found in the block without being inside a return
+  // and after IIFE wrapper
   processFunctions(statements, config)
 
   processCoffeeClasses(statements) if config.coffeeClasses

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1549,8 +1549,10 @@ function processProgram(root: BlockStatement): void
   let rootIIFE: ASTNode
   if config.iife or config.repl
     // Avoid top-level await if code is async (same as CoffeeScript),
+    // and avoid top-level yield* if code is a generator,
     // so that code works in CommonJS environment and so REPL can eval it
-    rootIIFE = wrapIIFE root.expressions, root.topLevelAwait
+    rootIIFE = wrapIIFE root.expressions, root.topLevelAwait,
+      if root.topLevelYield then "*"
     newExpressions: StatementTuple[] := [['', rootIIFE]]
     root.children = root.children.map & is root.expressions ? newExpressions : &
     root.expressions = newExpressions

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -601,6 +601,7 @@ export type BlockStatement =
   implicitlyReturned?: boolean  // fat arrow function with no braces
   root?: boolean  // is this the global root block for the program?
   topLevelAwait?: boolean // for root block, is there top-level `await`? (before any IIFE wrapping)
+  topLevelYield?: boolean // for root block, is there top-level `yield`? (before any IIFE wrapping)
   parent?: Parent
 
 export type ImportDeclaration

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -38,6 +38,15 @@ describe "iife directive", ->
     (async ()=>{return console.log((await fetch('https://civet.dev')).status)})()
   """
 
+  testCase """
+    generator
+    ---
+    "civet iife"
+    yield 5
+    ---
+    (function*(){yield 5})()
+  """
+
 describe "repl directive", ->
   testCase """
     top-level declarations

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -1,4 +1,6 @@
 {testCase} from ./helper.civet
+{compile} from ../source/main.civet
+assert from assert
 
 describe "iife directive", ->
   testCase """
@@ -46,6 +48,35 @@ describe "iife directive", ->
     ---
     (function*(){yield 5})()
   """
+
+  describe "topLevel", ->
+    function ast(code: string)
+      compile ```
+        "civet iife"
+        ${code}
+      ```, ast: true
+
+    it "simple no await", =>
+      assert.equal (ast("5") |> await |> .topLevelAwait), false
+    it "simple await", =>
+      assert.equal (ast("await 5") |> await |> .topLevelAwait), true
+    it "await in function", =>
+      assert.equal (ast("=> await 5") |> await |> .topLevelAwait), false
+    it "await in do", =>
+      assert.equal (ast("do await 5") |> await |> .topLevelAwait), true
+    it "await in async do", =>
+      assert.equal (ast("async do await 5") |> await |> .topLevelAwait), false
+
+    it "simple no yield", =>
+      assert.equal (ast("5") |> await |> .topLevelYield), false
+    it "simple yield", =>
+      assert.equal (ast("yield 5") |> await |> .topLevelYield), true
+    it "yield in function", =>
+      assert.equal (ast("-> yield 5") |> await |> .topLevelYield), false
+    it "yield in do", =>
+      assert.equal (ast("do yield 5") |> await |> .topLevelYield), true
+    it "yield in do*", =>
+      assert.equal (ast("do* yield 5") |> await |> .topLevelYield), false
 
 describe "repl directive", ->
   testCase """


### PR DESCRIPTION
Fix #1659 by skipping top-level `yield*` in the `iife` wrapper, same as we did for `await`.

I also noticed that `topLevelAwait` (and now `topLevelYield`) were computed before we processed `async do` and `do*` which can shield the top level from these. So now we build the IIFE wrapper after `do` processing, but before function processing so we still get implicit return etc. Added some tests for these flags.