### PR TITLE
Bun --watch flag issue

### DIFF
--- a/source/bun-civet.civet
+++ b/source/bun-civet.civet
@@ -17,19 +17,23 @@ import { plugin, file } from 'bun'
 await plugin {
   name: 'Civet loader'
   setup(builder)
-    { compile } := await import('./main.mjs')
+    { compile } := await import './main.mjs'
     //transpiler := new Transpiler loader: 'tsx'
-
-    builder.onLoad filter: /\.civet$/, ({path}) =>
-      source := file path |> .text() |> await
-      // Compiling and running at the same time, so enable comptime
-      // to ensure any async promises get resolved
-      contents .= await compile source, comptime: true
-      // Transpile directly as workaround to loader spec below not working
-      //contents = await transpiler.transform contents
-
-      return {
-        contents
-        loader: 'tsx'
-      }
+    const cache = new Map<string, string>
+    builder.onLoad filter: /\.civet$/, ({ path }) =>
+      contents:
+        try
+          source := file path |> .text() |> await
+          // Compiling and running at the same time, so enable comptime
+          // to ensure any async promises get resolved
+          contents .= await compile source, comptime: true
+          // Transpile directly as workaround to loader spec below not working
+          // contents = await transpiler.transform contents
+          cache.set path, contents
+          contents
+        catch ex
+          // log the error, use the cache or an empty module
+          console.error ex
+          (cache.get path) ?? 'void 0'
+      loader: 'tsx'
 }


### PR DESCRIPTION
Hey! Thank you for this amazing software.

The only issue I had was an issue with `bun` when using the `--watch` flag.

When the compilation of a given module fails with a syntax error, it prevents the plugin from generating any more modules. This breaks the `--watch` flag features.

Instead of failing, it makes sense to catch the error, log it to stderr, and then use a previously cached version of that module.

Features added:

- Bugfix: Prevent plugin from crashing
- Bugfix: Report errors to console for end users

A few questions:

1. Is there a specific coding style I should conform to? Or is this solution fine?
2. How can we "test" this, or should we just accept that it can't be tested well?

To try it out locally:

1. [Install Bun](https://bun.sh/)
2. Initialize a bun project `bun init -y`
3. Add `bunfig.toml` with `preload = ["./dist/bun-civet.mjs"]`
4. Create `index.civet` with `Bun.write "./test.txt", "Hello world!"`
5. `bun --watch index.civet`
6. Add a syntax error (like a bunch of `=`'s) and change the `"Hello world!"` string to something else
7. Notice that `./text.txt` remains unmodified
8. Remove the syntax errors from `index.civet`
9. Check `./text.txt` for the corresponding changes

I'm very happy to help or make modifications.