### PR TITLE
Dynamic `import` expressions support `*`, `default`; they and globs support strings and computed names

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3072,6 +3072,8 @@ You can also use `import` declarations as expressions, as a shorthand for
 urlPath := import {
   fileURLToPath, pathToFileURL
 } from url
+url := import * from url
+Foo := import default from Foo
 </Playground>
 
 ### Export Shorthand

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1503,9 +1503,9 @@ CallExpression
       children: [$1, ...$2, ...rest.flat()],
     })
   # Import declaration as an expression
-  Import _ ( DynamicNamedImports / IdentifierName ) __ FromClause ->
+  Import _ DynamicImportContents __ FromClause ->
     return dynamizeImportDeclarationExpression($0)
-  FromClause:from __:fws Import:i _:iws ( DynamicNamedImports / IdentifierName ):imports ->
+  FromClause:from __:fws Import:i _:iws DynamicImportContents:imports ->
     return dynamizeImportDeclarationExpression([i, iws, imports, fws, from])
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
@@ -5859,6 +5859,11 @@ DynamicNamedImports
       specifiers,
     }
 
+DynamicImportContents
+  DynamicNamedImports
+  IdentifierName
+  Star
+
 # https://262.ecma-international.org/#prod-FromClause
 FromClause
   From __ ModuleSpecifier:module ->
@@ -6951,7 +6956,7 @@ SingleQuote
 
 Star
   "*" ->
-    return { $loc, token: $1 }
+    return { $loc, token: $1, type: "Star" }
 
 Static
   "static" NonIdContinue ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1503,9 +1503,9 @@ CallExpression
       children: [$1, ...$2, ...rest.flat()],
     })
   # Import declaration as an expression
-  Import _ DynamicNamedImports __ FromClause ->
+  Import _ ( DynamicNamedImports / IdentifierName ) __ FromClause ->
     return dynamizeImportDeclarationExpression($0)
-  FromClause:from __:fws Import:i _:iws DynamicNamedImports:imports ->
+  FromClause:from __:fws Import:i _:iws ( DynamicNamedImports / IdentifierName ):imports ->
     return dynamizeImportDeclarationExpression([i, iws, imports, fws, from])
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1503,9 +1503,9 @@ CallExpression
       children: [$1, ...$2, ...rest.flat()],
     })
   # Import declaration as an expression
-  Import _ NamedImports __ FromClause ->
+  Import _ DynamicNamedImports __ FromClause ->
     return dynamizeImportDeclarationExpression($0)
-  FromClause:from __:fws Import:i _:iws NamedImports:imports ->
+  FromClause:from __:fws Import:i _:iws DynamicNamedImports:imports ->
     return dynamizeImportDeclarationExpression([i, iws, imports, fws, from])
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
@@ -5849,6 +5849,16 @@ OperatorNamedImports
       specifiers,
     }
 
+# Allows { default, "foo bar" } because dynamic imports allow them;
+# forbids { type foo } because dynamic imports don't allow them
+DynamicNamedImports
+  OpenBrace DynamicImportSpecifier*:specifiers ( __ Comma )? __ CloseBrace ->
+    return {
+      type: "Declaration",
+      children: $0,
+      specifiers,
+    }
+
 # https://262.ecma-international.org/#prod-FromClause
 FromClause
   From __ ModuleSpecifier:module ->
@@ -5916,6 +5926,19 @@ OperatorImportSpecifier
       behavior,
       children: [$1, $2, $3?.error, $4],
     }
+
+DynamicImportSpecifier
+  __ ( TypeKeyword __ &DynamicModuleExportName )?:ts DynamicModuleExportName:source ( ImportAsToken __ DynamicModuleExportName )?:binding ObjectPropertyDelimiter ->
+    return {
+      source,
+      binding: binding?.[2],
+      ts: !!ts, // true causes an error later
+      children: $0,
+    }
+
+DynamicModuleExportName
+  ModuleExportName
+  ComputedPropertyName
 
 ImportAsToken
   __ As

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5871,9 +5871,9 @@ ImportAssertion
 
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier
-  ( __ TypeKeyword )? ImportSpecifier ->
-    if (!$1) return $2
-    return { ts: true, children: $0, binding: $2.binding }
+  __ TypeKeyword ImportSpecifier ->
+    return { ts: true, children: $0, binding: $3.binding }
+  ImportSpecifier
   # `operator id` blesses `id` as operator; doesn't make sense with `type`
   __:ws Operator OperatorImportSpecifier:spec ->
     if (spec.binding.type !== "Identifier") {

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -1,8 +1,10 @@
 import type {
+  AccessStart
   ASTLeaf
   ASTNode
   ASTNodeParent
   ASTRef
+  AwaitExpression
   Binding
   BlockStatement
   Declaration
@@ -544,26 +546,42 @@ function dynamizeImportDeclaration(decl)
   }
 
 function dynamizeImportDeclarationExpression($0: [ASTNode, Whitespace, ASTNode, Whitespace, ASTNode])
-  [imp, ws1, named, ws2, from] := $0
-  object := convertNamedImportsToObject named
-  dot := "."
-  processCallMemberExpression
-    type: "CallExpression"
+  [imp, ws1, imports, ws2, from] := $0
+  awaitExpression: AwaitExpression :=
+    type: "AwaitExpression"
     children: []
-      parenthesizeExpression
-        type: "AwaitExpression"
+      { type: "Await", children: ["await"] }
+      " "
+      imp
+      trimFirstSpace ws2
+      dynamizeFromClause from
+  dot: AccessStart :=
+    type: "AccessStart"
+    children: ["."]
+    optional: false
+  switch imports?.type
+    when "Identifier" // default import
+      processCallMemberExpression
+        type: "CallExpression"
         children: []
-          { type: "Await", children: ["await"] }
-          " "
-          imp
-          trimFirstSpace(ws2)
-          dynamizeFromClause(from)
-      {}
-        type: "PropertyGlob"
-        dot
-        object
-        children: [ws1, dot, object]
-        reversed: true
+          parenthesizeExpression awaitExpression
+          {}
+            type: "PropertyAccess"
+            dot
+            name: "default"
+            children: [ws1, dot, "default"]
+    when "Declaration" // named imports
+      object := convertNamedImportsToObject imports
+      processCallMemberExpression
+        type: "CallExpression"
+        children: []
+          parenthesizeExpression awaitExpression
+          {}
+            type: "PropertyGlob"
+            dot
+            object
+            children: [ws1, dot, object]
+            reversed: true
 
 function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSNode, ExpressionNode])
   let extendsToken, extendsTarget, ws: WSNode

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -15,6 +15,7 @@ import type {
   SwitchStatement
   TypeSuffix
   WithClause
+  Whitespace
   WSNode
 } from ./types.civet
 
@@ -45,6 +46,7 @@ import {
   literalType
   makeLeftHandSideExpression
   makeNode
+  parenthesizeExpression
   spliceChild
   trimFirstSpace
   updateParentPointers
@@ -541,25 +543,27 @@ function dynamizeImportDeclaration(decl)
     ]
   }
 
-function dynamizeImportDeclarationExpression($0)
+function dynamizeImportDeclarationExpression($0: [ASTNode, Whitespace, ASTNode, Whitespace, ASTNode])
   [imp, ws1, named, ws2, from] := $0
-  object := convertNamedImportsToObject(named)
+  object := convertNamedImportsToObject named
   dot := "."
   processCallMemberExpression
-    type: "CallExpression",
-    children: [
-      { type: "Await", children: "await" }, " "
-      imp
-      trimFirstSpace(ws2)
-      dynamizeFromClause(from)
-      {
+    type: "CallExpression"
+    children: []
+      parenthesizeExpression
+        type: "AwaitExpression"
+        children: []
+          { type: "Await", children: ["await"] }
+          " "
+          imp
+          trimFirstSpace(ws2)
+          dynamizeFromClause(from)
+      {}
         type: "PropertyGlob"
         dot
         object
         children: [ws1, dot, object]
         reversed: true
-      }
-    ]
 
 function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSNode, ExpressionNode])
   let extendsToken, extendsTarget, ws: WSNode

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -570,6 +570,8 @@ function dynamizeImportDeclarationExpression($0: [ASTNode, Whitespace, ASTNode, 
             dot
             name: "default"
             children: [ws1, dot, "default"]
+    when "Star"
+      parenthesizeExpression awaitExpression
     when "Declaration" // named imports
       object := convertNamedImportsToObject imports
       processCallMemberExpression
@@ -582,6 +584,8 @@ function dynamizeImportDeclarationExpression($0: [ASTNode, Whitespace, ASTNode, 
             object
             children: [ws1, dot, object]
             reversed: true
+    else
+      throw new Error "Unsupported dynamic import"
 
 function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSNode, ExpressionNode])
   let extendsToken, extendsTarget, ws: WSNode

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -587,7 +587,10 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
       parts := []
       let ref
       // add ref to ensure object base evaluated only once
-      if prefix.length > 1 and glob.object.properties# > 1
+      if needsRef(prefix) and glob.object.properties# > 1
+        // unwrap unnecessary parentheses in ref assignment
+        if prefix is like [{ type: "ParenthesizedExpression", implicit: true }]
+          prefix = [ prefix[0].expression ]
         ref = makeRef()
         { refAssignment } := makeRefAssignment ref, prefix
         // First use of prefix assigns ref

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -595,7 +595,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         { refAssignment } := makeRefAssignment ref, prefix
         // First use of prefix assigns ref
         prefix = [ makeLeftHandSideExpression refAssignment ]
-      prefix = prefix.concat glob.dot
+      prefixDot .= [ ...prefix, glob.dot ]
 
       for part of glob.object.properties
         if part.type is "Error"
@@ -606,7 +606,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
             type: "Error"
             message: "Glob pattern cannot have method definition"
           continue
-        if part.value and part.value.type is not in ["CallExpression", "MemberExpression", "Identifier"] as (string?)[]
+        if part.value and part.value.type is not in ["CallExpression", "MemberExpression", "Identifier", "StringLiteral", "ComputedPropertyName"] as (string?)[]
           parts.push
             type: "Error"
             message: `Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`
@@ -623,10 +623,23 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         [name, value] = [value, name] if glob.reversed
 
         unless suppressPrefix // Don't prefix @ shorthand
-          value = prefix.concat trimFirstSpace value
+          if value.type is "StringLiteral"
+            value = [ ...prefix,
+              type: "Index"
+              children: [ "[", trimFirstSpace(value), "]" ]
+            ]
+          else if value.type is "ComputedPropertyName"
+            value = [ ...prefix,
+              type: "Index"
+              children: [ trimFirstSpace value ]
+            ]
+          else
+            value = [ ...prefixDot, trimFirstSpace value ]
           // Switch from refAssignment to ref
-          prefix = [ ref ] ++ glob.dot if ref?
-        if (wValue) value.unshift(wValue)
+          if ref?
+            prefix = [ ref ]
+            prefixDot = [ ...prefix, glob.dot ]
+        if (wValue) value.unshift wValue
         if part.type is "SpreadProperty"
           parts.push {
             type: part.type

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -130,6 +130,7 @@ export type OtherNode =
   | ReturnValue
   | SliceExpression
   | SpreadElement
+  | Star
   | ThisType
   | TypeArgument
   | TypeArguments
@@ -627,6 +628,10 @@ export type ExportDeclaration
   parent?: Parent
   ts?: boolean
   declaration?: ASTNode
+
+export type Star
+  type: "Star"
+  token: "*"
 
 export type ModuleSpecifier
   type: "ModuleSpecifier"

--- a/test/function.civet
+++ b/test/function.civet
@@ -612,15 +612,6 @@ describe "function", ->
     })
   """
 
-  throws """
-    doesn't allow import inside of function
-    ---
-    (x) ->
-      import * from 'x'
-    ---
-    ParseError
-  """
-
   testCase """
     fat arrow
     ---

--- a/test/import.civet
+++ b/test/import.civet
@@ -362,6 +362,14 @@ describe "import", ->
     """
 
     testCase """
+      namespace dynamic import declaration expression
+      ---
+      fs := import * from fs
+      ---
+      const fs = (await import("fs"))
+    """
+
+    testCase """
       string dynamic import declaration expression
       ---
       fs := import { "string literal", `template string`, [x+y] } from fs

--- a/test/import.civet
+++ b/test/import.civet
@@ -344,6 +344,22 @@ describe "import", ->
     """
 
     testCase """
+      default dynamic import declaration expression
+      ---
+      fs := import { default } from fs
+      ---
+      const fs = {default:(await import("fs")).default}
+    """
+
+    testCase """
+      string dynamic import declaration expression
+      ---
+      fs := import { "string literal", `template string`, [x+y] } from fs
+      ---
+      let ref;const fs = {"string literal":(ref = await import("fs"))["string literal"],[`template string`]:ref[`template string`],[x+y]:ref[x+y]}
+    """
+
+    testCase """
       dynamic import declaration expression
       ---
       fs := import { readFileSync, writeFile as wf, writeFileSync: wfs } from fs

--- a/test/import.civet
+++ b/test/import.civet
@@ -352,6 +352,16 @@ describe "import", ->
     """
 
     testCase """
+      unbraced default dynamic import declaration expression
+      ---
+      fs1 := import default from fs
+      fs2 := import fs from fs
+      ---
+      const fs1 = (await import("fs")) .default
+      const fs2 = (await import("fs")) .default
+    """
+
+    testCase """
       string dynamic import declaration expression
       ---
       fs := import { "string literal", `template string`, [x+y] } from fs

--- a/test/import.civet
+++ b/test/import.civet
@@ -340,7 +340,7 @@ describe "import", ->
       ---
       fs := import { readFileSync } from fs
       ---
-      const fs = {readFileSync:await import("fs").readFileSync}
+      const fs = {readFileSync:(await import("fs")).readFileSync}
     """
 
     testCase """
@@ -364,7 +364,7 @@ describe "import", ->
       ---
       data := import { version } from package.json with type: 'json'
       ---
-      const data = {version:await import("package.json", {with:{type: 'json'}}).version}
+      const data = {version:(await import("package.json", {with:{type: 'json'}})).version}
     """
 
     // #1307

--- a/test/object.civet
+++ b/test/object.civet
@@ -1379,6 +1379,14 @@ describe "object", ->
     """
 
     testCase """
+      strings and computed properties
+      ---
+      x.{"hello world", `template string`, [a+b]}
+      ---
+      ({"hello world":x["hello world"], [`template string`]:x[`template string`], [a+b]:x[a+b]})
+    """
+
+    testCase """
       assignment
       ---
       obj.{ a, b: c, d : e } = x

--- a/test/object.civet
+++ b/test/object.civet
@@ -1324,6 +1324,14 @@ describe "object", ->
     """
 
     testCase """
+      parenthesized left-hand side
+      ---
+      (x+y).{a,b}
+      ---
+      let ref;({a:(ref = (x+y)).a,b:ref.b})
+    """
+
+    testCase """
       no ref if single right-hand side
       ---
       a.b.{x}

--- a/test/types/import.civet
+++ b/test/types/import.civet
@@ -48,6 +48,22 @@ describe "[TS] import", ->
   """
 
   testCase """
+    import type variable
+    ---
+    import { type } from "foo"
+    ---
+    import { type } from "foo"
+  """
+
+  testCase """
+    import type variable shorthand
+    ---
+    { type } from "foo"
+    ---
+    import { type } from "foo"
+  """
+
+  testCase """
     import type
     ---
     function adopt(p: import("./module").Pet) {


### PR DESCRIPTION
## Features
* In expression context, `import * from module`  compiles to `import("module")`
* In expression context, `import default from module` compiles to `import("module").default`. So does `import module from module` (the name gets ignored).
* In expression context, ``import { "string literal", `template literal`, [computed] } from module`` works, because we can.
* Globs support this too: ``foo.{"string literal", `template literal`, [computed]}``. This is more consistent with existing features `foo."string literal"`, ``foo.`template literal` ``

## Fixes
* In expression context, `import { x } from foo` compiled to `{x:await import("foo").x}` which was incorrect. Now correctly compiles to `{x:(await import("foo")).x}`
* In statement context, `import { type } from foo` works now, as it does in TypeScript; previously, it failed to parse!
* Fixes #1803
* Glob `(x+y).{a,b}` now correctly uses a ref for `x+y`.