### PR TITLE
Pattern `name^: value` binds `name`, while `name: value` never does

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1646,6 +1646,16 @@ switch x
     type
 </Playground>
 
+Object properties with value matchers are not bound by default (similar to
+[object destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)).
+Add a trailing `^` to bind them:
+
+<Playground>
+switch x
+  {type^: /list/, content^: [first, ...]}
+    console.log type, content, first
+</Playground>
+
 Use `^x` to refer to variable `x` in the parent scope,
 as opposed to a generic name that gets destructured.
 (This is called "pinning" in

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2176,10 +2176,10 @@ BindingProperty
 
   # NOTE: Allow ::T type suffix before value
   # NOTE: name^ means we should bind name despite having a value
-  _? PropertyName:name Caret?:bind _? Colon _? ( BindingIdentifier / BindingPattern ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _?:ws1 PropertyName:name Caret?:bind _?:ws2 Colon:colon _?:ws3 ( BindingIdentifier / BindingPattern ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "BindingProperty",
-      children: [$1, name, $3, $4, $5, value, initializer],  // omit typeSuffix
+      children: [ws1, name, ws2, colon, ws3, value, initializer],  // omit typeSuffix
       name,
       value,
       typeSuffix,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2175,7 +2175,8 @@ BindingProperty
   BindingRestProperty
 
   # NOTE: Allow ::T type suffix before value
-  _? PropertyName:name _? Colon _? ( BindingIdentifier / BindingPattern ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+  # NOTE: name^ means we should bind name despite having a value
+  _? PropertyName:name Caret?:bind _? Colon _? ( BindingIdentifier / BindingPattern ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "BindingProperty",
       children: [$1, name, $3, $4, $5, value, initializer],  // omit typeSuffix
@@ -2184,12 +2185,48 @@ BindingProperty
       typeSuffix,
       initializer,
       names: value.names,
+      bind: !!bind,
     }
 
-  _?:ws Caret?:pin BindingIdentifier:binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
-    let children = [ws, binding, initializer]  // omit pin and typeSuffix
-
+  # NOTE: ^name is short for property `name: ^name`
+  _?:ws Caret:pin BindingIdentifier:binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+    // Note that this has the name but not the value.
+    // This is what we want when destructuring, but not in function params.
+    const children = [ws, binding]
     // TODO make this work with pin
+    if (binding.type === "AtBinding") {
+      children.push({
+        type: "Error",
+        message: "Pinned properties do not yet work with @binding",
+      })
+    }
+    if (typeSuffix) {
+      children.push({
+        type: "Error",
+        message: "Pinned properties cannot have type annotations",
+      })
+    }
+    if (initializer) {
+      children.push({
+        type: "Error",
+        message: "Pinned properties cannot have initializers",
+      })
+    }
+    return {
+      type: "PinProperty",
+      children,
+      name: binding,
+      value: {
+        type: "PinPattern",
+        children: [binding],
+        expression: binding,
+      },
+    }
+
+  # NOTE: name^ means we should bind name, but we do anyway, so allow but ignore
+  _?:ws BindingIdentifier:binding Caret?:bind BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+    const children = [ws, binding, initializer]  // omit bind, typeSuffix
+
     if (binding.type === "AtBinding") {
       return {
         type: "AtBindingProperty",
@@ -2202,34 +2239,6 @@ BindingProperty
       }
     }
 
-    if (pin) {
-      // Note that this has the name but not the value.
-      // This is what we want when destructuring, but not in function params.
-      children = [ws, binding]
-      if (typeSuffix) {
-        children.push({
-          type: "Error",
-          message: "Pinned properties cannot have type annotations",
-        })
-      }
-      if (initializer) {
-        children.push({
-          type: "Error",
-          message: "Pinned properties cannot have initializers",
-        })
-      }
-      return {
-        type: "PinProperty",
-        children,
-        name: binding,
-        value: {
-          type: "PinPattern",
-          children: [binding],
-          expression: binding,
-        },
-      }
-    }
-
     return {
       type: "BindingProperty",
       children,
@@ -2239,6 +2248,7 @@ BindingProperty
       initializer,
       names: binding.names,
       identifier: binding,
+      bind: !!bind,
     }
 
 # https://262.ecma-international.org/#prod-BindingRestProperty

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -13,9 +13,9 @@ import type {
   Identifier
   ObjectBindingPatternContent
   ParenthesizedExpression
-  ParseRule
   PatternClause
   PatternExpression
+  PinProperty
   StatementTuple
   SwitchStatement
 } from ./types.civet
@@ -29,6 +29,7 @@ import {
   isExit
   makeLeftHandSideExpression
   makeNode
+  prepend
   replaceNode
   updateParentPointers
 } from ./util.civet
@@ -58,7 +59,6 @@ import {
 import {
   ReservedWord
 } from ../parser.hera
-declare var ReservedWord: ParseRule
 
 function processPatternTest(lhs: ASTNode, patterns: PatternExpression[]): ASTNode
   { ref, refAssignmentComma } := maybeRefAssignment lhs, "m"
@@ -303,6 +303,9 @@ function getPatternBlockPrefix(
   // Gather bindings
   [splices, thisAssignments] .= gatherBindingCode(pattern)
   patternBindings := nonMatcherBindings(pattern)
+  subbindings :=
+    for each p of gatherRecursiveAll patternBindings, (& as BindingProperty).subbinding?
+      prepend ", ", (p as BindingProperty).subbinding
 
   splices = splices.map (s) => [", ", nonMatcherBindings(s)]
   thisAssignments = thisAssignments.map ['', &, ";"]
@@ -312,7 +315,7 @@ function getPatternBlockPrefix(
   [
     ['', {
       type: "Declaration"
-      children: [decl, patternBindings, typeSuffix, " = ", ref, ...splices]
+      children: [decl, patternBindings, typeSuffix, " = ", ref, ...subbindings, ...splices]
       names: []
       bindings: [] // avoid implicit return of any bindings
     }, ";"]
@@ -338,42 +341,52 @@ function elideMatchersFromArrayBindings(elements: ArrayBindingPatternContent): A
                 c is element.binding ? binding : c
             }
 
-function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternContent): ASTNode
-  properties.map (p) =>
+function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternContent): ObjectBindingPatternContent
+  for each p of properties
     switch p.type
-      when "BindingProperty"
+      when "BindingProperty", "PinProperty"
         { children, name, value, bind } := p
         [ws] := children
 
         shouldElide := (or)
           name.type is "NumericLiteral" and !value?.name
           name.type is "ComputedPropertyName" and value?.subtype is "NumericLiteral"
-
         if shouldElide
           if bind
-            return
-              type: "Error"
-              message: `Cannot bind ${name.type}`
-          return
+            type: "Error" as const
+            message: `Cannot bind ${name.type}`
+          else
+            continue
+        else
 
-        switch value?.type
-          when "ArrayBindingPattern", "ObjectBindingPattern"
-            bindings := nonMatcherBindings(value)
-            return {
-              ...p,
-              children: [ws, name, bindings && ": ", bindings, p.delim],
-            }
-          when "Identifier", undefined
-            return p
-          else // "Literal", "RegularExpressionLiteral", "StringLiteral"
-            if bind
-              return {
+          let contents: (BindingProperty | PinProperty)?
+          switch value?.type
+            when "ArrayBindingPattern", "ObjectBindingPattern"
+              bindings := nonMatcherBindings(value)
+              contents = {
                 ...p
-                children: [ws, name, p.delim]
+                value: bindings
+                children: [ws, name, bindings && ": ", bindings, p.delim]
               }
-            else return
-      else // "PinProperty", "BindingRestProperty"
-        return p
+            when "Identifier", undefined
+              contents = p
+            else // "Literal", "RegularExpressionLiteral", "StringLiteral"
+              contents = undefined
+          if bind
+            {
+              ...p
+              children: [ws, name, p.delim]
+              subbinding: if contents?.value
+                . contents.value
+                . " = "
+                . name
+            }
+          else if contents
+            contents
+          else
+            continue
+      else // "BindingRestProperty"
+        p
 
 function nonMatcherBindings(pattern: ASTNodeObject)
   switch pattern.type

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -11,6 +11,7 @@ import type {
   ContinueStatement
   ElseClause
   Identifier
+  ObjectBindingPatternContent
   ParenthesizedExpression
   ParseRule
   PatternClause
@@ -337,45 +338,42 @@ function elideMatchersFromArrayBindings(elements: ArrayBindingPatternContent): A
                 c is element.binding ? binding : c
             }
 
-function elideMatchersFromPropertyBindings(properties) {
-  return properties.map((p) => {
-    switch (p.type) {
-      case "BindingProperty": {
-        const { children, name, value } = p
-        const [ws] = children
+function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternContent): ASTNode
+  properties.map (p) =>
+    switch p.type
+      when "BindingProperty"
+        { children, name, value, bind } := p
+        [ws] := children
 
         shouldElide := (or)
           name.type is "NumericLiteral" and !value?.name
           name.type is "ComputedPropertyName" and value?.subtype is "NumericLiteral"
 
-        return if shouldElide
+        if shouldElide
+          if bind
+            return
+              type: "Error"
+              message: `Cannot bind ${name.type}`
+          return
 
-        switch (value and value.type) {
+        switch value?.type
           when "ArrayBindingPattern", "ObjectBindingPattern"
             bindings := nonMatcherBindings(value)
             return {
               ...p,
               children: [ws, name, bindings && ": ", bindings, p.delim],
             }
-          when "Identifier"
+          when "Identifier", undefined
             return p
-          case "Literal":
-          case "RegularExpressionLiteral":
-          case "StringLiteral":
-          default:
-            return {
-              ...p,
-              children: [ws, name, p.delim],
-            }
-        }
-      }
-      case "PinProperty":
-      case "BindingRestProperty":
-      default:
+          else // "Literal", "RegularExpressionLiteral", "StringLiteral"
+            if bind
+              return {
+                ...p
+                children: [ws, name, p.delim]
+              }
+            else return
+      else // "PinProperty", "BindingRestProperty"
         return p
-    }
-  })
-}
 
 function nonMatcherBindings(pattern: ASTNodeObject)
   switch pattern.type

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -871,6 +871,7 @@ export type BindingProperty =
   typeSuffix: TypeSuffix?
   initializer: Initializer?
   delim: ASTNode
+  bind?: boolean
 
 export type PinProperty =
   type: "PinProperty"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -872,6 +872,7 @@ export type BindingProperty =
   initializer: Initializer?
   delim: ASTNode
   bind?: boolean
+  subbinding?: ASTNode
 
 export type PinProperty =
   type: "PinProperty"
@@ -906,7 +907,7 @@ export type BindingRestProperty =
   names?: string[]
 
 export type ObjectBindingPatternContent =
-  (BindingProperty | PinProperty | AtBindingProperty | BindingRestProperty)[]
+  (BindingProperty | PinProperty | AtBindingProperty | BindingRestProperty | ASTError)[]
 
 export type ObjectBindingPattern =
   type: "ObjectBindingPattern",

--- a/test/if.civet
+++ b/test/if.civet
@@ -1119,12 +1119,12 @@ describe "if", ->
     testCase """
       if declaration with values
       ---
-      if {type: "Identifier", name: /^[A-Z]*$/} := node
+      if {type: "Identifier", name^: /^[A-Z]*$/} := node
         console.log "upper case", name
       else
         console.log "not upper case"
       ---
-      if ((node) && typeof node === 'object' && 'type' in node && node.type === "Identifier" && 'name' in node && typeof node.name === 'string' && /^[A-Z]*$/.test(node.name)) {const {type, name} = node;
+      if ((node) && typeof node === 'object' && 'type' in node && node.type === "Identifier" && 'name' in node && typeof node.name === 'string' && /^[A-Z]*$/.test(node.name)) {const { name} = node;
         console.log("upper case", name)
       }
       else {
@@ -1381,7 +1381,7 @@ describe "if", ->
       if {x, ^y} := obj
         console.log x
       ---
-      if ((obj) && typeof obj === 'object' && 'x' in obj && 'y' in obj && obj.y === y) {const {x, y} = obj;
+      if ((obj) && typeof obj === 'object' && 'x' in obj && 'y' in obj && obj.y === y) {const {x,} = obj;
         console.log(x)
       }
     """
@@ -1389,7 +1389,7 @@ describe "if", ->
     testCase """
       duplicate bindings
       ---
-      if [{type: "text"}, {type: "image"}] := array
+      if [{type^: "text"}, {type^: "image"}] := array
         console.log type
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1057,6 +1057,17 @@ describe "switch", ->
         {a, b: 3}
           console.log a, b
       ---
+      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && x.b === 3) {const {a,} = x;
+          console.log(a, b)}
+    """
+
+    testCase """
+      object pattern with bind and matcher
+      ---
+      switch x
+        {a^, b^: 3}
+          console.log a, b
+      ---
       if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && x.b === 3) {const {a, b} = x;
           console.log(a, b)}
     """
@@ -1065,7 +1076,7 @@ describe "switch", ->
       object pattern with post rest matcher
       ---
       switch x
-        {a, b..., c: 3}
+        {a, b..., c^: 3}
           console.log a, b, c
       ---
       if(typeof x === 'object' && x != null && 'a' in x && 'c' in x && x.c === 3) {const {a, c, ...b} = x;
@@ -1079,7 +1090,7 @@ describe "switch", ->
         {a, b: ^b}
           console.log a, b
       ---
-      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && x.b === b) {const {a, b} = x;
+      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && x.b === b) {const {a,} = x;
           console.log(a, b)}
     """
 
@@ -1090,7 +1101,7 @@ describe "switch", ->
         {a, ^b}
           console.log a, b
       ---
-      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && x.b === b) {const {a, b} = x;
+      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && x.b === b) {const {a,} = x;
           console.log(a, b)}
     """
 
@@ -1103,6 +1114,18 @@ describe "switch", ->
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
       if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && Array.isArray(x.b) && len(x.b, 2)) {const {a, b: [c, d]} = x;
+          console.log(a, c, d)}
+    """
+
+    testCase """
+      object pattern with bind and array binding match
+      ---
+      switch x
+        {a, b^: [c, d]}
+          console.log a, c, d
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      if(typeof x === 'object' && x != null && 'a' in x && 'b' in x && Array.isArray(x.b) && len(x.b, 2)) {const {a, b} = x, [c, d] = b;
           console.log(a, c, d)}
     """
 
@@ -1467,7 +1490,7 @@ describe "switch", ->
       duplicate bindings
       ---
       switch x
-        [{type: "text"}, {type: "image"}]
+        [{type^: "text"}, {type^: "image"}]
           x
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
@@ -1490,7 +1513,7 @@ describe "switch", ->
       duplicate bindings with rest
       ---
       switch x
-        [{type: "text"}, ..., {type: "image"}]
+        [{type^: "text"}, ..., {type^: "image"}]
           x
       ---
       if(Array.isArray(x) && x.length >= 2 && typeof x[0] === 'object' && x[0] != null && 'type' in x[0] && x[0].type === "text" && typeof x[x.length - 1] === 'object' && x[x.length - 1] != null && 'type' in x[x.length - 1] && x[x.length - 1].type === "image") {const [{type: type1}, ...ref] = x, [{type: type2}] = ref.splice(-1);const type = [type1, type2];
@@ -1547,7 +1570,7 @@ describe "switch", ->
       aliased duplicate bindings
       ---
       switch data
-        {a: 'z', a: 'x'}
+        {a^: 'z', a^: 'x'}
           a
       ---
       if(typeof data === 'object' && data != null && 'a' in data && data.a === 'z' && 'a' in data && data.a === 'x') {const {a: a1, a: a2} = data;const a = [a1, a2];

--- a/test/try.civet
+++ b/test/try.civet
@@ -329,8 +329,8 @@ describe "try", ->
         foo()
       catch <? RangeError, <? ReferenceError
         console.log 'R...Error'
-      catch {message: /bad/}
-        console.log 'bad'
+      catch {message^: /bad/}
+        console.log 'bad', message
       catch e
         console.log 'other', e
       ---
@@ -341,7 +341,7 @@ describe "try", ->
         console.log('R...Error')
       }
       else if(typeof e1 === 'object' && e1 != null && 'message' in e1 && typeof e1.message === 'string' && /bad/.test(e1.message)) {const {message} = e1;
-        console.log('bad')
+        console.log('bad', message)
       }
       else  {let e = e1;
         console.log('other', e)


### PR DESCRIPTION
Fixes #1660 by no longer binding `name` in object pattern properties with literal values: `name: "string"`, `name: 42`, or `name: /regex/`. The general rule is now this: if a property has a value, then it doesn't get bound. This seems like a natural extension of how destructuring assignment works.

New feature `name^: value` binds `name`. This also works when checking other properties. For example, the pattern `{parent^: {type: "BlockStatement", expressions}}` binds `parent` and `expression` in two destructurings: `{parent} = x, {expressions} = parent`.

BREAKING CHANGE: Pattern matching with `{name: literal}` no longer binds `name`; use `{name^: literal}` to bind.