### PR TITLE
Parallel testing via `CIVET_THREADS` (Mocha's `--parallel`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,12 @@ You can run all tests via
 yarn test
 ```
 
+To use multiple cores while testing:
+
+```sh
+CIVET_THREADS=4 yarn test
+```
+
 A useful trick when developing is to pick one test and add
 [the `.only` suffix](https://mochajs.org/#exclusive-tests)
 so that it is the only test that runs.

--- a/build/test.sh
+++ b/build/test.sh
@@ -2,5 +2,13 @@
 
 set -euo pipefail
 
-c8 mocha "$@"
+# Translate CIVET_THREADS into Mocha's --parallel
+# In particular, CIVET_THREADS Workers don't work within Mocha
+args=""
+if [ ! -z "${CIVET_THREADS:-}" ]; then
+  args="--parallel -j $CIVET_THREADS"
+  export CIVET_THREADS=
+fi
+
+c8 mocha $args "$@"
 tsc --noEmit


### PR DESCRIPTION
`CIVET_THREADS=4 yarn test` currently crashes. I'm guessing Mocha doesn't like our spawning of workers within tests?

As a workaround to this, I modified the test script to translate `CIVET_THREADS` into the corresponding Mocha options: `--parallel -j 4`. This seems to speed things up. (On my machine, tests go from 21.3s to 14s.)

Now you can set `export CIVET_THREADS=4` globally and both `yarn build` and `yarn test` will speed up.