### PR TITLE
LSP handling of TypeScript crashing

### DIFF
--- a/lsp/source/server.mts
+++ b/lsp/source/server.mts
@@ -1045,11 +1045,12 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
           severity: DiagnosticSeverity.Error,
           range: {
             start: { line: 0, character: 0 },
-            end: { line: 0, character: Math.min(1, diagDocument.getText().length) },
+            end: { line: 0, character: 1 },
           },
           message,
           source: 'civet',
         })
+        break
       }
     }
 


### PR DESCRIPTION
Currently, loading `main.civet` in this repo crashes the LSP entirely. With this PR, it at least only takes out feedback for `main.civet` and other files continue to work. And you get a clearer error message, both in the Output tab and as feedback on the first character.