### PR TITLE
Fix complex one-line `if` then blocks via bracing

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -13,6 +13,7 @@ import {
   append,
   blockWithPrefix,
   braceBlock,
+  bracedBlock,
   convertNamedImportsToObject,
   convertObjectToJSXAttributes,
   convertWithClause,
@@ -4624,12 +4625,7 @@ IfStatement
     }
     // Ensure semicolon separating single line from `else`
     if (block.bare && e) {
-      const semicolon = ";"
-      block = {
-        ...block,
-        semicolon,
-        children: [...block.children, semicolon],
-      }
+      block = bracedBlock(block)
     }
     return {
       type: "IfStatement",
@@ -4643,11 +4639,7 @@ IfStatement
   IfClause:clause BlockOrEmpty:block ElseClause?:e ->
     // Ensure semicolon separating single line from `else`
     if (block.bare && e) {
-      block = {
-        ...block,
-        semicolon: ";",
-        children: [...block.children, ";"],
-      }
+      block = bracedBlock(block)
     }
     return {
       type: "IfStatement",

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -51,12 +51,12 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
 
   return block
 
-// Add braces if block lacks them
+/** Add braces if block lacks them */
 function braceBlock(block: BlockStatement): void
   if block.bare and not block.root
     if block.children is block.expressions
       block.children = [block.expressions]
-    block.children.unshift(" {")
+    block.children.unshift " {"
     block.children.push "}"
     { implicitlyReturned } := block
     block.bare = block.implicitlyReturned = false
@@ -76,6 +76,12 @@ function duplicateBlock(block: BlockStatement): BlockStatement
     expressions,
     children,
   }
+
+/** Non-destructive braceBlock */
+function bracedBlock(block: BlockStatement): BlockStatement
+  block = duplicateBlock block
+  braceBlock block
+  block
 
 function makeEmptyBlock(): BlockStatement
   const expressions = []
@@ -251,6 +257,7 @@ function blockContainingStatement(exp: ASTNodeObject)
 export {
   blockWithPrefix
   braceBlock
+  bracedBlock
   duplicateBlock
   getIndent
   blockContainingStatement

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -440,13 +440,13 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
     when "IfStatement"
       // if block
       assignResults(exp.then, collect)
-      if exp.then.bare and not exp.then.semicolon
-        exp.then.children.push exp.then.semicolon = ";"
 
       // else block
       if exp.else
         assignResults(exp.else.block, collect)
       else // Add else block pushing undefined if no else block
+        // Ensure then block is properly terminated for added else block
+        braceBlock exp.then
         exp.children.push([" else {", collect("void 0"), "}"])
       return
     when "PatternMatchingStatement"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -106,6 +106,7 @@ import {
   blockContainingStatement
   blockWithPrefix
   braceBlock
+  bracedBlock
   duplicateBlock
   hoistRefDecs
   makeBlockFragment
@@ -1954,12 +1955,14 @@ export {
   attachPostfixStatementAsExpression
   blockWithPrefix
   braceBlock
+  bracedBlock
   convertNamedImportsToObject
   convertObjectToJSXAttributes
   convertWithClause
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
+  duplicateBlock
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   expressionizeTypeIf

--- a/test/auto-const.civet
+++ b/test/auto-const.civet
@@ -554,11 +554,11 @@ describe "auto-const", ->
       e = 5
     a = 6
     ---
-    let a, b, c, d
+    let a, b, d
     if (a = 1) {
       a = 2
     }
-    else if (b = 2) c = 3;
+    else if (b = 2) { const c = 3}
     else if (d = 3) {
       a = 4
     }

--- a/test/auto-let.civet
+++ b/test/auto-let.civet
@@ -554,11 +554,11 @@ describe "complicated auto-let", ->
       e = 5
     a = 6
     ---
-    let a, b, c, d
+    let a, b, d
     if (a = 1) {
       a = 2
     }
-    else if (b = 2) c = 3;
+    else if (b = 2) { let c = 3}
     else if (d = 3) {
       a = 4
     }

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -298,7 +298,7 @@ describe "examples (from real life)", ->
     ---
     date := if x==1 then "a" else "b"
     ---
-    let ref;if (x==1) ref = "a"; else ref = "b";const date =ref
+    let ref;if (x==1) { ref = "a"} else ref = "b";const date =ref
   """
 
   testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -842,7 +842,7 @@ describe "for", ->
           if true then 'yes' else 'no'
       ---
       const results=[];for (let i1 = 0; i1 <= 7; ++i1) {const i = i1;
-          if (true) results.push('yes'); else results.push('no')
+          if (true) { results.push('yes')} else results.push('no')
         };const check =results
     """
 

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -570,7 +570,7 @@ describe "&. function block shorthand", ->
     ---
     roundUp := if even then & else &+1
     ---
-    let ref;if (even) ref = $ => $; else ref = $1 => $1+1;const roundUp =ref
+    let ref;if (even) { ref = $ => $} else ref = $1 => $1+1;const roundUp =ref
   """
 
   testCase """
@@ -580,7 +580,7 @@ describe "&. function block shorthand", ->
       if & then x else y
     ---
     () => {
-      return $ => { if ($) return x; else return y}
+      return $ => { if ($) { return x} else return y}
     }
   """
 

--- a/test/function.civet
+++ b/test/function.civet
@@ -1960,7 +1960,7 @@ describe "function", ->
       ---
       (x) -> if x then a else b
       ---
-      (function(x) { if (x) return a; else return b })
+      (function(x) { if (x) { return a} else return b })
     """
 
     testCase """
@@ -1968,7 +1968,7 @@ describe "function", ->
       ---
       (x) => if x then a else b
       ---
-      (x) => { if (x) return a; else return b }
+      (x) => { if (x) { return a} else return b }
     """
 
     testCase """
@@ -2280,7 +2280,7 @@ describe "function", ->
       ---
       (function() {
         const results=[];while (x) {
-          if (a) return true; else {results.push(void 0)}
+          if (a) { return true} else {results.push(void 0)}
         };return results;
       })
     """

--- a/test/if.civet
+++ b/test/if.civet
@@ -312,7 +312,7 @@ describe "if", ->
     ---
     if (x) y else z
     ---
-    if (x) y; else z
+    if (x) { y} else z
   """
 
   testCase """
@@ -407,7 +407,7 @@ describe "if", ->
     ---
     if true then y else z
     ---
-    if (true) y; else z
+    if (true) { y} else z
   """
 
   testCase """
@@ -415,7 +415,7 @@ describe "if", ->
     ---
     unless false then y else z
     ---
-    if (!false) y; else z
+    if (!false) { y} else z
   """
 
   testCase """
@@ -423,7 +423,7 @@ describe "if", ->
     ---
     if (true) y else z
     ---
-    if (true) y; else z
+    if (true) { y} else z
   """
 
   testCase """
@@ -475,7 +475,7 @@ describe "if", ->
     if (true) 5
     else 3
     ---
-    if (true) 5;
+    if (true) { 5}
     else 3
   """
 


### PR DESCRIPTION
Fixes #1706 as discussed in https://github.com/DanielXMoore/Civet/issues/1706#issuecomment-2730164047

> My only minor suggestion is replacing the first space, if it exists, with the open brace and a trailing space, if it exists, with the closing brace to keep the source alignment as close as possible with the transpiled code.

I'm not sure this is that easy to do, given that we'd like to do this local to the block. It does seem that the leading space is often part of the block, but the trailing space isn't. Notably, here's the relevant code in `braceBlock`:

```js
    block.children.unshift " {"
    block.children.push "}"
```

I've always found this asymmetric. I could see
1. removing the space before the `{`, or
2. adding a space before the `}`.

Having half of the braces be spaced feels a bit weird... but also fine. I'd like to settle on what changes to make (if any) before changing anything, because this affects 135 tests. Mostly in pattern matching, e.g.:

```js
switch x
  < 0 then console.log "it's negative"
  > 0 then console.log "it's positive"
  is 0 then console.log "it's zero"
  else console.log "it's something else"
---
// current
if(x < 0) { console.log("it's negative")}
else if(x > 0) { console.log("it's positive")}
else if(x === 0) { console.log("it's zero")}
// option 1
if(x < 0){ console.log("it's negative")}
else if(x > 0){ console.log("it's positive")}
else if(x === 0){ console.log("it's zero")}
// option 2
if(x < 0) { console.log("it's negative") }
else if(x > 0) { console.log("it's positive") }
else if(x === 0) { console.log("it's zero") }
```

Here's an example where we're inconsistent (we favor spaces in a different bracing application):

```js
=> for x of y
=> for [x] of y
---
// current
() => { const results=[];for (const x of y) {results.push(x)};return results; };
() => { const results1=[];for (const [x] of y) {results1.push([x])};return results1; }
// option 1
() => { const results=[];for (const x of y){results.push(x)};return results; };
() => { const results1=[];for (const [x] of y){results1.push([x])};return results1; }
// option 2
() => { const results=[];for (const x of y) { results.push(x) };return results; };
() => { const results1=[];for (const [x] of y) { results1.push([x]) };return results1; }
```