### PR TITLE
Throw on esbuild emitDeclaration misconfiguration

### DIFF
--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -346,7 +346,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
 
         if options.emitDeclaration
           if meta.framework is 'esbuild' and not esbuildOptions.outdir
-            console.log "WARNING: Civet unplugin's `emitDeclaration` requires esbuild's `outdir` option to be set;"
+            throw new Error "Civet unplugin's `emitDeclaration` requires esbuild's `outdir` option to be set;"
 
           // Removed duplicate slashed (`\`) versions of the same file for emit
           for file of fsMap.keys()


### PR DESCRIPTION
I lost too much time on this... :crying_cat_face: 

The warning was getting lost in TS error noise. If one specifies `emitDeclaration` and it doesn't emit then that should be an error.