### PR TITLE
Fix source map's `sources` using unplugin with `outputExtension`

### DIFF
--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -531,7 +531,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
           JSON.parse(sourceMap)
         else
           sourceMap.json
-            path.relative rootDir, id.replace /\.[jt]sx$/, ''
+            path.relative rootDir, extractCivetFilename(id, outExt).filename
             path.relative rootDir, id
 
       transformed: TransformResult .=


### PR DESCRIPTION
I think this was an oversight in #1733.