### PR TITLE
lsp: auto-regenerate textmate grammar based on a project config

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -64,6 +64,11 @@
         "command": "civet.action.restartServer",
         "title": "Restart Civet Language Server",
         "category": "Civet"
+      },
+      {
+        "command": "civet.action.regenerateGrammar",
+        "title": "Regenerate Syntax textmate highlighting based on Config",
+        "category": "Civet"
       }
     ]
   },

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -61,10 +61,22 @@ function activateClient(context: ExtensionContext)
   // Start the client. This will also launch the server
   client.start()
 
-  // Watch for changes to tsconfig.json, package.json, and civetconfig and restart the server
-  workspace.createFileSystemWatcher("**/{tsconfig,package,🐈,civetconfig,civet.config}.{json,yaml,yml,civet,js}").onDidChange =>
+  // Watch for config changes → regenerate grammar then restart LS
+  grammarWatcher := workspace.createFileSystemWatcher("**/{tsconfig,package,🐈,civetconfig,civet.config}.{json,yaml,yml,civet,js}")
+
+  restartAndRegen := async =>
+    // 1. Regenerate TextMate grammar from new config
+    await regenerateTextmate()
+    // 2. Restart language server so it picks up any new compile options
     await client?.stop()
     await client.start()
+
+  grammarWatcher.onDidChange restartAndRegen
+  grammarWatcher.onDidCreate restartAndRegen
+  grammarWatcher.onDidDelete restartAndRegen
+
+  // Keep watcher alive for the lifetime of the extension
+  context.subscriptions.push grammarWatcher
 
 function activateCommands(context: ExtensionContext)
   commandDisposable := vscode.commands.registerCommand "civet.action.restartServer", =>

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -68,10 +68,11 @@ function activateClient(context: ExtensionContext)
 
   restartAndRegen := async =>
     // 1. Regenerate TextMate grammar from new config
-    await regenerateTextmate(false)
-    // 2. Restart language server so it picks up any new compile options
-    await client?.stop()
-    await client.start()
+    result := await regenerateTextmate(false)
+    // 2. Check the `modified` flag, if the grammar file actually changed, restart the client
+    if result.modified
+      await client?.stop()
+      await client.start()
 
   grammarWatcher.onDidChange restartAndRegen
   grammarWatcher.onDidCreate restartAndRegen

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -66,7 +66,7 @@ function activateClient(context: ExtensionContext)
 
   restartAndRegen := async =>
     // 1. Regenerate TextMate grammar from new config
-    await regenerateTextmate()
+    await regenerateTextmate(false)
     // 2. Restart language server so it picks up any new compile options
     await client?.stop()
     await client.start()
@@ -86,7 +86,7 @@ function activateCommands(context: ExtensionContext)
   context.subscriptions.push commandDisposable
 
   context.subscriptions.push vscode.commands.registerCommand "civet.action.regenerateGrammar", =>
-    regenerateTextmate()
+    regenerateTextmate(true) // show output when run by a user
 
 export function deactivate()
   if (!client)

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -93,3 +93,5 @@ export function deactivate()
     return
 
   return client.stop()
+
+export { regenerateTextmate } from './regenerateTextmate.civet'

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from 'vscode'
+import { regenerateTextmate } from './regenerateTextmate.civet'
 
 * as path from path
 * as vscode from vscode
@@ -71,6 +72,9 @@ function activateCommands(context: ExtensionContext)
     await client.start()
 
   context.subscriptions.push commandDisposable
+
+  context.subscriptions.push vscode.commands.registerCommand "civet.action.regenerateGrammar", =>
+    regenerateTextmate()
 
 export function deactivate()
   if (!client)

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -15,6 +15,8 @@ import { regenerateTextmate } from './regenerateTextmate.civet'
 let client: LanguageClient
 
 export function activate(context: ExtensionContext)
+  regenerateTextmate(false)
+    .catch((err) -> console.warn "Civet: initial grammar regen failed", err)
   activateClient context
   activateCommands context
 

--- a/lsp/source/grammarList.civet
+++ b/lsp/source/grammarList.civet
@@ -26,11 +26,13 @@ CoffeeComment:
                           -   /       -> ‘divide-by’ operator
                           -   ]       -> length token inside brackets
 
-Edge-cases:
-  array.#          // length shorthand
-  object.#private  // JS private field
-  @[index %% #]    // length token in brackets
-  floor # / 2      // arithmetic
-  "#{interpolate}" // string interpolation
-  ### ###         // triple-hash block comments
+Edge-case matrix covered:
+  # comment               + comment
+  code  # trailing        + comment
+  array.# length          X not comment
+  object.#private         X not comment
+  @[index %% #]           X not comment
+  floor # / 2             X not comment
+  "#{interpolate}"        X not comment
+  ### ###             handled by separate block-comment rule
 ###

--- a/lsp/source/grammarList.civet
+++ b/lsp/source/grammarList.civet
@@ -4,7 +4,7 @@ export features = [
     marker: 'hash_comment' // The key for the repository
     snippet: `{
       "name": "comment.line.number-sign.civet",
-      "begin": "(?<=^|\\\\s)(?<!\\\\.)#(?!\\\\{)(?!\\\\s*/|\\\\s*\\])",
+      "begin": "(?<=^|\\\\s)(?<!\\\\.)#(?!(\\\\{|##|\\\\s*/|\\\\s*\\\\]))",
       "end": "$",
       "beginCaptures": {
         "0": {
@@ -14,3 +14,23 @@ export features = [
     }`
   }
 ]
+
+###
+CoffeeComment:
+  (?<=^|\s)      - preceded by BOL or whitespace
+  (?<!\.)        - NOT preceded by a dot
+  #              - the hash itself
+  (?!(\{|##|\s*/|\s*\]))   - NOT followed by any of:
+                          -   {       -> interpolation '#{'
+                          -   ##      -> triple-hash block comment
+                          -   /       -> ‘divide-by’ operator
+                          -   ]       -> length token inside brackets
+
+Edge-cases:
+  array.#          // length shorthand
+  object.#private  // JS private field
+  @[index %% #]    // length token in brackets
+  floor # / 2      // arithmetic
+  "#{interpolate}" // string interpolation
+  ### ###         // triple-hash block comments
+###

--- a/lsp/source/grammarList.civet
+++ b/lsp/source/grammarList.civet
@@ -1,0 +1,16 @@
+export features = [
+  {
+    key: 'coffeeComment'
+    marker: 'hash_comment' // The key for the repository
+    snippet: `{
+      "name": "comment.line.number-sign.civet",
+      "begin": "(?<=^|\\\\s)(?<!\\\\.)#(?!\\\\{)(?!\\\\s*/)(?!\\\\.)",
+      "end": "$",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.comment.civet"
+        }
+      }
+    }`
+  }
+]

--- a/lsp/source/grammarList.civet
+++ b/lsp/source/grammarList.civet
@@ -4,7 +4,7 @@ export features = [
     marker: 'hash_comment' // The key for the repository
     snippet: `{
       "name": "comment.line.number-sign.civet",
-      "begin": "(?<=^|\\\\s)(?<!\\\\.)#(?!\\\\{)(?!\\\\s*/)(?!\\\\.)",
+      "begin": "(?<=^|\\\\s)(?<!\\\\.)#(?!\\\\{)(?!\\\\s*/|\\\\s*\\])",
       "end": "$",
       "beginCaptures": {
         "0": {

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -46,9 +46,6 @@ export async function regenerateTextmate(showOutput = false)
       return undefined
     }) : undefined
     civetParseOpts = cfg?.parseOptions ?? {}
-    vscode.commands.executeCommand(
-      "workspace/didChangeCivetConfiguration", 
-      { parseOptions: civetParseOpts })
     out.appendLine(`Loaded parseOptions: ${JSON.stringify(civetParseOpts, null, 2)}`)
 
 

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -1,6 +1,6 @@
-* as vscode from vscode
-* as fs from node:fs/promises
-* as path from node:path
+* as vscode from 'vscode'
+* as path from 'node:path'
+{ promises as fsPromises } from 'node:fs'
 
 { findConfig, loadConfig as loadCivetConfig } from '@danielx/civet/config'
 { features } from './grammarList.civet'
@@ -19,6 +19,7 @@ export async function regenerateTextmate(showOutput = false)
   out.appendLine("Starting Civet grammar regeneration...")
 
   civetParseOpts .= {}
+  optionsModified .= false
 
   try
     workspaceFolder := vscode.workspace.workspaceFolders?.[0]
@@ -48,7 +49,11 @@ export async function regenerateTextmate(showOutput = false)
     civetParseOpts = cfg?.parseOptions ?? {}
     out.appendLine(`Loaded parseOptions: ${JSON.stringify(civetParseOpts, null, 2)}`)
 
-
+    // If parse options are empty, skip writing cache/grammar
+    if Object.keys(civetParseOpts).length is 0
+      out.appendLine('Warning: civetParseOpts is empty, skipping grammar/cache update.')
+      return { modified: false, parseOptions: civetParseOpts }
+    
     // 2 Locate grammar file within the extension bundle
     ext := vscode.extensions.getExtension 'DanielX.civet'
     if !ext
@@ -56,18 +61,40 @@ export async function regenerateTextmate(showOutput = false)
       out.appendLine(`ERROR: ${msg}`)
       vscode.window.showErrorMessage(msg)
       return { modified: false, parseOptions: civetParseOpts }
+    
     grammarFile := path.join ext.extensionPath, 'syntaxes', 'civet.json'
+    cacheFile := path.join ext.extensionPath, 'syntaxes', '.civet-grammar-cache.json'
     out.appendLine(`Found grammar file at: ${grammarFile}`)
 
-    // 3 Read and parse grammar
-    grammarUri := vscode.Uri.file(grammarFile)
-    rawGrammar := await vscode.workspace.fs.readFile(grammarUri)
-    grammar := JSON.parse(rawGrammar.toString())
+    // Check if options have changed by comparing with cache (async)
+    cachedOpts .= {}
+    try
+      await fsPromises.access cacheFile
+      const cachedContent = await fsPromises.readFile(cacheFile, 'utf8')
+      cachedOpts = JSON.parse(cachedContent)
+      out.appendLine('Found cached parse options')
+    catch err
+      // ENOENT = file not found -> treat as "no cache"; otherwise warn
+      if (err as any)?.code is not 'ENOENT'
+        out.appendLine(`Warning: Could not read cache file: ${err}`)
+
+    // Compare current options with cache
+    currentOptsStr := JSON.stringify(civetParseOpts)
+    cachedOptsStr := JSON.stringify(cachedOpts)
+    
+    if currentOptsStr is cachedOptsStr
+      out.appendLine('\nParse options unchanged from cache.')
+      return { modified: false, parseOptions: civetParseOpts }
+    
+    out.appendLine('\nParse options changed from cache - updating grammar...')
+
+    // 3 Read and parse grammar (async)
+    rawGrammar := await fsPromises.readFile(grammarFile, 'utf8')
+    grammar := JSON.parse(rawGrammar)
     grammar.repository ?= {}
     out.appendLine(`Successfully read and parsed grammar file.`)
 
     // 4 Iterate over feature table
-    modified .= false
     for feature of features
       out.appendLine(`\nProcessing feature: '${feature.key}'`)
       includeRule := { include: `#${feature.marker}` }
@@ -83,50 +110,65 @@ export async function regenerateTextmate(showOutput = false)
         if not hasRuleInRepo
           out.appendLine(`- ADDING rule to repository: '${feature.marker}'`)
           grammar.repository[feature.marker] = JSON.parse(feature.snippet)
-          modified = true
+          optionsModified = true
         if not hasRuleInPatterns
           out.appendLine(`- ADDING include to patterns: '${includeRule.include}'`)
           grammar.patterns.unshift(includeRule)
-          modified = true
+          optionsModified = true
 
       else  // should NOT have rule
         if hasRuleInRepo
           out.appendLine(`- REMOVING rule from repository: '${feature.marker}'`)
           delete grammar.repository[feature.marker]
-          modified = true
+          optionsModified = true
         if hasRuleInPatterns
           out.appendLine(`- REMOVING include from patterns: '${includeRule.include}'`)
           grammar.patterns = grammar.patterns.filter((rule: any) => rule.include !== includeRule.include)
-          modified = true
+          optionsModified = true
 
-    if not modified
+    if not optionsModified
       msg := 'Civet grammar is already up-to-date.'
       out.appendLine(`\n${msg}`)
-      vscode.window.showInformationMessage(msg)
-      return { modified, parseOptions: civetParseOpts }
+      return { modified: false, parseOptions: civetParseOpts }
+
+    out.appendLine('\nOptions changed – updating grammar.')
+    const newContent = JSON.stringify(grammar, null, 2)
     
-    out.appendLine('\nGrammar has been modified.')
-    // 5 Backup and write
+    // 5 Backup and write grammar
     try
-      await fs.copyFile grammarFile, grammarFile + '.bak'
+      await fsPromises.copyFile(grammarFile, grammarFile + '.bak')
       out.appendLine(`Successfully created backup: ${grammarFile}.bak`)
     catch err
       out.appendLine(`Warning: Could not create backup file. ${err}`)
     
-    newContent := JSON.stringify(grammar, null, 2)
-    await fs.writeFile grammarFile, newContent, 'utf8'
+    // Write both the grammar and cache atomically
+    await Promise.all([
+      fsPromises.writeFile(grammarFile, newContent, 'utf8'),
+      fsPromises.writeFile(cacheFile, currentOptsStr, 'utf8')
+    ])
+
+    // Optionally remove backup after successful write to avoid clutter
+    try
+      await fsPromises.unlink(grammarFile + '.bak')
+      out.appendLine(`Deleted temporary backup: ${grammarFile}.bak`)
+    catch err
+      // If file does not exist, warn accordingly
+      if (err as any)?.code is not 'ENOENT'
+        out.appendLine(`Warning: Could not delete backup file: ${err}`)
+    
     out.appendLine(`Successfully wrote updated grammar to: ${grammarFile}`)
+    out.appendLine(`Successfully updated cache file: ${cacheFile}`)
     out.appendLine('Reload the VS Code window ("Developer: Reload Window" or click the popup) to apply the new syntax highlighting.')
 
     // 6 Prompt user to reload
     btn := await vscode.window.showInformationMessage 'Civet grammar updated – reload window to apply.', 'Reload Window'
     if btn is 'Reload Window'
       vscode.commands.executeCommand 'workbench.action.reloadWindow'
-    return { modified, parseOptions: civetParseOpts }
+    return { modified: true, parseOptions: civetParseOpts }
   catch err
     out.show()
     message := err instanceof Error ? err.message : String(err)
     out.appendLine(`FATAL ERROR: ${message}`)
     vscode.window.showErrorMessage(`Civet: Failed to regenerate grammar – ${message}`)
 
-  return { modified: false, parseOptions: civetParseOpts ?? {} }
+  return { modified: optionsModified, parseOptions: civetParseOpts ?? {} }

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -8,13 +8,14 @@
 let output: vscode.OutputChannel | undefined
 
 // Entry point for VS Code command
-export async function regenerateTextmate()
+export async function regenerateTextmate(showOutput = false)
   if not output
     output = vscode.window.createOutputChannel("Civet Textmate Grammar")
   else
     output!.clear()
   out := output!
-  out.show()
+  if showOutput
+    out.show()
   out.appendLine("Starting Civet grammar regeneration...")
 
   try
@@ -120,6 +121,7 @@ export async function regenerateTextmate()
     if btn is 'Reload Window'
       vscode.commands.executeCommand 'workbench.action.reloadWindow'
   catch err
-    const message = err instanceof Error ? err.message : String(err)
+    out.show()
+    message := err instanceof Error ? err.message : String(err)
     out.appendLine(`FATAL ERROR: ${message}`)
     vscode.window.showErrorMessage(`Civet: Failed to regenerate grammar – ${message}`)

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -113,6 +113,7 @@ export async function regenerateTextmate()
     newContent := JSON.stringify(grammar, null, 2)
     await fs.writeFile grammarFile, newContent, 'utf8'
     out.appendLine(`Successfully wrote updated grammar to: ${grammarFile}`)
+    out.appendLine('Reload the VS Code window ("Developer: Reload Window" or click the popup) to apply the new syntax highlighting.')
 
     // 6 Prompt user to reload
     btn := await vscode.window.showInformationMessage 'Civet grammar updated – reload window to apply.', 'Reload Window'

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -18,13 +18,15 @@ export async function regenerateTextmate(showOutput = false)
     out.show()
   out.appendLine("Starting Civet grammar regeneration...")
 
+  civetParseOpts .= {}
+
   try
     workspaceFolder := vscode.workspace.workspaceFolders?.[0]
     if not workspaceFolder
       msg := 'Civet: No workspace folder – cannot regenerate grammar'
       out.appendLine(`ERROR: ${msg}`)
       vscode.window.showErrorMessage(msg)
-      return
+      return { modified: false, parseOptions: {} }
 
     // 1 Load Civet config (may return undefined)
     configPath := workspaceFolder.uri.fsPath
@@ -43,7 +45,10 @@ export async function regenerateTextmate(showOutput = false)
       out.appendLine(`ERROR loading config: ${err?.message ?? err}`)
       return undefined
     }) : undefined
-    civetParseOpts := cfg?.parseOptions ?? {}
+    civetParseOpts = cfg?.parseOptions ?? {}
+    vscode.commands.executeCommand(
+      "workspace/didChangeCivetConfiguration", 
+      { parseOptions: civetParseOpts })
     out.appendLine(`Loaded parseOptions: ${JSON.stringify(civetParseOpts, null, 2)}`)
 
 
@@ -53,7 +58,7 @@ export async function regenerateTextmate(showOutput = false)
       msg := 'Civet: Unable to locate extension path'
       out.appendLine(`ERROR: ${msg}`)
       vscode.window.showErrorMessage(msg)
-      return
+      return { modified: false, parseOptions: civetParseOpts }
     grammarFile := path.join ext.extensionPath, 'syntaxes', 'civet.json'
     out.appendLine(`Found grammar file at: ${grammarFile}`)
 
@@ -101,7 +106,7 @@ export async function regenerateTextmate(showOutput = false)
       msg := 'Civet grammar is already up-to-date.'
       out.appendLine(`\n${msg}`)
       vscode.window.showInformationMessage(msg)
-      return
+      return { modified, parseOptions: civetParseOpts }
     
     out.appendLine('\nGrammar has been modified.')
     // 5 Backup and write
@@ -120,8 +125,11 @@ export async function regenerateTextmate(showOutput = false)
     btn := await vscode.window.showInformationMessage 'Civet grammar updated – reload window to apply.', 'Reload Window'
     if btn is 'Reload Window'
       vscode.commands.executeCommand 'workbench.action.reloadWindow'
+    return { modified, parseOptions: civetParseOpts }
   catch err
     out.show()
     message := err instanceof Error ? err.message : String(err)
     out.appendLine(`FATAL ERROR: ${message}`)
     vscode.window.showErrorMessage(`Civet: Failed to regenerate grammar – ${message}`)
+
+  return { modified: false, parseOptions: civetParseOpts ?? {} }

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -1,0 +1,118 @@
+* as vscode from vscode
+* as fs from node:fs/promises
+* as path from node:path
+
+{ findConfig, loadConfig as loadCivetConfig } from '@danielx/civet/config'
+import { features } from './grammarList.civet'
+
+// Entry point for VS Code command
+export async function regenerateTextmate()
+  const output = vscode.window.createOutputChannel("Civet Grammar")
+  output.show()
+  output.appendLine("Starting Civet grammar regeneration...")
+
+  try
+    workspaceFolder := vscode.workspace.workspaceFolders?.[0]
+    if !workspaceFolder
+      const msg = 'Civet: No workspace folder – cannot regenerate grammar'
+      output.appendLine(`ERROR: ${msg}`)
+      vscode.window.showErrorMessage(msg)
+      return
+
+    // 1 Load Civet config (may return undefined)
+    configPath := workspaceFolder.uri.fsPath
+    output.appendLine(`Searching for Civet config in: ${configPath}`)
+    cfgFile := await findConfig(configPath).catch((err) => {
+      output.appendLine(`ERROR while searching for config: ${err?.message ?? err}`)
+      return undefined
+    })
+
+    if cfgFile
+      output.appendLine(`Found Civet config: ${cfgFile}`)
+    else
+      output.appendLine('No Civet config file found – using defaults')
+
+    cfg := cfgFile ? await loadCivetConfig(cfgFile).catch((err) => {
+      output.appendLine(`ERROR loading config: ${err?.message ?? err}`)
+      return undefined
+    }) : undefined
+    civetParseOpts := cfg?.parseOptions ?? {}
+    output.appendLine(`Loaded parseOptions: ${JSON.stringify(civetParseOpts, null, 2)}`)
+
+
+    // 2 Locate grammar file within the extension bundle
+    ext := vscode.extensions.getExtension 'DanielX.civet'
+    if !ext
+      const msg = 'Civet: Unable to locate extension path'
+      output.appendLine(`ERROR: ${msg}`)
+      vscode.window.showErrorMessage(msg)
+      return
+    grammarFile := path.join ext.extensionPath, 'syntaxes', 'civet.json'
+    output.appendLine(`Found grammar file at: ${grammarFile}`)
+
+    // 3 Read and parse grammar
+    grammarUri := vscode.Uri.file(grammarFile)
+    rawGrammar := await vscode.workspace.fs.readFile(grammarUri)
+    grammar := JSON.parse(rawGrammar.toString())
+    grammar.repository ?= {}
+    output.appendLine(`Successfully read and parsed grammar file.`)
+
+    // 4 Iterate over feature table
+    modified .= false
+    for feature of features
+      output.appendLine(`\nProcessing feature: '${feature.key}'`)
+      includeRule := { include: `#${feature.marker}` }
+      hasRuleInPatterns := grammar.patterns.some((rule: any) => rule.include === includeRule.include)
+      hasRuleInRepo := grammar.repository.hasOwnProperty(feature.marker)
+      shouldHaveRule := (civetParseOpts as any)[feature.key]
+
+      output.appendLine(`- Should have rule? ${shouldHaveRule ? 'Yes' : 'No'} (from config)`)
+      output.appendLine(`- Rule in patterns? ${hasRuleInPatterns ? 'Yes' : 'No'}`)
+      output.appendLine(`- Rule in repository? ${hasRuleInRepo ? 'Yes' : 'No'}`)
+
+      if shouldHaveRule
+        if not hasRuleInRepo
+          output.appendLine(`- ADDING rule to repository: '${feature.marker}'`)
+          grammar.repository[feature.marker] = JSON.parse(feature.snippet)
+          modified = true
+        if not hasRuleInPatterns
+          output.appendLine(`- ADDING include to patterns: '${includeRule.include}'`)
+          grammar.patterns.unshift(includeRule)
+          modified = true
+
+      else  // should NOT have rule
+        if hasRuleInRepo
+          output.appendLine(`- REMOVING rule from repository: '${feature.marker}'`)
+          delete grammar.repository[feature.marker]
+          modified = true
+        if hasRuleInPatterns
+          output.appendLine(`- REMOVING include from patterns: '${includeRule.include}'`)
+          grammar.patterns = grammar.patterns.filter((rule: any) => rule.include !== includeRule.include)
+          modified = true
+
+    if not modified
+      msg := 'Civet grammar is already up-to-date.'
+      output.appendLine(`\n${msg}`)
+      vscode.window.showInformationMessage(msg)
+      return
+    
+    output.appendLine('\nGrammar has been modified.')
+    // 5 Backup and write
+    try
+      await fs.copyFile grammarFile, grammarFile + '.bak'
+      output.appendLine(`Successfully created backup: ${grammarFile}.bak`)
+    catch err
+      output.appendLine(`Warning: Could not create backup file. ${err}`)
+    
+    newContent := JSON.stringify(grammar, null, 2)
+    await fs.writeFile grammarFile, newContent, 'utf8'
+    output.appendLine(`Successfully wrote updated grammar to: ${grammarFile}`)
+
+    // 6 Prompt user to reload
+    btn := await vscode.window.showInformationMessage 'Civet grammar updated – reload window to apply.', 'Reload Window'
+    if btn is 'Reload Window'
+      vscode.commands.executeCommand 'workbench.action.reloadWindow'
+  catch err
+    const message = err instanceof Error ? err.message : String(err)
+    output.appendLine(`FATAL ERROR: ${message}`)
+    vscode.window.showErrorMessage(`Civet: Failed to regenerate grammar – ${message}`)

--- a/lsp/source/regenerateTextmate.civet
+++ b/lsp/source/regenerateTextmate.civet
@@ -3,110 +3,116 @@
 * as path from node:path
 
 { findConfig, loadConfig as loadCivetConfig } from '@danielx/civet/config'
-import { features } from './grammarList.civet'
+{ features } from './grammarList.civet'
+
+let output: vscode.OutputChannel | undefined
 
 // Entry point for VS Code command
 export async function regenerateTextmate()
-  const output = vscode.window.createOutputChannel("Civet Grammar")
-  output.show()
-  output.appendLine("Starting Civet grammar regeneration...")
+  if not output
+    output = vscode.window.createOutputChannel("Civet Textmate Grammar")
+  else
+    output!.clear()
+  out := output!
+  out.show()
+  out.appendLine("Starting Civet grammar regeneration...")
 
   try
     workspaceFolder := vscode.workspace.workspaceFolders?.[0]
-    if !workspaceFolder
-      const msg = 'Civet: No workspace folder – cannot regenerate grammar'
-      output.appendLine(`ERROR: ${msg}`)
+    if not workspaceFolder
+      msg := 'Civet: No workspace folder – cannot regenerate grammar'
+      out.appendLine(`ERROR: ${msg}`)
       vscode.window.showErrorMessage(msg)
       return
 
     // 1 Load Civet config (may return undefined)
     configPath := workspaceFolder.uri.fsPath
-    output.appendLine(`Searching for Civet config in: ${configPath}`)
+    out.appendLine(`Searching for Civet config in: ${configPath}`)
     cfgFile := await findConfig(configPath).catch((err) => {
-      output.appendLine(`ERROR while searching for config: ${err?.message ?? err}`)
+      out.appendLine(`ERROR while searching for config: ${err?.message ?? err}`)
       return undefined
     })
 
     if cfgFile
-      output.appendLine(`Found Civet config: ${cfgFile}`)
+      out.appendLine(`Found Civet config: ${cfgFile}`)
     else
-      output.appendLine('No Civet config file found – using defaults')
+      out.appendLine('No Civet config file found – using defaults')
 
     cfg := cfgFile ? await loadCivetConfig(cfgFile).catch((err) => {
-      output.appendLine(`ERROR loading config: ${err?.message ?? err}`)
+      out.appendLine(`ERROR loading config: ${err?.message ?? err}`)
       return undefined
     }) : undefined
     civetParseOpts := cfg?.parseOptions ?? {}
-    output.appendLine(`Loaded parseOptions: ${JSON.stringify(civetParseOpts, null, 2)}`)
+    out.appendLine(`Loaded parseOptions: ${JSON.stringify(civetParseOpts, null, 2)}`)
 
 
     // 2 Locate grammar file within the extension bundle
     ext := vscode.extensions.getExtension 'DanielX.civet'
     if !ext
-      const msg = 'Civet: Unable to locate extension path'
-      output.appendLine(`ERROR: ${msg}`)
+      msg := 'Civet: Unable to locate extension path'
+      out.appendLine(`ERROR: ${msg}`)
       vscode.window.showErrorMessage(msg)
       return
     grammarFile := path.join ext.extensionPath, 'syntaxes', 'civet.json'
-    output.appendLine(`Found grammar file at: ${grammarFile}`)
+    out.appendLine(`Found grammar file at: ${grammarFile}`)
 
     // 3 Read and parse grammar
     grammarUri := vscode.Uri.file(grammarFile)
     rawGrammar := await vscode.workspace.fs.readFile(grammarUri)
     grammar := JSON.parse(rawGrammar.toString())
     grammar.repository ?= {}
-    output.appendLine(`Successfully read and parsed grammar file.`)
+    out.appendLine(`Successfully read and parsed grammar file.`)
 
     // 4 Iterate over feature table
     modified .= false
     for feature of features
-      output.appendLine(`\nProcessing feature: '${feature.key}'`)
+      out.appendLine(`\nProcessing feature: '${feature.key}'`)
       includeRule := { include: `#${feature.marker}` }
       hasRuleInPatterns := grammar.patterns.some((rule: any) => rule.include === includeRule.include)
       hasRuleInRepo := grammar.repository.hasOwnProperty(feature.marker)
       shouldHaveRule := (civetParseOpts as any)[feature.key]
 
-      output.appendLine(`- Should have rule? ${shouldHaveRule ? 'Yes' : 'No'} (from config)`)
-      output.appendLine(`- Rule in patterns? ${hasRuleInPatterns ? 'Yes' : 'No'}`)
-      output.appendLine(`- Rule in repository? ${hasRuleInRepo ? 'Yes' : 'No'}`)
+      out.appendLine(`- Should have rule? ${shouldHaveRule ? 'Yes' : 'No'} (from config)`)
+      out.appendLine(`- Rule in patterns? ${hasRuleInPatterns ? 'Yes' : 'No'}`)
+      out.appendLine(`- Rule in repository? ${hasRuleInRepo ? 'Yes' : 'No'}`)
 
       if shouldHaveRule
         if not hasRuleInRepo
-          output.appendLine(`- ADDING rule to repository: '${feature.marker}'`)
+          out.appendLine(`- ADDING rule to repository: '${feature.marker}'`)
           grammar.repository[feature.marker] = JSON.parse(feature.snippet)
           modified = true
         if not hasRuleInPatterns
-          output.appendLine(`- ADDING include to patterns: '${includeRule.include}'`)
+          out.appendLine(`- ADDING include to patterns: '${includeRule.include}'`)
           grammar.patterns.unshift(includeRule)
           modified = true
 
       else  // should NOT have rule
         if hasRuleInRepo
-          output.appendLine(`- REMOVING rule from repository: '${feature.marker}'`)
+          out.appendLine(`- REMOVING rule from repository: '${feature.marker}'`)
           delete grammar.repository[feature.marker]
           modified = true
         if hasRuleInPatterns
-          output.appendLine(`- REMOVING include from patterns: '${includeRule.include}'`)
+          out.appendLine(`- REMOVING include from patterns: '${includeRule.include}'`)
           grammar.patterns = grammar.patterns.filter((rule: any) => rule.include !== includeRule.include)
           modified = true
 
     if not modified
       msg := 'Civet grammar is already up-to-date.'
-      output.appendLine(`\n${msg}`)
+      out.appendLine(`\n${msg}`)
       vscode.window.showInformationMessage(msg)
       return
     
-    output.appendLine('\nGrammar has been modified.')
+    out.appendLine('\nGrammar has been modified.')
     // 5 Backup and write
     try
       await fs.copyFile grammarFile, grammarFile + '.bak'
-      output.appendLine(`Successfully created backup: ${grammarFile}.bak`)
+      out.appendLine(`Successfully created backup: ${grammarFile}.bak`)
     catch err
-      output.appendLine(`Warning: Could not create backup file. ${err}`)
+      out.appendLine(`Warning: Could not create backup file. ${err}`)
     
     newContent := JSON.stringify(grammar, null, 2)
     await fs.writeFile grammarFile, newContent, 'utf8'
-    output.appendLine(`Successfully wrote updated grammar to: ${grammarFile}`)
+    out.appendLine(`Successfully wrote updated grammar to: ${grammarFile}`)
 
     // 6 Prompt user to reload
     btn := await vscode.window.showInformationMessage 'Civet grammar updated – reload window to apply.', 'Reload Window'
@@ -114,5 +120,5 @@ export async function regenerateTextmate()
       vscode.commands.executeCommand 'workbench.action.reloadWindow'
   catch err
     const message = err instanceof Error ? err.message : String(err)
-    output.appendLine(`FATAL ERROR: ${message}`)
+    out.appendLine(`FATAL ERROR: ${message}`)
     vscode.window.showErrorMessage(`Civet: Failed to regenerate grammar – ${message}`)


### PR DESCRIPTION
### The Motivation: 
Previously, enabling a feature like coffeeComment in civetconfig.json would not visually update the syntax highlighting, linter error is gone, but syntax highlighting is static, it would still highlight different words with color inside of the # comment instead of it being a comment


### The Solution:
This PR implements a regeneration of a civet.json syntax file based on config (currently only for coffeeComment parse option), and a file watcher that monitors Civet config files. On any change, it automatically regenerates the TextMate grammar (if needed) while keeping previous behavior of restarting a language-server. 

The only thing user need to do -> reload the window. The toast appears for that, where you can click the  `Reload Window`

### Key Benefits
* Instant Visual Feedback: What you configure is what you see. Changes to syntax-related flags in civetconfig.json are immediately reflected in the editor after a quick reload.
* Future-Proof & Extensible: The new grammarList.civet provides a data-driven way to add new syntax features. Adding support for another config flag is now as simple as adding a new entry to that list.

How It Works:
1. A FileSystemWatcher in extension.civet listens for changes to config files.
2. On change, it calls the new regenerateTextmate command.
3. regenerateTextmate reads the project's config, iterates through features defined in grammarList.civet, and surgically injects or removes rules from syntaxes/civet.json.