### PR TITLE
Fix unwrapping of operator sections with placeholders

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1805,6 +1805,11 @@ function processPlaceholders(statements: StatementTuple[]): void
 
     replaceNode ancestor, fnExp, parent
 
+    // Preserve body property of any containing ampersand block
+    // so that we can unwrap in pipeline
+    if parent is like {type: "BlockStatement", parent: {type: "ArrowFunction", ampersandBlock: true, ^body}}
+      parent.parent.body = fnExp
+
     // Move a leading space outside the function wrapper
     if ws := getTrimmingSpace body
       inplaceInsertTrimmingSpace body, ""

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -34,7 +34,7 @@ function constructInvocation(fn: ExprWithComments, arg: ASTNode!)
   while expr.type is "ParenthesizedExpression"
     expr = expr.expression
   if expr.ampersandBlock
-    const { ref, body } = expr
+    { ref, body } := expr
 
     ref.type = "PipedExpression"
     ref.children = [makeLeftHandSideExpression(arg)]

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -1220,3 +1220,11 @@ describe "operator sections", ->
     ;
     $ => (foo($, 5)) + 1
   """
+
+  testCase """
+    pipe expression with section and placeholder
+    ---
+    1 |> (+ &)
+    ---
+    $ => 1+ $
+  """


### PR DESCRIPTION
Fixes #1682

This is pretty subtle: `replaceChild` doesn't preserve the aliasing in our grandparent's `body`. Because of `Wrapper` nodes in this context, it doesn't work (easily) to put this check into `replaceChild`. I *hope* this is the only place we need to do this (where we replace the top level of an ampersand block), but plausibly there are other uses of `replaceChild` with this issue.

An alternative would be to remove ampersand block's `body` properties altogether, and just use the block's first expression. Plausibly, we can decide whether to unwrap even without the `ampersandBlock` hint, checking for a single expression that uses the argument once. Then we could unwrap non-shorthand arrow functions too. Maybe an approach to try in the future.