### PR TITLE
Limit implicit JSX fragments to desired scenarios

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -91,6 +91,7 @@ export const state = {    // parser state
   forbidTrailingMemberProperty: [false],
   forbidNestedBinaryOp: [false],
   forbidNewlineBinaryOp: [false],
+  forbidImplicitFragment: [false],
   forbidPipeline: [false],
   JSXTagStack: [undefined],
 }
@@ -144,6 +145,12 @@ Object.defineProperties(state, {
       return s[s.length-1]
     },
   },
+  implicitFragmentForbidden: {
+    get() {
+      const {forbidImplicitFragment: s} = state
+      return s[s.length-1]
+    },
+  },
   pipelineForbidden: {
     get() {
       const {forbidPipeline: s} = state
@@ -169,13 +176,14 @@ function setOperatorBehavior(name, behavior) {
 
 export function getStateKey() {
   const stateInt =
-    ((state.currentIndent.level % 256) << 8) |
-    (state.classImplicitCallForbidden << 7) |
-    (state.indentedApplicationForbidden << 6) |
-    (state.bracedApplicationForbidden << 5) |
-    (state.trailingMemberPropertyForbidden << 4) |
-    (state.nestedBinaryOpForbidden << 3) |
-    (state.newlineBinaryOpForbidden << 2) |
+    ((state.currentIndent.level % 256) << 9) |
+    (state.classImplicitCallForbidden << 8) |
+    (state.indentedApplicationForbidden << 7) |
+    (state.bracedApplicationForbidden << 6) |
+    (state.trailingMemberPropertyForbidden << 5) |
+    (state.nestedBinaryOpForbidden << 4) |
+    (state.newlineBinaryOpForbidden << 3) |
+    (state.implicitFragmentForbidden << 2) |
     (state.pipelineForbidden << 1) |
     // This is slightly different than the rest of the state,
     // since it is affected by the directive prologue and may be hit
@@ -634,7 +642,9 @@ SingleLineBinaryOpRHS
 RHS
   # NOTE: Check for comptime block first, to avoid matching as function call
   ExpressionizedStatementWithTrailingCallExpressions
-  UnaryExpression
+  ForbidImplicitFragment UnaryExpression?:exp RestoreImplicitFragment ->
+    if (!exp) return $skip
+    return exp
 
 # https://262.ecma-international.org/#prod-UnaryExpression
 UnaryExpression
@@ -5412,7 +5422,7 @@ SingleLineExpressionWithIndentedApplicationForbidden
 # as arguments to implicit function calls.  This is useful in the context of
 # an `if` or `class` line where we don't want to treat the body as an object.
 ExpressionWithObjectApplicationForbidden
-  ForbidBracedApplication ForbidIndentedApplication Expression?:exp RestoreBracedApplication RestoreIndentedApplication ->
+  ForbidBracedApplication ForbidIndentedApplication ForbidImplicitFragment Expression?:exp RestoreBracedApplication RestoreIndentedApplication RestoreImplicitFragment ->
     if (exp) return exp
     return $skip
 
@@ -5535,6 +5545,25 @@ NewlineBinaryOpAllowed
     }
     if (state.newlineBinaryOpForbidden) return $skip
 
+AllowImplicitFragment
+  "" ->
+    state.forbidImplicitFragment.push(false)
+
+ForbidImplicitFragment
+  "" ->
+    state.forbidImplicitFragment.push(true)
+
+RestoreImplicitFragment
+  "" ->
+    state.forbidImplicitFragment.pop()
+
+ImplicitFragmentAllowed
+  "" ->
+    if (config.verbose) {
+      console.log("forbidImplicitFragment:", state.forbidImplicitFragment)
+    }
+    if (state.implicitFragmentForbidden) return $skip
+
 AllowPipeline
   "" ->
     state.forbidPipeline.push(false)
@@ -5555,10 +5584,10 @@ PipelineAllowed
     if (state.pipelineForbidden) return $skip
 
 AllowAll
-  AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNestedBinaryOp AllowNewlineBinaryOp AllowPipeline
+  AllowTrailingMemberProperty AllowBracedApplication AllowIndentedApplication AllowClassImplicitCall AllowNestedBinaryOp AllowNewlineBinaryOp AllowImplicitFragment AllowPipeline
 
 RestoreAll
-  RestoreTrailingMemberProperty RestoreBracedApplication RestoreIndentedApplication RestoreClassImplicitCall RestoreNestedBinaryOp RestoreNewlineBinaryOp RestorePipeline
+  RestoreTrailingMemberProperty RestoreBracedApplication RestoreIndentedApplication RestoreClassImplicitCall RestoreNestedBinaryOp RestoreNewlineBinaryOp RestoreImplicitFragment RestorePipeline
 
 # https://262.ecma-international.org/#prod-ExpressionStatement
 CommaExpressionStatement
@@ -5670,7 +5699,9 @@ MaybeNestedNonPipelineExpression
     if (!expression) return $skip
     if (!trailing) return expression
     return [ expression, trailing ]
-  NonPipelineExpression
+  ForbidImplicitFragment NonPipelineExpression?:expression RestoreImplicitFragment ->
+    if (!expression) return $skip
+    return expression
 
 MaybeNestedPostfixedExpression
   # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
@@ -5680,7 +5711,9 @@ MaybeNestedPostfixedExpression
     if (!expression) return $skip
     if (!trailing) return expression
     return [ expression, trailing ]
-  PostfixedExpression
+  ForbidImplicitFragment PostfixedExpression?:expression RestoreImplicitFragment ->
+    if (!expression) return $skip
+    return expression
 
 NestedPostfixedExpressionNoTrailing
   NestedBulletedArray
@@ -5697,7 +5730,9 @@ MaybeNestedExpression
     if (!expression) return $skip
     if (!trailing) return expression
     return [ expression, trailing ]
-  Expression
+  ForbidImplicitFragment Expression?:expression RestoreImplicitFragment ->
+    if (!expression) return $skip
+    return expression
 
 # MaybeNestedExpression but where expression needs to be output with
 # parentheses if indented, so that the expression starts on the same line.
@@ -5708,7 +5743,7 @@ MaybeParenNestedExpression
   &( _? PostfixStatement NoBlock ) -> ""
   # Not nested case
   !EOS Expression -> $2
-  # Avoid wrapping array/object return value in parentheses.
+  # Avoid double wrapping nested array/object return value in parentheses.
   &EOS ( ArrayLiteral / ObjectLiteral ) -> $2
   # Value after `return` needs to be wrapped in parentheses
   # if it starts on another line.
@@ -7067,18 +7102,23 @@ Yield
 ## JSX
 
 JSXImplicitFragment
-  JSXTag ( Nested ( JSXTag / JSXAngleChild ) )* ->
-    const jsx = $2.length === 0 ? $1 : {
+  # Always allow a single JSX tag.
+  # Implicit fragment can be explicitly forbidden; it also inherits
+  # forbidden status from binary ops on the following line.
+  JSXTag:first ( ImplicitFragmentAllowed NestedBinaryOpAllowed NewlineBinaryOpAllowed ( Nested ( JSXTag / JSXAngleChild ) )* )?:rest ->
+    rest = rest ? rest[3] : []
+    const jsx = rest.length === 0 ? first : {
       type: "JSXFragment",
       children: [
         "<>\n",
         state.currentIndent.token,
-        ...$0,
+        first,
+        ...rest,
         "\n",
         state.currentIndent.token,
         "</>",
       ],
-      jsxChildren: [$1].concat($2.map(([, tag]) => tag)),
+      jsxChildren: [ first, ...rest.map(([, tag]) => tag) ],
     }
     const type = typeOfJSX(jsx, config)
     return type ? [
@@ -7758,9 +7798,7 @@ JSXAngleChild
   CloseAngleBracket JSXCodeChild -> $2
 
 JSXCodeChild
-  InsertInlineOpenBrace:open JSXCodeChildExpression:expression InsertCloseBrace:close ->
-    if (!expression) return $skip
-    return [ open, expression, close ]  // omit >
+  InsertInlineOpenBrace JSXCodeChildExpression InsertCloseBrace
 
 JSXCodeChildExpression
   # First check for unindented expression (same line)
@@ -9057,6 +9095,7 @@ Reset
     state.forbidTrailingMemberProperty = [false]
     state.forbidNestedBinaryOp = [false]
     state.forbidNewlineBinaryOp = [false]
+    state.forbidImplicitFragment = [false]
     state.forbidPipeline = [false]
     state.JSXTagStack = [undefined]
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1938,76 +1938,59 @@ function reorderBindingRestProperty(props)
 
   return { children, names }
 
-function typeOfJSX(node, config) {
-  switch (node.type) {
-    case "JSXElement":
-      return typeOfJSXElement(node, config)
-    case "JSXFragment":
-      return typeOfJSXFragment(node, config)
-  }
-}
+function typeOfJSX(node, config)
+  switch node.type
+    when "JSXElement"
+      typeOfJSXElement node, config
+    when "JSXFragment"
+      typeOfJSXFragment node, config
 
-function typeOfJSXElement(node, config) {
-  if (config.solid) {
-    if (config.server and !config.client) {  // server only
+function typeOfJSXElement(node, config)
+  if config.solid
+    if config.server and not config.client  // server only
       return ["string"]
-    }
-    let { tag } = node
+    { tag } := node
     // "An intrinsic element always begins with a lowercase letter,
     // and a value-based element always begins with an uppercase letter."
     // [https://www.typescriptlang.org/docs/handbook/jsx.html]
-    const clientType =
+    clientType :=
       tag[0] is tag[0].toLowerCase() ?
-        [getHelperRef("IntrinsicElements"), '<"', tag, '">'] :
-        ['ReturnType<typeof ', tag, '>']
-    if (config.server) {  // isomorphic code for client + server
-      return ["string", " | ", clientType]
-    } else {  // client only (default)
+        [ getHelperRef("IntrinsicElements"), '<"', tag, '">' ] :
+        [ 'ReturnType<typeof ', tag, '>' ]
+    if config.server  // isomorphic code for client + server
+      return [ "string", " | ", clientType ]
+    else  // client only (default)
       return clientType
-    }
-  }
-}
 
-function typeOfJSXFragment(node, config) {
-  if (config.solid) {
-    let type = []
+function typeOfJSXFragment(node, config)
+  if config.solid
+    type .= []
     let lastType
-    for (let child of node.jsxChildren) {
-      switch (child.type) {
-        case "JSXText":
+    for child of node.jsxChildren
+      switch child.type
+        when "JSXText"
           // Solid combines multiple consecutive texts into one string
-          if (lastType !== "JSXText") {
-            type.push("string")
-          }
-          break
-        case "JSXElement":
-          type.push(typeOfJSXElement(child, config))
-          break
-        case "JSXFragment":
+          unless lastType is "JSXText"
+            type.push "string"
+        when "JSXElement"
+          type.push typeOfJSXElement child, config
+        when "JSXFragment"
           // Solid flattens fragments of fragments into one array.
-          type.push(...typeOfJSXFragment(child, config))
-          break
-        case "JSXChildExpression":
+          type.push ...typeOfJSXFragment child, config
+        when "JSXChildExpression"
           // Solid discards empty expressions
-          if (child.expression) {
-            type.push(["typeof ", child.expression])
-          }
-          break
-        default:
-          throw new Error(`unknown child in JSXFragment: ${JSON.stringify(child)}`)
-      }
+          if child.expression
+            type.push [ "typeof ", child.expression ]
+        else
+          throw new Error `unknown child in JSXFragment: ${JSON.stringify(child)}`
       lastType = child.type
-    }
     // Solid doesn't wrap single fragment child in an array
-    if (type.length is 1) {
+    if type# is 1
       return type[0]
-    } else {
-      type = type.flatMap((t) => [t, ", "])
+    else
+      type = type.flatMap [&, ", "]
       type.pop() // remove trailing comma
-      return ["[", type, "]"]
-    }
-  }
-}
+      return [ "[", type, "]" ]
 
 export {
   addPostfixStatement

--- a/test/jsx/indent.civet
+++ b/test/jsx/indent.civet
@@ -650,81 +650,172 @@ describe "Implicit JSX fragments", ->
     ]
   """
 
-  describe "> children instead of braces", ->
-    testCase """
-      single line
-      ---
-      <div>
-        >'Hello '
-        > name |> .first
-      ---
-      <div>
-        {'Hello '}
-        { name.first}
-      </div>
-    """
+  testCase """
+    no implicit fragment in function call
+    ---
+    =>
+      f <foo>
+      <bar>
+    ---
+    () => {
+      f(<foo />)
+      return <bar />
+    }
+  """
 
-    testCase """
-      single-line if/else
-      ---
-      <div>
-        >if greeting
-          'Hello'
-        else
-          'Goodbye'
-      ---
-      <div>
-        {(greeting?
-          'Hello'
-        :
-          'Goodbye')}
-      </div>
-    """
+  testCase """
+    no implicit fragment in assignment
+    ---
+    =>
+      x = <foo>
+      <bar>
+    ---
+    () => {
+      x = <foo />
+      return <bar />
+    }
+  """
 
-    testCase """
-      indented
-      ---
-      <div>
-        Hello
-        >
-          {first, last} := name()
-          ` ${first} ${last}`
-        !
-      ---
-      <div>
-        Hello
-        {(()=>{ {
-          const {first, last} = name()
-          return ` ${first} ${last}`
-        }})()}
-        !
-      </div>
-    """
+  testCase """
+    no implicit fragment in declaration
+    ---
+    =>
+      x := <foo>
+      <bar>
+    ---
+    () => {
+      const x = <foo />
+      return <bar />
+    }
+  """
 
-    testCase """
-      indented from opening tag
-      ---
-      <div>>
+  testCase """
+    no implicit fragment in if declaration
+    ---
+    =>
+      if x := <foo>
+      <bar>
+    ---
+    () => {
+      let ref;if ((ref = <foo />)) {const x = ref;}
+      return <bar />
+    }
+  """
+
+  testCase """
+    no implicit fragment in if statement
+    ---
+    =>
+      if <foo>
+      <bar>
+    ---
+    () => {
+      if (<foo />) {}
+      return <bar />
+    }
+  """
+
+  testCase """
+    no implicit fragment in > child
+    ---
+    <foo>
+      > <first>
+      <second>
+    ---
+    <foo>
+      { <first />}
+      <second />
+    </foo>
+  """
+
+  testCase """
+    no implicit fragment after binary
+    ---
+    =>
+      x + <foo>
+      <bar>
+    ---
+    () => {
+      x + <foo />
+      return <bar />
+    }
+  """
+
+describe "> children instead of braces", ->
+  testCase """
+    single line
+    ---
+    <div>
+      >'Hello '
+      > name |> .first
+    ---
+    <div>
+      {'Hello '}
+      { name.first}
+    </div>
+  """
+
+  testCase """
+    single-line if/else
+    ---
+    <div>
+      >if greeting
+        'Hello'
+      else
+        'Goodbye'
+    ---
+    <div>
+      {(greeting?
+        'Hello'
+      :
+        'Goodbye')}
+    </div>
+  """
+
+  testCase """
+    indented
+    ---
+    <div>
+      Hello
+      >
         {first, last} := name()
-        `Hello ${first} ${last}`
-      ---
-      <div>{(()=>{ {
+        ` ${first} ${last}`
+      !
+    ---
+    <div>
+      Hello
+      {(()=>{ {
         const {first, last} = name()
-        return `Hello ${first} ${last}`
+        return ` ${first} ${last}`
       }})()}
-      </div>
-    """
+      !
+    </div>
+  """
 
-    testCase """
-      implicit fragment
-      ---
-      <node>
-      > if cond
-        <sibling>
-      ---
-      <>
-      <node />
-      { (cond?
-        <sibling />:void 0)}
-      </>
-    """
+  testCase """
+    indented from opening tag
+    ---
+    <div>>
+      {first, last} := name()
+      `Hello ${first} ${last}`
+    ---
+    <div>{(()=>{ {
+      const {first, last} = name()
+      return `Hello ${first} ${last}`
+    }})()}
+    </div>
+  """
+
+  testCase """
+    implicit fragment
+    ---
+    <node>
+    > if cond
+      <sibling>
+    ---
+    <>
+    <node />
+    { (cond?
+      <sibling />:void 0)}
+    </>
+  """


### PR DESCRIPTION
Fixes #1801

It seems like we needed a new flag for this, because we have some scenarios where we want to allow a nested binary operator but not a nested JSX tag (though also re-used some existing flags).

I might have missed some contexts where implicit JSX fragments should be forbidden, but it's easy to add them now.