### PR TITLE
unplugin support for `#` in paths

### DIFF
--- a/source/unplugin/unplugin.civet
+++ b/source/unplugin/unplugin.civet
@@ -52,7 +52,8 @@ type CacheEntry
   result?: TransformResult
   promise?: Promise<void>
 
-postfixRE := /[?#].*$/s
+queryPostfixRE := /\?.*$/s
+escapedHashRE := /\0#/g
 isWindows := os.platform() is 'win32'
 windowsSlashRE := /\\/g
 civetSuffix := '.civet'
@@ -67,19 +68,33 @@ or needs an implicit .civet extension, or isn't Civet-related at all.
 */
 function extractCivetFilename(id: string, outputExtension: string): {filename: string, postfix: string}
   postfix .= ''
-  filename .= id.replace postfixRE, (match) =>
+  // Webpack escapes literal `#` in `loaderContext.resource` as `\0#` so it
+  // can distinguish path characters from fragment suffixes. Undo that first.
+  id = id.replace escapedHashRE, '#'
+  // `?` is always treated as a suffix. Raw `?` is impossible in Windows paths,
+  // and we rely on query suffixes across bundlers.
+  filename .= id.replace queryPostfixRE, (match) =>
     postfix = match
     ''
   // Normally the outputExtension (.jsx/.tsx by default) should be present,
   // but sometimes (e.g. esbuild's alias feature) load directly without resolve
   if filename.endsWith outputExtension
     filename = filename[< -outputExtension#]
+  // `#` may be either a literal path character or a fragment-like suffix.
+  // Keep it when the file exists as written; otherwise strip one rightmost
+  // `#...` suffix and let later resolution check whether file exists.
+  hashIndex := filename.lastIndexOf '#'
+  if hashIndex >= 0 and not tryStatSync filename
+    postfix = filename[hashIndex..] + postfix
+    filename = filename[..<hashIndex]
+    if filename.endsWith outputExtension
+      filename = filename[< -outputExtension#]
   {filename, postfix}
 
 function tryStatSync(file: string): fs.Stats?
   try
     // The "throwIfNoEntry" is a performance optimization for cases where the file does not exist
-    return fs.statSync(file, { throwIfNoEntry: false });
+    return fs.statSync file, throwIfNoEntry: false
 
 export function slash(p: string): string
   p.replace windowsSlashRE, '/'


### PR DESCRIPTION
It was mentioned on Discord that the unplugin doesn't work when a directory (or filename) has a `#` character in it, at least with Webpack.

This PR should fix that, while still supporting `#` as a special suffix character as used in some systems, via a simple heuristic: if the file exists before stripping a `#` suffix, then don't strip it. (By contrast, we currently strip all `#` suffixes.)

I tested in `integration/unplugin-examples/webpack` by changing `module.civet` to `mod#ule.civet` (not committed here). Webpack has a second issue (maybe eventually fixed in https://github.com/unjs/unplugin/pull/592) that `#` in paths are encoded as `\0#`. Looking for this as opposed to raw `#` would be another way to fix this issue, but it'd be specific to Webpack, and it's arguably a bug in unplugin, so I'd rather not rely on it.