### PR TITLE
Fix property `::` typing with private fields

### DIFF
--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -3,7 +3,6 @@ import type {
   ASTNode
   ASTNodeObject
   BindingPattern
-  BindingProperty
   BindingRestElement
   Children
   HasSubbinding
@@ -240,7 +239,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
               [ ...ws, prop.name, typeSuffix, prop.delim ] as Children
             when "AtBindingProperty"
               ws := prop.children[...prop.children.indexOf prop.binding]
-              [ ...ws, prop.ref.id, typeSuffix, prop.delim ] as Children
+              [ ...ws, prop.ref.id.replace(/^#/, ''), typeSuffix, prop.delim ] as Children
             when "BindingRestProperty"
               restType = prop.typeSuffix?.t
               continue

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -99,6 +99,7 @@ import {
   maybeRef
   maybeRefAssignment
   needsRef
+  populateRefs
 } from ./ref.civet
 
 import {
@@ -1660,36 +1661,6 @@ function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
     if classExp.name and classExp.parent is topBlock or classExp.parent is like {type: "ReturnStatement", parent: ^topBlock}
       classExp.children.unshift classExp.name, "="
       root.expressions.splice i++, 0, ["", `var ${classExp.name}`, ";"]
-
-function populateRefs(statements: ASTNode): void {
-  const refNodes = gatherRecursive(statements, .type is "Ref")
-
-  if (refNodes.length) {
-    // Find all ids within nested scopes
-    const ids = gatherRecursive(statements, (s) => s.type is "Identifier")
-    const names = new Set(ids.flatMap(({ names }) => names or []))
-
-    // Populate each ref
-    refNodes.forEach((ref) => {
-      const { type, base } = ref
-      if (type !== "Ref") return
-
-      ref.type = "Identifier"
-
-      let n = 0
-      let name = base
-
-      // check for name collisions and increment name suffix
-      while (names.has(name)) {
-        n++
-        name = `${base}${n}`
-      }
-
-      names.add(name)
-      ref.children = ref.names = [name]
-    })
-  }
-}
 
 function processPlaceholders(statements: StatementTuple[]): void
   placeholderMap := new Map<ASTNodeObject, (Placeholder)[]>()

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -2,12 +2,17 @@ import type {
   ASTNode
   ASTNodeObject
   ASTRef
-} from "./types.civet"
+  ASTString
+} from ./types.civet
+
+import {
+  gatherRecursive
+} from ./traversal.civet
 
 import {
   isWhitespaceOrEmpty
   makeNode
-} from "./util.civet"
+} from ./util.civet
 
 function makeRef(base = "ref", id = base): ASTRef
   return {
@@ -83,10 +88,36 @@ function maybeRefAssignment(exp: ASTNode, base: string = "ref"): {
   else
     { ref, ...makeRefAssignment ref, exp }
 
+function populateRefs(statements: ASTNode): void
+  refNodes := gatherRecursive statements, .type is "Ref"
+  return unless refNodes#
+
+  // Find all ids within nested scopes
+  ids := gatherRecursive statements, .type is "Identifier"
+  names := new Set ids.flatMap { names } => names or []
+
+  // Populate each ref
+  for each ref of refNodes
+    continue unless ref.type is "Ref" // skip if already populated
+    { base } := ref
+    ref.type = "Identifier"
+
+    n .= 0
+    name .= base
+
+    // check for name collisions and increment name suffix
+    while names.has name
+      n++
+      name = `${base}${n}`
+
+    names.add name
+    ref.children = ref.names = [name as ASTString]
+
 export {
   makeRef
   makeRefAssignment
   maybeRef
   maybeRefAssignment
   needsRef
+  populateRefs
 }

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -579,7 +579,9 @@ export type Optional
 
 export type ASTRef =
   type: "Ref"
+  /** Prefix for eventual ref id. Includes leading `_` for reserved words */
   base: string
+  /** Original id that base was based on. Includes leading `#` for private fields */
   id: string
   token?: undefined
   /** NOTE: Currently parent may be inaccurate since multiple copies of the same ASTRef can exist in the tree. */

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -512,6 +512,23 @@ describe "[TS] class", ->
     """
 
     testCase """
+      nested private fields
+      ---
+      class UserAccount
+        @([{#name:: string, #id:: number}, #keep:: boolean])
+          id
+      ---
+      class UserAccount {
+        #name: string;#id: number;#keep: boolean;constructor([{name,id:  id1}, keep]: [{name: string, id: number}, boolean]) {
+          this.#name = name;
+          this.#id = id1;
+          this.#keep = keep;
+          id
+        }
+      }
+    """
+
+    testCase """
       override
       ---
       class UserAccount


### PR DESCRIPTION
Fixes #1667 

Also move `populateRefs` to ref.civet where it seems to belong.  (No functional changes to this function, just Civetification.)