### PR TITLE
unplugin fix Vite HMR with `?query`

### DIFF
--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -589,13 +589,12 @@ export const rawPlugin: Parameters<typeof createUnplugin<PluginOptions>>[0] =
         return unless file.endsWith '.civet'
         // Convert into path as would be output by `resolveId`
         resolvedId := slash path.resolve(file) + outExt
-        // Check for module with this name
-        module := server.moduleGraph.getModuleById resolvedId
-        if module
+        // Check for modules for this file
+        if fileModules := server.moduleGraph.getModulesByFile resolvedId
           // Invalidate modules depending on this one
           server.moduleGraph.onFileChange resolvedId
           // Hot reload this module
-          return [ ...modules, module ]
+          return [ ...modules, ...fileModules ]
         modules
     }
 


### PR DESCRIPTION
When testing #1839, I noticed that HMR was broken when editing `main.civet` because its id was `main.civet.tsx?transform`. This change seems to ignore the query part and correctly just use the filename.