### PR TITLE
LSP completion at end of file

### DIFF
--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -544,9 +544,8 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   // -1: Gets inside closing quotes for import file completion.
   p += heuristics.cursorOffsetAdjustment
   if (isLikelyImportContext) {
-    // If we're at `import ` followed by EOF, sourcemapping is a bit wonky,
-    // and we start on the left of the implicit "" instead of the right.
-    // So now we've gone one step left when we need to go one step right.
+    // When we type `import` at EOF, sourcemapping is a bit wonky,
+    // and we end up to the left of the quotes instead of inside them.
     const start = transpiledDoc.positionAt(p)
     const quoteRangeText = transpiledDoc.getText({
       start,


### PR DESCRIPTION
This started as an implementation of the optimization mentioned in https://github.com/DanielXMoore/Civet/pull/1855#discussion_r2868067387

But then I noticed that, at end of file, `import "` and `import '` failed to produce completions (while `import ` worked fine). This PR makes a few more tweaks to fix that.

@seanstrom would you mind testing once more?