### PR TITLE
LSP: fix(diagnostics), ensure immediate updates for opened dependent files on change

### DIFF
--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -725,12 +725,14 @@ const updateProjectDiagnostics = async (
   // A single, short delay before starting the update for a project.
   await setTimeout(diagnosticsPropagationDelay);
 
-  for (const sourceFile of program.getSourceFiles()) {
+  const projectFiles = program.getSourceFiles();
+  for (const sourceFile of projectFiles) {
     if (status.isCanceled) return;
 
-    // We only send diagnostics for files the user actually has open,
-    // even though we're checking every file in the project for correctness.
-    const docUri = pathToFileURL(sourceFile.fileName).toString();
+    // We only need to send diagnostics for files the user has open
+    // TypeScript is analyzing all files in memory anyway
+    const rawFileName = service.getSourceFileName(sourceFile.fileName);
+    const docUri = pathToFileURL(rawFileName).toString();
     const doc = documents.get(docUri);
     if (doc) {
       await updateDiagnosticsForDoc(doc, service);


### PR DESCRIPTION
Hey, quick fix for my previous refactor

### **The Problem (Bug)**

Currently, if a user modifies an exported member in `export.civet`, any other open file (`import.civet`) that imports that member does not instantly receive updated diagnostic errors even when files are open in editor. It appears only after direct edit in the `import.civet`

### **How to Replicate**

1.  **Create two files:**

    *   `export.civet`:
        ```
        abc := 321
        export {abc}
        ```

    *   `import.civet`:
        ```
        import {abc} from './export.civet'
        ```

2.  **Open both files** in the editor. Observe that there are no errors.

3.  **In `export.civet`**, change the exported variable name:
    ```civet
    // From
    abc := 321
    export {abc}

    // To
    a := 321
    export {a}
    ```

4.  **Observe (The Bug):** Switch to the `import.civet` file. No diagnostic error is shown. The linter is silent, even though the import of `abc` is now invalid.

5.  **Expected Behavior:** The moment `export.civet` is saved or changed, an error should immediately appear in `import.civet`, highlighting that `abc` is not an exported member.

### **The Solution**

The root cause of this bug was a path mismatch within the `updateProjectDiagnostics` function. The function iterates through all files in the TypeScript program using `program.getSourceFiles()`. 

The fix is to use **`service.getSourceFileName(sourceFile.fileName)`**. This method correctly resolves the path known by the TypeScript service back to its original source file path. This ensures we can reliably find the corresponding open document in our `documents` map and push the updated diagnostics to the editor immediately after a dependency changes.

Happy to hear any thoughts, its a small, but important fix imo