### PR TITLE
Fix missing space in terse `get`/`set` definitions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3976,6 +3976,7 @@ MethodDefinition
 MethodModifier
   # NOTE: Merged get/set definitions
   GetOrSet:kind _?:ws &ClassElementName ->
+    if (!ws) ws = " "
     return {
       // no async or generator, because getters and setters can't be
       modifier: {

--- a/test/object.civet
+++ b/test/object.civet
@@ -461,6 +461,26 @@ describe "object", ->
     }
   """
 
+  testCase """
+    method get/set without space
+    ---
+    x = {
+      get#()
+        return 5
+      set#(v)
+        throw new Error
+    }
+    ---
+    x = {
+      get length() {
+        return 5
+      },
+      set length(v) {
+        throw new Error
+      }
+    }
+  """
+
   describe "get shorthand", ->
     testCase """
       object getter


### PR DESCRIPTION
Fixes #1783