### PR TITLE
fix(lsp): simple updates for tests for async TSService + removed hardcoded paths

### DIFF
--- a/lsp/test/service.civet
+++ b/lsp/test/service.civet
@@ -2,38 +2,37 @@ import TSService from "../source/lib/typescript-service.mjs"
 import { pathToFileURL } from "url"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import fs from "fs"
-import ts from "typescript"
 
 { forwardMap } from ../source/lib/util.mjs
 
 assert from assert
 
-loadFile := (service: ReturnType<typeof TSService>, path: string) ->
+loadFile := async (service: Awaited<ReturnType<typeof TSService>>, path: string) ->
   document := TextDocument.create(pathToFileURL(path).href, "civet", 0, fs.readFileSync(path, "utf8"))
   service.host.addOrUpdateDocument(document)
 
 describe "ts service", ->
+  @timeout 5000
   it "should launch ts service", async ->
-    service := TSService pathToFileURL("./integration/project-test/").href
-
+    service := await TSService(pathToFileURL("./integration/project-test/").href)
     await service.loadPlugins()
 
     filePath := "./integration/project-test/a.civet"
-    loadFile(service, filePath)
+    await loadFile(service, filePath)
 
-    diagnostics := service.getSemanticDiagnostics("/home/daniel/apps/civet/lsp/integration/project-test/a.civet.tsx")
+    diagnostics := service.getSemanticDiagnostics(filePath + ".tsx")
 
     console.log diagnostics
     // console.log service.host.getScriptFileNames()
 
     assert.equal diagnostics.length, 0
 
-    {transpiledDoc, sourcemapLines} := service.host.getMeta("/home/daniel/apps/civet/lsp/integration/project-test/a.civet")!
+    {transpiledDoc, sourcemapLines} := service.host.getMeta(filePath)!
 
     position := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {
       line: 0
       character: 0
     })
-    info := service.getQuickInfoAtPosition("/home/daniel/apps/civet/lsp/integration/project-test/a.civet.tsx", position)
+    info := service.getQuickInfoAtPosition(filePath + ".tsx", position)
 
     assert info

--- a/lsp/test/util.civet
+++ b/lsp/test/util.civet
@@ -25,7 +25,7 @@ describe "util", ->
       sourceMap: true
     })
 
-    linesMap := sourceMap.lines
+    linesMap := sourceMap.data.lines
     // console.log code, linesMap
 
     assert.deepEqual remapPosition({
@@ -52,7 +52,7 @@ describe "util", ->
 
     [0..6].forEach (i) ->
       srcColumn := i + 13
-      pos := forwardMap(sourceMap.lines, {line: 0, character: srcColumn})
+      pos := forwardMap(sourceMap.data.lines, {line: 0, character: srcColumn})
       srcStr := src.slice(srcColumn, srcColumn + 7)
       assert.equal srcStr.replace(" ", "("), generatedLines[pos.line].slice(pos.character, pos.character + 7)
 
@@ -71,7 +71,7 @@ describe "util", ->
     generatedLines := code.split("\n")
 
     [2..6].forEach (srcColumn, i) ->
-      pos := forwardMap(sourceMap.lines, {line: 1, character: srcColumn})
+      pos := forwardMap(sourceMap.data.lines, {line: 1, character: srcColumn})
       srcStr := srcLines[1].slice(srcColumn, srcColumn + 5 - i)
       generatedStr := generatedLines[pos.line].slice(pos.character, pos.character + 5 - i)
       assert.equal srcStr, generatedStr


### PR DESCRIPTION
Hey, got some simple positive changes here

- **Support Async `TSService`**: The tests have been updated with `async/await` to handle this correctly. A longer test timeout was also added to prevent premature failures.
- **Remove Hardcoded Paths**: The service tests used a hardcoded absolute file path (`/home/daniel/...`), which caused them to fail on any other machine.
- **Correct Sourcemap Access**: The utility tests were updated to access sourcemap lines via `sourceMap.data.lines` instead of `sourceMap.lines`
