### PR TITLE
More general expressions in indented forms of `implements` and `with`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -2641,7 +2641,7 @@ class Civet
   extends Animal
   implements
     Named
-    Character
+    Record string, number
 </Playground>
 
 ### Mixins
@@ -2673,7 +2673,7 @@ Long mixin lists can be indented:
 class Civet
   extends Animal
   with
-    Mixin1
+    Mixin1 arg
     Mixin2
 </Playground>
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1123,8 +1123,9 @@ ExtendsClause
 # with for mixin shorthand
 # class A extends B with C, D -> class A extends D(C(B))
 WithClause
-  # nested form where C, D appear on separate lines, indented
-  NotDedented With PushIndent ( Nested ExtendsTarget _? Comma? )*:targets PopIndent ->
+  # Nested form where C, D appear on separate lines, indented
+  # Also allows for arbitrary expressions
+  NotDedented With PushIndent ( Nested Expression _? Comma? )*:targets PopIndent ->
     if (!targets.length) return $skip
     targets = targets.map($ => $.slice(0, -1)) // strip Comma?
     return {
@@ -1184,8 +1185,9 @@ ExtendsTarget
     return makeLeftHandSideExpression(exp)
 
 ImplementsClause
-  # nested form where interfaces appear on separate lines, indented
-  ImplementsToken:i PushIndent ( Nested ImplementsTarget ArrayBulletDelimiter )*:targets PopIndent ->
+  # Nested form where interfaces appear on separate lines, indented
+  # Allows for implicit type arguments
+  ImplementsToken:i PushIndent ( Nested TypeIdentifier ArrayBulletDelimiter )*:targets PopIndent ->
     if (!targets.length) return $skip
     // remove final comma
     const last = targets.at(-1).slice(0, -1)
@@ -1194,6 +1196,7 @@ ImplementsClause
       ts: true,
       children: [i, targets],
     }
+  # Comma-separated list with explicit arguments
   ImplementsToken ImplementsTarget ( _? Comma ImplementsTarget )* ->
     return {
       ts: true,
@@ -1219,6 +1222,7 @@ ImplementsShorthand
   "<:" ->
     return { $loc, token: "implements " }
 
+# Like TypeIdentifier but forbidding implicit type arguments
 ImplementsTarget
   __ IdentifierName (Dot IdentifierName)* TypeArguments?
 
@@ -8300,6 +8304,19 @@ TypePrimary
       t,
       children: $0,
     }
+  TypeIdentifier
+  # NOTE: Check TypeFunction before parenthesized in order to distinguish between (a: T) => U and
+  # A parenthesized inline interface (a: T) ---> ({a: T})
+  # NOTE: Check Type before ( EOS Type ) to find implicit nested interfaces first. EOS would swallow the
+  # newline so Nested wouldn't match otherwise.
+  _? OpenParen AllowAll ( MaybeNestedType / ( EOS Type ) )? RestoreAll __ CloseParen ->
+    if (!$4) return $skip
+    return {
+      type: "TypeParenthesized",
+      children: [ $1, $2, $4, $6, $7 ],  // omit AllowAll/RestoreAll
+    }
+
+TypeIdentifier
   _? UnknownAlias ->
     return {
       type: "TypeIdentifier",
@@ -8313,16 +8330,6 @@ TypePrimary
       children: $0,
       raw: [$2.name, ...$3.map(([dot, id]) => dot.token + id.name), ].join(''),
       args,
-    }
-  # NOTE: Check TypeFunction before parenthesized in order to distinguish between (a: T) => U and
-  # A parenthesized inline interface (a: T) ---> ({a: T})
-  # NOTE: Check Type before ( EOS Type ) to find implicit nested interfaces first. EOS would swallow the
-  # newline so Nested wouldn't match otherwise.
-  _? OpenParen AllowAll ( MaybeNestedType / ( EOS Type ) )? RestoreAll __ CloseParen ->
-    if (!$4) return $skip
-    return {
-      type: "TypeParenthesized",
-      children: [ $1, $2, $4, $6, $7 ],  // omit AllowAll/RestoreAll
     }
 
 ImportType

--- a/test/class.civet
+++ b/test/class.civet
@@ -561,14 +561,14 @@ describe "class", ->
       implements
         B
         C,
-        D
+        D E, F
       foo = 1
     ---
     class A
       implements
         B,
         C,
-        D {
+        D<E, F> {
       foo = 1
     }
   """
@@ -1444,11 +1444,11 @@ describe "class", ->
         with
           B
           C,
-          D
+          D a, b
         x = 3
       ---
       class A extends 
-          D(
+          D(a, b)(
           C(
           B(Object))) {
         x = 3


### PR DESCRIPTION
As mentioned on Discord, the indented form of `implements` is practically begging to allow for implicit type arguments.
Now uses a new `TypeIdentifier` rule, extracted from `TypePrimary`.

And the indented form of `with` could be generalized a bit too. Before it didn't allow for implicit object children, but we can allow for an arbitrary expression now because we should be indented away from the class body.  (At least, I didn't have in mind that someone would indent the body *inside* the `with` clause 😬.)