### PR TITLE
Property `::` types with initializers are optional

### DIFF
--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -3,6 +3,7 @@ import type {
   ASTNode
   ASTNodeObject
   BindingPattern
+  BindingProperty
   BindingRestElement
   Children
   HasSubbinding
@@ -233,6 +234,8 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
             type: "TypeSuffix"
             ts: true
             children: [": unknown"]
+          if (prop as BindingProperty).initializer and not typeSuffix.optional
+            typeSuffix.children.unshift typeSuffix.optional = "?"
           switch prop.type
             when "BindingProperty"
               ws := prop.children[...prop.children.indexOf prop.name]

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -98,6 +98,14 @@ describe "[TS] destructuring", ->
     """
 
     testCase """
+      objects with initializers
+      ---
+      { name: {first:: string = "Hello", last?:: string = "World"} } := person
+      ---
+      const { name: {first = "Hello", last = "World"} }: { name: {first?: string, last?: string}} = person
+    """
+
+    testCase """
       array
       ---
       [ first:: string, last?:: string ] := person


### PR DESCRIPTION
Fixes #1698