### PR TITLE
Fix exit detection for `switch` with fallthrough

### DIFF
--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -213,10 +213,22 @@ function isExit(node: ASTNode): boolean
       isExit node.children[0][1]
     when "SwitchStatement"
       (and)
+        // Every clause should exit, or continue to next clause
+        for every clause of node.caseBlock.clauses
+          if clause.type is like "CaseClause", "WhenClause", "DefaultClause"
+            // `break` might jump to end of switch, so don't consider an exit
+            not (clause.type is "WhenClause" and clause.break) and
+            not gatherRecursiveWithinFunction(clause.block, .type is "BreakStatement")#
+          else
+            isExit clause.block
         // Ensure exhaustive by requiring an else/default clause
-        node.caseBlock.clauses.some .type is "DefaultClause"
-        // Every clause should exit
-        node.caseBlock.clauses.every isExit
+        for some clause, i of node.caseBlock.clauses
+          clause.type is "DefaultClause" and
+          // Require default clause to exit or continue to next clause
+          // (checked above) and eventually reach an exiting clause
+          for some later of node.caseBlock.clauses[i..]
+            later.type is like "CaseClause", "WhenClause", "DefaultClause" and
+            isExit later.block
     when "TryStatement"
       // Require all non-finally blocks to exit
       node.blocks.every isExit

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -462,6 +462,103 @@ describe "switch", ->
   """
 
   testCase """
+    when skips break when switch falls through but exits
+    ---
+    switch x
+      when 0
+        switch y
+          default
+            console.log 'default'
+          when 1
+            console.log '1'
+            continue switch
+          case 2
+            console.log '2'
+          when 3
+            return
+    ---
+    switch(x) {
+      case 0: {
+        switch(y) {
+          default:
+            console.log('default')
+          case 1: {
+            console.log('1')
+            \n      }
+          case 2:
+            console.log('2')
+          case 3: {
+            return
+          }
+        }
+      }
+    }
+  """
+
+  testCase """
+    when keeps break when switch breaks via when
+    ---
+    switch x
+      when 0
+        switch y
+          default
+            console.log 'default'
+          when 1
+            console.log '1'
+          case 2
+            console.log '2'
+          when 3
+            return
+    ---
+    switch(x) {
+      case 0: {
+        switch(y) {
+          default:
+            console.log('default')
+          case 1: {
+            console.log('1');break;
+          }
+          case 2:
+            console.log('2')
+          case 3: {
+            return
+          }
+        };break;
+      }
+    }
+  """
+
+  testCase """
+    when keeps break when switch breaks via case
+    ---
+    switch x
+      when 0
+        switch y
+          default
+            console.log 'default'
+          case 1
+            console.log '1'
+            break unless y?
+          when 2
+            return
+    ---
+    switch(x) {
+      case 0: {
+        switch(y) {
+          default:
+            console.log('default')
+          case 1:
+            console.log('1')
+            if (!(y != null)) { break }
+          case 2: {
+            return
+          }
+        };break;
+      }
+    }
+  """
+
+  testCase """
     don't fall through after omitted implicit return
     ---
     =>


### PR DESCRIPTION
Fixes #1710

Previously, I believe we accidentally claimed that some `switch` statements were exiting when they weren't, because `break` is considered an exit, but in the context of a `switch` they do the opposite of exit (they go to the statement after the `switch`). Now this is correctly detected as not exiting, and the remaining cases are correctly handled as fallthroughs: we check that the default clause, or one of the clauses it falls through to, has an actual exit (not a `break`).