### PR TITLE
Fix TypeScript type for `operator` option

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -32,7 +32,7 @@ declare module "@danielx/civet" {
      * (Can also map to OperatorBehavior as defined in source/types.civet,
      * but the details are subject to change.)
      */
-    operators: string[] | Record<string, string?>
+    operators: string[] | Record<string, string | undefined>
     react: boolean
     solid: boolean
     client: boolean


### PR DESCRIPTION
We probably need a way a CI test for at least TS parsability... Let me know if you have suggestions.