### PR TITLE
Allow binary operators after nested object literals and bulleted arrays, fix `++` with bulleted arrays

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,10 @@ jobs:
         cache: yarn
         node-version: 20
 
-    - name: Install and Test
+    - name: Install and Build
       # `yarn docs:build` includes `yarn build`
       run: |
         yarn
         yarn docs:build
+      env:
+        API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         yarn build
         yarn test
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: browser.js
         path: dist/browser.js

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -606,6 +606,8 @@ IsLike
 
 # Whitespace followed by RHS
 WRHS
+  NestedBulletedArray -> [undefined, $1]
+  NestedImplicitObjectLiteral -> [undefined, $1]
   PushIndent ( ( Nested _? ) RHS )?:wrhs PopIndent ->
     if (!wrhs) return $skip
     return wrhs
@@ -710,12 +712,13 @@ NWTypePostfix
 
 # https://262.ecma-international.org/#prod-UpdateExpression
 UpdateExpression
-  # NOTE: Not allowing whitespace betwen prefix and postfix increment operators and operand
-  UpdateExpressionSymbol UnaryWithoutParenthesizedAssignment ->
+  # NOTE: Not allowing whitespace between prefix and postfix increment operators and operand
+  # This is especially important for ++ to work as binary concat operator
+  UpdateExpressionSymbol:symbol !Whitespace UnaryWithoutParenthesizedAssignment:assigned ->
     return {
       type: "UpdateExpression",
-      assigned: $2,
-      children: $0,
+      assigned,
+      children: [symbol, assigned],
     }
   LeftHandSideExpression ( UpdateExpressionSymbol /(?!\p{ID_Start}|[_$0-9(\[{])/ )? ->
     if (!$2) return $1
@@ -5639,18 +5642,20 @@ Debugger
     return { $loc, token: $1 }
 
 MaybeNestedNonPipelineExpression
-  NestedBulletedArray
-  NestedImplicitObjectLiteral
-  PushIndent ( Nested NonPipelineExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+  # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
+  # the second case, where they get checked by PrimaryExpression,
+  # which then allows for trailing binary operators etc.
+  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested NonPipelineExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
     if (!expression) return $skip
     if (!trailing) return expression
     return [ expression, trailing ]
   NonPipelineExpression
 
 MaybeNestedPostfixedExpression
-  NestedBulletedArray
-  NestedImplicitObjectLiteral
-  PushIndent ( Nested PostfixedExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+  # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
+  # the second case, where they get checked by PrimaryExpression,
+  # which then allows for trailing binary operators etc.
+  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested PostfixedExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
     if (!expression) return $skip
     if (!trailing) return expression
     return [ expression, trailing ]
@@ -5664,9 +5669,10 @@ NestedPostfixedExpressionNoTrailing
     return expression
 
 MaybeNestedExpression
-  NestedBulletedArray
-  NestedImplicitObjectLiteral
-  PushIndent ( Nested Expression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+  # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
+  # the second case, where they get checked by PrimaryExpression,
+  # which then allows for trailing binary operators etc.
+  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested Expression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
     if (!expression) return $skip
     if (!trailing) return expression
     return [ expression, trailing ]

--- a/test/array.civet
+++ b/test/array.civet
@@ -841,6 +841,47 @@ describe "array", ->
       .toString())
     """
 
+    testCase """
+      with trailing type cast
+      ---
+      x =
+        . a
+        . b
+      as const
+      ---
+      x = [
+          a,
+          b] as const
+    """
+
+    testCase """
+      with trailing binary operator
+      ---
+      x =
+        . a
+        . b
+      ++ rest
+      ---
+      x = [
+          a,
+          b]
+      .concat(rest)
+    """
+
+    testCase """
+      with preceding and trailing binary operator
+      ---
+      x = front ++
+        . a
+        . b
+      ++ rest
+      ---
+      x = front.concat( [
+          a,
+          b])
+      .concat(rest)
+    """
+
   describe "[] followed by elements", ->
     testCase """
       indented

--- a/test/object.civet
+++ b/test/object.civet
@@ -772,7 +772,21 @@ describe "object", ->
       return ({a:(hasA? 1:void 0),
       b:(hasB? 2:void 0)})
     }
-  """; // TODO: thinks next triple quote is a call expression
+  """
+
+  testCase """
+    braceless object with trailing type cast
+    ---
+    x =
+      a: 1
+      b: 2
+    as const
+    ---
+    x = {
+      a: 1,
+      b: 2,
+    } as const
+  """
 
   """
     async


### PR DESCRIPTION
Fixes #1687. This bug was introduced by #1628 which innocently added checking for `NestedImplicitObjectLiteral`s next to `NestedBulletedArray`s in `MaybeNestedExpression`.

It turns out the "right" answer is to check for neither! Otherwise, we don't allow for binary operators after dedent after the nested object literal / bulleted array. Conveniently, we already check for `NestedImplicitObjectLiteral` and `NestedBulletedArray` within `PrimaryExpression` (as part of `ObjectLiteral` and `ArrayLiteral` respectively), so we don't need to do anything special here, except for *stopping* the `PushIndent Nested PopIndent` check in `MaybeNestedExpression`.

Along the way, I fixed another issue with the concat operator `++` followed by a bulleted array. Previously, this broke for two reasons: (1) `UpdateExpression` thought that this was an increment, despite the indentation after `++` (needed to explicitly `!Whitespace` to match the comment). (2) `WRHS` *did* need to check explicitly for `NestedImplicitObjectLiteral` and `NestedBulletedArray`, like `MaybeNestedExpression` used to. (Here it's the right thing to do, because any further binary operators will be handled by the parent `BinaryExpression`.)

Also fixed some unrelated CI issues that seem to have come up just from 2025 deprecations.