### PR TITLE
ESM loader supports civetconfig by default, and overriding configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ NOTES.md
 coverage/
 dist/
 node_modules/
+register-noconfig.js

--- a/.mocharc-self.json
+++ b/.mocharc-self.json
@@ -12,5 +12,8 @@
   "recursive": true,
   "spec": [
     "test"
+  ],
+  "exclude": [
+    "test/infra/config/**"
   ]
 }

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -11,5 +11,8 @@
   "recursive": true,
   "spec": [
     "test"
+  ],
+  "exclude": [
+    "test/infra/config/**"
   ]
 }

--- a/build/build.sh
+++ b/build/build.sh
@@ -12,6 +12,9 @@ node -e 'import("./node_modules/vite/dist/node/constants.js").then((c)=>console.
 cp types/types.d.ts types/config.d.ts dist/
 cp types/config.d.ts dist/config.d.mts
 
+# register-noconfig.js is made from register.js
+sed 's#//NOCONFIG//##g' register.js >register-noconfig.js
+
 # normal files
 civet --no-config build/esbuild.civet "$@"
 

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -93,6 +93,7 @@ Running in a particular environment?  Try one of these options:
 | `react`               | Use `className` instead of `class` in [JSX class shorthand](reference#class) |
 | `server`              | Code may run on server (currently just for [Solid](reference#solidjs)) |
 | [`solid`](reference#solidjs) | Automatic type casting of JSX |
+
 ## Local Configuration via Directives
 
 At the top of any Civet file (possibly after a `#!` line, comments,

--- a/civet.dev/getting-started.md
+++ b/civet.dev/getting-started.md
@@ -95,11 +95,14 @@ node --import @danielx/civet/register source.civet ...args...
 On Node <20.6.0, you also need to specify `--loader @danielx/civet/esm`
 for ESM `import` of .civet files.
 
-Directly execute a .civet or .ts source file that mixes .civet and .ts code,
-using [ts-node](https://typestrong.org/ts-node/):
+The registration scripts and CLI will automatically search for
+[Civet configuration files](config#global-configuration-via-config-files)
+in the source file's directory and ancestor directories.
+To disable this behavior, use one of the following:
 
 ```sh
-node --loader ts-node/esm --loader @danielx/civet/esm source.civet ...args...
+civet --no-config source.civet ...args...
+node --import @danielx/civet/register-noconfig source.civet ...args...
 ```
 
 ## Transpilation

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "./esm": "./dist/esm.mjs",
     "./esbuild-plugin": "./dist/esbuild-plugin.js",
     "./register": "./register.js",
+    "./register-noconfig": "./register-noconfig.js",
     "./config": {
       "types": "./dist/config.d.ts",
       "require": "./dist/config.js",

--- a/register.js
+++ b/register.js
@@ -9,6 +9,14 @@ for both ESM `import`s and CJS `require`s.
 node --import @danielx/civet/register source.civet
 ```
 
+If you don't want the loader to search for/use accompanying civetconfig files,
+you can use the `-noconfig` version (where `NOCONFIG` comments are removed):
+
+@example
+```bash
+node --import @danielx/civet/register-noconfig source.civet
+```
+
 On older Node, `require`ing this file will register the `.civet` extension
 for CJS `require`s.
 
@@ -37,7 +45,9 @@ try {
   const { register } = require('node:module');
   const { pathToFileURL } = require('node:url');
 
-  register('./dist/esm.mjs', pathToFileURL(__filename));
+  register('./dist/esm.mjs', pathToFileURL(__filename)
+    //NOCONFIG//, {data: {config: null}}
+  );
 } catch (e) {
   // older Node lacking module register
 }
@@ -53,6 +63,7 @@ if (require.extensions) {
       js: true,
       inlineMap: true,
       sync: true,
+      //NOCONFIG//config: null,
     });
     module._compile(js, filename);
   };

--- a/register.js
+++ b/register.js
@@ -24,6 +24,7 @@ If you want to configure the loader, you can make your own
 ```javascript
 import { register } from 'node:module';
 register('@danielx/civet/esm', import.meta.url, {data: {
+  //config: 'path/config.json',
   parseOptions: {
     // Add your parse options here
   },

--- a/register.js
+++ b/register.js
@@ -16,6 +16,20 @@ for CJS `require`s.
 ```bash
 node -r @danielx/civet/register source.civet
 ```
+
+If you want to configure the loader, you can make your own
+`register.mjs` along these lines:
+
+@example
+```javascript
+import { register } from 'node:module';
+register('@danielx/civet/esm', import.meta.url, {data: {
+  parseOptions: {
+    // Add your parse options here
+  },
+}});
+```
+
 */
 
 try {

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -39,7 +39,7 @@ export interface Options extends CompileOptions
   outputExt?: string
   outputPath?: path.ParsedPath
   eval?: string
-  config?: string | boolean | undefined
+  config?: string | false | undefined
   ast?: boolean | "raw"
   repl?: boolean
   typecheck?: boolean
@@ -424,9 +424,8 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     """
     process.exit(0)
 
-  unless options.config is false // --no-config
-    options.config ?= await findConfig process.cwd()
-
+  if options.config is undefined
+    options.config = await findConfig process.cwd()
   if options.config
     parsed := await loadConfig options.config as string
     options = {

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -98,7 +98,7 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
       when '--config'
         options.config = args[++i]
       when '--no-config'
-        options.config = false
+        options.config = null
       when '--civet'
         Object.assign options.parseOptions ??= {},
           parse `civet ${args[++i]}`,
@@ -424,7 +424,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     """
     process.exit(0)
 
-  if options.config is not false // --no-config
+  unless options.config is null // --no-config
     options.config ?= await findConfig process.cwd()
 
   if options.config

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -98,7 +98,7 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
       when '--config'
         options.config = args[++i]
       when '--no-config'
-        options.config = null
+        options.config = false
       when '--civet'
         Object.assign options.parseOptions ??= {},
           parse `civet ${args[++i]}`,
@@ -424,7 +424,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     """
     process.exit(0)
 
-  unless options.config is null // --no-config
+  unless options.config is false // --no-config
     options.config ?= await findConfig process.cwd()
 
   if options.config

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -46,7 +46,8 @@ register('@danielx/civet/esm', import.meta.url, {data: {
 type { ParseOptions } from @danielx/civet
 
 export type RegisterOptions
-  config?: string | null
+  /** config filename, or false/null to not look for default config file */
+  config?: string | false | null
   parseOptions?: ParseOptions
 
 baseURL := pathToFileURL(process.cwd() + '/').href
@@ -78,7 +79,7 @@ export async function load(url: string, context: any, next: any)
     { config } .= globalOptions
     if config is undefined
       config = await findConfig dirname path
-    if config <? "string"
+    if config
       loadedConfig = await loadConfig config
 
     options: Parameters<typeof compile>[1] & { sourceMap: true } :=

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -21,16 +21,38 @@ Previously depended on ts-node esm loader being downstream:
 ```bash
 node --loader ts-node/esm --loader @danielx/civet/esm source.civet
 ```
+
+If you want to configure this ESM loader, you can make your own
+`register.mjs` along these lines:
+
+@example
+```javascript
+import { register } from 'node:module';
+register('@danielx/civet/esm', import.meta.url, {data: {
+  parseOptions: {
+    // Add your parse options here
+  },
+}});
+```
+
 */
 
 { readFileSync } from fs
 { pathToFileURL, fileURLToPath } from url
 
-Civet from ./main.civet
-{ compile, SourceMap } := Civet
+{ compile, SourceMap } from ./main.civet
+type { ParseOptions } from @danielx/civet
+
+export type RegisterOptions
+  parseOptions?: ParseOptions
 
 baseURL := pathToFileURL(process.cwd() + '/').href
 extensionsRegex := /\.civet$/
+
+globalOptions: RegisterOptions .= {}
+
+export function initialize(options: RegisterOptions = {})
+  globalOptions = options
 
 export function resolve(specifier: string, context: any, next: any)
   { parentURL = baseURL } := context
@@ -48,12 +70,17 @@ export async function load(url: string, context: any, next: any)
   if context.format is "civet"
     path := fileURLToPath url
     source := readFileSync path, "utf8"
+
+    options: Parameters<typeof compile>[1] & { sourceMap: true } :=
+      filename: path
+      sourceMap: true
+      js: true
+    if globalOptions.parseOptions
+      options.parseOptions = globalOptions.parseOptions
+
     let tsSource, sourceMap
     try
-      {code: tsSource, sourceMap} = await compile source,
-        filename: path
-        sourceMap: true
-        js: true
+      {code: tsSource, sourceMap} = await compile source, options
     catch e
       console.error `Civet failed to compile ${url}:`, e
       throw e

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -37,13 +37,16 @@ register('@danielx/civet/esm', import.meta.url, {data: {
 
 */
 
-{ readFileSync } from fs
+{ readFile } from fs/promises
+{ dirname } from path
 { pathToFileURL, fileURLToPath } from url
 
 { compile, SourceMap } from ./main.civet
+{ findConfig, loadConfig } from ./config.civet
 type { ParseOptions } from @danielx/civet
 
 export type RegisterOptions
+  config?: string | null
   parseOptions?: ParseOptions
 
 baseURL := pathToFileURL(process.cwd() + '/').href
@@ -69,7 +72,14 @@ export function resolve(specifier: string, context: any, next: any)
 export async function load(url: string, context: any, next: any)
   if context.format is "civet"
     path := fileURLToPath url
-    source := readFileSync path, "utf8"
+    source := await readFile path, "utf8"
+
+    let loadedConfig: RegisterOptions?
+    { config } .= globalOptions
+    if config is undefined
+      config = await findConfig dirname path
+    if config <? "string"
+      loadedConfig = await loadConfig config
 
     options: Parameters<typeof compile>[1] & { sourceMap: true } :=
       filename: path
@@ -77,6 +87,8 @@ export async function load(url: string, context: any, next: any)
       js: true
     if globalOptions.parseOptions
       options.parseOptions = globalOptions.parseOptions
+    if loadedConfig?.parseOptions
+      options.parseOptions = {...options.parseOptions, ...loadedConfig.parseOptions}
 
     let tsSource, sourceMap
     try

--- a/source/unplugin/README.md
+++ b/source/unplugin/README.md
@@ -217,6 +217,7 @@ interface PluginOptions {
   ts?: 'civet' | 'esbuild' | 'tsc' | 'preserve'
   typecheck?: boolean | string
   cache?: boolean
+  config?: string | false | null
   parseOptions?: {
     comptime?: boolean
     coffeeCompat?: boolean
@@ -252,8 +253,8 @@ interface PluginOptions {
   Be sure to re-use plugins instead of calling the plugin generator repeatedly.
 - `threads`: Use specified number of Node worker threads to
   compile Civet files faster. Default: `0` (don't use threads), or `CIVET_THREADS` environment variable if set.
-- `config`: Civet config filename to load, or `null` to avoid looking for the
-  default config filenames in the project root directory.
+- `config`: Civet config filename to load, or `false`/`null` to avoid looking
+  for the default config filenames in the project root directory.
   See [Civet config](https://civet.dev/config).
 - `parseOptions`: Options object to pass to the Civet parser,
   like adding `"civet"` directives to all files.  Default: `{}`.

--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -43,8 +43,8 @@ export type PluginOptions
   threads?: number
   /** Cache compilation results based on file mtime (useful for serve or watch mode) */
   cache?: boolean
-  /** config filename, or null to not look for default config file */
-  config?: string? | null
+  /** config filename, or false/null to not look for default config file */
+  config?: string | false | null
   parseOptions?: ParseOptions
 
 type CacheEntry
@@ -147,9 +147,9 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
     enforce: 'pre'
 
     async buildStart(): Promise<void>
-      const civetConfigPath = 'config' in options
-        ? options.config
-        : await findInDir(process.cwd())
+      civetConfigPath .= options.config
+      if civetConfigPath is undefined
+        civetConfigPath = await findInDir process.cwd()
       if civetConfigPath
         compileOptions = await loadConfig civetConfigPath
       // Merge parseOptions, with plugin options taking priority

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -44,7 +44,7 @@ describe 'CLI parseArgs', ->
     argsOptions '--config custom-config.js', config: 'custom-config.js'
 
   it 'parses --no-config', =>
-    argsOptions '--no-config', config: null
+    argsOptions '--no-config', config: false
 
   it 'parses --civet', =>
     argsOptions '--civet coffeeCompat', parseOptions: coffeeCompat: true

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -44,7 +44,7 @@ describe 'CLI parseArgs', ->
     argsOptions '--config custom-config.js', config: 'custom-config.js'
 
   it 'parses --no-config', =>
-    argsOptions '--no-config', config: false
+    argsOptions '--no-config', config: null
 
   it 'parses --civet', =>
     argsOptions '--civet coffeeCompat', parseOptions: coffeeCompat: true

--- a/test/infra/config.civet
+++ b/test/infra/config.civet
@@ -6,7 +6,7 @@ describe "loading config", ->
     path := await findConfig("test/infra/config/")
     assert path, "should have found civetconfig.json"
     config := await loadConfig(path)
-    assert config.coffeeCompat
+    assert config.parseOptions?.coffeeCompat, "correct options from civetconfig.json"
 
   it "should load specified custom files", ->
     customConfig := await loadConfig("test/infra/config/customconfig.civet")

--- a/test/infra/config/civetconfig.json
+++ b/test/infra/config/civetconfig.json
@@ -1,3 +1,5 @@
 {
-  "coffeeCompat": true
+  "parseOptions": {
+    "coffeeCompat": true
+  }
 }

--- a/test/infra/config/needs-coffee.civet
+++ b/test/infra/config/needs-coffee.civet
@@ -1,0 +1,9 @@
+# This file is designed to parse only in coffeeCompat mode,
+# as specified by ./civetconfig.json.
+#
+# Thus you can test ESM's automatic civetconfig reading via
+#     node --import ../../../register.js needs-coffee.civet
+
+a = 5
+b = c ? a // a
+c = 0

--- a/test/infra/esm.civet
+++ b/test/infra/esm.civet
@@ -1,6 +1,6 @@
 { load as tsLoad } from ts-node/esm
 
-{ resolve, load } from ../../source/esm.civet
+{ initialize, resolve, load } from ../../source/esm.civet
 { pathToFileURL } from url
 
 assert from assert
@@ -13,6 +13,8 @@ describe "esm", ->
     resolve("somefile.js", {}, next)
 
   it "should load with ts-node", ->
+    initialize parseOptions: strict: true
+
     // This sets up a hacky loader next vaguely like the one in node's esm loading
     next := (url: string, context: unknown) ->
       // This simulates Node.js loading the modified source returned from the previous context
@@ -32,5 +34,9 @@ describe "esm", ->
     result := await load(url, context, next)
 
     assert result
+
+    // Avoid including the directive directly for proper testing
+    strictPattern := '"use ' + 'strict"'
+    assert result.source.includes(strictPattern), "initialize configuration"
 
     // console.log result.source

--- a/test/infra/esm.civet
+++ b/test/infra/esm.civet
@@ -28,7 +28,7 @@ describe "esm", =>
     // Also test configuration via `initialize`
     initialize
       parseOptions: strict: true
-      config: null
+      config: false
 
     // This sets up a hacky loader next vaguely like the one in node's esm loading
     next := (url: string, context: {source: string}) ->

--- a/test/infra/esm.civet
+++ b/test/infra/esm.civet
@@ -5,20 +5,35 @@
 
 assert from assert
 
-describe "esm", ->
-  it "should resolve", ->
-    next := ->
+describe "esm", =>
+  it "should resolve", =>
+    next := =>
 
     resolve("somefile.civet", {}, next)
     resolve("somefile.js", {}, next)
 
-  it "should load with ts-node", ->
-    initialize parseOptions: strict: true
+  it "should load config", =>
+    initialize config: './test/infra/config/civetconfig.json'
+    next := (_url: string, sourceEtc: {source: string}) => sourceEtc
+    context :=
+      format: "civet"
+    sourcePath := "./test/infra/config/needs-coffee.civet"
+    url := pathToFileURL(sourcePath).href
+
+    result := await load url, context, next
+    assert result, "compiled"
+    assert result.source?.includes("?? div"), "compiled CoffeeScript"
+
+  it "should load with ts-node", =>
+    // Also test configuration via `initialize`
+    initialize
+      parseOptions: strict: true
+      config: null
 
     // This sets up a hacky loader next vaguely like the one in node's esm loading
-    next := (url: string, context: unknown) ->
+    next := (url: string, context: {source: string}) ->
       // This simulates Node.js loading the modified source returned from the previous context
-      defaultLoad := async ->
+      defaultLoad := async =>
         return {
           source: context.source
         }
@@ -27,11 +42,10 @@ describe "esm", ->
 
     context :=
       format: "civet"
-
     sourcePath := "./source/esm.civet"
     url := pathToFileURL(sourcePath).href
 
-    result := await load(url, context, next)
+    result := await load url, context, next
 
     assert result
 

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -49,7 +49,7 @@ describe "integration", ->
     await execCmd 'bash -c "(cd integration/example && ../../dist/civet --no-config build.civet)"'
     data := JSON.parse(fs.readFileSync("integration/example/dist/main.js.map", "utf8"))
 
-    assert.equal data.sources[0], "source/main.civet"
+    assert.equal data.sources[0].replace(/\\/g, '/'), "source/main.civet"
 
   for mode of ["cjs", "esm"]
     it `should sourcemap correctly, ${mode} mode`, ->


### PR DESCRIPTION
* ESM loader by default now looks for civetconfig files in the directory of the source file and its ancestors, like the CLI already did for CJS files. This should also fix the CLI in ESM mode, which relied on the ESM loader. Fixes #1315 and part of #1239.
* `@danielx/civet/register-noconfig` disables this new behavior, but otherwise acts like `@danielx/civet/register`.
* ESM loader more generally supports configuration via `initialize` hook, specifiable via `data` option in [`module.register`](https://nodejs.org/api/module.html#moduleregisterspecifier-parenturl-options). This lets you build custom register modules with custom parse options, e.g. for testing.

Also fix a small issue with tests not working in Windows.

BREAKING CHANGE: If you don't use civetconfig files and want to be robust against their existence in ancestor directories, or want to maximize performance, use `@danielx/civet/register-noconfig` instead of `@danielx/civet/register`

BREAKING CHANGE: In unplugin settings, `config: undefined` no longer disables searching for config files. Use `config: false` or `config: null` instead.