### PR TITLE
Don't unwrap statement expressions that might be short-circuited

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -186,7 +186,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
 
   // Handle nested statement expression
   let ws
-  if Array.isArray(exp)
+  if Array.isArray exp
     ws = exp[0]
     exp = exp[1]!
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -146,6 +146,7 @@ import {
 } from ./binding.civet
 import {
   getPrecedence
+  isShortCircuitOp
   precedenceCustomDefault
   precedenceStep
   processBinaryOpExpression
@@ -1024,7 +1025,7 @@ function processAssignments(statements): void
   for each exp of gatherRecursiveAll statements, .type is "AssignmentExpression" or .type is "UpdateExpression"
     checkValidLHS exp.assigned
 
-    function extractAssignment(lhs)
+    function extractAssignment(lhs: ASTNodeObject)
       expr .= lhs
       while expr.type is "ParenthesizedExpression"
         expr = expr.expression
@@ -1074,8 +1075,12 @@ function processAssignments(statements): void
     let { lhs: $1, expression: $2 } = exp, tail = [], len = $1.length
 
     let block?: BlockStatement
-    // Extract StatementExpression as block
-    if blockContainingStatement(exp) and !$1.-1?.-1?.special// can only prepend to assignments that are children of blocks
+    // Extract StatementExpression as block,
+    // if this assignment is at the statement level,
+    // the last operator isn't special, and
+    // no operator might shortcut
+    if blockContainingStatement(exp) and !$1.-1?.-1?.special and
+       not isShortCircuitOp($1.-1?.-1)
       block = makeBlockFragment()
       if ref := prependStatementExpressionBlock(
         {type: "Initializer", expression: $2, children: [undefined, undefined, $2]}

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -65,6 +65,24 @@ function getPrecedence(op: BinaryOp): number
     precedenceMap.get(op.prec ?? op.token) ??
     if op.relational then precedenceRelational else precedenceCustomDefault
 
+/**
+ * Return whether the operator short-circuits, i.e., skips evaluating
+ * its right-hand side depending on the value of its left-hand side.
+ * Currently, this just applies to JavaScript operators, but we might add
+ * support for short-circuiting custom operators in the future.
+ */
+function isShortCircuitOp(op: BinaryOp): boolean
+  if {token} := op
+    isShortCircuitOp token
+  else if op <? "string"
+    // Strip = from ||=, &&=, ??=
+    if op.endsWith("=") and not op.endsWith("==")
+      op = op[<-1]
+    op is like "||", "&&", "??"
+  else
+    // For now, custom operators can't short-circuit
+    false
+
 function processBinaryOpExpression($0: [ASTNode, [ASTNode, BinaryOp, ASTNode, ASTNode][]])
   return processExpandedBinaryOpExpression expandChainedComparisons($0)
 
@@ -341,6 +359,7 @@ function expandChainedComparisons([first, binops]: [ASTNode, [ASTNode, BinaryOp,
 
 export {
   getPrecedence
+  isShortCircuitOp
   precedenceCustomDefault
   precedenceStep
   processBinaryOpExpression

--- a/test/do.civet
+++ b/test/do.civet
@@ -129,6 +129,57 @@ describe "do", ->
   """
 
   testCase """
+    short-circuit assigned
+    ---
+    x ?= do
+    x ??= do
+    x &&= do
+    x and= do
+    x ||= do
+    x or= do
+    ---
+    x ??= (()=>{{}})()
+    x ??= (()=>{{}})()
+    x &&= (()=>{{}})()
+    x &&= (()=>{{}})()
+    x ||= (()=>{{}})()
+    x ||= (()=>{{}})()
+  """
+
+  testCase """
+    non-short-circuit assigned
+    ---
+    x &= do
+    x |= do
+    x += do
+    x %= do
+    ---
+    let ref;{ref = void 0;};x &= ref
+    let ref1;{ref1 = void 0;};x |= ref1
+    let ref2;{ref2 = void 0;};x += ref2
+    let ref3;{ref3 = void 0;};x %= ref3
+  """
+
+  testCase """
+    special assigned
+    ---
+    x %%= do
+    ---
+    var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
+    x = modulo(x, (()=>{{}})())
+  """
+
+  testCase """
+    short-circuit only matters for last assignment
+    ---
+    x ?= y = do
+    x = y ?= do
+    ---
+    let ref;{ref = void 0;};x ??= y = ref
+    x = y ??= (()=>{{}})()
+  """
+
+  testCase """
     braces in a single line
     ---
     do { x } = y


### PR DESCRIPTION
Fixes #1817