### PR TITLE
Fix REPL continuation prompt to `...`, clarifying indentation

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -267,12 +267,13 @@ export function repl(args: string[], options: Options)
   } code.`
   global.quit = global.exit = => process.exit 0
   import * as nodeRepl from node:repl
-  r := nodeRepl.start
-    prompt:
-      switch
-        when options.ast then '🌲> '
-        when options.compile then '🐈> '
-        else '🐱> '
+  prompt :=
+    switch
+      when options.ast then '🌲> '
+      when options.compile then '🐈> '
+      else '🐱> '
+  r := nodeRepl.start {}
+    prompt
     writer:
       if options.ast
         (obj: unknown) =>
@@ -364,6 +365,32 @@ export function repl(args: string[], options: Options)
           callback null, result
       else  // still reading
         callback (new nodeRepl.Recoverable new Error "Enter a blank line to execute code."), null
+
+  // Hack to force '...' prompt for continuation input lines
+  bufferedCommandSymbol :=
+    Object.getOwnPropertySymbols(r).find (symbol) =>
+      symbol.description is 'bufferedCommand'
+  interfaceSetPrompt :=
+    Object.getPrototypeOf(Object.getPrototypeOf(r))?.setPrompt
+  writeToOutputSymbol :=
+    Object.getOwnPropertySymbols(Object.getPrototypeOf(Object.getPrototypeOf(r))).find (symbol) =>
+      symbol.description is '_writeToOutput'
+  if bufferedCommandSymbol and interfaceSetPrompt and writeToOutputSymbol
+    // Fix display of continuation prompt from `| ` to `... `
+    originalWriteToOutput := r[writeToOutputSymbol]
+    Object.defineProperty r, writeToOutputSymbol,
+      value: (text: string) =>
+        originalWriteToOutput.call r, text.replace /(^|\n)\| /g, '$1... '
+      configurable: true
+      writable: true
+    // Fix internal prompt string from `| ` to `... `
+    r.displayPrompt = (preserveCursor?: boolean) =>
+      interfaceSetPrompt.call r,
+        if r[bufferedCommandSymbol]?#
+          '... '
+        else
+          prompt
+      r.prompt preserveCursor
 
 export function cli(args = process.argv[2..])
   // process.argv gets overridden when running scripts, but gets saved here


### PR DESCRIPTION
Fixes #1768

This hack seems to work on older Node (I tested 20 and 22) before the continuation prompt changed, as well as modern Node (24) where this hack is necessary. Demo:

<img width="1407" height="1713" alt="image" src="https://github.com/user-attachments/assets/263c1a24-cedf-4cbc-b536-dbf0cc85d0c6" />

One catch here is that I didn't invent this hack. I actually thought it was impossible! But I thought I'd give GPT-5.2 Codex + OpenCode a try at it, and it figured out a way to get at those internal symbols that I thought were impenetrable.

We can revisit this when Node finally makes the continuation prompt reconfigurable (there have been various PR attempts, though none merged yet). Though we probably will need the hack for a while, until patched versions of Node become commonplace.