### PR TITLE
Don't treat `package.js/civet` as config

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -126,13 +126,13 @@ you can add one of the following files:
 * `🐈.json`
 * `civetconfig.json`
 * `civet.config.json`
+* Any of the above with a `.civet` or `.js` extension,
+  with code that `export default`s an object equivalent to a JSON file.
 * `package.json` with a `"civetConfig"` property
 * Any of the above with `.yaml` or `.yml` extension
   * Requires [yaml](https://eemeli.org/yaml) to be `install`ed as optional
   [`peerDependencies`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies)
   * In particular, supports [`package.yaml`](https://github.com/pnpm/pnpm/issues/1100) with a `"civetConfig"` property
-* Any of the above with a `.civet` or `.js` extension,
-  with code that `export default`s an object equivalent to a JSON file.
 
 The JSON data should consist of an object with a `"parseOptions"` property,
 which should be an object specifying one of more directives in the natural way.

--- a/source/config.civet
+++ b/source/config.civet
@@ -33,6 +33,9 @@ export function findInDir(dirPath: string): Promise<string | undefined>
   // Check for config files in order
   for each configName of configNames
     for each extension of configExtensions
+      // Avoid checking package.civet and package.js
+      // In particular, Meteor uses package.js for something else
+      continue if configName is "package" and extension is like ".civet", ".js"
       // Allow both .civetconfig.civet and civetconfig.civet
       for each entry of ["." + configName + extension, configName + extension]
         if entries.has(entry) and try fs.stat pathFor entry |> await |> .isFile()


### PR DESCRIPTION
I'm working on integrating Civet into [Meteor](https://meteor.com/), where [`package.js` has a special meaning](https://docs.meteor.com/api/package) (a sort of manifest when writing Meteor packages). Notably, `package.js` can't be executed without a bunch of Meteor-specific globals defined. So Civet configuration fails when trying to load `package.js`.

Hence I propose `package.js` should not be treated as a JavaScript equivalent of `package.json`, and can't be used to configure Civet. On the other hand, `package.yaml` has precedent (pnpm supports this), so I left the non-executable versions of `package`. (Incidentally, pnpm also supports `package.json5`, which we should probably allow when `json5` is installed.)

BREAKING CHANGE: Civet can no longer be configured from a default export of `package.js` or `package.civet`