### PR TITLE
Fix errors in TypeScript types

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -141,7 +141,7 @@ declare module "@danielx/civet" {
   }
 
   // TODO: Import ParseError class from Hera
-  export type ParseError = {
+  export class ParseError {
     name: "ParseError"
     message: string // filename:line:column header\nbody
     header: string
@@ -151,7 +151,8 @@ declare module "@danielx/civet" {
     column: number | string
     offset: number
   }
-  export type ParseErrors = {
+  export class ParseErrors {
+    constructor(errors: ParseError[])
     name: "ParseErrors"
     message: string
     errors: ParseError[]
@@ -217,9 +218,10 @@ declare module "@danielx/civet/config" {
   export function loadConfig(
     path: string
   ): Promise<import("@danielx/civet").CompileOptions>
-  export default {
-    findInDir,
-    findConfig,
-    loadConfig,
+  const Config: {
+    findInDir: typeof findInDir,
+    findConfig: typeof findConfig,
+    loadConfig: typeof loadConfig,
   }
+  export default Config
 }


### PR DESCRIPTION
I was building Hera and saw these errors from TypeScript (as a consumer of Civet's types):

```
node_modules/@danielx/civet/dist/types.d.ts:120:24 - error TS2693: 'ParseError' only refers to a type, but is being used as a value here.

120     ParseError: typeof ParseError
                           ~~~~~~~~~~
node_modules/@danielx/civet/dist/types.d.ts:121:25 - error TS2693: 'ParseErrors' only refers to a type, but is being used as a value here.

121     ParseErrors: typeof ParseErrors
                            ~~~~~~~~~~~
node_modules/@danielx/civet/dist/types.d.ts:152:18 - error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.

152   export default {
                     ~
153     findInDir,
    ~~~~~~~~~~~~~~
...
155     loadConfig,
    ~~~~~~~~~~~~~~~
156   }
    ~~~
```

These changes seem to fix all these errors, without introducing any new errors in the Civet build process.