### PR TITLE
lsp: async Civet config load, shadow-.civet resolution & opt-out on .ts/.js

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -65,7 +65,18 @@
         "title": "Restart Civet Language Server",
         "category": "Civet"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Civet",
+      "properties": {
+        "civet.langServer.includeTypescript": {
+          "type": "boolean",
+          "default": true,
+          "description": "If false, the Civet language server will not attach to JavaScript/TypeScript files, preventing duplicate definitions when another TS server is active."
+        }
+      }
+    }
   },
   "mocha": {
     "extension": [

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -38,17 +38,23 @@ function activateClient(context: ExtensionContext)
       transport: TransportKind.ipc
       options: debugOptions
 
+  // Read user setting to control whether the Civet LS should attach to JS/TS files
+  includeTS := vscode.workspace.getConfiguration('civet').get<boolean>('langServer.includeTypescript', true)
+
+  docSelector := [
+    { scheme: 'file', language: 'civet' }
+  ]
+
+  if includeTS
+    docSelector.push { scheme: 'file', language: 'javascript' }
+    docSelector.push { scheme: 'file', language: 'javascriptreact' }
+    docSelector.push { scheme: 'file', language: 'typescript' }
+    docSelector.push { scheme: 'file', language: 'typescriptreact' }
+
   // Options to control the language client
   clientOptions: LanguageClientOptions :=
-    // TODO: this is where we could add more based on plugins
     // Register the server for language files we care about
-    documentSelector: [
-      { scheme: 'file', language: 'civet' }
-      { scheme: 'file', language: 'javascript' }
-      { scheme: 'file', language: 'javascriptreact' }
-      { scheme: 'file', language: 'typescript' }
-      { scheme: 'file', language: 'typescriptreact' }
-    ]
+    documentSelector: docSelector
 
   // Create the language client and start the client.
   client = new LanguageClient

--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -56,7 +56,8 @@ const sourcePathToProjectPathMap = new Map<string, string>()
 const projectPathToPendingPromiseMap = new Map<string, Promise<void>>()
 
 // Mapping from project path -> TSService instance operating on that base directory
-const projectPathToServiceMap = new Map<string, ReturnType<typeof TSService>>()
+type ResolvedService = Awaited<ReturnType<typeof TSService>>
+const projectPathToServiceMap = new Map<string, ResolvedService>()
 
 let rootUri: string | undefined, rootDir: string | undefined;
 
@@ -102,7 +103,7 @@ const ensureServiceForSourcePath = async (sourcePath: string) => {
   let service = projectPathToServiceMap.get(projPath)
   if (service) return service
   console.log("Spawning language server for project path: ", projPath)
-  service = TSService(projPath)
+  service = await TSService(projPath)
   const initP = service.loadPlugins()
   projectPathToPendingPromiseMap.set(projPath, initP)
   await initP


### PR DESCRIPTION
### Motivation  
1.  **Random parseOptions not loaded errors** - when the TS server restarted it could compile before the Civet config promise resolved => linter errors in files
2.  **Duplicate diagnostics** - sometimes 2 linter errors in typescript files for the same thign (Civet LSP + TS).  
3.  **IDE navigation to a .civet and not generated .ts file** - when `foo.ts` and `foo.civet` coexist, we want the language server to prefer the Civet source first. Smooth exp with civetman (if there is a .ts is generated from .civet)

### What’s in this PR  
1. **Make `TSService` asynchronous**  
   * Await `CivetConfig.findConfig / loadConfig` so the service starts with the correct `CompileOptions`.  
2. **Opt-out flag for .ts / .js handling**  
   * New compiler-host switch (`allowTsJs?: boolean`, default `true`).  
   * When disabled the Civet LSP ignores plain `.ts/.js` files, avoiding duplicate diagnostics.  
3. **Shadow-file module resolution**  
   * In `resolveModuleNames` prefer a sibling `.civet` file over `.ts/.tsx/.mts/.cts`.  
   * Generates a virtual `foo.civet.tsx` file so TypeScript tooling continues to work.  

Let me know if you have any thoughts