### PR TITLE
Allow `>code` to continue an implicit JSX fragment

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7045,7 +7045,7 @@ Yield
 ## JSX
 
 JSXImplicitFragment
-  JSXTag ( Nested JSXTag )* ->
+  JSXTag ( Nested ( JSXTag / JSXAngleChild ) )* ->
     const jsx = $2.length === 0 ? $1 : {
       type: "JSXFragment",
       children: [

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -714,3 +714,17 @@ describe "Implicit JSX fragments", ->
       }})()}
       </div>
     """
+
+    testCase """
+      implicit fragment
+      ---
+      <node>
+      > if cond
+        <sibling>
+      ---
+      <>
+      <node />
+      { (cond?
+        <sibling />:void 0)}
+      </>
+    """


### PR DESCRIPTION
Fixes #1691 

Implicit JSX fragments still need to start with a "tag" (`<foo>` or `<!--comment-->`), but then they can continue with a `>code` sibling.

I'm still not allowing text (or enabled code) to continue an implicit JSX fragment, as that seems a little fragile. But at least now there's a simple workaround of writing `>'text'`.