### PR TITLE
Allow implicit object literal to end by `)`/`]`/`}`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2016,7 +2016,7 @@ ParameterElement
 
 ParameterElementDelimiter
   _? Comma
-  &( __ [)}] )
+  &( __ [)\]}] )
   &EOS InsertComma -> $2
 
 # https://262.ecma-international.org/#prod-BindingIdentifier
@@ -3615,8 +3615,8 @@ InlineObjectPropertyDelimiter
 
 ObjectPropertyDelimiter
   _? Comma
-  # Object closing delimits the property
-  &( __ "}" )
+  # Object closing delimits the property, as do end of array or parenthetical
+  &( __ [)\]}] )
   &EOS InsertComma ->
     return { ...$2, implicit: true }
 

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -75,7 +75,7 @@ describe "example code", ->
                                                         closingTagOpeningBracketLocationData: $1.closingTagOpeningBracketToken?.[2],
                                                         closingTagSlashLocationData:          $1.closingTagSlashToken?.[2],
                                                         closingTagNameLocationData:           $1.closingTagNameToken?.[2],
-                                                        closingTagClosingBracketLocationData: $1.closingTagClosingBracketToken?.[2],
+                                                        closingTagClosingBracketLocationData: $1.closingTagClosingBracketToken?.[2]
         }) })
       ]})
   """

--- a/test/function-application.civet
+++ b/test/function-application.civet
@@ -306,9 +306,22 @@ describe "function application", ->
     ---
     f({
       a: 1,
-      b: 2,
+      b: 2
     }
     )
+  """
+
+  testCase """
+    single nested object with implied braces as argument and tight close paren
+    ---
+    f(
+      a: 1
+      b: 2)
+    ---
+    f({
+      a: 1,
+      b: 2
+    })
   """
 
   testCase """
@@ -344,7 +357,7 @@ describe "function application", ->
       a: 1,
     }
     , {
-      b: 2,
+      b: 2
     }
     )
   """

--- a/test/if.civet
+++ b/test/if.civet
@@ -689,7 +689,7 @@ describe "if", ->
         hi
       ---
       if (foo({
-        a: 1,
+        a: 1
       })
       ) {
         hi
@@ -705,7 +705,7 @@ describe "if", ->
         hi
       ---
       if (x + (foo({
-        a: 1,
+        a: 1
       })
       )) {
         hi
@@ -721,7 +721,7 @@ describe "if", ->
         b: 2
       ---
       if (x + (foo({
-        a: 1,
+        a: 1
       })
       )) {
         ({b: 2})
@@ -739,7 +739,7 @@ describe "if", ->
       ---
       if ([
         foo({
-          a: 1,
+          a: 1
         })
       ]) {
         hi


### PR DESCRIPTION
Fixes #1781

Also removes some (but not all) added commas at the end of object literals, bringing us closer to the source.

@greghuc If you get a chance, feel free to test this as well. 😺