### PR TITLE
Fix ternary with trailing ? and indented values

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -975,7 +975,6 @@ ConditionalExpression
 
 TernaryRest
   NestedTernaryRest
-  # NOTE: Ternary `a ? b : c` is disabled if CoffeeScript binary existential `a ? b` is enabled
   # Trailing ?: condition ?
   #   then :
   #   else

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -975,13 +975,13 @@ ConditionalExpression
 
 TernaryRest
   NestedTernaryRest
+  # NOTE: Ternary `a ? b : c` is disabled if CoffeeScript binary existential `a ? b` is enabled
   # Trailing ?: condition ?
   #   then :
   #   else
   !CoffeeBinaryExistentialEnabled &[ \t] _ QuestionMark PushIndent (Nested Expression _ Colon Nested Expression)?:thenelse PopIndent ->
     return $skip unless thenelse
     return [$3, $4, ...thenelse]
-  # NOTE: Ternary `a ? b : c` is disabled if CoffeeScript binary existential `a ? b` is enabled
   !CoffeeBinaryExistentialEnabled &[ \t] _ QuestionMark MaybeNestedExpression __ Colon MaybeNestedExpression ->
     return $0.slice(2)
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -976,6 +976,13 @@ ConditionalExpression
 TernaryRest
   NestedTernaryRest
   # NOTE: Ternary `a ? b : c` is disabled if CoffeeScript binary existential `a ? b` is enabled
+  # Trailing ?: condition ?
+  #   then :
+  #   else
+  !CoffeeBinaryExistentialEnabled &[ \t] _ QuestionMark PushIndent (Nested Expression _ Colon Nested Expression)?:thenelse PopIndent ->
+    return $skip unless thenelse
+    return [$3, $4, ...thenelse]
+  # NOTE: Ternary `a ? b : c` is disabled if CoffeeScript binary existential `a ? b` is enabled
   !CoffeeBinaryExistentialEnabled &[ \t] _ QuestionMark MaybeNestedExpression __ Colon MaybeNestedExpression ->
     return $0.slice(2)
 

--- a/test/conditional.civet
+++ b/test/conditional.civet
@@ -49,6 +49,31 @@ describe "conditional", ->
     : z
   """
 
+  // #1933
+  testCase """
+    trailing ?/:
+    ---
+    x ?
+      y :
+      z
+    ---
+    x ?
+      y :
+      z
+  """
+
+  testCase """
+    trailing ?/: with complex condition
+    ---
+    typeof token is "string" ?
+      token :
+      undefined
+    ---
+    typeof token === "string" ?
+      token :
+      undefined
+  """
+
   // #1309
   testCase """
     indented chain

--- a/test/conditional.civet
+++ b/test/conditional.civet
@@ -74,6 +74,22 @@ describe "conditional", ->
       undefined
   """
 
+  testCase """
+    chained trailing ?/:
+    ---
+    a ?
+      b :
+      c ?
+        d :
+        e
+    ---
+    a ?
+      b :
+      c ?
+        d :
+        e
+  """
+
   // #1309
   testCase """
     indented chain


### PR DESCRIPTION
Fixes #1933

Add a new `TernaryRest` alternative to handle the form:
```civet
condition ?
  then :
  else
```

Previously, `MaybeNestedExpression` at the `then` position would incorrectly parse `then :\n  else` as an implicit object literal `{then: else}`, consuming the ternary colon. The fix uses `PushIndent` to enter the indented context first, then parses `Expression _ Colon` followed by another `Nested Expression` for the else branch.

Generated with [Claude Code](https://claude.ai/code)