### PR TITLE
Require `from` in backwards `import`/`export` to fix ambiguity with dynamic `import`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3058,13 +3058,12 @@ export default x := 5
 ### Backward Import/Export
 
 Similar to Python, you can put `from` before `import`/`export`.
-Furthermore, `from` is optional.
 This can improve autocompletion behavior.
 
 <Playground>
 from fs/promises import { readFile, writeFile }
-./util import * as util
-./package.json with {type: 'json'} export { version }
+from ./util import * as util
+from ./package.json with {type: 'json'} export { version }
 </Playground>
 
 ## Comments

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5756,8 +5756,8 @@ ImportDeclaration
     }
     const children = [i, t, imports, w, from]
     return { type: "ImportDeclaration", ts: !!t, children, imports, from }
-  # NOTE: [from] ... import ... reverse syntax
-  ImpliedFromClause:from __:fws Import:i __:iws Operator OperatorBehavior?:behavior __:ows OperatorNamedImports:imports ->
+  # NOTE: from ... import ... reverse syntax
+  FromClause:from __:fws Import:i __:iws Operator OperatorBehavior?:behavior __:ows OperatorNamedImports:imports ->
     const errors = []
     if (behavior?.error) errors.push(behavior.error)
     imports.specifiers.forEach((spec) => {
@@ -5771,7 +5771,7 @@ ImportDeclaration
       imports,
       from,
     }
-  ImpliedFromClause:from __:fws Import:i __:iws ( TypeKeyword __ )?:t ImportClause:imports ->
+  FromClause:from __:fws Import:i __:iws ( TypeKeyword __ )?:t ImportClause:imports ->
     return {
       type: "ImportDeclaration",
       children: [ i, iws, t, imports, fws, from ],
@@ -5845,15 +5845,6 @@ FromClause
   From __ ModuleSpecifier:module ->
     if (!Array.isArray(module)) return $0
     return [ $1, $2, ...module ]
-
-ImpliedFromClause
-  ( ( From __ ) / ImpliedFrom ) ModuleSpecifier:module ->
-    if (!Array.isArray(module)) return $0
-    return [ $1, ...module ]
-
-ImpliedFrom
-  "" ->
-    return { $loc, token: "from " }
 
 # https://github.com/tc39/proposal-import-assertions
 # https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#import-assertions
@@ -6028,8 +6019,8 @@ ExportDeclaration
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
   Export __ ExportFromClause:exports __ FromClause ->
     return { type: "ExportDeclaration", ts: exports.ts, children: $0 }
-  # NOTE: [from] ... export ... reverse syntax
-  ImpliedFromClause:from __:fws Export:e __:ews ExportFromClause:exports ->
+  # NOTE: from ... export ... reverse syntax
+  FromClause:from __:fws Export:e __:ews ExportFromClause:exports ->
     return {
       type: "ExportDeclaration",
       ts: exports.ts,

--- a/test/export.civet
+++ b/test/export.civet
@@ -296,25 +296,3 @@ describe "export", ->
       export type { Type1, Type2 } from "./module"
       export { version } from "./package.json" with {type: "json"}
     """
-
-    testCase """
-      top-level implicit from
-      ---
-      "./module" export {x}
-      ./module export {y}
-      node:fs export { readFile }
-      ./module export * as module
-      ./module export a, b
-      ./module export type T1, T2
-      ./module export type { Type1, Type2 }
-      ./package.json with {type: "json"} export { version }
-      ---
-      export {x} from "./module"
-      export {y} from "./module"
-      export { readFile } from "node:fs"
-      export * as module from "./module"
-      export {a, b} from "./module"
-      export type {T1, T2} from "./module"
-      export type { Type1, Type2 } from "./module"
-      export { version } from "./package.json" with {type: "json"}
-    """

--- a/test/import.civet
+++ b/test/import.civet
@@ -261,10 +261,12 @@ describe "import", ->
       await import "./x.js"
       promise := import "./x.js"
       fetch = => import "./x.js"
+      await import name
       ---
       await import("./x.js")
       const promise = import("./x.js")
       fetch = () => import("./x.js")
+      await import(name)
     """
 
     testCase """
@@ -477,30 +479,6 @@ describe "import", ->
     """
 
     testCase """
-      top-level implicit from
-      ---
-      "./module" import {x}
-      ./module import {y}
-      node:fs import { readFile }
-      ./module import * as module
-      ./module import moduleDefault
-      ./module import type Type
-      ./module import type { Type1, Type2 }
-      ./package.json with {type: "json"} import { version }
-      ./operators import operator {a, b}
-      ---
-      import {x} from "./module"
-      import {y} from "./module"
-      import { readFile } from "node:fs"
-      import * as module from "./module"
-      import moduleDefault from "./module"
-      import type Type from "./module"
-      import type { Type1, Type2 } from "./module"
-      import { version } from "./package.json" with {type: "json"}
-      import {a, b} from "./operators"
-    """
-
-    testCase """
       dynamic declaration explicit from
       ---
       =>
@@ -510,27 +488,6 @@ describe "import", ->
         from ./module import * as module
         from ./module import moduleDefault
         from ./package.json with {type: "json"} import { version }
-      ---
-      async () => {
-        const {x} = await import("./module")
-        const {y} = await import("./module")
-        const {readFile} = await import("node:fs")
-        const module = await import("./module")
-        const moduleDefault = (await import("./module")).default
-        const {version} = await import("./package.json", {with:{type: "json"}});return {version}
-      }
-    """
-
-    testCase """
-      dynamic declaration implicit from
-      ---
-      =>
-        "./module" import {x}
-        ./module import {y}
-        node:fs import { readFile }
-        ./module import * as module
-        ./module import moduleDefault
-        ./package.json with {type: "json"} import { version }
       ---
       async () => {
         const {x} = await import("./module")


### PR DESCRIPTION
**New behavior:** `a import b` means `a(import(b))`
**Old behavior:** `a import b` means `import b from a`

In particular, this is definitely what we want when `a` is `await`, fixing #1712.

BREAKING CHANGE: `module import spec` needs to written as `from module import spec` (`from` can no longer be omitted)