### PR TITLE
Fix unplugin on Node 25

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@types/assert": "^1.5.6",
     "@types/mocha": "^10.0.8",
     "@types/node": "^22.10.2",
-    "@typescript/vfs": "^1.6.0",
+    "@typescript/vfs": "^1.6.4",
     "c8": "^7.12.0",
     "esbuild": "0.24.0",
     "marked": "^4.2.4",

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -51,6 +51,9 @@ describe "integration", ->
 
     assert.equal data.sources[0].replace(/\\/g, '/'), "source/main.civet"
 
+  it "should load bundled unplugin when localStorage lacks getItem", ->
+    await execCmd '''node -e "globalThis.localStorage = {}; require('./dist/unplugin/unplugin.js')"'''
+
   for mode of ["cjs", "esm"]
     it `should sourcemap correctly, ${mode} mode`, ->
       {err, stderr} := await execCmdError `bash -c "(cd integration/example && ../../dist/civet --no-config error-${mode}.civet)"`

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,6 +531,13 @@
   dependencies:
     debug "^4.1.1"
 
+"@typescript/vfs@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.6.4.tgz#7543a3bd961727eb51c8bdafc3ed5e0fb5f56dff"
+  integrity sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==
+  dependencies:
+    debug "^4.4.3"
+
 "@vue/compiler-core@3.3.4":
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.3.4.tgz#7fbf591c1c19e1acd28ffd284526e98b4f581128"
@@ -893,6 +900,13 @@ debug@^4.3.5:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  dependencies:
+    ms "^2.1.3"
+
+debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 


### PR DESCRIPTION
* `@typescript/vfs` had the code `typeof localStorage !== "undefined" && /*#__PURE__*/localStorage.getItem("DEBUG")`
* Node 25 (or Node 24 with `--experimental-webstorage`) sets `localStorage` to `{}` (or the contents of `--localstorage-file`), which causes that code to crash.
* Latest `@typescript/vfs` replaces the code with `typeof localStorage !== "undefined" && typeof localStorage.getItem === 'function' && /*#__PURE__*/localStorage.getItem("DEBUG")` which at least stops the crash.
  * See https://github.com/microsoft/TypeScript-Website/pull/3450

If you'd rather I edit out the debugging code from `@typescript/vfs`, let me know.