### PR TITLE
Fix emitDeclaration builds in ESM unplugin output.

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -222,6 +222,8 @@ for format of ["esm", "cjs"]
     mainFields: ['module', 'main']
     target: "esNext"
     outdir: out 'unplugin'
+    banner: if format is "esm"
+      js: "import { createRequire as __civetCreateRequire } from 'node:module'; const require = __civetCreateRequire(import.meta.url);"
     outExtension: ".js": if format is "esm" then ".mjs" else ".js"
     plugins: [
       rewriteCivetImports

--- a/integration/example/build-emit-declaration.civet
+++ b/integration/example/build-emit-declaration.civet
@@ -1,0 +1,18 @@
+// Regression coverage for emitDeclaration in ESM esbuild plugin mode
+esbuild from esbuild
+
+civetPlugin from ../../dist/unplugin/esbuild.mjs
+
+esbuild.build {
+  format: 'esm'
+  entryPoints: ['source/main.civet'],
+  tsconfig: "./tsconfig.json",
+  bundle: true
+  outdir: 'dist'
+  plugins: [
+    civetPlugin({
+      ts: "civet"
+      emitDeclaration: true
+    })
+  ]
+}

--- a/integration/example/tsconfig.json
+++ b/integration/example/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "source/**/*.civet"
+  ]
+}

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -54,6 +54,13 @@ describe "integration", ->
   it "should load bundled unplugin when localStorage lacks getItem", ->
     await execCmd '''node -e "globalThis.localStorage = {}; require('./dist/unplugin/unplugin.js')"'''
 
+  it "should build with esbuild plugin and emit declaration files", ->
+    @timeout 10000
+    await execCmd 'bash -c "(cd integration/example && ../../dist/civet --no-config build-emit-declaration.civet)"'
+    dts := fs.readFileSync("integration/example/dist/source/main.civet.d.ts", "utf8")
+    assert.match dts, /declare /
+    assert.match dts, /export default/
+
   for mode of ["cjs", "esm"]
     it `should sourcemap correctly, ${mode} mode`, ->
       {err, stderr} := await execCmdError `bash -c "(cd integration/example && ../../dist/civet --no-config error-${mode}.civet)"`


### PR DESCRIPTION
Provide a Node require shim for the bundled ESM unplugin build and add an integration regression test covering esbuild + emitDeclaration output.