### PR TITLE
Support TypeScript 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "vue": "^3.2.45"
   },
   "peerDependencies": {
-    "typescript": "^4.5 || ^5.0",
+    "typescript": ">=4.5",
     "yaml": "^2.4.5"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
I could alternatively just add `|| ^6.0` but I assume we want to maintain compatibility with all future TS versions.