### PR TITLE
Build and test use sourcemaps and default to up to 4 threads

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 out="${CIVET_DIST:-dist}"
 civet_bin="${CIVET_BIN:-civet}"
 
+# Default to up to 4 compiler threads during builds.
+# Set CIVET_THREADS=N to override, or CIVET_THREADS=0 to disable.
+export CIVET_THREADS="${CIVET_THREADS:-$(node -e 'const cpus = require("os").cpus().length; process.stdout.write(String(Math.min(cpus, 4)))')}"
+
 # clean build
 rm -rf "$out"
 mkdir "$out"

--- a/build/build.sh
+++ b/build/build.sh
@@ -8,6 +8,9 @@ civet_bin="${CIVET_BIN:-civet}"
 # Set CIVET_THREADS=N to override, or CIVET_THREADS=0 to disable.
 export CIVET_THREADS="${CIVET_THREADS:-$(node -e 'const cpus = require("os").cpus().length; process.stdout.write(String(Math.min(cpus, 4)))')}"
 
+# Use sourcemaps so errors have correct line numbers.
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--enable-source-maps"
+
 # clean build
 rm -rf "$out"
 mkdir "$out"

--- a/build/cache-utils.js
+++ b/build/cache-utils.js
@@ -68,8 +68,7 @@ function compileWithCache(source, filename, module = true) {
 
   let js;
   if (type === 'hera') {
-    // TODO: Eventually compose the sourcemaps for more accurate remapping
-    const civetOutput = heraCompile(source, { filename, module });
+    const civetOutput = heraCompile(source, { filename, module, inlineMap: true });
     js = civetCompile(civetOutput, { filename, js: true, inlineMap: true, sync: true });
   } else {
     js = civetCompile(source, { filename, js: true, inlineMap: true, sync: true });

--- a/build/test.sh
+++ b/build/test.sh
@@ -13,6 +13,9 @@ if [ "$threads" != "0" ]; then
 fi
 export CIVET_THREADS=
 
+# Use sourcemaps so errors have correct line numbers.
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--enable-source-maps"
+
 if [ "${CIVET_COVERAGE:-0}" = "1" ]; then
   c8 mocha $args "$@"
 else

--- a/build/test.sh
+++ b/build/test.sh
@@ -2,11 +2,11 @@
 
 set -euo pipefail
 
-# Enable parallel mocha by default using available CPU count.
+# Enable parallel mocha by default, capped to avoid oversubscribing large machines.
 # Set CIVET_THREADS=N to override, or CIVET_THREADS=0 to disable.
 # Note: CIVET_THREADS refers to Mocha --parallel workers (separate processes),
 # not Node.js worker_threads, which don't work within Mocha.
-threads="${CIVET_THREADS:-$(node -e 'process.stdout.write(String(require("os").cpus().length))')}"
+threads="${CIVET_THREADS:-$(node -e 'const cpus = require("os").cpus().length; process.stdout.write(String(Math.min(cpus, 4)))')}"
 args=""
 if [ "$threads" != "0" ]; then
   args="--parallel -j $threads"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
-    "@danielx/civet": "0.9.4",
+    "@danielx/civet": "0.11.6",
     "@danielx/hera": "0.8.19",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
     "@danielx/civet": "0.11.6",
-    "@danielx/hera": "0.8.19",
+    "@danielx/hera": "0.8.20",
     "@prettier/sync": "^0.5.2",
     "@types/assert": "^1.5.6",
     "@types/mocha": "^10.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 0.11.6
         version: 0.11.6(typescript@5.8.3)(yaml@2.8.3)
       '@danielx/hera':
-        specifier: 0.8.19
-        version: 0.8.19
+        specifier: 0.8.20
+        version: 0.8.20
       '@prettier/sync':
         specifier: ^0.5.2
         version: 0.5.5(prettier@3.8.1)
@@ -761,8 +761,8 @@ packages:
     resolution: {integrity: sha512-YPqnLGZH7EML3t7u8KlBwjg9rv5h0gWIt8Kr3sZYB6rq1bqHgv30yQAyBs0hf1WTB76NQgA0ErJeIRbOuzRahw==}
     hasBin: true
 
-  '@danielx/hera@0.8.19':
-    resolution: {integrity: sha512-D8Sw2uEfxx2mXD5t0dMxYExNMcLWrJ5roRVwrMGjvGcC47/Rp9ZjMUjA+rvYZu9UclUZB/CKUXK4D3W204EwpA==}
+  '@danielx/hera@0.8.20':
+    resolution: {integrity: sha512-0bjwD05ZIGZ0w6Jcw06+eOU7a7P52YtLqjIXynLFftg4iV1DYCoDrd4qHp4DT+/nbTvOeX5RV88ldoZfD3X5sQ==}
     hasBin: true
 
   '@discoveryjs/json-ext@0.5.7':
@@ -6889,7 +6889,7 @@ snapshots:
 
   '@danielx/hera@0.7.12': {}
 
-  '@danielx/hera@0.8.19': {}
+  '@danielx/hera@0.8.20': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^7.29.2
         version: 7.29.2
       '@danielx/civet':
-        specifier: 0.9.4
-        version: 0.9.4(typescript@5.8.3)(yaml@2.8.3)
+        specifier: 0.11.6
+        version: 0.11.6(typescript@5.8.3)(yaml@2.8.3)
       '@danielx/hera':
         specifier: 0.8.19
         version: 0.8.19
@@ -744,14 +744,16 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@danielx/civet@0.9.4':
-    resolution: {integrity: sha512-o/ZeZ6ogv2mY0UFTB7g3YJF3xrXh+++eApKGBSzfuQGsJbCcl3ORkTWSiW3q/7UlBvd7+fH2fOTXdsXc6jGiag==}
+  '@danielx/civet@0.11.6':
+    resolution: {integrity: sha512-KPCF4ngJsabPzEBdUxk7FcONwT+rP/yvwJChfDfzLXJYwCqvMRW2c7yQ31Ve6dAz2tSHya3NhTS1BDbmGInxMQ==}
     engines: {node: '>=19 || ^18.6.0 || ^16.17.0'}
     hasBin: true
     peerDependencies:
-      typescript: ^4.5 || ^5.0
+      typescript: '>=4.5'
       yaml: ^2.4.5
     peerDependenciesMeta:
+      typescript:
+        optional: true
       yaml:
         optional: true
 
@@ -6877,16 +6879,13 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@danielx/civet@0.9.4(typescript@5.8.3)(yaml@2.8.3)':
+  '@danielx/civet@0.11.6(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@typescript/vfs': 1.6.4(typescript@5.8.3)
-      typescript: 5.8.3
       unplugin: 2.3.11
     optionalDependencies:
+      typescript: 5.8.3
       yaml: 2.8.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@danielx/hera@0.7.12': {}
 


### PR DESCRIPTION
1. `pnpm build` now runs in parallel by default if `CIVET_THREADS` is unset, like `pnpm test`
   * (This was buggy in older Civet because of the way Hera started using Civet, so it was waiting for an updated Civet release.)
2. Both build and test now limit parallelism to 4 threads.
   * At least on Windows, I don't see a performance gain above this on a 24-core machine, because of thread startup cost. Other machines may vary, but can still override with CIVET_THREADS.
   * Probably also a little more polite not to take over an entire machine.
3. Hera + Civet sourcemap composition is now active, thanks to updated Civet and Hera
4. Enable Node's built-in sourcemap support in both build and test so that these nice sourcemaps get used when reporting errors.

## Example

Added an artificial error on line 8367:

```diff
diff --git a/source/parser.hera b/source/parser.hera
index 9932b8e6..554ba830 100644
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8364,6 +8364,7 @@ TypeIndexedAccess

 UnknownAlias
   "???" ->
+    throw new Error('hi')
     return { $loc, token: "unknown" }

 TypePrimary
```

`pnpm test` gives reasonable first line in traceback:

```
  1) unknown
       ??? alias:
     Error: hi
      at <anonymous> (source\parser.hera:8367:11)
      at C:\Users\edemaine\Projects\Civet\node_modules\.pnpm\@danielx+hera@0.8.20\node_modules\@danielx\hera\dist\machine.js:287:25
      at $EVENT (node_modules\.pnpm\@danielx+hera@0.8.20\node_modules\@danielx\hera\dist\machine.js:315:16)
      at Array.UnknownAlias (file:///C:/Users/edemaine/Projects/Civet/source/parser.hera:12730:44)
      at C:\Users\edemaine\Projects\Civet\node_modules\.pnpm\@danielx+hera@0.8.20\node_modules\@danielx\hera\dist\machine.js:106:27
      at Array.<anonymous> (node_modules\.pnpm\@danielx+hera@0.8.20\node_modules\@danielx\hera\dist\machine.js:265:20)
      at $EVENT_C (node_modules\.pnpm\@danielx+hera@0.8.20\node_modules\@danielx\hera\dist\machine.js:335:24)
      at Array.TypeIdentifier (file:///C:/Users/edemaine/Projects/Civet/source/parser.hera:12820:46)
      at $EVENT_C (node_modules\.pnpm\@danielx+hera@0.8.20\node_modules\@danielx\hera\dist\machine.js:335:24)
      at Array.TypePrimary (file:///C:/Users/edemaine/Projects/Civet/source/parser.hera:12786:43)
```