### PR TITLE
CLI passes SIGINT etc signals onto ESM scripts

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -567,7 +567,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
         child := fork filename, [
           ...scriptArgs
         ], {
-          execArgv,
+          execArgv
           stdio: 'inherit'
         }
         child.on 'exit', (code) =>
@@ -576,6 +576,10 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
             await fs.unlink filename
 
           process.exit code ?? 1
+        // Instead of default behavior of exiting, pass on signals to
+        // child process and let it decide whether to exit
+        for signal of ['SIGINT', 'SIGTERM', 'SIGHUP']
+          process.on signal, => child.kill signal
 
       else
         await import '../register.js'


### PR DESCRIPTION
Currently, if you run `civet script.civet` where `script.civet` is ESM (e.g. uses `import`), then the script runs in a child process. Sending a signal to the `civet` process will kill the `civet` process without affecting the `script.civet` child. This doesn't seem ideal...

With this PR, `civet` signals are just passed onto the `script.civet` child. And only if `script.civet` exits does the `civet` parent exit. I *think* this is better behavior, though it's not entirely clear. Motivation for the new behavior is [these lines of CoffeeScript](https://github.com/jashkenas/coffeescript/blob/817c39a13065a900725943c33a79252a69d779e2/src/command.coffee#L539).

One weirdness is that, with this PR, if you hit <kbd>Ctrl-C</kbd>, then the child `script.civet` gets *two* SIGINT signals, one directly because it's in the foreground process group, and one forwarded from the parent. I still think this is better behavior than the current Civet: if the child decides to capture SIGINT and do something other than exit, then currently the parent will exit and the child keeps running. With this PR, the parent will keep running whenever the child does.

If we wanted to remove the second SIGINT, we could just not forward SIGINT signals (but override Node's default behavior of exiting). But then someone explicitly doing `kill -INT <civet process id>` would have no effect, which feels weird. So I think this PR's behavior is the best...?  You'll only see two SIGINTs in the unusual case of not exiting upon SIGINT.