### PR TITLE
Fix REPL handling of blank lines on Node 24

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -291,6 +291,8 @@ export function repl(args: string[], options: Options)
           else
             ''
     eval: (input: string, context, filename: string, callback) ->
+      // Newer Node versions use \r for intermediate line endings
+      input = input.replace /\r/g, '\n'
       if input is '\n'  // blank input
         callback null, undefined
       else if input in ['quit\n', 'exit\n', 'quit()\n', 'exit()\n']


### PR DESCRIPTION
On Node 24 (.4.1 and .5 at least), the REPL is broken in that it no longer correctly detects a blank line to execute or compile the code.  Apparently new Nodes provide an input that contains `\r` for newlines for all but the final `\n`.  (Tested on both Windows and Linux, so doesn't seem to be OS dependent.)