### PR TITLE
Indented forms of `implements` and `with`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2634,6 +2634,16 @@ class Civet < Animal <: Named
 class Civet <: Animal, Named
 </Playground>
 
+Long `implements` lists can be indented:
+
+<Playground>
+class Civet
+  extends Animal
+  implements
+    Named
+    Character
+</Playground>
+
 ### Mixins
 
 Civet experimentally defines a "mixin" to be a function mapping a class to
@@ -2655,6 +2665,16 @@ The extended class defaults to `Object`.
 
 <Playground>
 class Civet with Mixin1, Mixin2
+</Playground>
+
+Long mixin lists can be indented:
+
+<Playground>
+class Civet
+  extends Animal
+  with
+    Mixin1
+    Mixin2
 </Playground>
 
 ### Decorators

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1122,24 +1122,33 @@ ExtendsClause
 # with for mixin shorthand
 # class A extends B with C, D -> class A extends D(C(B))
 WithClause
-  __ With __:ws ExtendsTarget:t ( "," __ ExtendsTarget )*:rest ->
+  # nested form where C, D appear on separate lines, indented
+  NotDedented With PushIndent ( Nested ExtendsTarget _? Comma? )*:targets PopIndent ->
+    if (!targets.length) return $skip
+    targets = targets.map($ => $.slice(0, -1)) // strip Comma?
     return {
       type: "WithClause",
       children: $0,
-      targets: [[ws, t], ...rest.map(([_comma, ws, target]) => [ws, target])],
+      targets,
+    }
+  NotDedented With NotDedented:ws ExtendsTarget:t ( _? Comma NotDedented ExtendsTarget )*:rest ->
+    return {
+      type: "WithClause",
+      children: $0,
+      targets: [[ws, t], ...rest.map(([ws1, _comma, ws2, target]) => [prepend(ws1, ws2), target])],
     }
 
 ExtendsToken
   # NOTE: Added "<" extends shorthand
-  Loc:l _?:ws ExtendsShorthand:t " "? ->
+  NotDedented:ws InsertSpace:s ExtendsShorthand:t " "? ->
     return {
       type: "Extends",
       children: [
-        ws || { $loc: l.$loc, token: " " },
+        ws.length ? ws : s,
         t,
       ],
     }
-  _? Extends ->
+  NotDedented Extends ->
     return {
       type: "Extends",
       children: $0,
@@ -1174,7 +1183,17 @@ ExtendsTarget
     return makeLeftHandSideExpression(exp)
 
 ImplementsClause
-  ImplementsToken ImplementsTarget ( Comma ImplementsTarget )* ->
+  # nested form where interfaces appear on separate lines, indented
+  ImplementsToken:i PushIndent ( Nested ImplementsTarget ArrayBulletDelimiter )*:targets PopIndent ->
+    if (!targets.length) return $skip
+    // remove final comma
+    const last = targets.at(-1).slice(0, -1)
+    targets = targets.slice(0, -1).concat(last)
+    return {
+      ts: true,
+      children: [i, targets],
+    }
+  ImplementsToken ImplementsTarget ( _? Comma ImplementsTarget )* ->
     return {
       ts: true,
       children: $0,
@@ -1182,7 +1201,7 @@ ImplementsClause
 
 ImplementsToken
   # NOTE: Added "<:" implements shorthand
-  Loc:l __:ws ImplementsShorthand:token " "? ->
+  Loc:l NotDedented:ws ImplementsShorthand:token " "? ->
     const children = [ ...ws, token ]
 
     if (!ws.length) {
@@ -1191,7 +1210,7 @@ ImplementsToken
 
     return { children }
 
-  __ "implements" NonIdContinue ->
+  NotDedented "implements" NonIdContinue ->
     $2 = { $loc, token: $2 }
     return [$1, $2]
 

--- a/test/class.civet
+++ b/test/class.civet
@@ -544,6 +544,36 @@ describe "class", ->
   """
 
   testCase """
+    multiple implements with space
+    ---
+    class A implements B , C
+      foo = 1
+    ---
+    class A implements B , C {
+      foo = 1
+    }
+  """
+
+  testCase """
+    multiple implements indented
+    ---
+    class A
+      implements
+        B
+        C,
+        D
+      foo = 1
+    ---
+    class A
+      implements
+        B,
+        C,
+        D {
+      foo = 1
+    }
+  """
+
+  testCase """
     extends obj member class
     ---
     class A extends Foo.Bar.Baz
@@ -1403,6 +1433,24 @@ describe "class", ->
         x = 3
       ---
       class A extends C(B(Object)) {
+        x = 3
+      }
+    """
+
+    testCase """
+      indented
+      ---
+      class A
+        with
+          B
+          C,
+          D
+        x = 3
+      ---
+      class A extends 
+          D(
+          C(
+          B(Object))) {
         x = 3
       }
     """


### PR DESCRIPTION
Fixes #1707 by adding a nested list form of both `implements` and `with`.
Also convert some `__` to `NotDedented`, allow spaces before commas, etc.