### PR TITLE
Implicit `async`, `AutoPromise`, `function*` propagate to overloads

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -170,18 +170,7 @@ function wrapTypeInApplication(t: TypeNode, id: ASTNode, raw?: string): TypeNode
 function implicitFunctionBlock(f): void
   if (f.abstract or f.block or f.signature?.optional) return
 
-  { name, parent } := f
-  ancestor .= parent
-  child .= f
-  if ancestor?.type is "ExportDeclaration"
-    child = ancestor
-    ancestor = ancestor.parent
-  expressions := ancestor?.expressions ?? ancestor?.elements
-  currentIndex := expressions?.findIndex [, def] => def is child
-  following .= currentIndex >= 0 and expressions[currentIndex + 1]?.[1]
-  following = following.declaration if following?.type is 'ExportDeclaration'
-
-  if f.type is following?.type and name? is following.name
+  if followingOverloads(f)#
     f.ts = true
   else
     block := makeEmptyBlock()
@@ -189,6 +178,41 @@ function implicitFunctionBlock(f): void
     f.block = block
     f.children.push(block)
     f.ts = false
+
+function overloadsInDirection(f: FunctionNode, direction: number): FunctionNode[]
+  return [] unless f.name?
+
+  ancestor .= f.parent
+  child: ASTNode .= f
+  if ancestor?.type is "ExportDeclaration"
+    child = ancestor
+    ancestor = ancestor.parent
+  return [] unless ancestor?.type is "BlockStatement"
+
+  {expressions} := ancestor
+  index .= findChildIndex expressions, child
+  return [] unless index >= 0
+
+  if direction < 0
+    while --index >= 0
+      candidate .= expressions[index][1]
+      break unless candidate
+      candidate = candidate.declaration if candidate.type is "ExportDeclaration"
+      break unless candidate and candidate.type is f.type and candidate.name is f.name
+      candidate
+  else
+    while ++index < expressions#
+      candidate .= expressions[index][1]
+      break unless candidate
+      candidate = candidate.declaration if candidate.type is "ExportDeclaration"
+      break unless candidate and candidate.type is f.type and candidate.name is f.name
+      candidate
+
+function precedingOverloads(f: FunctionNode): FunctionNode[]
+  return overloadsInDirection f, -1
+
+function followingOverloads(f: FunctionNode): FunctionNode[]
+  return overloadsInDirection f, +1
 
 function processReturn(f: FunctionNode, implicitReturns: boolean): void
   { returnType } .= f.signature
@@ -1041,7 +1065,7 @@ function processParams(f: FunctionNode): void
       index .= findChildIndex classExpressions, f
       assert.notEqual index, -1, "Could not find constructor in class"
       // Put fields before all constructor overloads so they remain consecutive
-      index-- while classExpressions[index-1]?[1] is like {type: "MethodDefinition", name: "constructor"}
+      index -= precedingOverloads(f)#
       fStatement := classExpressions[index]
       for each parameter of gatherRecursive parameters, .type is "Parameter"
         {accessModifier} := parameter
@@ -1126,10 +1150,11 @@ function findSuperCall(block: BlockStatement): number
 function processSignature(f: FunctionNode): void
   {block, signature} := f
 
+  addAsync .= false
+  addGenerator .= false
   if not f.async?# and hasAwait(block)
     if f.async?
-      f.async.push "async "
-      signature.modifier.async = true
+      addAsync = true
     else
       for each a of gatherRecursiveWithinFunction block, .type is "Await"
         i := findChildIndex a.parent, a
@@ -1140,8 +1165,7 @@ function processSignature(f: FunctionNode): void
 
   if not f.generator?# and hasYield(block)
     if f.generator?
-      f.generator.push "*"
-      signature.modifier.generator = true
+      addGenerator = true
     else
       for each y of gatherRecursiveWithinFunction block, .type is "YieldExpression"
         i := y.children.findIndex .type is "Yield"
@@ -1150,12 +1174,20 @@ function processSignature(f: FunctionNode): void
           type: "Error"
           message: `yield invalid in ${f.type is "ArrowFunction" ? "=> arrow function" : signature.modifier.get ? "getter" : signature.modifier.set ? "setter" : signature.name}` // name likely constructor
 
-  if signature.modifier.async and not signature.modifier.generator and
-     signature.returnType and not isPromiseType signature.returnType.t
-    replaceNode
-      signature.returnType.t
-      wrapTypeInPromise signature.returnType.t
-      signature.returnType // explicit parent in case type is an array node
+  for each overload of [f, ...precedingOverloads f]
+    if addAsync and overload.async? and not overload.async#
+      overload.async.push "async "
+      overload.signature.modifier.async = true
+    if addGenerator and overload.generator? and not overload.generator#
+      overload.generator.push "*"
+      overload.signature.modifier.generator = true
+
+    if overload.signature.modifier.async and not overload.signature.modifier.generator and
+      overload.signature.returnType and not isPromiseType overload.signature.returnType.t
+      replaceNode
+        overload.signature.returnType.t
+        wrapTypeInPromise overload.signature.returnType.t
+        overload.signature.returnType // explicit parent in case type is an array node
 
 function processFunctions(statements, config): void
   for each f of gatherRecursiveAll statements, .type is "FunctionExpression" or .type is "ArrowFunction" or .type is "MethodDefinition"

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -128,6 +128,25 @@ describe "[TS] class", ->
   """
 
   testCase """
+    overload methods inherit implicit async
+    ---
+    class UserAccount
+      load(value: number): number
+      async load(value: string): string
+      load(value: number | string): number | string
+        await Promise.resolve value
+    ---
+    type AutoPromise<T> = Promise<Awaited<T>>;
+    class UserAccount {
+      async load(value: number): AutoPromise<number>
+      async load(value: string): AutoPromise<string>
+      async load(value: number | string): AutoPromise<number | string> {
+        return await Promise.resolve(value)
+      }
+    }
+  """
+
+  testCase """
     static members
     ---
     class UserAccount

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -389,6 +389,53 @@ describe "[TS] function", ->
   """
 
   testCase """
+    overloads inherit implicit async
+    ---
+    function read(value: number): number
+    async function read(value: string): string
+    function read(value: number | string): number | string
+      await Promise.resolve value
+    ---
+    type AutoPromise<T> = Promise<Awaited<T>>;
+    async function read(value: number): AutoPromise<number>
+    async function read(value: string): AutoPromise<string>
+    async function read(value: number | string): AutoPromise<number | string> {
+      return await Promise.resolve(value)
+    }
+  """
+
+  testCase """
+    overloads inherit implicit generator
+    ---
+    function gen(value: number): Generator<number, void>
+    function* gen(value: string): Generator<string, void>
+    function gen(value: number | string): Generator<number | string, void>
+      yield value
+    ---
+    function* gen(value: number): Generator<number, void>
+    function* gen(value: string): Generator<string, void>
+    function* gen(value: number | string): Generator<number | string, void> {
+      yield value
+    }
+  """
+
+  testCase """
+    export overloads inherit implicit async
+    ---
+    export function load(value: number): number
+    export async function load(value: string): string
+    export function load(value: number | string): number | string
+      await Promise.resolve value
+    ---
+    type AutoPromise<T> = Promise<Awaited<T>>;
+    export async function load(value: number): AutoPromise<number>
+    export async function load(value: string): AutoPromise<string>
+    export async function load(value: number | string): AutoPromise<number | string> {
+      return await Promise.resolve(value)
+    }
+  """
+
+  testCase """
     complex
     ---
     declare function $C<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T[number]>


### PR DESCRIPTION
Fixes #1850

Includes a new helper to find surrounding overloads, which we did in a couple of places before. 