### PR TITLE
Range literal improvements: faster, fix doubly strict

### DIFF
--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -97,15 +97,17 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
       sign := range.increasing ? "+" : "-"
       end = makeLeftHandSideExpression end
       children =
-        . "((s) => Array.from({length: "
-        . range.increasing ? [ws2, end, " - s"] : ["s - ", ws2, end]
-        . lengthAdjustExpression
-        . "}, (_, i) => s ", sign, " i))"
+        . getHelperRef range.increasing ? 'range' : 'revRange'
         . "("
         . if range.left.inclusive
             start
           else
             [makeLeftHandSideExpression(start), ` ${sign} 1`]
+        . ","
+        . if range.right.inclusive
+            [makeLeftHandSideExpression(end), ` ${sign} 1`]
+          else
+            end
         . ...ws1, ")"
     else
       children =

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -72,13 +72,11 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
           . "]"
       else
         children =
-          . getHelperRef "stringRange"
+          . getHelperRef startCode <= endCode ? "stringRange" : "revStringRange"
           . "("
           . startCode.toString()
           . ", "
           . length.toString()
-          . ", "
-          . (startCode <= endCode).toString()
           . ")"
       children.unshift range.error if range.error?
     else if startValue <? "number" and endValue <? "number"

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -78,7 +78,7 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
           . ", "
           . length.toString()
           . ", "
-          . step.toString()
+          . (startCode <= endCode).toString()
           . ")"
       children.unshift range.error if range.error?
     else if startValue <? "number" and endValue <? "number"

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -46,9 +46,6 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
         Math.abs
   lengthAdjust :=
     1 - Number(not range.left.inclusive) - Number(not range.right.inclusive)
-  lengthAdjustExpression :=
-    if lengthAdjust > 0 then ` + ${lengthAdjust}`
-    else if lengthAdjust < 0 then ` - ${-lengthAdjust}`
 
   let children: Children?
   if start is like {type: "Literal"} and end is like {type: "Literal"}
@@ -116,9 +113,13 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
         . ...ws1, ")"
     else
       children =
-        . "((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)"
-        . lengthAdjustExpression
-        . "}, (_, i) => s + i * step)})"
+        . "((s, e) => s > e ? "
+        . getHelperRef("revRange"), "(s, e"
+        . if range.right.inclusive then " - 1"
+        . ") : "
+        . getHelperRef("range"), "(s, e"
+        . if range.right.inclusive then " + 1"
+        . "))"
         . "(", start, ...ws1, comma, ws2, end, ")"
 
   {

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -75,9 +75,14 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
           . "]"
       else
         children =
-          . `Array.from({length: ${length.toString()}}, `
-          . "(_, i) => String.fromCharCode(", startCode.toString()
-          . step > 0 ? " + " : " - ", "i))"
+          . getHelperRef "stringRange"
+          . "("
+          . startCode.toString()
+          . ", "
+          . length.toString()
+          . ", "
+          . step.toString()
+          . ")"
       children.unshift range.error if range.error?
     else if startValue <? "number" and endValue <? "number"
       step := startValue <= endValue ? 1 : -1

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -63,15 +63,16 @@ declareHelper := {
       }
       "\n"
     ]]
-  rslice(rsliceRef): void
-    RSliceable := makeRef "RSliceable"
+  RSliceable(RSliceableRef): void
     state.prelude.push ["",
-      ts [ "type ", RSliceable, "<R> = string | {length: number; slice(start: number, end: number): {reverse(): R}}\n" ]
+      ts [ "type ", RSliceableRef, "<R> = string | {length: number; slice(start: number, end: number): {reverse(): R}}\n" ]
     ]
+  rslice(rsliceRef): void
+    RSliceableRef := getHelperRef "RSliceable"
     state.prelude.push ["", [
       preludeVar
       rsliceRef
-      ts [ ": <R, T extends string | ", RSliceable, "<R>>(a: T, start?: number, end?: number) => T extends string ? string : T extends ", RSliceable, "<infer R> ? R : never" ]
+      ts [ ": <R, T extends string | ", RSliceableRef, "<R>>(a: T, start?: number, end?: number) => T extends string ? string : T extends ", RSliceableRef, "<infer R> ? R : never" ]
       " = ((a, start = -1, end = -1) => {\n"
       "  const l = a.length\n"
       "  if (start < 0) start += l\n"
@@ -230,10 +231,21 @@ function peekHelperRef(base: HelperName): ASTRef?
  * Extract a subarray of the prelude array that just contains the
  * helper functions used in the given subtree
  */
-function extractPreludeFor(node: ASTNode): ASTNode[]
-  helpers .= new Set Object.values state.helperRefs
-  helpers = new Set gatherRecursive node, helpers@has
-  state.prelude.filter (s) => (gatherRecursive s, helpers@has)#
+function extractPreludeFor(node: ASTNode): StatementTuple[]
+  return state.prelude unless state.prelude#
+  allHelpers := new Set Object.values state.helperRefs
+  isHelper := allHelpers@has as (node: ASTNode) => node is ASTRef
+  usedHelpers := new Set gatherRecursive node, isHelper
+  // Find helpers used within helpers
+  loop
+    prelude .= state.prelude.filter (s) =>
+      (gatherRecursive s, usedHelpers@has as (node: ASTNode) => node is ASTRef)#
+    changed .= false
+    for each helper of gatherRecursive prelude, isHelper
+      unless usedHelpers.has helper
+        usedHelpers.add helper
+        changed = true
+    return prelude unless changed
 
 export {
   extractPreludeFor

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -128,13 +128,13 @@ declareHelper := {
     state.prelude.push ["", [
       preludeVar
       stringRangeRef
-      ts [ ": (start: number, length: number, step: number) => string[]" ]
+      ts [ ": (start: number, length: number, ascending: boolean) => string[]" ]
       " "
       """
-      = (start, length, step) => {
+      = (start, length, ascending) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (step > 0) {
+        if (ascending) {
           for (let i = 0; i < length; ++i) {
             arr[i] = String.fromCharCode(start + i);
           }

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -87,6 +87,42 @@ declareHelper := {
       "  }\n"
       "})"
     ], ";\n"]
+  range(rangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      rangeRef
+      ts [ ": (start: number, end: number) => number[]" ]
+      " "
+      """
+      = (start, end) => {
+        const length = end - start;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = i + start;
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
+  revRange(revRangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      revRangeRef
+      ts [ ": (start: number, end: number) => number[]" ]
+      " "
+      """
+      = (start, end) => {
+        const length = start - end;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - i;
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
   div(divRef): void
     state.prelude.push ["", [ // [indent, statement]
       preludeVar

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -106,23 +106,6 @@ declareHelper := {
       }
       """
     ], ";\n"]
-  stringRange(stringRangeRef): void
-    state.prelude.push ["", [
-      preludeVar
-      stringRangeRef
-      ts [ ": (start: number, length: number, step: number) => string[]" ]
-      " "
-      """
-      = (start, length, step) => {
-        if (length <= 0) return [];
-        const arr = Array(length);
-        for (let i = 0; i < length; ++i) {
-          arr[i] = String.fromCharCode(start + i * step);
-        }
-        return arr;
-      }
-      """
-    ], ";\n"]
   revRange(revRangeRef): void
     state.prelude.push ["", [
       preludeVar
@@ -136,6 +119,29 @@ declareHelper := {
         const arr = Array(length);
         for (let i = 0; i < length; ++i) {
           arr[i] = start - i;
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
+  stringRange(stringRangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      stringRangeRef
+      ts [ ": (start: number, length: number, step: number) => string[]" ]
+      " "
+      """
+      = (start, length, step) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        if (step > 0) {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start + i);
+          }
+        } else {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start - i);
+          }
         }
         return arr;
       }

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -128,20 +128,31 @@ declareHelper := {
     state.prelude.push ["", [
       preludeVar
       stringRangeRef
-      ts [ ": (start: number, length: number, ascending: boolean) => string[]" ]
+      ts [ ": (start: number, length: number) => string[]" ]
       " "
       """
-      = (start, length, ascending) => {
+      = (start, length) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (ascending) {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start + i);
-          }
-        } else {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start - i);
-          }
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i);
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
+  revStringRange(revStringRangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      revStringRangeRef
+      ts [ ": (start: number, length: number) => string[]" ]
+      " "
+      """
+      = (start, length) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start - i);
         }
         return arr;
       }

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -106,6 +106,23 @@ declareHelper := {
       }
       """
     ], ";\n"]
+  stringRange(stringRangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      stringRangeRef
+      ts [ ": (start: number, length: number, step: number) => string[]" ]
+      " "
+      """
+      = (start, length, step) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i * step);
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
   revRange(revRangeRef): void
     state.prelude.push ["", [
       preludeVar

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -151,7 +151,11 @@ import {
 } from ./unary.civet
 import { createConstLetDecs, createVarDecs } from ./auto-dec.civet
 import { expressionizeComptime, processComptime } from ./comptime.civet
-import { getHelperRef, peekHelperRef } from ./helper.civet
+import {
+  extractPreludeFor
+  getHelperRef
+  peekHelperRef
+} from ./helper.civet
 
 import {
   dedentBlockString
@@ -1590,8 +1594,8 @@ function processProgram(root: BlockStatement): void
 
   processCoffeeClasses(statements) if config.coffeeClasses
 
-  // Insert prelude
-  statements.unshift(...state.prelude)
+  // Insert prelude, dropping any actually unused helpers
+  statements.unshift ...extractPreludeFor statements
 
   if config.autoLet
     createConstLetDecs(statements, [], "let")

--- a/test/compat/coffee-range.civet
+++ b/test/compat/coffee-range.civet
@@ -1,30 +1,51 @@
 { testCase, evalsTo } from "../helper.civet"
 
 describe "coffeeRange", ->
-  evalsTo """
-    "civet coffeeRange";
-    [0..100]
-  """, [0..100]
+  it "coffeeRange behaves like range", ->
+    evalsTo """
+      "civet coffeeRange"
+      [0..100]
+    """, [0..100]
 
-  evalsTo """
-    "civet coffeeRange";
-    [0...100]
-  """, [0...100]
+    evalsTo """
+      "civet coffeeRange"
+      [0...100]
+    """, [0...100]
 
-  evalsTo """
-    "civet coffeeRange";
-    [100..0]
-  """, [100>=..>=0]
+    evalsTo """
+      "civet coffeeRange"
+      [100..0]
+    """, [100>=..>=0]
 
-  evalsTo """
-    "civet coffeeRange";
-    [100...0]
-  """, [100>=..>0]
+    evalsTo """
+      "civet coffeeRange"
+      [100...0]
+    """, [100>=..>0]
+
+    evalsTo """
+      "civet coffeeRange"
+      [' '..'~']
+    """, [' '..'~']
+
+    evalsTo """
+      "civet coffeeRange"
+      [' '...'~']
+    """, [' '...'~']
+
+    evalsTo """
+      "civet coffeeRange"
+      ['~'..' ']
+    """, ['~'>=..>=' ']
+
+    evalsTo """
+      "civet coffeeRange"
+      ['~'...' ']
+    """, ['~'>=..>' ']
 
   testCase """
     [0..10]
     ---
-    "civet coffeeRange";
+    "civet coffeeRange"
     [0..10]
     ---
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/test/compat/coffee-range.civet
+++ b/test/compat/coffee-range.civet
@@ -127,5 +127,14 @@ describe "coffeeRange", ->
     "civet coffeeRange"
     [a..<b]
     ---
-    ((s) => Array.from({length: b - s}, (_, i) => s + i))(a)
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    range(a,b)
   """

--- a/test/compat/coffee-range.civet
+++ b/test/compat/coffee-range.civet
@@ -1,10 +1,30 @@
-{ testCase } from "../helper.civet"
+{ testCase, evalsTo } from "../helper.civet"
 
 describe "coffeeRange", ->
+  evalsTo """
+    "civet coffeeRange";
+    [0..100]
+  """, [0..100]
+
+  evalsTo """
+    "civet coffeeRange";
+    [0...100]
+  """, [0...100]
+
+  evalsTo """
+    "civet coffeeRange";
+    [100..0]
+  """, [100>=..>=0]
+
+  evalsTo """
+    "civet coffeeRange";
+    [100...0]
+  """, [100>=..>0]
+
   testCase """
     [0..10]
     ---
-    "civet coffeeRange"
+    "civet coffeeRange";
     [0..10]
     ---
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -34,7 +54,25 @@ describe "coffeeRange", ->
     "civet coffeeRange"
     [0...256]
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s)}, (_, i) => s + i * step)})(0,256)
+    var revRange: (start: number, end: number) => number[] = (start, end) => {
+      const length = start - end;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = start - i;
+      }
+      return arr;
+    };
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    ((s, e) => s > e ? revRange(s, e) : range(s, e))(0,256)
   """
 
   testCase """
@@ -43,7 +81,25 @@ describe "coffeeRange", ->
     "civet coffeeRange"
     [0..255]
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => s + i * step)})(0,255)
+    var revRange: (start: number, end: number) => number[] = (start, end) => {
+      const length = start - end;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = start - i;
+      }
+      return arr;
+    };
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    ((s, e) => s > e ? revRange(s, e - 1) : range(s, e + 1))(0,255)
   """
 
   testCase """
@@ -69,7 +125,25 @@ describe "coffeeRange", ->
     "civet coffeeRange"
     [x - 5 .. x + 5]
     ---
-    ((s, e) => {let step = e > s ? 1 : -1; return Array.from({length: Math.abs(e - s) + 1}, (_, i) => s + i * step)})(x - 5 , x + 5)
+    var revRange: (start: number, end: number) => number[] = (start, end) => {
+      const length = start - end;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = start - i;
+      }
+      return arr;
+    };
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    ((s, e) => s > e ? revRange(s, e - 1) : range(s, e + 1))(x - 5 , x + 5)
   """
 
   testCase """

--- a/test/range.civet
+++ b/test/range.civet
@@ -1,4 +1,4 @@
-{ testCase, throws } from "./helper.civet"
+{ testCase, throws, evalsTo } from "./helper.civet"
 
 describe "range", ->
   testCase """
@@ -56,15 +56,53 @@ describe "range", ->
     ---
     [0...256]
     ---
-    ((s) => Array.from({length: 256 - s}, (_, i) => s + i))(0)
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    range(0,256)
   """
+
+  closedAscendingArr := [0..100]
+  halfClosedAscendingArr := [0...100]
+  openAscendingArr := [1..<100]
+
+  evalsTo '[0..100]', closedAscendingArr
+  evalsTo '[0..<=100]', closedAscendingArr
+  evalsTo '[0<=..<=100]', closedAscendingArr
+  evalsTo '[0...100]', halfClosedAscendingArr
+  evalsTo '[0..<100]', halfClosedAscendingArr
+  evalsTo '[0<=..<100]', halfClosedAscendingArr
+  evalsTo '[0<..<100]', openAscendingArr
+
+  closedDescendingArr: number[] := [0>=..>=100]
+  halfClosedDescendingArr: number[] := [0>=..>100]
+  openDescendingArr: number[] := [0>..>100]
+
+  evalsTo '[0>=..>=100]', closedDescendingArr
+  evalsTo '[0>=..>100]', halfClosedDescendingArr
+  evalsTo '[0>..>100]', openDescendingArr
 
   testCase """
     [0..255]
     ---
     [0..255]
     ---
-    ((s) => Array.from({length: 255 - s + 1}, (_, i) => s + i))(0)
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    range(0,255 + 1)
   """
 
   testCase """
@@ -137,7 +175,16 @@ describe "range", ->
     ---
     [x - 5 .. x + 5]
     ---
-    ((s) => Array.from({length:  (x + 5) - s + 1}, (_, i) => s + i))(x - 5 )
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
+    range(x - 5,(x + 5) + 1 )
   """
 
   testCase """
@@ -203,9 +250,18 @@ describe "range", ->
     [0...10]
     [0...n]
     ---
+    var range: (start: number, end: number) => number[] = (start, end) => {
+      const length = end - start;
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = i + start;
+      }
+      return arr;
+    };
     f();
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-    ((s) => Array.from({length: n - s}, (_, i) => s + i))(0)
+    range(0,n)
   """
 
   describe "inequalities on range", ->
@@ -382,7 +438,16 @@ describe "range", ->
       ---
       [a..<b]
       ---
-      ((s) => Array.from({length: b - s}, (_, i) => s + i))(a)
+      var range: (start: number, end: number) => number[] = (start, end) => {
+        const length = end - start;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = i + start;
+        }
+        return arr;
+      };
+      range(a,b)
     """
 
     testCase """
@@ -390,7 +455,16 @@ describe "range", ->
       ---
       [a..<=b]
       ---
-      ((s) => Array.from({length: b - s + 1}, (_, i) => s + i))(a)
+      var range: (start: number, end: number) => number[] = (start, end) => {
+        const length = end - start;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = i + start;
+        }
+        return arr;
+      };
+      range(a,b + 1)
     """
 
     testCase """
@@ -398,7 +472,16 @@ describe "range", ->
       ---
       [a<..b]
       ---
-      ((s) => Array.from({length: b - s}, (_, i) => s + i))(a + 1)
+      var range: (start: number, end: number) => number[] = (start, end) => {
+        const length = end - start;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = i + start;
+        }
+        return arr;
+      };
+      range(a + 1,b + 1)
     """
 
     testCase """
@@ -406,7 +489,16 @@ describe "range", ->
       ---
       [a<..<b]
       ---
-      ((s) => Array.from({length: b - s - 1}, (_, i) => s + i))(a + 1)
+      var range: (start: number, end: number) => number[] = (start, end) => {
+        const length = end - start;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = i + start;
+        }
+        return arr;
+      };
+      range(a + 1,b)
     """
 
     throws """
@@ -422,7 +514,16 @@ describe "range", ->
       ---
       [a..>b]
       ---
-      ((s) => Array.from({length: s - b}, (_, i) => s - i))(a)
+      var revRange: (start: number, end: number) => number[] = (start, end) => {
+        const length = start - end;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - i;
+        }
+        return arr;
+      };
+      revRange(a,b)
     """
 
     testCase """
@@ -430,7 +531,16 @@ describe "range", ->
       ---
       [a>..b]
       ---
-      ((s) => Array.from({length: s - b}, (_, i) => s - i))(a - 1)
+      var revRange: (start: number, end: number) => number[] = (start, end) => {
+        const length = start - end;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - i;
+        }
+        return arr;
+      };
+      revRange(a - 1,b - 1)
     """
 
     testCase """
@@ -438,7 +548,16 @@ describe "range", ->
       ---
       [a ?? aa >.. b ?? bb]
       ---
-      ((s) => Array.from({length: s -  (b ?? bb)}, (_, i) => s - i))((a ?? aa) - 1 )
+      var revRange: (start: number, end: number) => number[] = (start, end) => {
+        const length = start - end;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - i;
+        }
+        return arr;
+      };
+      revRange((a ?? aa) - 1,(b ?? bb) - 1 )
     """
 
     testCase """
@@ -446,7 +565,16 @@ describe "range", ->
       ---
       [a>..>b]
       ---
-      ((s) => Array.from({length: s - b - 1}, (_, i) => s - i))(a - 1)
+      var revRange: (start: number, end: number) => number[] = (start, end) => {
+        const length = start - end;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - i;
+        }
+        return arr;
+      };
+      revRange(a - 1,b)
     """
 
     testCase """
@@ -454,5 +582,14 @@ describe "range", ->
       ---
       [a /*1*/ < /*2*/ .. /*3*/ < /*4*/ b]
       ---
-      ((s) => Array.from({length:  /*3*/  /*4*/ b - s - 1}, (_, i) => s + i))(a + 1 /*1*/  /*2*/ )
+      var range: (start: number, end: number) => number[] = (start, end) => {
+        const length = end - start;
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = i + start;
+        }
+        return arr;
+      };
+      range(a + 1, /*4*/ b /*1*/  /*2*/ )
     """

--- a/test/range.civet
+++ b/test/range.civet
@@ -213,10 +213,10 @@ describe "range", ->
     ---
     [' '..'~']
     ---
-    var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+    var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
       if (length <= 0) return [];
       const arr = Array(length);
-      if (step > 0) {
+      if (ascending) {
         for (let i = 0; i < length; ++i) {
           arr[i] = String.fromCharCode(start + i);
         }
@@ -227,7 +227,7 @@ describe "range", ->
       }
       return arr;
     };
-    stringRange(32, 95, 1)
+    stringRange(32, 95, true)
   """
 
   testCase """
@@ -409,10 +409,10 @@ describe "range", ->
       ---
       [' '..<'~']
       ---
-      var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (step > 0) {
+        if (ascending) {
           for (let i = 0; i < length; ++i) {
             arr[i] = String.fromCharCode(start + i);
           }
@@ -423,7 +423,29 @@ describe "range", ->
         }
         return arr;
       };
-      stringRange(32, 94, 1)
+      stringRange(32, 94, true)
+    """
+
+    testCase """
+      ..> long with strings
+      ---
+      ['~'..>' ']
+      ---
+      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        if (ascending) {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start + i);
+          }
+        } else {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start - i);
+          }
+        }
+        return arr;
+      };
+      stringRange(126, 94, false)
     """
 
     testCase """
@@ -431,10 +453,10 @@ describe "range", ->
       ---
       [' '<..'~']
       ---
-      var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (step > 0) {
+        if (ascending) {
           for (let i = 0; i < length; ++i) {
             arr[i] = String.fromCharCode(start + i);
           }
@@ -445,7 +467,7 @@ describe "range", ->
         }
         return arr;
       };
-      stringRange(33, 94, 1)
+      stringRange(33, 94, true)
     """
 
     testCase """
@@ -453,10 +475,10 @@ describe "range", ->
       ---
       [' '<..<'~']
       ---
-      var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (step > 0) {
+        if (ascending) {
           for (let i = 0; i < length; ++i) {
             arr[i] = String.fromCharCode(start + i);
           }
@@ -467,7 +489,7 @@ describe "range", ->
         }
         return arr;
       };
-      stringRange(33, 93, 1)
+      stringRange(33, 93, true)
     """
 
     throws """

--- a/test/range.civet
+++ b/test/range.civet
@@ -213,21 +213,15 @@ describe "range", ->
     ---
     [' '..'~']
     ---
-    var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
+    var stringRange: (start: number, length: number) => string[] = (start, length) => {
       if (length <= 0) return [];
       const arr = Array(length);
-      if (ascending) {
-        for (let i = 0; i < length; ++i) {
-          arr[i] = String.fromCharCode(start + i);
-        }
-      } else {
-        for (let i = 0; i < length; ++i) {
-          arr[i] = String.fromCharCode(start - i);
-        }
+      for (let i = 0; i < length; ++i) {
+        arr[i] = String.fromCharCode(start + i);
       }
       return arr;
     };
-    stringRange(32, 95, true)
+    stringRange(32, 95)
   """
 
   testCase """
@@ -409,21 +403,15 @@ describe "range", ->
       ---
       [' '..<'~']
       ---
-      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
+      var stringRange: (start: number, length: number) => string[] = (start, length) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (ascending) {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start + i);
-          }
-        } else {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start - i);
-          }
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i);
         }
         return arr;
       };
-      stringRange(32, 94, true)
+      stringRange(32, 94)
     """
 
     testCase """
@@ -431,21 +419,15 @@ describe "range", ->
       ---
       ['~'..>' ']
       ---
-      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
+      var revStringRange: (start: number, length: number) => string[] = (start, length) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (ascending) {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start + i);
-          }
-        } else {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start - i);
-          }
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start - i);
         }
         return arr;
       };
-      stringRange(126, 94, false)
+      revStringRange(126, 94)
     """
 
     testCase """
@@ -453,21 +435,15 @@ describe "range", ->
       ---
       [' '<..'~']
       ---
-      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
+      var stringRange: (start: number, length: number) => string[] = (start, length) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (ascending) {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start + i);
-          }
-        } else {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start - i);
-          }
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i);
         }
         return arr;
       };
-      stringRange(33, 94, true)
+      stringRange(33, 94)
     """
 
     testCase """
@@ -475,21 +451,15 @@ describe "range", ->
       ---
       [' '<..<'~']
       ---
-      var stringRange: (start: number, length: number, ascending: boolean) => string[] = (start, length, ascending) => {
+      var stringRange: (start: number, length: number) => string[] = (start, length) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        if (ascending) {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start + i);
-          }
-        } else {
-          for (let i = 0; i < length; ++i) {
-            arr[i] = String.fromCharCode(start - i);
-          }
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i);
         }
         return arr;
       };
-      stringRange(33, 93, true)
+      stringRange(33, 93)
     """
 
     throws """

--- a/test/range.civet
+++ b/test/range.civet
@@ -68,45 +68,46 @@ describe "range", ->
     range(0,256)
   """
 
-  closedAscendingArr := [0..100]
-  halfClosedAscendingArr := [0...100]
-  openAscendingArr := [1..<100]
+  it "evals to the correct ranges", ->
+    closedAscendingArr := i for let i = 0; i <= 100; i++ // [0..100]
+    halfClosedAscendingArr := i for let i = 0; i < 100; i++ // [0..<100]
+    openAscendingArr := i for let i = 1; i < 100; i++ // [0<..<100]
 
-  evalsTo '[0..100]', closedAscendingArr
-  evalsTo '[0..<=100]', closedAscendingArr
-  evalsTo '[0<=..<=100]', closedAscendingArr
-  evalsTo '[0...100]', halfClosedAscendingArr
-  evalsTo '[0..<100]', halfClosedAscendingArr
-  evalsTo '[0<=..<100]', halfClosedAscendingArr
-  evalsTo '[0<..<100]', openAscendingArr
+    evalsTo '[0..100]', closedAscendingArr
+    evalsTo '[0..<=100]', closedAscendingArr
+    evalsTo '[0<=..<=100]', closedAscendingArr
+    evalsTo '[0...100]', halfClosedAscendingArr
+    evalsTo '[0..<100]', halfClosedAscendingArr
+    evalsTo '[0<=..<100]', halfClosedAscendingArr
+    evalsTo '[0<..<100]', openAscendingArr
 
-  closedDescendingArr: number[] := [100>=..>=0]
-  halfClosedDescendingArr: number[] := [100>=..>0]
-  openDescendingArr: number[] := [99>=..>0]
+    closedDescendingArr := closedAscendingArr.reverse()
+    halfClosedDescendingArr := i for let i = 100; i > 0; i-- // [100>=..>0]
+    openDescendingArr := openAscendingArr.reverse()
 
-  evalsTo '[100>=..>=0]', closedDescendingArr
-  evalsTo '[100>=..>0]', halfClosedDescendingArr
-  evalsTo '[100>..>0]', openDescendingArr
+    evalsTo '[100>=..>=0]', closedDescendingArr
+    evalsTo '[100>=..>0]', halfClosedDescendingArr
+    evalsTo '[100>..>0]', openDescendingArr
 
-  stringClosedAscendingArr := [' '..'~']
-  stringHalfClosedAscendingArr := [' '...'~']
-  stringOpenAscendingArr := ['!'..<'~']
+    stringClosedAscendingArr := [' '..'~']
+    stringHalfClosedAscendingArr := [' '...'~']
+    stringOpenAscendingArr := ['!'..<'~']
 
-  evalsTo "[' '..'~']", stringClosedAscendingArr
-  evalsTo "[' '..<='~']", stringClosedAscendingArr
-  evalsTo "[' '<=..<='~']", stringClosedAscendingArr
-  evalsTo "[' '...'~']", stringHalfClosedAscendingArr
-  evalsTo "[' '..<'~']", stringHalfClosedAscendingArr
-  evalsTo "[' '<=..<'~']", stringHalfClosedAscendingArr
-  evalsTo "[' '<..<'~']", stringOpenAscendingArr
+    evalsTo "[' '..'~']", stringClosedAscendingArr
+    evalsTo "[' '..<='~']", stringClosedAscendingArr
+    evalsTo "[' '<=..<='~']", stringClosedAscendingArr
+    evalsTo "[' '...'~']", stringHalfClosedAscendingArr
+    evalsTo "[' '..<'~']", stringHalfClosedAscendingArr
+    evalsTo "[' '<=..<'~']", stringHalfClosedAscendingArr
+    evalsTo "[' '<..<'~']", stringOpenAscendingArr
 
-  stringClosedDescendingArr := ['~'>=..>=' ']
-  stringHalfClosedDescendingArr := ['~'>=..>' ']
-  stringOpenDescendingArr := ['}'>=..>' ']
+    stringClosedDescendingArr := stringClosedAscendingArr.reverse()
+    stringHalfClosedDescendingArr := ['~'>=..>' ']
+    stringOpenDescendingArr := stringOpenAscendingArr.reverse()
 
-  evalsTo "['~'>=..>=' ']", stringClosedDescendingArr
-  evalsTo "['~'>=..>' ']", stringHalfClosedDescendingArr
-  evalsTo "['~'>..>' ']", stringOpenDescendingArr
+    evalsTo "['~'>=..>=' ']", stringClosedDescendingArr
+    evalsTo "['~'>=..>' ']", stringHalfClosedDescendingArr
+    evalsTo "['~'>..>' ']", stringOpenDescendingArr
 
   testCase """
     [0..255]
@@ -215,8 +216,14 @@ describe "range", ->
     var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
       if (length <= 0) return [];
       const arr = Array(length);
-      for (let i = 0; i < length; ++i) {
-        arr[i] = String.fromCharCode(start + i * step);
+      if (step > 0) {
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i);
+        }
+      } else {
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start - i);
+        }
       }
       return arr;
     };
@@ -405,8 +412,14 @@ describe "range", ->
       var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        for (let i = 0; i < length; ++i) {
-          arr[i] = String.fromCharCode(start + i * step);
+        if (step > 0) {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start + i);
+          }
+        } else {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start - i);
+          }
         }
         return arr;
       };
@@ -421,8 +434,14 @@ describe "range", ->
       var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        for (let i = 0; i < length; ++i) {
-          arr[i] = String.fromCharCode(start + i * step);
+        if (step > 0) {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start + i);
+          }
+        } else {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start - i);
+          }
         }
         return arr;
       };
@@ -437,8 +456,14 @@ describe "range", ->
       var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
         if (length <= 0) return [];
         const arr = Array(length);
-        for (let i = 0; i < length; ++i) {
-          arr[i] = String.fromCharCode(start + i * step);
+        if (step > 0) {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start + i);
+          }
+        } else {
+          for (let i = 0; i < length; ++i) {
+            arr[i] = String.fromCharCode(start - i);
+          }
         }
         return arr;
       };

--- a/test/range.civet
+++ b/test/range.civet
@@ -80,13 +80,33 @@ describe "range", ->
   evalsTo '[0<=..<100]', halfClosedAscendingArr
   evalsTo '[0<..<100]', openAscendingArr
 
-  closedDescendingArr: number[] := [0>=..>=100]
-  halfClosedDescendingArr: number[] := [0>=..>100]
-  openDescendingArr: number[] := [0>..>100]
+  closedDescendingArr: number[] := [100>=..>=0]
+  halfClosedDescendingArr: number[] := [100>=..>0]
+  openDescendingArr: number[] := [99>=..>0]
 
-  evalsTo '[0>=..>=100]', closedDescendingArr
-  evalsTo '[0>=..>100]', halfClosedDescendingArr
-  evalsTo '[0>..>100]', openDescendingArr
+  evalsTo '[100>=..>=0]', closedDescendingArr
+  evalsTo '[100>=..>0]', halfClosedDescendingArr
+  evalsTo '[100>..>0]', openDescendingArr
+
+  stringClosedAscendingArr := [' '..'~']
+  stringHalfClosedAscendingArr := [' '...'~']
+  stringOpenAscendingArr := ['!'..<'~']
+
+  evalsTo "[' '..'~']", stringClosedAscendingArr
+  evalsTo "[' '..<='~']", stringClosedAscendingArr
+  evalsTo "[' '<=..<='~']", stringClosedAscendingArr
+  evalsTo "[' '...'~']", stringHalfClosedAscendingArr
+  evalsTo "[' '..<'~']", stringHalfClosedAscendingArr
+  evalsTo "[' '<=..<'~']", stringHalfClosedAscendingArr
+  evalsTo "[' '<..<'~']", stringOpenAscendingArr
+
+  stringClosedDescendingArr := ['~'>=..>=' ']
+  stringHalfClosedDescendingArr := ['~'>=..>' ']
+  stringOpenDescendingArr := ['}'>=..>' ']
+
+  evalsTo "['~'>=..>=' ']", stringClosedDescendingArr
+  evalsTo "['~'>=..>' ']", stringHalfClosedDescendingArr
+  evalsTo "['~'>..>' ']", stringOpenDescendingArr
 
   testCase """
     [0..255]
@@ -192,7 +212,15 @@ describe "range", ->
     ---
     [' '..'~']
     ---
-    Array.from({length: 95}, (_, i) => String.fromCharCode(32 + i))
+    var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+      if (length <= 0) return [];
+      const arr = Array(length);
+      for (let i = 0; i < length; ++i) {
+        arr[i] = String.fromCharCode(start + i * step);
+      }
+      return arr;
+    };
+    stringRange(32, 95, 1)
   """
 
   testCase """
@@ -374,7 +402,15 @@ describe "range", ->
       ---
       [' '..<'~']
       ---
-      Array.from({length: 94}, (_, i) => String.fromCharCode(32 + i))
+      var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i * step);
+        }
+        return arr;
+      };
+      stringRange(32, 94, 1)
     """
 
     testCase """
@@ -382,7 +418,15 @@ describe "range", ->
       ---
       [' '<..'~']
       ---
-      Array.from({length: 94}, (_, i) => String.fromCharCode(33 + i))
+      var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i * step);
+        }
+        return arr;
+      };
+      stringRange(33, 94, 1)
     """
 
     testCase """
@@ -390,15 +434,15 @@ describe "range", ->
       ---
       [' '<..<'~']
       ---
-      Array.from({length: 93}, (_, i) => String.fromCharCode(33 + i))
-    """
-
-    testCase """
-      <..< long with strings
-      ---
-      [' '<..<'~']
-      ---
-      Array.from({length: 93}, (_, i) => String.fromCharCode(33 + i))
+      var stringRange: (start: number, length: number, step: number) => string[] = (start, length, step) => {
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = String.fromCharCode(start + i * step);
+        }
+        return arr;
+      };
+      stringRange(33, 93, 1)
     """
 
     throws """


### PR DESCRIPTION
Started out as an efficiency improvement -- the difference is modest in Safari, but drastic in Chromium and Firefox -- see [this benchmark](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJ5ZVJycDVXNjYwN2ZBWFQxYllycy0iLCJjb2RlIjoiKChzKSA9PiBBcnJheS5mcm9tKHsgbGVuZ3RoOiA5OTk5IC0gcyArIDEgfSwgKF8sIGkpID0-IHMgKyBpKSkoMCkiLCJuYW1lIjoiQ2l2ZXQgd2F5IiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6InZ3MWhVa3RnSURZVGNtQUNteGNtTSIsImNvZGUiOiJsZXQgeCA9IDEwMDAwO1xuY29uc3QgYXJyID0gW107XG53aGlsZSAoeC0tKSB7XG4gIGFyclt4XSA9IHg7XG59XG5hcnIiLCJuYW1lIjoid2hpbGUoeC0tKSIsImRlcGVuZGVuY2llcyI6W119LHsiaWQiOiJRd3F2MkZoTE8tZ1pXVXl3OWJRanUiLCJjb2RlIjoiWy4uLkFycmF5KDEwMDAwKS5rZXlzKCldIiwiZGVwZW5kZW5jaWVzIjpbXSwibmFtZSI6IlNwcmVhZCBBcnJheSgpLmtleXMifSx7ImlkIjoieFZUcHFod1ZOcHM0ZWNpcUJndFJKIiwiY29kZSI6IkFycmF5KDEwMDAwKS5maWxsKCkubWFwKChfLCBpKSA9PiBpKSIsImRlcGVuZGVuY2llcyI6W10sIm5hbWUiOiJBcnJheSgpLmZpbGwoKS5tYXAifSx7ImlkIjoiNDJrb1hvZ0gybVQtQm93NXdEaTQyIiwiY29kZSI6ImNvbnN0IGFyciA9IFtdO1xuZm9yIChsZXQgaSA9IDA7IGkgPCAxMDAwMDsgKytpKSB7XG4gIGFyci5wdXNoKGkpO1xufVxuYXJyIiwiZGVwZW5kZW5jaWVzIjpbXSwibmFtZSI6IlB1c2ggbG9vcCJ9LHsiaWQiOiJ2SlVqX0VqUUhRcFZRX3FEYkV6a1UiLCJjb2RlIjoiY29uc3QgYXJyID0gQXJyYXkoMTAwMDApO1xuZm9yIChsZXQgaSA9IDA7IGkgPCAxMDAwMDsgKytpKSB7XG4gIGFycltpXSA9IGk7XG59XG5hcnIiLCJkZXBlbmRlbmNpZXMiOltdLCJuYW1lIjoiUHJlYWxsb2NhdGVkIGZvciBsb29wIn1dLCJjb25maWciOnsibmFtZSI6IlJhbmdlIG9mIDEwayBlbGVtZW50cyIsInBhcmFsbGVsIjp0cnVlLCJnbG9iYWxUZXN0Q29uZmlnIjp7ImRlcGVuZGVuY2llcyI6W119LCJkYXRhQ29kZSI6InJldHVybiB1bmRlZmluZWQifX0). However, this also fixes a couple unreported bugs:
- `[0<..<100]` is mistakenly equivalent to `[1..<99]`, not `[1..<100]`
- Reverse ranges are inferred as `any[]`, not `number[]`, in some contexts