### PR TITLE
Fix when pipelines can continue without indentation

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -981,8 +981,15 @@ PipelineExpressionBody
       ...rest.map(([nested, line]) => [nested, ...line]).flat()
     ]
 
-  # Otherwise allow for any not-dedented chain
-  ( NotDedented Pipe __ PipelineTailItem )+
+  # Otherwise allow for any not-dedented chain,
+  # assuming not-dedented binary operators are allowed
+  NewlineBinaryOpAllowed ( NotDedented Pipe __ PipelineTailItem )+ -> $2
+
+  # If binary operators need to be indented, and we didn't match above,
+  # still need to allow same-line pipelines
+  !NewlineBinaryOpAllowed PipelineExpressionBodySameLine ->
+    if (!$2.length) return $skip
+    return $2
 
 PipelineExpressionBodySameLine
   ( _? Pipe __ PipelineTailItem )*
@@ -1006,7 +1013,9 @@ PipelineTailItem
     return makeAmpersandFunction({
       body: [" ", $1, ...$2],
     })
-  PipelineHeadItem -> $1
+  ForbidNewlineBinaryOp PipelineHeadItem? RestoreNewlineBinaryOp ->
+    if (!$2) return $skip
+    return $2
 
 # https://262.ecma-international.org/#prod-PrimaryExpression
 PrimaryExpression

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -900,3 +900,37 @@ describe "pipe", ->
     ---
     [].map(f(g(1)))
   """
+
+  testCase """
+    & doesn't grab unindented pipeline on next line
+    ---
+    x := y
+    |> if foo() then .a() else &
+    |> .b()
+    ---
+    const x = (foo()? ($ => $.a()) : ($1 => $1))(y).b()
+  """
+
+  testCase """
+    & grabs indented pipeline on next line
+    ---
+    x := y
+    |> if foo() then .a() else &
+      |> .b()
+    ---
+    const x = (foo()? ($ => $.a()) : ($1 => $1.b()))(y)
+  """
+
+  testCase """
+    not-dedented pipeline allowed in indented block
+    ---
+    x := y
+    |> do
+      &
+      |> .b()
+    |> .c()
+    ---
+    const x = (()=>{{
+      return $ => $.b()
+    }})()(y).c()
+  """


### PR DESCRIPTION
Fixes #1832 by forbidding not-dedented pipelines when not-dedented binary operators aren't allowed, and forbids not-dedented binary operators right after a pipe operator. The parsing code is a little messy, but I couldn't think of an easy optimization; let me know if you spot anything.

Hmm, I guess this approach does mean that code like this breaks:

```js
x := y
  |> if foo() then .a() else &
  |> .b()
  + 5
  |> x
```

Currently, it compiles, where the middle step is `.b() + 5`. With this PR, it doesn't. Should we try to support this, or was it unintended/unimportant?

BREAKING CHANGE: Binary operators can no longer be indented at the same level as pipeline (`|>`)