### PR TITLE
Explicit changelog build script shell

### DIFF
--- a/build/changelog.civet
+++ b/build/changelog.civet
@@ -13,6 +13,7 @@ process.chdir join (dirname fileURLToPath import.meta.url), '..'
 
 function run(command: string, args: string[], options?: object): string
   sub := spawnSync command, args, {
+    shell: 'bash'
     encoding: 'utf8'
     maxBuffer: 32 * 1024 * 1024  // 32 MB
     ...options
@@ -83,7 +84,7 @@ if [, version] := readFileSync('package.json', encoding: 'utf8').match /^  "vers
 // Tag version commits
 
 existingTag: Map<string, string> := new Map  // tag -> commit
-run 'git', ['tag', '--list', '--format=%(object) %(refname:short)', 'v\\*']
+run 'git', ['tag', '--list', '--format="%(object) %(refname:short)"', 'v\\*']
 .split '\n'
 .forEach (line) =>
   [commit, tag] := line.split ' '


### PR DESCRIPTION
Changelog script wasn't working for me unless I was explicit about the shell.