### PR TITLE
Fix typo in cheatsheet

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -211,8 +211,8 @@ switch x
 ```ts
 // JSX
 // Better binding
-<button props.click> Click Me </button>
-<button @click> Click Me Also </button>
+<button props.onClick>Click Me</button>
+<button @onClick>Click Me Also</button>
 
 // Closing is optional
 <div>


### PR DESCRIPTION
The example include a space inside `<button>`. I don't think this is how we should write JSX though. Normally, a button should not contain outer space.

I like: `<button props.click>Click Me</button>`
I don't like: `<button props.click> Click Me </button>`


Also, I use this: `<button onclick=(.target.value |> setValue)>Click Me`