### PR TITLE
Inline sourcemaps use new `outputFilename` option, set by CLI

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -474,6 +474,19 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       errors++
       continue
 
+    outputPath: path.FormatInputPathObject := options.outputPath ??
+      path.parse filename
+      ||> delete .base  // use name and ext
+      ||> .ext +=  // default extension
+        if options.js
+          ".jsx"
+        else
+          ".tsx"
+      ||> ($) =>  // `output` option overrides
+        $.dir = options.outputDir if options.outputDir?
+        $.ext = options.outputExt if options.outputExt?
+    outputFilename := path.format outputPath
+
     // Transpile
     let output: string
     try
@@ -484,7 +497,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
         |> await
         |> .code
       else
-        output = await compile content!, {...options, filename}
+        output = await compile content!, {...options, filename, outputFilename}
     catch error
       //console.error `${filename} failed to transpile:`
       console.error error
@@ -497,24 +510,13 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       if (stdin and not options.output) or options.output is '-'
         process.stdout.write output
       else
-        targetPath: path.FormatInputPathObject .= path.parse filename
-        delete targetPath.base  // use name and ext
-        // Default extension
-        if options.js
-          targetPath.ext += ".jsx"
-        else
-          targetPath.ext += ".tsx"
-        // `output` option overrides
-        targetPath.dir = options.outputDir if options.outputDir?
-        targetPath.ext = options.outputExt if options.outputExt?
-        targetPath = options.outputPath if options.outputPath?
         // Make output directory in case it doesn't already exist
-        await fs.mkdir targetPath.dir, recursive: true if targetPath.dir
-        targetFilename := path.format targetPath
+        outputDir := path.dirname outputFilename
+        await fs.mkdir outputDir, recursive: true unless outputDir is '.'
         try
-          await fs.writeFile targetFilename, output
+          await fs.writeFile outputFilename, output
         catch error
-          console.error `${targetFilename} failed to write:`
+          console.error `${outputFilename} failed to write:`
           console.error error
           errors++
     else if options.run

--- a/source/main.civet
+++ b/source/main.civet
@@ -78,6 +78,7 @@ uncacheable := new Set [
 
 export type CompilerOptions
   filename?: string
+  outputFilename?: string
   sourceMap?: boolean
   inlineMap?: boolean
   ast?: boolean | "raw"
@@ -218,7 +219,9 @@ export function compile<const T extends CompilerOptions>(src: string | Buffer, o
 
       if options.inlineMap
         //@ts-ignore
-        return `${code}\n${options.sourceMap.comment filename, filename + '.tsx'}`
+        outputFilename := options.outputFilename ??
+          (options.js ? filename + '.jsx' : filename + '.tsx')
+        return `${code}\n${options.sourceMap.comment filename, outputFilename}`
       else
         return {
           code,

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -24,6 +24,18 @@ describe "source map", ->
 
     assert.deepEqual parsed.lines, sourceMap.lines
 
+  it "uses outputFilename in inline source maps", ->
+    src := "x := 1\n"
+    output := await compile src,
+      inlineMap: true
+      filename: "input.civet"
+      outputFilename: "output.ts"
+
+    match := output.match /sourceMappingURL=data:application\/json;base64,([+a-zA-Z0-9\/]*=?=?)/
+    assert.ok match
+    json := SourceMap.parseWithLines match[1]
+    assert.equal json.file, "output.ts"
+
   describe "decodeVLQ error cases", ->
     it "should throw error for unexpected early end of mapping data", ->
       // Test with an incomplete VLQ sequence that ends abruptly

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -54,6 +54,10 @@ declare module "@danielx/civet" {
      */
     filename?: string
     /**
+     * Output (transpiled) filename to record in inline source maps.
+     */
+    outputFilename?: string
+    /**
      * Whether to return a source map in addition to transpiled code.
      * If false (the default), `compile` just returns transpiled code.
      * If true (and `inlineMap` is false/unspecified),


### PR DESCRIPTION
Fixes #1829

We don't have end-to-end CLI tests, but I tested most options by hand.

CLI doesn't yet support outputting `.map` files so no changes there.