### PR TITLE
lsp refactor: enhance Type Safety and resolve Linter errors

### DIFF
--- a/lsp/source/lib/typescript-service.mts
+++ b/lsp/source/lib/typescript-service.mts
@@ -47,8 +47,8 @@ try {
 }
 
 interface SourceMap {
-  lines: CivetSourceMap["lines"]
-  data: CivetSourceMap["data"]
+  lines?: CivetSourceMap["data"]["lines"]  // New format: direct lines access
+  data?: CivetSourceMap["data"]             // Old format: nested in data
 }
 
 // ts doesn't have this key in the type
@@ -390,18 +390,17 @@ function TSHost(
     return snapshot
   }
 
-  function createOrUpdateMeta(path: string, transpiledDoc: TextDocument, sourcemapLines?: SourceMap["lines"], parseErrors?: (Error | ParseError)[], fatal?: boolean) {
+  function createOrUpdateMeta(path: string, transpiledDoc: TextDocument, sourcemapLines?: SourceMap["lines"], parseErrors?: (Error | ParseError)[], fatal: boolean = false) {
     let meta = fileMetaData.get(path)
 
     if (!meta) {
-      meta = {
+      const newMeta: FileMeta = {
         sourcemapLines,
         transpiledDoc,
         parseErrors,
         fatal,
       }
-
-      fileMetaData.set(path, meta)
+      fileMetaData.set(path, newMeta)
     } else {
       meta.sourcemapLines = sourcemapLines
       meta.parseErrors = parseErrors
@@ -421,7 +420,7 @@ function TSHost(
 
     if (result) {
       const { code: transpiledCode, sourceMap, errors } = result
-      const sourceMapLines = sourceMap?.lines ?? sourceMap?.data.lines // older Civet
+      const sourceMapLines = sourceMap?.lines ?? sourceMap?.data?.lines // older Civet
       createOrUpdateMeta(sourcePath, transpiledDoc, sourceMapLines, errors, false)
       TextDocument.update(transpiledDoc, [{ text: transpiledCode }], version)
 

--- a/lsp/source/lib/util.mts
+++ b/lsp/source/lib/util.mts
@@ -19,13 +19,13 @@ import vs, {
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import assert from 'assert';
-import { SourceMap } from '@danielx/civet';
+import type { SourceMap, SourcemapLines } from '@danielx/civet/ts-diagnostic';
 import {
   flattenDiagnosticMessageText,
   remapRange,
 } from '@danielx/civet/ts-diagnostic';
 
-export type SourcemapLines = SourceMap['data']['lines'];
+export type { SourceMap, SourcemapLines } from '@danielx/civet/ts-diagnostic';
 
 export {
   flattenDiagnosticMessageText,
@@ -294,6 +294,8 @@ export function containsRange(range: Range, otherRange: Range): boolean {
   }
   return true;
 }
+
+const isFourTuple = (m: SourceMap): m is [number, number, number, number] => m.length === 4;
 /**
  * The normal direction for sourcemapping is reverse, given a position in the generated file it points to a position in the source file.
  *
@@ -318,12 +320,12 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
     foundLine = -1,
     foundOffset = -1
 
-  sourcemapLines.forEach((line, i) => {
+  sourcemapLines.forEach((line: SourcemapLines[number], i) => {
     col = 0
     line.forEach((mapping) => {
       col += mapping[0]
 
-      if (mapping.length === 4) {
+      if (isFourTuple(mapping)) {
         // find best line without going beyond
         const [_p, _f, srcLine, srcOffset] = mapping
         if (srcLine <= origLine) {

--- a/lsp/source/lib/util.mts
+++ b/lsp/source/lib/util.mts
@@ -25,7 +25,7 @@ import {
   remapRange,
 } from '@danielx/civet/ts-diagnostic';
 
-export type SourcemapLines = SourceMap['lines'];
+export type SourcemapLines = SourceMap['data']['lines'];
 
 export {
   flattenDiagnosticMessageText,

--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -88,7 +88,7 @@ const getProjectPathFromSourcePath = (sourcePath: string): string => {
   // Otherwise, check whether we're inside the root
   if (!projPath) {
     if (rootDir != null && sourcePath.startsWith(rootDir)) {
-      projPath = rootUri!
+      projPath = rootUri ?? pathToFileURL(path.dirname(sourcePath) + "/").toString()
     } else {
       projPath = pathToFileURL(path.dirname(sourcePath) + "/").toString()
     }

--- a/lsp/tsconfig.json
+++ b/lsp/tsconfig.json
@@ -7,7 +7,8 @@
   },
   "include": [
     "source",
-    "test"
+    "test",
+    "types/civet-ts-diagnostic.d.ts"
   ],
   "exclude": [
     ".vscode-test"

--- a/lsp/types/civet-ts-diagnostic.d.ts
+++ b/lsp/types/civet-ts-diagnostic.d.ts
@@ -1,0 +1,33 @@
+declare module '@danielx/civet/ts-diagnostic' {
+  import type { DiagnosticMessageChain } from 'typescript'
+
+  interface Position {
+    line: number
+    character: number
+  }
+
+  interface Range {
+    start: Position
+    end: Position
+  }
+
+  type SourceMapping = [number] | [number, number, number, number]
+  type SourcemapLines = SourceMapping[][]
+
+  export type { SourcemapLines }
+
+  export function remapPosition(
+    position: Position,
+    sourcemapLines?: SourcemapLines
+  ): Position
+
+  export function remapRange(
+    range: Range,
+    sourcemapLines?: SourcemapLines
+  ): Range
+
+  export function flattenDiagnosticMessageText(
+    diag: string | DiagnosticMessageChain | undefined,
+    indent?: number
+  ): string
+}

--- a/lsp/types/civet-ts-diagnostic.d.ts
+++ b/lsp/types/civet-ts-diagnostic.d.ts
@@ -11,10 +11,10 @@ declare module '@danielx/civet/ts-diagnostic' {
     end: Position
   }
 
-  type SourceMapping = [number] | [number, number, number, number]
-  type SourcemapLines = SourceMapping[][]
+  type SourceMap = [number] | [number, number, number, number]
+  type SourcemapLines = SourceMap[][]
 
-  export type { SourcemapLines }
+  export type { SourcemapLines, SourceMap }
 
   export function remapPosition(
     position: Position,


### PR DESCRIPTION
### Motivation

This PR is a follow-up to my previous work on the LSP and focuses on improving the overall health of the codebase. While working on the async loading fix, I identified several areas where we could significantly enhance type safety, fix latent errors, and clean up the code to make it more robust and easier to maintain.

This PR has **no intended change in user-facing behavior**, other than increased stability

### Key Improvements

This refactoring can be broken down into four main categories:

**1. Added Type Declarations for `@danielx/civet/ts-diagnostic`**
*   A new `types/civet-ts-diagnostic.d.ts` file has been added to provide formal TypeScript definitions for this module.
*   **Benefit:** Proper static-check our interactions for the `remapPosition`, `remapRange`  etc

**2. Strengthened TypeScript Type Safety**
*   Replaced simple Type Assertion with a Type Guard (is) (`.filter(d => !!d)`) as Location with proper(`.filter((d): d is Location => !!d)`).
*   Corrected error handling types from a broad `Error | ParseError` union to a more precise `Error & {line?: number, ...}` intersection, which accurately reflects the shape of the data.
*   Added explicit types to variables and function returns (e.g., `details: string[]`, `getProjectPathFromSourcePath(...): string`) to make the code more self-documenting and prevent type-related bugs.
*   Only interested in `triggerKind` and `triggerCharacter` from the `context` object. I don't care about anything else it might contain.
*   Introduced a readable `isFourTuple` type guard to clarify types when processing sourcemap data.

**3. Polished Robustness**
*   Fixed a potential crash by adding optional chaining (`sourceMap?.data?.lines`). The previous code could throw an error if `sourceMap.data` was undefined.
*   Made the `fatal` parameter in `createOrUpdateMeta` more robust by giving it a default value (`fatal: boolean = false`) instead of relying on it being `undefined`.
*   Improved project path resolution by adding a fallback. (we have it earlier, but its more readable that way + removes the linter error) If the LSP's `rootUri` isn't set, it now gracefully defaults to using the directory of the current source file as the project root

**4. General Code Cleanup**
*   Removed/commented out unused variables and imports (`hasDiagnosticRelatedInformationCapability`, `timers/promises`).
*   Refactored `setTimeout` calls to use a standard `new Promise` wrapper for consistency.

Overall, these changes should make the LSP codebase cleaner, safer, and more resilient to future changes. Happy to discuss any of the changes in more detail