### PR TITLE
Improve Playground error styling

### DIFF
--- a/civet.dev/.vitepress/components/Playground.vue
+++ b/civet.dev/.vitepress/components/Playground.vue
@@ -219,7 +219,12 @@ const playgroundUrl = computed(() => {
 }
 
 .col--error {
-  border: 1px solid var(--vp-c-red-dimm-1);
+  border: 1px solid var(--vp-c-red-3);
+}
+.col--error > .code--output:has(.crash) {
+  color: var(--vp-c-red-1);
+  padding: 0 18px; /* match shiki padding */
+  font-size: var(--vp-code-font-size);
 }
 
 .scroll {
@@ -344,5 +349,11 @@ input {
   position: absolute;
   top: -1px;
   left: 4.5px;
+}
+</style>
+
+<style>
+.col--error h3 {
+  margin-top: 16px;
 }
 </style>

--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -37,7 +37,12 @@ onmessage = async (e) => {
       postMessage({ uid, inputHtml, outputHtml, error });
     } else {
       console.error(error)
-      postMessage({ uid, inputHtml, outputHtml: error.message, error });
+      let outputHtml = (error.stack ?? `${error.name}: ${error.message}`)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+      outputHtml = `<h3>Compiler crashed; please report as a compiler bug.</h3><pre class="shiki crash">${outputHtml}</pre>`;
+      postMessage({ uid, inputHtml, outputHtml, error });
     }
   }
 


### PR DESCRIPTION
## Civet errors gain red border:

Before:
![image](https://github.com/user-attachments/assets/539d2b19-25fd-4c5e-9ec0-84fa386f8323)

After:
![image](https://github.com/user-attachments/assets/d2fb55f4-ae4b-4423-8733-df8327236bbc)

This was clearly intended by the CSS, but the red variable wasn't assigned; fixed to choose an existing variable.

## Civet compiler crashes get formatted nicer:

Before:
![image](https://github.com/user-attachments/assets/e6f7a396-120b-444a-9c26-abdfa5d3f1f9)

After:
![image](https://github.com/user-attachments/assets/76e5c00c-2c9b-4508-9613-3d347afbf003)
