### PR TITLE
Typed pinned arguments such as `(^x: T) =>`; forbid implicit object literals in pinned patterns

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2083,6 +2083,15 @@ AtIdentifierRef
     return makeRef(id.name)
 
 PinPattern
+  # Forbid ImplicitObjectLiterals such as `x: y` in pinned pattern,
+  # to allow for typed arguments of the form `(^x: T) =>`
+  # and because comparing to object literals isn't generally helpful
+  Caret IdentifierName:expression &Colon ->
+    return {
+      type: "PinPattern",
+      children: [expression],
+      expression,
+    }
   Caret SingleLineExpressionWithIndentedApplicationForbidden:expression ->
     return {
       type: "PinPattern",

--- a/test/function.civet
+++ b/test/function.civet
@@ -479,6 +479,14 @@ describe "function", ->
       (a1) => {a = a1;return  1}
     """
 
+    testCase """
+      typed
+      ---
+      function initialize(^options: Options)
+      ---
+      function initialize(options1: Options){options = options1;}
+    """
+
   describe "named destructured parameters", ->
     testCase """
       named object


### PR DESCRIPTION
Fixes #1732

This change makes the following code no longer parse:

```js
switch x
  ^a: b
```

But I'd argue that the current compilation isn't very helpful, as object literals will never equal a given object.

```js
if(x === {a: b}) {}
```