### PR TITLE
CoffeeScript classes support static fields/methods

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3547,10 +3547,12 @@ loop
 <Playground>
 "civet coffeeClasses autoVar"
 class X
-  privateVar = 5
+  privateStaticVar = 5
+  @publicStaticVar = 6
   constructor: (@x) ->
   get: -> @x
   bound: => @x
+  @staticFunc: -> @publicStaticVar
 </Playground>
 
 ### IIFE Wrapper

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -14,6 +14,8 @@ import {
   blockWithPrefix,
   braceBlock,
   bracedBlock,
+  convertArrowFunctionToMethod,
+  convertFunctionToMethod,
   convertNamedImportsToObject,
   convertObjectToJSXAttributes,
   convertWithClause,
@@ -1264,6 +1266,14 @@ NestedClassElement
 
 # https://262.ecma-international.org/#prod-ClassElement
 ClassElement
+  # CoffeeScript public static class variable: @identifier = Expression
+  # CoffeeScript private static class variable: identifier = Expression
+  CoffeeClassesEnabled Decorators?:decorators ( Declare _? )?:declare AccessModifier?:access ( Static _? )?:static_ ( Override _? )?:override ActualAssignment:assignment -> 
+    return {
+      type: static_ ? "CoffeeClassPublic" : "CoffeeClassPrivate",
+      children: [decorators, declare, access, static_, override, assignment],
+      assignment
+    }
   # NOTE: Combined optional static and Method/Field definition
   Decorators?:decorators ( Declare _? )?:declare AccessModifier?:access ( Static _? )?:static_ ( Override _? )?:override ClassElementDefinition:definition ->
     const ts = definition.ts || !!declare;
@@ -1333,42 +1343,10 @@ FieldDefinition
   CoffeeClassesEnabled ClassElementName:id _? Colon __ AssignmentExpression:exp ->
     switch (exp.type) {
       case "FunctionExpression": {
-        const fnTokenIndex = exp.children.findIndex(c => c?.token?.startsWith("function"))
-        // copy
-        const children = exp.children.slice()
-        if (exp.generator) {
-          // replace "function" and move generator ahead of id
-          children.splice(fnTokenIndex, 2, children[fnTokenIndex+1], id)
-        } else {
-          // replace "function" token with id
-          children.splice(fnTokenIndex, 1, id)
-        }
-        return {
-          ...exp,
-          type: "MethodDefinition",
-          name: id.name,
-          signature: { ...exp.signature, id, name: id.name },
-          children,
-        }
+        return convertFunctionToMethod(id, exp)
       }
       case "ArrowFunction": {
-        const block = {...exp.block} // prepare for bracing
-        const children = exp.children
-        .filter(c => !(Array.isArray(c) && c[c.length-1]?.token?.includes("=>")))
-        .map(c => c === exp.block ? block : c)
-        children.unshift(id)
-        exp = {
-          ...exp,
-          type: "MethodDefinition",
-          name: id.name,
-          signature: { ...exp.signature, id, name: id.name },
-          block,
-          children,
-          autoBind: true
-        }
-        block.parent = exp // needed by braceBlock
-        braceBlock(block)
-        return exp
+        return convertArrowFunctionToMethod(id, exp)
       }
       default:
         return {
@@ -1391,15 +1369,6 @@ FieldDefinition
       typeSuffix,
       children: $0,
       readonly,
-    }
-
-  # In a CoffeeScript class, `x = y` makes a private variable x visible
-  # only within the class scope only
-  CoffeeClassesEnabled ActualAssignment:assignment ->
-    return {
-      type: "CoffeeClassPrivate",
-      children: [ assignment ],
-      assignment,
     }
 
   ( Abstract _? )?:abstract ( Readonly _? )?:readonly ClassElementName:id TypeSuffix?:typeSuffix Initializer?:initializer ->

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -142,7 +142,8 @@ function createVarDecs(block: BlockStatement, scopes, pushVar?): void
       assignmentStatements ++=
         findAssignments assignmentStatements.map((s) => s.children), decs
 
-    assignmentStatements
+    // Ignore assignment statements for public static class assignments, which don't need declaration
+    assignmentStatements.filter !(&.parent?.type is "CoffeeClassPublic")
 
   // Let descendent blocks add the var at the outer enclosing function scope
   pushVar ?= (name: string) =>

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -829,6 +829,42 @@ function convertMethodToFunction(method)
     block
   }
 
+function convertFunctionToMethod(id, exp)
+  fnTokenIndex := exp.children.findIndex (c) -> c?.token?.startsWith("function")
+  // copy
+  children := exp.children.slice()
+  if exp.generator
+    // replace "function" and move generator ahead of id
+    children.splice(fnTokenIndex, 2, children[fnTokenIndex+1], id)
+  else
+    // replace "function" token with id
+    children.splice(fnTokenIndex, 1, id)
+  
+  {
+    ...exp,
+    type: "MethodDefinition",
+    name: id.name,
+    signature: { ...exp.signature, id, name: id.name },
+    children
+  }
+
+function convertArrowFunctionToMethod(id, exp)
+  block := {...exp.block} // prepare for bracing
+  children := exp.children.filter((c) -> !(Array.isArray(c) && c[c.length-1]?.token?.includes("=>"))).map((c) -> c === exp.block ? block : c)
+  children.unshift(id)
+  exp = {
+    ...exp,
+    type: "MethodDefinition",
+    name: id.name,
+    signature: { ...exp.signature, id, name: id.name },
+    block,
+    children,
+    autoBind: true
+  }
+  block.parent = exp // needed by braceBlock
+  braceBlock(block)
+  exp
+
 // Convert NamedImports into equivalent ObjectExpression or ObjectBindingPattern
 function convertNamedImportsToObject(node, pattern?: boolean)
   properties := node.specifiers.map (specifier) =>
@@ -1524,6 +1560,16 @@ function processCoffeeClasses(statements: StatementTuple[]): void
         ...for each [, a] of autoBinds
           [indent, ["this.", a.name, " = this.", a.name, ".bind(this)"], ";"]
 
+    public_static_function_assignments := expressions.filter((&[1]?.type is "CoffeeClassPublic") && (&[1].assignment?.expression?.type is "FunctionExpression")).map &[1].assignment
+    for public_static_function_assignment of public_static_function_assignments
+      id := public_static_function_assignment.lhs[0][1]
+      replaceNode public_static_function_assignment, convertFunctionToMethod(id, public_static_function_assignment.expression)
+
+    public_static_arrow_function_assignments := expressions.filter((&[1]?.type is "CoffeeClassPublic") && (&[1].assignment?.expression?.type is "ArrowFunction")).map &[1].assignment
+    for public_static_arrow_function_assignment of public_static_arrow_function_assignments
+      id := public_static_arrow_function_assignment.lhs[0][1]
+      replaceNode public_static_arrow_function_assignment, convertArrowFunctionToMethod(id, public_static_arrow_function_assignment.expression)
+    
     // In a CoffeeScript class, `x = y` makes a private variable x visible
     // only within the class scope only, implemented via IIFE wrapper
     privates := expressions.filter &[1]?.type is "CoffeeClassPrivate"
@@ -1956,6 +2002,8 @@ export {
   blockWithPrefix
   braceBlock
   bracedBlock
+  convertArrowFunctionToMethod
+  convertFunctionToMethod
   convertNamedImportsToObject
   convertObjectToJSXAttributes
   convertWithClause

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -94,6 +94,7 @@ export type OtherNode =
   | CaseBlock
   | CaseClause
   | CoffeeClassPrivate
+  | CoffeeClassPublic
   | CommentNode
   | ComputedPropertyName
   | ConditionFragment
@@ -1154,6 +1155,16 @@ export type CoffeeClassPrivate
   type: "CoffeeClassPrivate"
   children: Children
   parent?: Parent
+  assignment: AssignmentExpression
+  id: ASTNode
+  typeSuffix?: TypeSuffix?
+  initializer: Initializer
+
+export type CoffeeClassPublic
+  type: "CoffeeClassPublic"
+  children: Children
+  parent?: Parent
+  assignment: AssignmentExpression
   id: ASTNode
   typeSuffix?: TypeSuffix?
   initializer: Initializer

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -112,3 +112,84 @@ describe "coffeeClasses", ->
       }
     }})()
   """
+
+  testCase """
+    private static class functions
+    ---
+    "civet coffeeCompat"
+    class MathOps
+      ADD = (a, b) -> a + b
+      increment: (value) ->
+        console.log ADD(value, 1)
+    ---
+    var MathOps;
+    MathOps = (()=>{
+      var ADD;
+      ADD = function(a, b) { return a + b }
+      return class MathOps {
+      increment(value) {
+        return console.log(ADD(value, 1))
+      }
+    }})()
+  """
+
+  testCase """
+    private static class fat-arrow functions
+    ---
+    "civet coffeeCompat"
+    class MathOps
+      ADD = (a, b) => a + b
+      increment: (value) ->
+        console.log ADD(value, 1)
+    ---
+    var MathOps;
+    MathOps = (()=>{
+      var ADD;
+      ADD = (a, b) => a + b
+      return class MathOps {
+      increment(value) {
+        return console.log(ADD(value, 1))
+      }
+    }})()
+  """
+
+  testCase """
+    public static class function assignment
+    ---
+    "civet coffeeClasses"
+    class MathOps
+      @add = (a, b) -> a + b
+    ---
+    class MathOps {
+      static add(a, b) { return a + b }
+    }
+  """
+
+  testCase """
+    public static class fat-arrow function assignment
+    ---
+    "civet coffeeClasses"
+    class MathOps
+      @add = (a, b) => a + b
+    ---
+    class MathOps {
+      static add(a, b) {return  a + b}
+    }
+  """
+
+  testCase """
+    public static class field assignment
+    ---
+    "civet coffeeClasses"    
+    class MathOps
+      @PI = 3.14      
+      circleArea: (radius) ->
+        MathOps.PI * radius * radius
+    ---
+    class MathOps {
+      static PI = 3.14      
+      circleArea(radius) {
+        return MathOps.PI * radius * radius
+      }
+    }
+  """


### PR DESCRIPTION
Add support for Coffeescript public statics
* Fixes https://github.com/DanielXMoore/Civet/issues/1760
* Adds support for Coffeescript public static form, for assignment of values, functions, and fat-arrow functions
* Expands tests for already-supported Coffeescript private state form
* Updates reference docs to reflect changes