### PR TITLE
Fix unplugin source map directories

### DIFF
--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -525,8 +525,8 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           JSON.parse(sourceMap)
         else
           sourceMap.json
-            path.basename id.replace /\.[jt]sx$/, ''
-            path.basename id
+            path.relative rootDir, id.replace /\.[jt]sx$/, ''
+            path.relative rootDir, id
 
       transformed: TransformResult .=
         code: compiled

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -49,7 +49,7 @@ describe "integration", ->
     await execCmd 'bash -c "(cd integration/example && ../../dist/civet --no-config build.civet)"'
     data := JSON.parse(fs.readFileSync("integration/example/dist/main.js.map", "utf8"))
 
-    assert.equal data.sources[0], "main.civet"
+    assert.equal data.sources[0], "source/main.civet"
 
   for mode of ["cjs", "esm"]
     it `should sourcemap correctly, ${mode} mode`, ->


### PR DESCRIPTION
This adds the directory paths to the sourcemaps so they don't all end up at the root.