### PR TITLE
Fix expressionization of `if` in some cases, improve errors from threads

### DIFF
--- a/source/node-worker.civet
+++ b/source/node-worker.civet
@@ -14,7 +14,7 @@ async do
         when "compile"
           result = await (compile as any) ...args
         else
-          throw `Unknown operation: ${op}`
+          throw new Error `Unknown operation: ${op}`
       // If we pass in an `errors` option, its modification is part of output
       parentPort!.postMessage {id, result, errors: args[1]?.errors}
     catch error

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -100,11 +100,11 @@ real block and won't be wrapped with braces.
 function makeBlockFragment(): BlockStatement
   expressions: StatementTuple[] := []
   return {
-    type: "BlockStatement",
-    children: expressions,
-    parent: undefined,
-    expressions,
-    bare: false,
+    type: "BlockStatement"
+    children: expressions
+    parent: undefined
+    expressions
+    bare: false
     root: false
   }
 
@@ -187,7 +187,7 @@ function processBlocks(statements: StatementTuple[]): void
 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion
 */
 function insertSemicolon(statements: StatementTuple[]): void
-  l := statements.length
+  l := statements#
   for each s, i of statements
     if i < l - 1
       if needsPrecedingSemicolon(statements[i + 1][1])

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -194,7 +194,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
 
   pre: ASTNode[] := []
   statementExp := exp.statement
-  blockStatement: StatementTuple := ["", statementExp]
+  blockStatement: StatementTuple := [ws || "", statementExp, ";"]
   let ref: ASTRef
 
   if statementExp.type is "IterationExpression"
@@ -212,16 +212,16 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
       assignResults blockStatement, (resultNode) =>
         //@ts-ignore
         makeNode
-          type: "AssignmentExpression",
+          type: "AssignmentExpression"
           children: [ref, " = ", resultNode]
           parent: statement
 
       refDec :=
-        type: "Declaration",
-        children: ["let ", ref, ";"],
+        type: "Declaration"
+        children: ["let ", ref]
 
       // @ts-ignore
-      pre.unshift refDec
+      pre.unshift ["", refDec, ";"]
     else
       wrapIterationReturningResults statement, => undefined
       ref = initializer.expression = initializer.children[2] = statement.resultsRef
@@ -237,15 +237,13 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
 
     refDec :=
       type: "Declaration",
-      children: ["let ", ref, ";"],
+      children: ["let ", ref],
 
-    pre.unshift refDec
-    //@ts-ignore
-    pre.push ws if ws
+    pre.unshift ["", refDec, ";"]
 
   // insert statement before the declaration
   //@ts-ignore
-  statement.children.unshift(pre, blockStatement, ";")
+  statement.children.unshift(...pre, blockStatement)
   updateParentPointers blockStatement, statement
 
   return ref

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -268,7 +268,7 @@ function isExpression(node: ASTNode): boolean
 
 function expressionizeBlock(blockOrExpression: ASTNode)
   if { expressions } := blockOrExpression
-    l := expressions.length
+    l := expressions#
     results := []
 
     for [ws, s, _delim], i of expressions

--- a/source/worker-pool.civet
+++ b/source/worker-pool.civet
@@ -45,6 +45,8 @@ export class WorkerPool
       callback := @callbacks.get(response.id)!
       @callbacks.delete response.id
       if response.error
+        // Give worker time to output its error message
+        await new Promise (done) => setTimeout done, 0
         message := `${response.error.name}: ${response.error.message}`
         error :=
           if response.error.type in globalThis

--- a/test/do.civet
+++ b/test/do.civet
@@ -198,7 +198,8 @@ describe "do", ->
           y := x * x
           y * y
     ---
-    const results=[];for (const x of items) {
+    const results=[];
+      for (const x of items) {
         {
           const y = x * x
           results.push(y * y)

--- a/test/for.civet
+++ b/test/for.civet
@@ -841,7 +841,8 @@ describe "for", ->
         for i of [0..7]
           if true then 'yes' else 'no'
       ---
-      const results=[];for (let i1 = 0; i1 <= 7; ++i1) {const i = i1;
+      const results=[];
+        for (let i1 = 0; i1 <= 7; ++i1) {const i = i1;
           if (true) { results.push('yes')} else results.push('no')
         };const check =results
     """
@@ -934,7 +935,8 @@ describe "for", ->
         for item, index of array
           `${index}. ${item}`
       ---
-      const results=[];let i = 0;for (const item of array) {const index = i++;
+      const results=[];let i = 0;
+        for (const item of array) {const index = i++;
           results.push(`${index}. ${item}`)
         };const strings =results
     """
@@ -976,7 +978,8 @@ describe "for", ->
         for each char of arg[1..]
           `-${char}`
       ---
-      const results=[];for (let ref = arg.slice(1), i1 = 0, len = ref.length; i1 < len; i1++) {const char = ref[i1];
+      const results=[];
+        for (let ref = arg.slice(1), i1 = 0, len = ref.length; i1 < len; i1++) {const char = ref[i1];
           results.push(`-${char}`)
         };args.splice(i, i + 1 - i, ...results)
     """
@@ -1692,7 +1695,8 @@ describe "for", ->
         for item of items
           item.pre, ...item.mid, item.post, ... item.tail
       ---
-      const results=[];for (const item of items) {
+      const results=[];
+        for (const item of items) {
           results.push(item.pre, ...item.mid, item.post, ... item.tail)
         };const result =results
     """

--- a/test/if.civet
+++ b/test/if.civet
@@ -798,6 +798,22 @@ describe "if", ->
     """
 
     testCase """
+      if expression with arrays
+      ---
+      [a] = if cond
+        [1]
+      else
+        [2]
+      ---
+      let ref;if (cond) {
+        ref = [1]
+      }
+      else {
+        ref = [2]
+      };[a] = ref
+    """
+
+    testCase """
       if expression with else on same line
       ---
       x = if (y)

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -487,7 +487,8 @@ describe "pipe", ->
         for x of y
           x ||> f
       ---
-      const results1=[];for (const x of y) {
+      const results1=[];
+        for (const x of y) {
           f(x);results1.push(x)
         };const results =results1
     """


### PR DESCRIPTION
Fixes #1777 (the compilation error, not the eslint plugin ignoring settings)

This was a tough one to track down. It turned out that `prependStatementExpressionBlock` wasn't correctly building statement tuples, despite some tuples being created. (For example, `";"` was added as its own "tuple".) Now it does, which fixed the problem. It also preserves whitespace in a few more cases, which is a nice bonus.

I also added a timeout of 0 when a worker returns an error, which seems to give the worker time to output its version of the error, which generally has a better stack trace. This helps for future debugging.