### PR TITLE
Tests for CLI output filename generation

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -224,6 +224,20 @@ function readFiles(filenames: string[], evalString?: string): AsyncGenerator<Rea
     catch error
       yield {filename, error, stdin}
 
+export function makeOutputFilename(filename: string, options: Options): string
+  outputPath: path.FormatInputPathObject := options.outputPath ??
+    path.parse filename
+    ||> delete .base  // use name and ext
+    ||> .ext +=  // default extension
+      if options.js
+        ".jsx"
+      else
+        ".tsx"
+    ||> ($) =>  // `output` option overrides
+      $.dir = options.outputDir if options.outputDir?
+      $.ext = options.outputExt if options.outputExt?
+  path.format outputPath
+
 declare global
   var quit: () => void, exit: () => void
   var v8debug: unknown
@@ -518,18 +532,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       errors++
       continue
 
-    outputPath: path.FormatInputPathObject := options.outputPath ??
-      path.parse filename
-      ||> delete .base  // use name and ext
-      ||> .ext +=  // default extension
-        if options.js
-          ".jsx"
-        else
-          ".tsx"
-      ||> ($) =>  // `output` option overrides
-        $.dir = options.outputDir if options.outputDir?
-        $.ext = options.outputExt if options.outputExt?
-    outputFilename := path.format outputPath
+    outputFilename := makeOutputFilename filename, options
 
     // Transpile
     let output: string

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1,6 +1,6 @@
 assert from assert
 path from path
-{ parseArgs, type Options, type ParsedArgs } from ../source/cli.civet
+{ parseArgs, makeOutputFilename, type Options, type ParsedArgs } from ../source/cli.civet
 
 function argsParse(args: string | string[], parsed: ParsedArgs): Promise<void>
   args = args.split /\s+/ if args <? 'string'
@@ -219,6 +219,16 @@ describe 'CLI parseArgs', ->
         outputExt: '.js'
         outputPath: undefined
         parseOptions: rewriteCivetImports: '.js'
+
+  it 'resolves output filename for multi-dot input with -o .ts', =>
+    inputFilename := 'src/lib/something.lib.civet'
+    {filenames, options} := await parseArgs ['-c', '-o', '.ts', inputFilename], true
+    expectedPath := path.parse inputFilename
+    delete expectedPath.base
+    expectedPath.ext = '.ts'
+    outputFilename := makeOutputFilename filenames[0], options
+    assert.equal outputFilename, path.format expectedPath
+    assert.doesNotMatch outputFilename, /\.civet/
 
   it `parses -e`, =>
     argsOptions '-e console.log("hello")',


### PR DESCRIPTION
This PR exports the CLI code that generates output filenames (which is a bit complicated), so that it can be tested and guarantee that #1846 doesn't regress.