### PR TITLE
lsp(feat): Add option to disable language server for JS/TS files

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -65,7 +65,18 @@
         "title": "Restart Civet Language Server",
         "category": "Civet"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Civet",
+      "properties": {
+        "civet.langServer.includeTypescript": {
+          "type": "boolean",
+          "default": true,
+          "description": "If false, the Civet language server will not attach to JavaScript/TypeScript files, preventing duplicate definitions when another TS server is active."
+        }
+      }
+    }
   },
   "mocha": {
     "extension": [

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -38,17 +38,22 @@ function activateClient(context: ExtensionContext)
       transport: TransportKind.ipc
       options: debugOptions
 
+  docSelector := [
+    { scheme: 'file', language: 'civet' }
+  ]
+  // Read user setting to control whether the Civet LS should attach to JS/TS files
+  includeTS := vscode.workspace.getConfiguration('civet').get<boolean>('langServer.includeTypescript', true)
+  if includeTS
+    docSelector.push { scheme: 'file', language: 'javascript' }
+    docSelector.push { scheme: 'file', language: 'javascriptreact' }
+    docSelector.push { scheme: 'file', language: 'typescript' }
+    docSelector.push { scheme: 'file', language: 'typescriptreact' }
+
   // Options to control the language client
   clientOptions: LanguageClientOptions :=
     // TODO: this is where we could add more based on plugins
     // Register the server for language files we care about
-    documentSelector: [
-      { scheme: 'file', language: 'civet' }
-      { scheme: 'file', language: 'javascript' }
-      { scheme: 'file', language: 'javascriptreact' }
-      { scheme: 'file', language: 'typescript' }
-      { scheme: 'file', language: 'typescriptreact' }
-    ]
+    documentSelector: docSelector
 
   // Create the language client and start the client.
   client = new LanguageClient


### PR DESCRIPTION
This PR introduces a new configuration setting to prevent the Civet language server from providing diagnostics for JavaScript and TypeScript files.

### The Problem

When working in a project that already has a dedicated TypeScript language server active (built into VS Code), the Civet language server also attaches to `.js` and `.ts` files and 

This results in **duplicate diagnostics** for the same code, which can be noisy and confusing 

### The Solution

This PR introduces a new VS Code setting:
`"civet.langServer.includeTypescript"`

This setting allows users to control whether the Civet Language Server should activate for JavaScript and TypeScript files.

*   It defaults to `true` to maintain the existing behavior for all current users, ensuring no breaking changes.
*   When a user sets it to `false`, the language client will only register itself for `.civet` files, resolving the duplicate diagnostics issue.