### PR TITLE
Fix `export`ing statement expressions

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -19,6 +19,7 @@ import type {
 } from ./types.civet
 
 import {
+  blockContainingStatement
   blockWithPrefix
   braceBlock
   makeEmptyBlock
@@ -157,7 +158,9 @@ function processDeclarations(statements: StatementTuple[]): void
             expression: "undefined"
             children: [" = ", "undefined"]
 
-      if initializer
+      // If this declaration is at the top level (not e.g. inside an
+      // ExportDeclaration), try to pull out any statement expressions
+      if initializer and blockContainingStatement declaration
         prependStatementExpressionBlock initializer, declaration
 
   for each statement of gatherRecursiveAll statements, .type is "ForStatement"

--- a/test/export.civet
+++ b/test/export.civet
@@ -18,6 +18,30 @@ describe "export", ->
   """
 
   testCase """
+    const shorthand
+    ---
+    export x := 3
+    ---
+    export const x = 3
+  """
+
+  testCase """
+    const shorthand with if/then
+    ---
+    export x := if cond then a else b
+    ---
+    export const x = (cond? a : b)
+  """
+
+  testCase """
+    const shorthand with for loop
+    ---
+    export x := for a of b
+    ---
+    export const x = (()=>{const results=[];for (const a of b) {results.push(a)}return results})()
+  """
+
+  testCase """
     export default thin arrow function
     ---
     export default x:= ->


### PR DESCRIPTION
Fixes #1708 

The attempt to lift statement expressions out of the initializers of declarations was missing a check to see whether the declaration is top level. I think we didn't think about this case because declarations are mostly forced to be top-level because of the grammar, but `ExportDeclaration` is at least one thing that could surround them. By contrast, assignments (see `processAssignments`) already had such a check (`blockContainingStatement`), so I basically just copied that.

We could of course consider a smarter compilation specific to `export`:

```js
export x := if a then b else c
---
let ref
if (a) { x = b }
else { x = c }
export const x = ref
```

This could still be done in the future. In any case I think we should have this check.