### PR TITLE
Fix tight binary XOR `^` treated as named binding pattern

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -750,6 +750,12 @@ UpdateExpression
       children: [$1, $2[0]],
     }
 
+# UpdateExpression that's the left-hand side of an ActualAssignment,
+# so supports top-level NamedBindingPattern
+UpdateExpressionPattern
+  NamedBindingPattern
+  UpdateExpression
+
 UpdateExpressionSymbol
   "++" / "--" ->
     return { $loc, token: $1 }
@@ -807,7 +813,7 @@ ActualAssignment
   # NOTE: Consolidated assignment ops
   # NOTE: UpdateExpression instead of LeftHandSideExpression to allow
   # e.g. ++x *= 2 which we later convert to ++x, x *= 2
-  ( NotDedented UpdateExpression WAssignmentOp )+ MaybeNestedExpression ->
+  ( NotDedented UpdateExpressionPattern WAssignmentOp )+ MaybeNestedExpression ->
     $1 = $1.map(x => [x[0], x[1], ...x[2]])
     $0 = [$1, $2]
     return {
@@ -826,7 +832,7 @@ NonPipelineActualAssignment
   # NOTE: Consolidated assignment ops
   # NOTE: UpdateExpression instead of LeftHandSideExpression to allow
   # e.g. ++x *= 2 which we later convert to ++x, x *= 2
-  ( NotDedented UpdateExpression WAssignmentOp )+ MaybeNestedNonPipelineExpression ->
+  ( NotDedented UpdateExpressionPattern WAssignmentOp )+ MaybeNestedNonPipelineExpression ->
     $1 = $1.map((x) => [x[0], x[1], ...x[2]])
     $0 = [$1, $2]
     return {
@@ -1510,7 +1516,6 @@ LeftHandSideExpression
       children: $0,
       expression,
     }
-  NamedBindingPattern
   CallExpression
   # NOTE: OptionalExpression is merged into CallExpression
 

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -413,6 +413,16 @@ describe "assignment", ->
     x = y, {a, b} = x, [c, d] = b
   """
 
+  testCase """
+    named destructuring assignment with arrays
+    ---
+    [a^[b, c], d^[e, f], g] = y
+    x^[a^[b, c], d^[e, f], g] = y
+    ---
+    [a, d, g] = y, [b, c] = a, [e, f] = d
+    x = y, [a, d, g] = x, [b, c] = a, [e, f] = d
+  """
+
   describe.skip "TOMAYBE", ->
     testCase """
       multiple single line const assignments

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -448,6 +448,14 @@ describe "binary operations", ->
   """
 
   testCase """
+    tight bitwise literal
+    ---
+    a^1
+    ---
+    a^1
+  """
+
+  testCase """
     bitwise
     ---
     a | b


### PR DESCRIPTION
Fixes #1766