### PR TITLE
unplugin supports `?worker` imports in Vite 7

### DIFF
--- a/integration/unplugin-examples/vite/src/main.civet
+++ b/integration/unplugin-examples/vite/src/main.civet
@@ -1,3 +1,10 @@
 {a} from "./module"
+MyWorker from "./worker.civet?worker"
 
 console.log a
+
+worker := new MyWorker()
+worker.onmessage = (event) ->
+  console.log "Worker says:", event.data
+  document.body.appendChild document.createTextNode "Worker says: " + event.data + "\n"
+worker.postMessage "ping"

--- a/integration/unplugin-examples/vite/src/worker.civet
+++ b/integration/unplugin-examples/vite/src/worker.civet
@@ -1,0 +1,2 @@
+self.onmessage = (event) ->
+  postMessage event.data + " from worker"

--- a/integration/unplugin-examples/vite/vite.config.js
+++ b/integration/unplugin-examples/vite/vite.config.js
@@ -1,6 +1,13 @@
 import civetVitePlugin from '@danielx/civet/vite';
 import { defineConfig } from 'vite';
 
+const civet = civetVitePlugin({
+  ts: "preserve"
+});
+
 export default defineConfig({
-  plugins: [civetVitePlugin({})],
+  plugins: [civet],
+  worker: {
+    plugins: () => [civet],
+  },
 });

--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -56,6 +56,7 @@ postfixRE := /[?#].*$/s
 isWindows := os.platform() is 'win32'
 windowsSlashRE := /\\/g
 civetSuffix := '.civet'
+workerRE := /(?:\?|&)(?:worker|sharedworker)(?:&|$|#)/
 
 /**
 Extract a possible Civet filename from an id, after removing a possible
@@ -133,6 +134,7 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
   let esbuildOptions: BuildOptions
   let configErrors: Diagnostic[]?
   let configFileNames: string[]
+  skipWorker .= false
 
   tsPromise := if transformTS or ts is "tsc"
     import('typescript').then .default
@@ -412,11 +414,13 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
       return resolved + outExt + postfix
 
     loadInclude(id)
-      extractCivetFilename(id, outExt).filename.endsWith civetSuffix
+      {filename, postfix} := extractCivetFilename id, outExt
+      return false if skipWorker and workerRE.test postfix
+      filename.endsWith civetSuffix
 
     async load(id)
       {filename} .= extractCivetFilename id, outExt
-      return null unless filename.endsWith civetSuffix
+      // We're guaranteed to have .civet extension here by loadInclude
 
       filename = path.resolve rootDir, filename
       @addWatchFile filename
@@ -552,6 +556,13 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
     }
     vite: {
       config(config: UserConfig): void
+        // Vite 7 requires us to skip processing ?worker
+        // and instead process a followup request for ?worker_file
+        // Luckily, Vite 7 introduced @meta.viteVersion for detection
+        //@ts-ignore lacking type for this
+        if @?meta?viteVersion and 7 <= Number @meta.viteVersion.split('.')[0]
+          skipWorker = true
+
         rootDir = path.resolve process.cwd(), config.root ?? ''
 
         if implicitExtension


### PR DESCRIPTION
Fixes #1789

I tested the now-worker-enabled example in `integration/unplugin-examples/vite` on Vite 6.4.1 (latest 6), 7.0.0, 7.3.1 (latest 7), and 8.0.0-beta.8.