### PR TITLE
lsp: Make TSService initialization async to fix config loading race condition

### DIFF
--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -451,7 +451,7 @@ function TSHost(
   }
 }
 
-function TSService(projectURL = "./", logger: Console | RemoteConsole = console) {
+async function TSService(projectURL = "./", logger: Console | RemoteConsole = console) {
   logger.info("CIVET VSCODE PLUGIN " + version)
   logger.info("TYPESCRIPT " + typescriptVersion)
 
@@ -512,16 +512,19 @@ function TSService(projectURL = "./", logger: Console | RemoteConsole = console)
   }
 
   let civetConfig: CompileOptions = {}
-  CivetConfig.findConfig(projectPath).then(async (configPath) => {
+  try {
+    const configPath = await CivetConfig.findConfig(projectPath)
     if (configPath) {
       logger.info("Loading Civet config @ " + configPath)
       const config = await CivetConfig.loadConfig(configPath)
       logger.info("Found civet config!")
       civetConfig = config
-    } else logger.info("No Civet config found")
-  }).catch((e: unknown) => {
+    } else {
+      logger.info("No Civet config found")
+    }
+  } catch (e) {
     logger.error("Error loading Civet config " + e)
-  })
+  }
 
   return Object.assign({}, service, {
     host,

--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -57,7 +57,8 @@ const sourcePathToProjectPathMap = new Map<string, string>()
 const projectPathToPendingPromiseMap = new Map<string, Promise<void>>()
 
 // Mapping from project path -> TSService instance operating on that base directory
-const projectPathToServiceMap = new Map<string, ReturnType<typeof TSService>>()
+type ResolvedService = Awaited<ReturnType<typeof TSService>>
+const projectPathToServiceMap = new Map<string, ResolvedService>()
 
 let rootUri: string | undefined, rootDir: string | undefined;
 
@@ -103,7 +104,7 @@ const ensureServiceForSourcePath = async (sourcePath: string) => {
   let service = projectPathToServiceMap.get(projPath)
   if (service) return service
   logger.log("Spawning language server for project path: " + projPath)
-  service = TSService(projPath, connection.console)
+  service = await TSService(projPath, connection.console)
   const initP = service.loadPlugins()
   projectPathToPendingPromiseMap.set(projPath, initP)
   await initP


### PR DESCRIPTION
Hey, this PR addresses a crucial race condition that prevented `civetconfig.json` from being applied on initial project load.

### The Problem

On startup, the Civet LSP would often initialize and perform an initial lint of open files *before* the `civetconfig.json` file was fully parsed and loaded.

This resulted in incorrect diagnostics being shown to the user. For example, features enabled in the config (like `coffeeIsnt`) would be incorrectly ignored. The correct diagnostics would only appear after the user edited the file, which forced the LSP to re-evaluate the document with the now-loaded configuration.

### The Solution

This PR refactors the `TSService` initialization to be asynchronous. By using `async/await`, we now ensure that the configuration is fully loaded and applied *before* the service reports that it's ready and begins validating documents.

This guarantees that the very first set of diagnostics a user sees is always based on their project's specific configuration, leading to a much more reliable and intuitive experience.

### Steps to Replicate

**1. Setup your project:**
*   Create a new project folder.
*   Create a `civetconfig.json`:
    ```json
    {
      "parseOptions": {
        "coffeeIsnt": true
      }
    }
    ```
*   Create a `.civet` file:
    ```civet
    a := 123
    if 124 isnt a
      console.log 'Hello'
    ```

**2. Reproduce the bug:**
*   Open the project in your editor and reload the window.
*   **Do not edit the file.**
*   Observe the error on the `isnt` keyword.
*   **Buggy Behavior:** You will see a TypeScript error like `Cannot find name 'isnt'. ts(2304)`.

**3. Verify the fix (on this PR's branch):**
*   Switch to lsp from this branch.
*   Reload the window.
*   **Do not edit the file.**
*   Observe the warning on the `isnt` comparison.
*   **Correct Behavior:** You should immediately see the correct linter warning, such as `"This comparison appears to be unintentional."`

I believe it's a positive change. Let me know if you have any thoughts