### PR TITLE
Document `class with A, B` mixins

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2634,6 +2634,23 @@ class Civet < Animal <: Named
 class Civet <: Animal, Named
 </Playground>
 
+### Mixins
+
+Civet experimentally defines a "mixin" to be a function mapping a class to
+a class (e.g., returning a subclass with added functionality),
+and provides syntax for applying one or more mixins to the base class
+you're extending:
+
+<Playground>
+class Civet extends Animal with Mixin1, Mixin2
+</Playground>
+
+The extended class defaults to `Object`:
+
+<Playground>
+class Civet with Mixin1, Mixin2
+</Playground>
+
 ### Decorators
 
 Civet uses [`@` for `this`](#this), so decorators need to use `@@`:

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2638,14 +2638,20 @@ class Civet <: Animal, Named
 
 Civet experimentally defines a "mixin" to be a function mapping a class to
 a class (e.g., returning a subclass with added functionality),
-and provides syntax for applying one or more mixins to the base class
+and provides `with` syntax for applying one or more mixins to the base class
 you're extending:
 
 <Playground>
-class Civet extends Animal with Mixin1, Mixin2
+function Movable(C)
+  class extends C
+    move(@x, @y)
+class Civet extends Animal with Movable
+  @()
+    @move 0, 0
 </Playground>
 
-The extended class defaults to `Object`:
+Mixins get applied left to right.
+The extended class defaults to `Object`.
 
 <Playground>
 class Civet with Mixin1, Mixin2


### PR DESCRIPTION
Fixes #1697 

When writing this, I wondered one thing: should we instead use the following existing syntax? (though it doesn't currently compile)

```js
class Civet extends Animal |> Mixin1 |> Mixin2
```

(Or maybe we discussed this already?)

It's more annoying if you want to write `class Civet with Mixin1, Mixin2`:

```js
class Civet extends Object |> Mixin1 |> Mixin2
```
