### PR TITLE
feat(lsp): add LSP completions for import paths

### DIFF
--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -409,6 +409,7 @@ connection.onCompletion(async ({ textDocument, position, context: _context }) =>
   const completionOptions: GetCompletionsAtPositionOptions = {
     includeExternalModuleExports: completionConfiguration.autoImportSuggestions,
     includeInsertTextCompletions: true,
+    includeCompletionsForImportStatements: true,
   }
 
   if (context?.triggerKind) {


### PR DESCRIPTION
might resolve #1824 

### Summary

* This change adds support for LSP completions when typing a file-path in an import statement.
  * Now both TypeScript and Civet LSP completions will include `.civet` files in the completions list
* There also a small change to fix LSP completions for optional values to not insert the trailing `?` character.
* And there's another small change to allow for LSP completions when importing a module export.

### Notes

* This implementation gathers the `.civet` files by scanning the import-path directory, and it handles resolving TypeScript path-aliases. We may want to consider a different approach based on the discussion in #1824 
* Mainly publishing this pull-request to share the results of some tinkering, and possibly adapt it to the preferred solution.

### Demo

Here's a small demo of the LSP Completions inside TypeScript and Civet files

https://github.com/user-attachments/assets/6d475d17-0b3a-46fb-9e2d-ca36f3de8214
