### PR TITLE
Convert LSP source and build to use Civet

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'lsp/**'
+  pull_request:
+    paths:
+      - 'lsp/**'
+
+name: LSP
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and test
+        run: pnpm build && pnpm test && pnpm e2e
+        working-directory: lsp

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -12,7 +12,7 @@ name: LSP
 
 jobs:
   e2e:
-    name: E2E Tests
+    name: LSP Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +31,14 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Cache VS Code download
+        uses: actions/cache@v4
+        with:
+          path: ~/.vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('lsp/package.json') }}
+          restore-keys: |
+            vscode-test-${{ runner.os }}-
 
       - name: Build root package
         run: pnpm build

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build root package
+        run: pnpm build
+
       - name: Build and test
         run: pnpm build && pnpm test && pnpm e2e
         working-directory: lsp

--- a/integration/unplugin-examples/esbuild/package.json
+++ b/integration/unplugin-examples/esbuild/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@danielx/civet": "workspace:*",
-    "esbuild": "latest"
+    "esbuild": "^0.28.0"
   }
 }

--- a/integration/unplugin-examples/esbuild/package.json
+++ b/integration/unplugin-examples/esbuild/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@danielx/civet": "workspace:*",
-    "esbuild": "^0.28.0"
+    "esbuild": "^0.27.7"
   }
 }

--- a/lsp/.gitignore
+++ b/lsp/.gitignore
@@ -1,3 +1,4 @@
 *.metafile
 *.vsix
 open-vsx-token
+.vscode-test/

--- a/lsp/.mocharc.json
+++ b/lsp/.mocharc.json
@@ -4,11 +4,8 @@
     "civet"
   ],
   "require": [
-    "source-map-support"
-  ],
-  "loader": [
-    "ts-node/esm",
-    "@danielx/civet/esm"
+    "source-map-support",
+    "../build/register.js"
   ],
   "reporter": "spec",
   "recursive": true,

--- a/lsp/.vscode/launch.json
+++ b/lsp/.vscode/launch.json
@@ -1,17 +1,45 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
 {
   "version": "0.2.0",
   "configurations": [
     {
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
-      "name": "Launch Extension",
-      "outFiles": [
-        "${workspaceFolder}/dist/**/*.js"
-      ],
-      "preLaunchTask": "yarn build-dev",
+      "type": "extensionHost",
       "request": "launch",
-      "type": "extensionHost"
+      "name": "Launch Client",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "outFiles": ["${workspaceRoot}/dist/**/*.js"],
+      "preLaunchTask": "pnpm: build-dev"
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to Server",
+      "port": 6009,
+      "restart": {
+        "delay": 1000,
+        "maxAttempts": 15
+      },
+      "outFiles": ["${workspaceRoot}/dist/**/*.js"]
+    },
+    {
+      "name": "Language Server E2E Test",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}",
+        "--extensionTestsPath=${workspaceRoot}/e2e/dist/index",
+        "${workspaceRoot}/e2e/fixture"
+      ],
+      "outFiles": ["${workspaceRoot}/dist/**/*.js", "${workspaceRoot}/e2e/dist/**/*.js"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Client + Server",
+      "configurations": ["Launch Client", "Attach to Server"],
+      "presentation": { "order": 0 }
     }
   ]
 }

--- a/lsp/.vscode/tasks.json
+++ b/lsp/.vscode/tasks.json
@@ -2,12 +2,12 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "npm",
-      "script": "build-dev",
+      "type": "shell",
+      "command": "pnpm run build-dev",
       "group": "build",
       "problemMatcher": [],
-      "label": "yarn build-dev",
-      "detail": "bash ./build/build.sh"
+      "label": "pnpm: build-dev",
+      "detail": "bash ./build/build.sh development"
     }
   ]
 }

--- a/lsp/build/build.civet
+++ b/lsp/build/build.civet
@@ -4,6 +4,12 @@ civetPlugin from @danielx/civet/esbuild
 minify := false // !watch or process.argv.includes '--minify'
 sourcemap := true
 
+extensionExcludes := process.env.NODE_ENV is "development" ?
+  [
+    'vscode-languageclient'
+  ]
+: [ ]
+
 build({
   +metafile
   entryPoints: ['source/extension.civet']
@@ -11,6 +17,7 @@ build({
   bundle: true
   external: [
     'vscode'
+    ...extensionExcludes
   ]
   format: "cjs"
   sourcemap

--- a/lsp/build/build.civet
+++ b/lsp/build/build.civet
@@ -38,7 +38,7 @@ additionalExcludes := process.env.NODE_ENV is "development" ?
 
 build({
   +metafile
-  entryPoints: ['source/server.mts']
+  entryPoints: ['source/server.civet']
   outdir: 'dist'
   tsconfig: "./tsconfig.json"
   format: "cjs"

--- a/lsp/build/build.civet
+++ b/lsp/build/build.civet
@@ -59,3 +59,21 @@ build({
 .then ({metafile}) ->
   { writeFileSync } := await import('fs')
   writeFileSync 'server.metafile', JSON.stringify(metafile)
+
+// E2E test runner and test files
+{ readdirSync } from fs
+build({
+  entryPoints:
+    readdirSync('e2e').filter((f: string) => f.endsWith('.civet')).map((f: string) => `e2e/${f}`)
+  outdir: 'e2e/dist'
+  tsconfig: "./tsconfig.json"
+  format: "cjs"
+  +bundle
+  packages: 'external'
+  platform: 'node'
+  sourcemap: true
+  plugins: [
+    civetPlugin ts: 'civet'
+  ]
+}).catch ->
+  process.exit 1

--- a/lsp/build/build.sh
+++ b/lsp/build/build.sh
@@ -5,7 +5,7 @@ export NODE_ENV=${1-}
 
 rm -rf dist
 
-node_modules/.bin/civet build/build.civet
+${CIVET_BIN:-../dist/civet} build/build.civet
 
 mkdir -p dist/lib
 cp node_modules/typescript/lib/lib.*.d.ts dist/lib

--- a/lsp/e2e/at-completions.test.civet
+++ b/lsp/e2e/at-completions.test.civet
@@ -1,0 +1,35 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, activate } from ./helper.civet
+
+suite '@foo completions', =>
+  test 'Does not insert extra this. when completing after @', async =>
+    // widget.civet has `@n` inside a method — transpiles to `this.n`
+    // Completions should offer `name` not `this.name`
+    docUri := getDocUri('widget.civet')
+    await activate(docUri)
+
+    // Line 3 (0-indexed): `    @n` — cursor after the `n` at col 6
+    position := new vscode.Position(3, 6)
+    completions := await vscode.commands.executeCommand(
+      'vscode.executeCompletionItemProvider',
+      docUri,
+      position
+    ) as vscode.CompletionList
+
+    assert.ok completions?.items.length > 0, 'Expected completions after @n'
+
+    // Every item's insertText and label must not contain `this.`
+    for item of completions.items
+      insertText := typeof item.insertText === 'string'
+        ? item.insertText
+        : item.insertText?.value ?? ''
+      label := typeof item.label === 'string' ? item.label : item.label.label
+      assert.ok !insertText.includes('this.'),
+        `Completion '${label}' has insertText containing 'this.': ${insertText}`
+      assert.ok !label.includes('this.'),
+        `Completion label contains 'this.': ${label}`
+
+    // `name` should be among the offered completions
+    labels := completions.items.map((i) => typeof i.label === 'string' ? i.label : i.label.label)
+    assert.ok labels.includes('name'), `Expected 'name' in completions, got: ${labels.join(', ')}`

--- a/lsp/e2e/at-completions.test.civet
+++ b/lsp/e2e/at-completions.test.civet
@@ -1,5 +1,5 @@
-* as vscode from vscode
-* as assert from assert
+{ commands, Position, type CompletionList } from vscode
+assert from assert
 { getDocUri, activate } from ./helper.civet
 
 suite '@foo completions', =>
@@ -10,26 +10,27 @@ suite '@foo completions', =>
     await activate(docUri)
 
     // Line 3 (0-indexed): `    @n` — cursor after the `n` at col 6
-    position := new vscode.Position(3, 6)
-    completions := await vscode.commands.executeCommand(
+    position := new Position(3, 6)
+    completions := await commands.executeCommand(
       'vscode.executeCompletionItemProvider',
       docUri,
       position
-    ) as vscode.CompletionList
+    ) as CompletionList
 
-    assert.ok completions?.items.length > 0, 'Expected completions after @n'
+    assert completions?.items.length > 0, 'Expected completions after @n'
 
     // Every item's insertText and label must not contain `this.`
     for item of completions.items
-      insertText := typeof item.insertText === 'string'
+      insertText := item.insertText <? 'string'
         ? item.insertText
         : item.insertText?.value ?? ''
-      label := typeof item.label === 'string' ? item.label : item.label.label
-      assert.ok !insertText.includes('this.'),
+      label := item.label <? 'string' ? item.label : item.label.label
+
+      assert !insertText.includes('this.'),
         `Completion '${label}' has insertText containing 'this.': ${insertText}`
-      assert.ok !label.includes('this.'),
+      assert !label.includes('this.'),
         `Completion label contains 'this.': ${label}`
 
     // `name` should be among the offered completions
-    labels := completions.items.map((i) => typeof i.label === 'string' ? i.label : i.label.label)
-    assert.ok labels.includes('name'), `Expected 'name' in completions, got: ${labels.join(', ')}`
+    labels := completions.items.map((i) => i.label <? 'string' ? i.label : i.label.label)
+    assert labels.includes('name'), `Expected 'name' in completions, got: ${labels.join(', ')}`

--- a/lsp/e2e/completion.test.civet
+++ b/lsp/e2e/completion.test.civet
@@ -1,0 +1,18 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, activate } from ./helper.civet
+
+suite 'Completion', =>
+  test 'Returns completions for console.', async =>
+    // Use the fixture file, add a line with console. and trigger completions
+    docUri := getDocUri('console.civet')
+    await activate(docUri)
+
+    completions := await vscode.commands.executeCommand(
+      'vscode.executeCompletionItemProvider',
+      docUri,
+      new vscode.Position(0, 8)
+    ) as vscode.CompletionList
+
+    labels := completions?.items.map((i) => typeof i.label === 'string' ? i.label : i.label.label)
+    assert.ok labels?.includes('log'), `Expected 'log' in console completions, got: ${labels?.join(', ')}`

--- a/lsp/e2e/completion.test.civet
+++ b/lsp/e2e/completion.test.civet
@@ -1,26 +1,27 @@
-* as vscode from vscode
-* as assert from assert
+{ commands, Position } from vscode
+type { CompletionList, CompletionItem } from vscode
+assert from assert
 { getDocUri, activate, poll } from ./helper.civet
 
 suite 'Completion', =>
-  test 'Returns completions for console.', async =>
+  test 'Returns completions for console.', =>
     docUri := getDocUri('console.civet')
     await activate(docUri)
 
     // Poll until TypeScript has loaded project types and returns member completions.
     // On first request the server may return scope-level completions before the
     // full type graph (lib.dom / @types/node) is ready.
-    getLabel := (i: vscode.CompletionItem) =>
-      typeof i.label === 'string' ? i.label : i.label.label
+    getLabel := (i: CompletionItem) =>
+      i.label <? 'string' ? i.label : i.label.label
 
     completions := await poll(
-      () => vscode.commands.executeCommand(
+      () => commands.executeCommand(
         'vscode.executeCompletionItemProvider'
         docUri
-        new vscode.Position(0, 8)
-      ) as Promise<vscode.CompletionList>
+        new Position(0, 8)
+      ) as Promise<CompletionList>
       (list) => list?.items.some((i) => getLabel(i) === 'log')
     )
 
     labels := completions.items.map(getLabel)
-    assert.ok labels.includes('log'), `Expected 'log' in console completions, got: ${labels.join(', ')}`
+    assert labels.includes('log'), `Expected 'log' in console completions, got: ${labels.join(', ')}`

--- a/lsp/e2e/completion.test.civet
+++ b/lsp/e2e/completion.test.civet
@@ -1,18 +1,26 @@
 * as vscode from vscode
 * as assert from assert
-{ getDocUri, activate } from ./helper.civet
+{ getDocUri, activate, poll } from ./helper.civet
 
 suite 'Completion', =>
   test 'Returns completions for console.', async =>
-    // Use the fixture file, add a line with console. and trigger completions
     docUri := getDocUri('console.civet')
     await activate(docUri)
 
-    completions := await vscode.commands.executeCommand(
-      'vscode.executeCompletionItemProvider',
-      docUri,
-      new vscode.Position(0, 8)
-    ) as vscode.CompletionList
+    // Poll until TypeScript has loaded project types and returns member completions.
+    // On first request the server may return scope-level completions before the
+    // full type graph (lib.dom / @types/node) is ready.
+    getLabel := (i: vscode.CompletionItem) =>
+      typeof i.label === 'string' ? i.label : i.label.label
 
-    labels := completions?.items.map((i) => typeof i.label === 'string' ? i.label : i.label.label)
-    assert.ok labels?.includes('log'), `Expected 'log' in console completions, got: ${labels?.join(', ')}`
+    completions := await poll(
+      () => vscode.commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new vscode.Position(0, 8)
+      ) as Promise<vscode.CompletionList>
+      (list) => list?.items.some((i) => getLabel(i) === 'log')
+    )
+
+    labels := completions.items.map(getLabel)
+    assert.ok labels.includes('log'), `Expected 'log' in console completions, got: ${labels.join(', ')}`

--- a/lsp/e2e/definition.test.civet
+++ b/lsp/e2e/definition.test.civet
@@ -1,6 +1,6 @@
-* as vscode from vscode
-* as assert from assert
-{ getDocUri, getDocPath, activate } from ./helper.civet
+{ commands, Position, type Location } from vscode
+assert from assert
+{ getDocUri, activate } from ./helper.civet
 
 suite 'Go To Definition', =>
   test 'Jumps to definition in another Civet file', async =>
@@ -9,13 +9,13 @@ suite 'Go To Definition', =>
     docUri := getDocUri('consumer.civet')
     await activate(docUri)
 
-    position := new vscode.Position(0, 2)
-    defs := await vscode.commands.executeCommand(
+    position := new Position(0, 2)
+    defs := await commands.executeCommand(
       'vscode.executeDefinitionProvider',
       docUri,
       position
-    ) as vscode.Location[]
+    ) as Location[]
 
-    assert.ok defs?.length > 0, 'Expected at least one definition'
+    assert defs?.length > 0, 'Expected at least one definition'
     defUri := defs[0].uri
-    assert.ok defUri.fsPath.endsWith('valid.civet'), `Expected definition in valid.civet, got: ${defUri.fsPath}`
+    assert defUri.fsPath.endsWith('valid.civet'), `Expected definition in valid.civet, got: ${defUri.fsPath}`

--- a/lsp/e2e/definition.test.civet
+++ b/lsp/e2e/definition.test.civet
@@ -1,0 +1,21 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, getDocPath, activate } from ./helper.civet
+
+suite 'Go To Definition', =>
+  test 'Jumps to definition in another Civet file', async =>
+    // consumer.civet imports `greet` from valid.civet
+    // Position of `greet` on line 0 of consumer.civet
+    docUri := getDocUri('consumer.civet')
+    await activate(docUri)
+
+    position := new vscode.Position(0, 2)
+    defs := await vscode.commands.executeCommand(
+      'vscode.executeDefinitionProvider',
+      docUri,
+      position
+    ) as vscode.Location[]
+
+    assert.ok defs?.length > 0, 'Expected at least one definition'
+    defUri := defs[0].uri
+    assert.ok defUri.fsPath.endsWith('valid.civet'), `Expected definition in valid.civet, got: ${defUri.fsPath}`

--- a/lsp/e2e/diagnostics.test.civet
+++ b/lsp/e2e/diagnostics.test.civet
@@ -1,5 +1,5 @@
 * as vscode from vscode
-* as assert from assert
+assert from assert
 { getDocUri, activate, onNextDiagnostics, poll } from ./helper.civet
 
 suite 'Diagnostics', =>
@@ -22,5 +22,5 @@ suite 'Diagnostics', =>
       (d) => d.length >= 1
     )
 
-    assert.ok diagnostics.length >= 1, 'Expected at least one diagnostic'
+    assert diagnostics.length >= 1, 'Expected at least one diagnostic'
     assert.strictEqual diagnostics[0].severity, vscode.DiagnosticSeverity.Error

--- a/lsp/e2e/diagnostics.test.civet
+++ b/lsp/e2e/diagnostics.test.civet
@@ -1,0 +1,21 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, activate } from ./helper.civet
+
+suite 'Diagnostics', =>
+  test 'Reports no diagnostics for valid Civet', async =>
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    diagnostics := vscode.languages.getDiagnostics(docUri)
+
+    assert.strictEqual diagnostics.length, 0, 'Expected no diagnostics for valid civet'
+
+  test 'Reports a type error for invalid Civet', async =>
+    docUri := getDocUri('invalid.civet')
+    await activate(docUri)
+
+    diagnostics := vscode.languages.getDiagnostics(docUri)
+
+    assert.ok diagnostics.length >= 1, 'Expected at least one diagnostic'
+    assert.strictEqual diagnostics[0].severity, vscode.DiagnosticSeverity.Error

--- a/lsp/e2e/diagnostics.test.civet
+++ b/lsp/e2e/diagnostics.test.civet
@@ -1,13 +1,14 @@
 * as vscode from vscode
 * as assert from assert
-{ getDocUri, activate } from ./helper.civet
+{ getDocUri, activate, onNextDiagnostics, poll } from ./helper.civet
 
 suite 'Diagnostics', =>
   test 'Reports no diagnostics for valid Civet', async =>
     docUri := getDocUri('valid.civet')
+    // Subscribe before activate so we can't miss the event
+    diagPromise := onNextDiagnostics(docUri)
     await activate(docUri)
-
-    diagnostics := vscode.languages.getDiagnostics(docUri)
+    diagnostics := await diagPromise
 
     assert.strictEqual diagnostics.length, 0, 'Expected no diagnostics for valid civet'
 
@@ -15,7 +16,11 @@ suite 'Diagnostics', =>
     docUri := getDocUri('invalid.civet')
     await activate(docUri)
 
-    diagnostics := vscode.languages.getDiagnostics(docUri)
+    // Poll until errors appear — a first empty event may fire before analysis finishes
+    diagnostics := await poll(
+      () => Promise.resolve(vscode.languages.getDiagnostics(docUri))
+      (d) => d.length >= 1
+    )
 
     assert.ok diagnostics.length >= 1, 'Expected at least one diagnostic'
     assert.strictEqual diagnostics[0].severity, vscode.DiagnosticSeverity.Error

--- a/lsp/e2e/document-symbols.test.civet
+++ b/lsp/e2e/document-symbols.test.civet
@@ -1,5 +1,5 @@
-* as vscode from vscode
-* as assert from assert
+{ commands, type DocumentSymbol } from vscode
+assert from assert
 { getDocUri, activate } from ./helper.civet
 
 suite 'Document Symbols', =>
@@ -7,23 +7,23 @@ suite 'Document Symbols', =>
     docUri := getDocUri('valid.civet')
     await activate(docUri)
 
-    symbols := await vscode.commands.executeCommand(
+    symbols := await commands.executeCommand(
       'vscode.executeDocumentSymbolProvider',
       docUri
-    ) as vscode.DocumentSymbol[]
+    ) as DocumentSymbol[]
 
-    assert.ok symbols?.length > 0, 'Expected at least one symbol'
+    assert symbols?.length > 0, 'Expected at least one symbol'
     names := symbols.map (s) => s.name
-    assert.ok names.includes('greet'), `Expected 'greet' in symbols, got: ${names.join(', ')}`
+    assert names.includes('greet'), `Expected 'greet' in symbols, got: ${names.join(', ')}`
 
   test 'Includes exported variable in symbols', async =>
     docUri := getDocUri('valid.civet')
     await activate(docUri)
 
-    symbols := await vscode.commands.executeCommand(
+    symbols := await commands.executeCommand(
       'vscode.executeDocumentSymbolProvider',
       docUri
-    ) as vscode.DocumentSymbol[]
+    ) as DocumentSymbol[]
 
     names := symbols.map (s) => s.name
-    assert.ok names.includes('x'), `Expected 'x' in symbols, got: ${names.join(', ')}`
+    assert names.includes('x'), `Expected 'x' in symbols, got: ${names.join(', ')}`

--- a/lsp/e2e/document-symbols.test.civet
+++ b/lsp/e2e/document-symbols.test.civet
@@ -1,0 +1,29 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, activate } from ./helper.civet
+
+suite 'Document Symbols', =>
+  test 'Returns symbols for a Civet file', async =>
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    symbols := await vscode.commands.executeCommand(
+      'vscode.executeDocumentSymbolProvider',
+      docUri
+    ) as vscode.DocumentSymbol[]
+
+    assert.ok symbols?.length > 0, 'Expected at least one symbol'
+    names := symbols.map (s) => s.name
+    assert.ok names.includes('greet'), `Expected 'greet' in symbols, got: ${names.join(', ')}`
+
+  test 'Includes exported variable in symbols', async =>
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    symbols := await vscode.commands.executeCommand(
+      'vscode.executeDocumentSymbolProvider',
+      docUri
+    ) as vscode.DocumentSymbol[]
+
+    names := symbols.map (s) => s.name
+    assert.ok names.includes('x'), `Expected 'x' in symbols, got: ${names.join(', ')}`

--- a/lsp/e2e/fixture/console.civet
+++ b/lsp/e2e/fixture/console.civet
@@ -1,0 +1,1 @@
+console.

--- a/lsp/e2e/fixture/consumer.civet
+++ b/lsp/e2e/fixture/consumer.civet
@@ -1,0 +1,3 @@
+{ greet } from ./valid.civet
+
+greet("world")

--- a/lsp/e2e/fixture/invalid.civet
+++ b/lsp/e2e/fixture/invalid.civet
@@ -1,0 +1,2 @@
+// Type error: string not assignable to number
+x: number := "not a number"

--- a/lsp/e2e/fixture/tsconfig.json
+++ b/lsp/e2e/fixture/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "NodeNext",
+    "target": "es2020"
+  }
+}

--- a/lsp/e2e/fixture/valid.civet
+++ b/lsp/e2e/fixture/valid.civet
@@ -1,0 +1,5 @@
+/** A greeting function */
+export function greet(name: string): string
+  `Hello, ${name}!`
+
+export x := 42

--- a/lsp/e2e/fixture/widget.civet
+++ b/lsp/e2e/fixture/widget.civet
@@ -1,0 +1,4 @@
+class Widget
+  name: string := "widget"
+  render()
+    @n

--- a/lsp/e2e/helper.civet
+++ b/lsp/e2e/helper.civet
@@ -5,18 +5,45 @@ export var doc: vscode.TextDocument
 export var editor: vscode.TextEditor
 
 // Activates the civet extension
-export async function activate(docUri: vscode.Uri)
+export function activate(docUri: vscode.Uri)
   ext := vscode.extensions.getExtension('DanielX.civet')!
   await ext.activate()
   try
     doc = await vscode.workspace.openTextDocument(docUri)
     editor = await vscode.window.showTextDocument(doc)
-    await sleep(2000) // Wait for server activation
   catch e
     console.error(e)
 
-function sleep(ms: number)
-  new Promise (resolve) => setTimeout(resolve, ms)
+// Subscribe to the next diagnostics change for docUri and return the result.
+// Call this BEFORE activate() so the event can't be missed.
+export function onNextDiagnostics(docUri: vscode.Uri, timeout = 1000): Promise<vscode.Diagnostic[]>
+  new Promise (resolve, reject) =>
+    timer := setTimeout(
+      () => reject(new Error(`onNextDiagnostics timed out for ${docUri.fsPath}`))
+      timeout
+    )
+    disposable := vscode.languages.onDidChangeDiagnostics (e) =>
+      if e.uris.some (u) => u.fsPath is docUri.fsPath
+        disposable.dispose()
+        clearTimeout timer
+        resolve vscode.languages.getDiagnostics(docUri)
+
+// Retry an async function until predicate passes or timeout exceeded.
+// Useful when a language feature (e.g. type-based completions) requires
+// project-level analysis that finishes after textDocument/didOpen.
+export function poll<T>(
+  fn: () => Promise<T>
+  predicate: (v: T) => boolean
+  timeout = 2000
+  interval = 20
+): Promise<T>
+  deadline := Date.now() + timeout
+  loop
+    result := await fn()
+    return result if predicate result
+    if Date.now() >= deadline
+      throw new Error `poll timed out after ${timeout}ms`
+    await new Promise<void> (r) => setTimeout r, interval
 
 export getDocPath := (p: string) =>
   path.resolve(__dirname, '../fixture', p)

--- a/lsp/e2e/helper.civet
+++ b/lsp/e2e/helper.civet
@@ -18,11 +18,14 @@ export function activate(docUri: vscode.Uri)
 // Call this BEFORE activate() so the event can't be missed.
 export function onNextDiagnostics(docUri: vscode.Uri, timeout = 1000): Promise<vscode.Diagnostic[]>
   new Promise (resolve, reject) =>
+    disposable: vscode.Disposable .= undefined!
     timer := setTimeout(
-      () => reject(new Error(`onNextDiagnostics timed out for ${docUri.fsPath}`))
+      () =>
+        disposable?.dispose()
+        reject(new Error(`onNextDiagnostics timed out for ${docUri.fsPath}`))
       timeout
     )
-    disposable := vscode.languages.onDidChangeDiagnostics (e) =>
+    disposable = vscode.languages.onDidChangeDiagnostics (e) =>
       if e.uris.some (u) => u.fsPath is docUri.fsPath
         disposable.dispose()
         clearTimeout timer

--- a/lsp/e2e/helper.civet
+++ b/lsp/e2e/helper.civet
@@ -1,0 +1,25 @@
+* as vscode from vscode
+* as path from path
+
+export var doc: vscode.TextDocument
+export var editor: vscode.TextEditor
+
+// Activates the civet extension
+export async function activate(docUri: vscode.Uri)
+  ext := vscode.extensions.getExtension('DanielX.civet')!
+  await ext.activate()
+  try
+    doc = await vscode.workspace.openTextDocument(docUri)
+    editor = await vscode.window.showTextDocument(doc)
+    await sleep(2000) // Wait for server activation
+  catch e
+    console.error(e)
+
+function sleep(ms: number)
+  new Promise (resolve) => setTimeout(resolve, ms)
+
+export getDocPath := (p: string) =>
+  path.resolve(__dirname, '../fixture', p)
+
+export getDocUri := (p: string) =>
+  vscode.Uri.file(getDocPath(p))

--- a/lsp/e2e/helper.civet
+++ b/lsp/e2e/helper.civet
@@ -19,12 +19,11 @@ export function activate(docUri: vscode.Uri)
 export function onNextDiagnostics(docUri: vscode.Uri, timeout = 1000): Promise<vscode.Diagnostic[]>
   new Promise (resolve, reject) =>
     disposable: vscode.Disposable .= undefined!
-    timer := setTimeout(
-      () =>
-        disposable?.dispose()
-        reject(new Error(`onNextDiagnostics timed out for ${docUri.fsPath}`))
-      timeout
-    )
+    timer := setTimeout =>
+      disposable?.dispose()
+      reject(new Error(`onNextDiagnostics timed out for ${docUri.fsPath}`))
+    , timeout
+
     disposable = vscode.languages.onDidChangeDiagnostics (e) =>
       if e.uris.some (u) => u.fsPath is docUri.fsPath
         disposable.dispose()

--- a/lsp/e2e/hover.test.civet
+++ b/lsp/e2e/hover.test.civet
@@ -1,0 +1,37 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, activate } from ./helper.civet
+
+suite 'Hover', =>
+  test 'Returns type info when hovering over an identifier', async =>
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    // Hover over 'x' on line 4 (`export x := 42`)
+    position := new vscode.Position(4, 7)
+    hovers := await vscode.commands.executeCommand(
+      'vscode.executeHoverProvider',
+      docUri,
+      position
+    ) as vscode.Hover[]
+
+    assert.ok hovers.length > 0, 'Expected hover results'
+    content := hovers[0].contents[0]
+    text := typeof content === 'string' ? content : content.value
+    assert.ok text.includes('42') or text.includes('number'), `Expected type info, got: ${text}`
+
+  test 'Returns JSDoc comment on hover', async =>
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    // Hover over 'greet' on line 1 (`export function greet(...)`)
+    position := new vscode.Position(1, 16)
+    hovers := await vscode.commands.executeCommand(
+      'vscode.executeHoverProvider',
+      docUri,
+      position
+    ) as vscode.Hover[]
+
+    assert.ok hovers.length > 0, 'Expected hover results'
+    text := hovers.flatMap((h) => h.contents).map((c) => typeof c === 'string' ? c : c.value).join('\n')
+    assert.ok text.includes('greet') or text.includes('string'), `Expected function signature, got: ${text}`

--- a/lsp/e2e/hover.test.civet
+++ b/lsp/e2e/hover.test.civet
@@ -1,5 +1,5 @@
-* as vscode from vscode
-* as assert from assert
+{ commands, Position, type Hover } from vscode
+assert from assert
 { getDocUri, activate } from ./helper.civet
 
 suite 'Hover', =>
@@ -8,29 +8,29 @@ suite 'Hover', =>
     await activate(docUri)
 
     // Hover over 'x' on line 4 (`export x := 42`)
-    position := new vscode.Position(4, 7)
-    hovers := await vscode.commands.executeCommand(
+    position := new Position(4, 7)
+    hovers := await commands.executeCommand(
       'vscode.executeHoverProvider',
       docUri,
       position
-    ) as vscode.Hover[]
+    ) as Hover[]
 
-    assert.ok hovers.length > 0, 'Expected hover results'
+    assert hovers.length > 0, 'Expected hover results'
     content := hovers[0].contents[0]
     text := typeof content === 'string' ? content : content.value
-    assert.ok text.includes('42') or text.includes('number'), `Expected type info, got: ${text}`
+    assert text.includes('42') or text.includes('number'), `Expected type info, got: ${text}`
 
   test 'Returns JSDoc comment on hover', async =>
     docUri := getDocUri('valid.civet')
     await activate(docUri)
 
     // Hover over 'greet' on line 1 (`export function greet(...)`)
-    position := new vscode.Position(1, 16)
-    hovers := await vscode.commands.executeCommand(
+    position := new Position(1, 16)
+    hovers := await commands.executeCommand(
       'vscode.executeHoverProvider',
       docUri,
       position
-    ) as vscode.Hover[]
+    ) as Hover[]
 
     assert.ok hovers.length > 0, 'Expected hover results'
     text := hovers.flatMap((h) => h.contents).map((c) => typeof c === 'string' ? c : c.value).join('\n')

--- a/lsp/e2e/index.civet
+++ b/lsp/e2e/index.civet
@@ -1,10 +1,10 @@
-* as path from path
-* as fs from fs
+path from path
+fs from fs
 Mocha from mocha
 
 export function run(): Promise<void>
   mocha := new Mocha({ ui: 'tdd', color: true })
-  mocha.timeout(60000)
+  mocha.timeout 5000
 
   testsRoot := __dirname
   files := fs.readdirSync(testsRoot).filter (f) => f.endsWith('.test.js')

--- a/lsp/e2e/index.civet
+++ b/lsp/e2e/index.civet
@@ -1,0 +1,22 @@
+* as path from path
+* as fs from fs
+Mocha from mocha
+
+export function run(): Promise<void>
+  mocha := new Mocha({ ui: 'tdd', color: true })
+  mocha.timeout(60000)
+
+  testsRoot := __dirname
+  files := fs.readdirSync(testsRoot).filter (f) => f.endsWith('.test.js')
+  files.forEach (f) => mocha.addFile(path.resolve(testsRoot, f))
+
+  new Promise<void> (resolve, reject) =>
+    try
+      mocha.run (failures) =>
+        if failures > 0
+          reject(new Error(`${failures} tests failed.`))
+        else
+          resolve()
+    catch err
+      console.error(err)
+      reject(err)

--- a/lsp/e2e/references.test.civet
+++ b/lsp/e2e/references.test.civet
@@ -1,0 +1,37 @@
+* as vscode from vscode
+* as assert from assert
+{ getDocUri, activate } from ./helper.civet
+
+suite 'Find All References', =>
+  test 'Finds references to a function across files', async =>
+    // valid.civet line 1 (0-indexed): `export function greet(...)`
+    // Position on `greet` — col 16
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    position := new vscode.Position(1, 16)
+    refs := await vscode.commands.executeCommand(
+      'vscode.executeReferenceProvider',
+      docUri,
+      position
+    ) as vscode.Location[]
+
+    assert.ok refs?.length > 0, 'Expected at least one reference'
+    paths := refs.map (r) => r.uri.fsPath
+    assert.ok paths.some((p) => p.endsWith('consumer.civet')),
+      `Expected a reference in consumer.civet, got: ${paths.join(', ')}`
+
+  test 'Finds definition site among references', async =>
+    docUri := getDocUri('valid.civet')
+    await activate(docUri)
+
+    position := new vscode.Position(1, 16)
+    refs := await vscode.commands.executeCommand(
+      'vscode.executeReferenceProvider',
+      docUri,
+      position
+    ) as vscode.Location[]
+
+    paths := refs.map (r) => r.uri.fsPath
+    assert.ok paths.some((p) => p.endsWith('valid.civet')),
+      `Expected the definition site in valid.civet, got: ${paths.join(', ')}`

--- a/lsp/e2e/runTest.civet
+++ b/lsp/e2e/runTest.civet
@@ -1,14 +1,50 @@
 * as path from path
 { runTests } from @vscode/test-electron
+{ spawn } from child_process
+* as readline from readline
 
-async function main()
-  try
-    extensionDevelopmentPath := path.resolve(__dirname, '../../')
-    extensionTestsPath := path.resolve(__dirname, './index')
-    workspacePath := path.resolve(__dirname, '../fixture')
-    await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: [workspacePath] })
-  catch err
-    console.error('Failed to run e2e tests:', err)
-    process.exit(1)
+// Strip ANSI escape codes for pattern matching (keep original for output)
+stripAnsi := (s: string) => s.replace /\x1b\[[0-9;]*m/g, ''
 
-main()
+// Lines emitted by VS Code/Electron internals that add no test value
+vscodeLine := (line: string) =>
+  s := stripAnsi line
+  /^\[\d+:\d+\//.test(s) or                    // Chromium [pid:date/time:level:file] ...
+  /^\[main \d{4}-/.test(s) or                  // [main 2026-...]
+  s.startsWith('NativeExtensionHostFactory.') or
+  s is 'workbench#open()' or
+  s.startsWith('Started local extension host') or
+  s.startsWith('IExtensionHostStarter') or
+  s.startsWith('Loading development extension') or
+  s.startsWith('Settings Sync:') or
+  s.startsWith('Extension host test runner exit code:') or
+  s.startsWith('Asking native host service to exit') or
+  /^Exit code:\s+\d/.test(s)
+
+// On Linux CI without a display, re-spawn under xvfb-run for a virtual framebuffer
+if process.env.CI and !process.env.RUNNING_UNDER_XVFB
+  child := spawn 'xvfb-run', ['-a', process.execPath, process.argv[1]], {
+    env: { ...process.env, RUNNING_UNDER_XVFB: '1' }
+  }
+
+  for [stream, dest] of [[child.stdout, process.stdout], [child.stderr, process.stderr]]
+    rl := readline.createInterface { input: stream }
+    rl.on 'line', (line) =>
+      unless vscodeLine line
+        dest.write line + '\n'
+
+  child.on 'close', (code) =>
+    process.exit code ?? 1
+
+else
+  async function main()
+    try
+      extensionDevelopmentPath := path.resolve(__dirname, '../../')
+      extensionTestsPath := path.resolve(__dirname, './index')
+      workspacePath := path.resolve(__dirname, '../fixture')
+      await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: [workspacePath] })
+    catch err
+      console.error('Failed to run e2e tests:', err)
+      process.exit(1)
+
+  main()

--- a/lsp/e2e/runTest.civet
+++ b/lsp/e2e/runTest.civet
@@ -1,0 +1,14 @@
+* as path from path
+{ runTests } from @vscode/test-electron
+
+async function main()
+  try
+    extensionDevelopmentPath := path.resolve(__dirname, '../../')
+    extensionTestsPath := path.resolve(__dirname, './index')
+    workspacePath := path.resolve(__dirname, '../fixture')
+    await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: [workspacePath] })
+  catch err
+    console.error('Failed to run e2e tests:', err)
+    process.exit(1)
+
+main()

--- a/lsp/e2e/runTest.civet
+++ b/lsp/e2e/runTest.civet
@@ -27,7 +27,7 @@ if process.env.CI and !process.env.RUNNING_UNDER_XVFB
     env: { ...process.env, RUNNING_UNDER_XVFB: '1' }
   }
 
-  for [stream, dest] of [[child.stdout, process.stdout], [child.stderr, process.stderr]]
+  for [stream, dest] of [[child.stdout, process.stdout], [child.stderr, process.stderr]] as const
     rl := readline.createInterface { input: stream }
     rl.on 'line', (line) =>
       unless vscodeLine line

--- a/lsp/integration/project-test/tsconfig.json
+++ b/lsp/integration/project-test/tsconfig.json
@@ -6,6 +6,7 @@
     "jsx": "preserve",
     "typeRoots": [
       "../../node_modules/@types"
-    ]
+    ],
+    "types": ["node"]
   }
 }

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -84,7 +84,26 @@
     "package": "bash ./build/build.sh && vsce package --no-dependencies",
     "vsce-publish": "bash ./build/build.sh && vsce publish --no-dependencies",
     "test": "mocha --config .mocharc.json",
+    "test:coverage": "c8 mocha --config .mocharc.json",
+    "e2e": "node e2e/dist/runTest",
     "watch": "node build.mjs --watch"
+  },
+  "c8": {
+    "all": true,
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "extension": [
+      ".civet",
+      ".ts"
+    ],
+    "include": [
+      "source"
+    ],
+    "exclude": [
+      "source/extension.civet"
+    ]
   },
   "dependencies": {
     "@danielx/civet": "workspace:*",
@@ -100,9 +119,8 @@
     "esbuild": "0.27.5",
     "esbuild-visualizer": "^0.3.1",
     "mocha": "^10.7.3",
-    "nyc": "^15.1.0",
+    "c8": "^10.1.3",
     "source-map-support": "^0.5.21",
-    "ts-node": "^10.6.0",
     "typescript": "5.8.3",
     "vscode-languageclient": "^8.0.2",
     "vscode-languageserver": "^8.0.2",

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -119,7 +119,7 @@
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",
     "c8": "^11.0.0",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.27.7",
     "esbuild-visualizer": "^0.7.0",
     "mocha": "^11.7.5",
     "source-map-support": "^0.5.21",

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -107,23 +107,23 @@
   },
   "dependencies": {
     "@danielx/civet": "workspace:*",
-    "vscode-uri": "^3.0.8"
+    "vscode-uri": "^3.1.0"
   },
   "devDependencies": {
-    "@danielx/hera": "^0.7.12",
-    "@types/mocha": "^10.0.8",
-    "@types/node": "^18.0.0",
-    "@types/vscode": "^1.63.0",
-    "@vscode/test-electron": "^2.1.2",
-    "@vscode/vsce": "^2.19.0",
-    "esbuild": "0.27.5",
-    "esbuild-visualizer": "^0.3.1",
-    "mocha": "^10.7.3",
-    "c8": "^10.1.3",
+    "@danielx/hera": "^0.8.20",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^25.5.2",
+    "@types/vscode": "^1.115.0",
+    "@vscode/test-electron": "^2.5.2",
+    "@vscode/vsce": "^3.7.1",
+    "c8": "^11.0.0",
+    "esbuild": "^0.28.0",
+    "esbuild-visualizer": "^0.7.0",
+    "mocha": "^11.7.5",
     "source-map-support": "^0.5.21",
-    "typescript": "5.8.3",
-    "vscode-languageclient": "^8.0.2",
-    "vscode-languageserver": "^8.0.2",
-    "vscode-languageserver-textdocument": "^1.0.7"
+    "typescript": "6.0.2",
+    "vscode-languageclient": "^9.0.1",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.12"
   }
 }

--- a/lsp/package.json
+++ b/lsp/package.json
@@ -85,6 +85,7 @@
     "vsce-publish": "bash ./build/build.sh && vsce publish --no-dependencies",
     "test": "mocha --config .mocharc.json",
     "test:coverage": "c8 mocha --config .mocharc.json",
+    "coverage:show": "node scripts/show-uncovered.mjs",
     "e2e": "node e2e/dist/runTest",
     "watch": "node build.mjs --watch"
   },
@@ -92,7 +93,8 @@
     "all": true,
     "reporter": [
       "lcov",
-      "text"
+      "text",
+      "json"
     ],
     "extension": [
       ".civet",

--- a/lsp/scripts/show-uncovered.mjs
+++ b/lsp/scripts/show-uncovered.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * show-uncovered.mjs
+ *
+ * Reads coverage/coverage-final.json and prints uncovered code with context,
+ * formatted for easy reading by humans or LLM agents.
+ *
+ * Usage:
+ *   node scripts/show-uncovered.mjs [file-pattern] [--context N]
+ *
+ * Examples:
+ *   node scripts/show-uncovered.mjs
+ *   node scripts/show-uncovered.mjs typescript-service
+ *   node scripts/show-uncovered.mjs --context 5
+ */
+
+import { readFileSync, existsSync } from "fs"
+import { resolve, relative } from "path"
+
+const args = process.argv.slice(2)
+const patternArg = args.find((a) => !a.startsWith("--"))
+const contextIdx = args.indexOf("--context")
+const CONTEXT = contextIdx !== -1 ? parseInt(args[contextIdx + 1], 10) : 3
+
+const coveragePath = resolve("coverage/coverage-final.json")
+if (!existsSync(coveragePath)) {
+  console.error("No coverage data found. Run pnpm test:coverage first.")
+  process.exit(1)
+}
+
+const coverage = JSON.parse(readFileSync(coveragePath, "utf8"))
+
+for (const [filePath, data] of Object.entries(coverage)) {
+  const rel = relative(process.cwd(), filePath)
+  if (patternArg && !rel.includes(patternArg)) continue
+
+  // Collect uncovered statement line numbers (1-based)
+  const uncoveredLines = new Set()
+  for (const [id, count] of Object.entries(data.s)) {
+    if (count === 0) {
+      const loc = data.statementMap[id]
+      for (let l = loc.start.line; l <= loc.end.line; l++) uncoveredLines.add(l)
+    }
+  }
+
+  if (uncoveredLines.size === 0) continue
+
+  // Read source
+  if (!existsSync(filePath)) continue
+  const lines = readFileSync(filePath, "utf8").split("\n")
+
+  // Group consecutive uncovered lines into ranges
+  const sorted = [...uncoveredLines].sort((a, b) => a - b)
+  const ranges = []
+  let start = sorted[0], end = sorted[0]
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] <= end + 1) {
+      end = sorted[i]
+    } else {
+      ranges.push([start, end])
+      start = end = sorted[i]
+    }
+  }
+  ranges.push([start, end])
+
+  console.log(`\n${"=".repeat(60)}`)
+  console.log(`FILE: ${rel}  (${uncoveredLines.size} uncovered lines in ${ranges.length} region(s))`)
+  console.log(`${"=".repeat(60)}`)
+
+  // Merge nearby ranges so we don't print the same context twice
+  const merged = [ranges[0]]
+  for (let i = 1; i < ranges.length; i++) {
+    const prev = merged[merged.length - 1]
+    if (ranges[i][0] - prev[1] <= CONTEXT * 2 + 1) {
+      prev[1] = ranges[i][1]
+    } else {
+      merged.push(ranges[i])
+    }
+  }
+
+  for (const [rStart, rEnd] of merged) {
+    const from = Math.max(1, rStart - CONTEXT)
+    const to = Math.min(lines.length, rEnd + CONTEXT)
+    console.log(`\n  Lines ${rStart}–${rEnd}:`)
+    for (let l = from; l <= to; l++) {
+      const marker = uncoveredLines.has(l) ? ">>>" : "   "
+      const lineNum = String(l).padStart(4)
+      console.log(`  ${marker} ${lineNum}: ${lines[l - 1]}`)
+    }
+  }
+}
+
+console.log("")

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -5,9 +5,9 @@ type { ExtensionContext } from vscode
 { workspace } := vscode
 
 {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
+  LanguageClient
+  LanguageClientOptions
+  ServerOptions
   TransportKind
 } from vscode-languageclient/node
 

--- a/lsp/source/extension.civet
+++ b/lsp/source/extension.civet
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from 'vscode'
+type { ExtensionContext } from vscode
 
 * as path from path
 * as vscode from vscode

--- a/lsp/source/lib/previewer.civet
+++ b/lsp/source/lib/previewer.civet
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-{ JSDocTagInfo, SymbolDisplayPart } from typescript
+{ type JSDocTagInfo, type SymbolDisplayPart } from typescript
 
 /* tslint:disable:max-line-length */
 /**
@@ -34,9 +34,7 @@ function processInlineTags(text: string): string {
 }
 
 function getTagBodyText(tag: JSDocTagInfo): string | undefined {
-  if (!tag.text) {
-    return undefined;
-  }
+  return unless tag.text
 
   // Convert to markdown code block if it is not already one
   function makeCodeblock(text: string): string {
@@ -82,9 +80,7 @@ export function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
         param := body[1];
         doc := body[2];
         label := `*@${tag.name}* \`${param}\``;
-        if (!doc) {
-          return label;
-        }
+        return label unless doc
         return label + (doc.match(/\r\n|\n/g) ? '  \n' + processInlineTags(doc) : ` — ${processInlineTags(doc)}`);
       }
   }
@@ -92,9 +88,7 @@ export function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
   // Generic tag
   label := `*@${tag.name}*`;
   text := getTagBodyText(tag);
-  if (!text) {
-    return label;
-  }
+  return label unless text
   return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`);
 }
 

--- a/lsp/source/lib/previewer.civet
+++ b/lsp/source/lib/previewer.civet
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { JSDocTagInfo, SymbolDisplayPart } from "typescript";
+{ JSDocTagInfo, SymbolDisplayPart } from typescript
 
 /* tslint:disable:max-line-length */
 /**
@@ -49,7 +49,7 @@ function getTagBodyText(tag: JSDocTagInfo): string | undefined {
   switch (tag.name) {
     case 'example':
       // check for caption tags, fix for #79704
-      const captionTagMatches = plain(tag.text).match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
+      captionTagMatches := plain(tag.text).match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
       if (captionTagMatches && captionTagMatches.index === 0) {
         return captionTagMatches[1] + '\n\n' + makeCodeblock(plain(tag.text).substr(captionTagMatches[0]!.length));
       } else {
@@ -57,7 +57,7 @@ function getTagBodyText(tag: JSDocTagInfo): string | undefined {
       }
     case 'author':
       // fix obsucated email address, #80898
-      const emailMatch = plain(tag.text).match(/(.+)\s<([-.\w]+@[-.\w]+)>/);
+      emailMatch := plain(tag.text).match(/(.+)\s<([-.\w]+@[-.\w]+)>/);
 
       if (emailMatch === null) {
         return plain(tag.text);
@@ -77,11 +77,11 @@ export function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
     case 'extends':
     case 'param':
     case 'template':
-      const body = plain(tag.text || '').split(/^(\S+)\s*-?\s*/);
+      body := plain(tag.text || '').split(/^(\S+)\s*-?\s*/);
       if (body?.length === 3) {
-        const param = body[1];
-        const doc = body[2];
-        const label = `*@${tag.name}* \`${param}\``;
+        param := body[1];
+        doc := body[2];
+        label := `*@${tag.name}* \`${param}\``;
         if (!doc) {
           return label;
         }
@@ -90,8 +90,8 @@ export function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
   }
 
   // Generic tag
-  const label = `*@${tag.name}*`;
-  const text = getTagBodyText(tag);
+  label := `*@${tag.name}*`;
+  text := getTagBodyText(tag);
   if (!text) {
     return label;
   }

--- a/lsp/source/lib/previewer.civet
+++ b/lsp/source/lib/previewer.civet
@@ -10,88 +10,73 @@
  * Adapted from https://github.com/microsoft/vscode/blob/8ba70d8bdc3a10e3143cc4a131f333263bc48eef/extensions/typescript-language-features/src/utils/previewer.ts
  */
 
-function replaceLinks(text: string): string {
-  return (
-    text
-      // Http(s) links
-      .replace(
-        /\{@(link|linkplain|linkcode) (https?:\/\/[^ |}]+?)(?:[| ]([^{}\n]+?))?\}/gi,
-        (_, tag: string, link: string, text?: string) => {
-          switch (tag) {
-            case 'linkcode':
-              return `[\`${text ? text.trim() : link}\`](${link})`;
+function replaceLinks(text: string)
+  text
+    // Http(s) links
+    .replace
+      /\{@(link|linkplain|linkcode) (https?:\/\/[^ |}]+?)(?:[| ]([^{}\n]+?))?\}/gi
+      (_, tag: string, link: string, text?: string) =>
+        switch tag
+          case 'linkcode':
+            return `[\`${text ? text.trim() : link}\`](${link})`
 
-            default:
-              return `[${text ? text.trim() : link}](${link})`;
-          }
-        }
-      )
-  );
-}
+          default:
+            return `[${text ? text.trim() : link}](${link})`
 
-function processInlineTags(text: string): string {
-  return replaceLinks(text);
-}
+function processInlineTags(text: string)
+  replaceLinks(text)
 
-function getTagBodyText(tag: JSDocTagInfo): string | undefined {
+function getTagBodyText(tag: JSDocTagInfo)
   return unless tag.text
 
   // Convert to markdown code block if it is not already one
-  function makeCodeblock(text: string): string {
-    if (text.match(/^\s*[~`]{3}/g)) {
-      return text;
-    }
-    return '```\n' + text + '\n```';
-  }
+  function makeCodeblock(text: string)
+    if text.match(/^\s*[~`]{3}/g)
+      return text
 
-  switch (tag.name) {
+    return '```\n' + text + '\n```'
+
+  switch tag.name
     case 'example':
       // check for caption tags, fix for #79704
-      captionTagMatches := plain(tag.text).match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/);
-      if (captionTagMatches && captionTagMatches.index === 0) {
-        return captionTagMatches[1] + '\n\n' + makeCodeblock(plain(tag.text).substr(captionTagMatches[0]!.length));
-      } else {
-        return makeCodeblock(plain(tag.text));
-      }
+      captionTagMatches := plain(tag.text).match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/)
+      if captionTagMatches and captionTagMatches.index is 0
+        return captionTagMatches[1] + '\n\n' + makeCodeblock(plain(tag.text).substr(captionTagMatches[0]!.length))
+      return makeCodeblock(plain(tag.text))
+
     case 'author':
       // fix obsucated email address, #80898
-      emailMatch := plain(tag.text).match(/(.+)\s<([-.\w]+@[-.\w]+)>/);
+      emailMatch := plain(tag.text).match(/(.+)\s<([-.\w]+@[-.\w]+)>/)
 
-      if (emailMatch === null) {
-        return plain(tag.text);
-      } else {
-        return `${emailMatch[1]} ${emailMatch[2]}`;
-      }
+      if emailMatch is null
+        return plain(tag.text)
+
+      return `${emailMatch[1]} ${emailMatch[2]}`
+
     case 'default':
-      return makeCodeblock(plain(tag.text));
-  }
+      return makeCodeblock(plain(tag.text))
 
-  return processInlineTags(plain(tag.text));
-}
+  return processInlineTags(plain(tag.text))
 
-export function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
-  switch (tag.name) {
+export function getTagDocumentation(tag: JSDocTagInfo)
+  switch tag.name
     case 'augments':
     case 'extends':
     case 'param':
     case 'template':
-      body := plain(tag.text || '').split(/^(\S+)\s*-?\s*/);
-      if (body?.length === 3) {
-        param := body[1];
-        doc := body[2];
-        label := `*@${tag.name}* \`${param}\``;
+      body := plain(tag.text or '').split(/^(\S+)\s*-?\s*/)
+      if body?.length is 3
+        param := body[1]
+        doc := body[2]
+        label := `*@${tag.name}* \`${param}\``
         return label unless doc
-        return label + (doc.match(/\r\n|\n/g) ? '  \n' + processInlineTags(doc) : ` — ${processInlineTags(doc)}`);
-      }
-  }
+        return label + (doc.match(/\r\n|\n/g) ? '  \n' + processInlineTags(doc) : ` — ${processInlineTags(doc)}`)
 
   // Generic tag
-  label := `*@${tag.name}*`;
-  text := getTagBodyText(tag);
+  label := `*@${tag.name}*`
+  text := getTagBodyText(tag)
   return label unless text
-  return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`);
-}
+  return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` — ${text}`)
 
-export function plain(parts: SymbolDisplayPart[] | string): string {
-  return processInlineTags(typeof parts === 'string' ? parts : parts.map((part) => part.text).join(''));
-}
+export function plain(parts: SymbolDisplayPart[] | string)
+  return processInlineTags(parts <? 'string' ? parts : parts.map((part) => part.text).join(''))

--- a/lsp/source/lib/previewer.civet
+++ b/lsp/source/lib/previewer.civet
@@ -99,5 +99,5 @@ export function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
 }
 
 export function plain(parts: SymbolDisplayPart[] | string): string {
-  return processInlineTags(typeof parts === 'string' ? parts : parts.map(part => part.text).join(''));
+  return processInlineTags(typeof parts === 'string' ? parts : parts.map((part) => part.text).join(''));
 }

--- a/lsp/source/lib/textRendering.civet
+++ b/lsp/source/lib/textRendering.civet
@@ -5,158 +5,136 @@ type JSDocTagInfo = ts.server.protocol.JSDocTagInfo
 
 // Based on https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
 
-export function asPlainText(parts: SymbolDisplayPart[] | string): string {
-  if (typeof parts === "string") return parts
-  return parts.map((part) => part.text).join('')
-}
+export function asPlainText(parts: SymbolDisplayPart[] | string)
+  return parts if parts <? 'string'
+  parts.map((part) => part.text).join('')
 
-export function asPlainTextWithLinks(parts: SymbolDisplayPart[] | string | undefined): string {
-  if (!parts) return ''
-  if (typeof parts === 'string') return parts
+export function asPlainTextWithLinks(parts: SymbolDisplayPart[] | string | undefined)
+  return '' unless parts
+  return parts if parts <? 'string'
   out .= ""
   let currentLink: {
     name?: string
     target?: FileSpan
     text?: string
     linkcode: boolean
-  } | undefined
-  for (const part of parts) {
-    switch (part.kind) {
+  }?
+
+  for part of parts
+    switch part.kind
       case "link":
-        if (currentLink) {
-          if (currentLink.target) {
+        if currentLink
+          if currentLink.target
             //const file = filePathConverter.toResource(currentLink.target.file)
-            const args = {
-              //file: { ...file.toJSON(), $mid: undefined },
-              file: currentLink.target.file,
-              position: {
-                lineNumber: currentLink.target.start.line - 1,
+            args :=
+              //file: { ...file.toJSON(), $mid: undefined }
+              file: currentLink.target.file
+              position:
+                lineNumber: currentLink.target.start.line - 1
                 column: currentLink.target.start.offset - 1
-              }
-            }
-            const command = "command:_typescript.openJsDocLink?" +
+
+            command := "command:_typescript.openJsDocLink?" +
               encodeURIComponent(JSON.stringify([args]))
-            const linkText = currentLink.text || escapeBackTicks(currentLink.name ?? "")
+            linkText := currentLink.text or escapeBackTicks(currentLink.name or "")
+
             out += `[${currentLink.linkcode ? '`' + linkText + '`' : linkText}](${command})`
-          } else {
-            const text = currentLink.text ?? currentLink.name
-            if (text) {
-              if (/^https?:/.test(text)) {
-                const subparts = text.split(' ')
-                if (subparts.length === 1 && !currentLink.linkcode) {
+          else
+            if text := currentLink.text ?? currentLink.name
+              if /^https?:/.test(text)
+                subparts := text.split(' ')
+                if subparts.length is 1 and !currentLink.linkcode
                   out += `<${subparts[0]}>`
-                } else {
-                  const linkText = subparts.length > 1
+                else
+                  linkText := subparts.length > 1
                     ? subparts.slice(1).join(' ')
                     : subparts[0]
                   out += `[${currentLink.linkcode ? '`' + escapeBackTicks(linkText) + '`' : linkText}](${subparts[0]})`
-                }
-              } else {
+              else
                 out += escapeBackTicks(text)
-              }
-            }
-          }
-        } else {
-          currentLink = {
-            linkcode: part.text === "{@linkcode "
-          }
-        }
+        else
+          currentLink =
+            linkcode: part.text is "{@linkcode "
         currentLink = undefined
         break
-      case "linkName":
-        if (currentLink) {
+      when "linkName":
+        if currentLink
           currentLink.name = part.text
           // @ts-ignore Proto.JSDocLinkDisplayPart
           currentLink.target = part.target
-        }
-        break
-      case "linkText":
-        if (currentLink) currentLink.text = part.text
-        break
+      when "linkText":
+        if currentLink
+          currentLink.text = part.text
       default:
         out += part.text
-    }
-  }
+
   return out
-}
 
-function escapeBackTicks(text: string): string {
-  return text.replace(/`/g, '\\$&');
-}
+function escapeBackTicks(text: string)
+  text.replace(/`/g, '\\$&')
 
-export function tagsToMarkdown(tags: JSDocTagInfo[]): string {
-  return tags.map(getTagDocumentation).join('  \n\n')
-}
+export function tagsToMarkdown(tags: JSDocTagInfo[])
+  tags.map(getTagDocumentation).join('  \n\n')
 
-function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
-  switch (tag.name) {
-    case "augments":
-    case "extends":
-    case "param":
-    case "template":
+function getTagDocumentation(tag: JSDocTagInfo)
+  switch tag.name
+    when "augments", "extends", "param", "template"
       body := getTagBody(tag)
-      if (body?.length === 3) {
-        const [, param, doc] = body
+      if body?.length is 3
+        [, param, doc] := body
         label := `*@${tag.name}* \`${param}\``
-        if (!doc) return label
+        return label unless doc
         return label + (doc.match(/\r\n|\n/g) ? '  \n' + doc : ` \u2014 ${doc}`)
-      }
-      break
-    case "return":
-    case "returns":
-      if (!tag.text?.length) return undefined
-      break
-  }
+
+    when "return", "returns":
+      return undefined unless tag.text?.length
+
   label := `*@${tag.name}*`
   text := getTagBodyText(tag)
-  if (!text) return label
+  return label unless text
   return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` \u2014 ${text}`)
-}
 
-function getTagBody(tag: JSDocTagInfo): Array<string> | undefined {
-  if (tag.name === "template") {
+function getTagBody(tag: JSDocTagInfo)
+  if tag.name is "template"
     parts := tag.text
-    if (parts && typeof parts !== "string") {
+    if parts and parts !<? "string"
       params := parts
-      .filter((p) => p.kind === "typeParameterName")
-      .map((p) => p.text)
+      .filter .kind is "typeParameterName"
+      .map .text
       .join(", ")
+
       docs := parts
-      .filter((p) => p.kind === "text")
+      .filter .kind is "text"
       .map((p) => asPlainTextWithLinks(p.text.replace(/^\s*-?\s*/, "")))
       .join(", ")
       return params ? ["", params, docs] : undefined
-    }
-  }
-  return asPlainTextWithLinks(tag.text).split(/^(\S+)\s*-?\s*/)
-}
 
-function getTagBodyText(tag: JSDocTagInfo): string | undefined {
+  return asPlainTextWithLinks(tag.text).split(/^(\S+)\s*-?\s*/)
+
+function getTagBodyText(tag: JSDocTagInfo)
   if (!tag.text) return
 
-  function makeCodeblock(text: string): string {
+  function makeCodeblock(text: string)
     if (/^\s*[~`]{3}/m.test(text)) return text
-    return '```\n' + text + '\n```';
-  }
+    return '```\n' + text + '\n```'
 
   text .= asPlainTextWithLinks(tag.text)
-  switch (tag.name) {
-    case "example":
-      text = asPlainText(tag.text)
+
+  switch tag.name
+    when "example":
+      text = asPlainText tag.text
       captionTagMatches := text.match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/)
-      if (captionTagMatches && captionTagMatches.index === 0) {
-        return captionTagMatches[1] + "\n" +
+
+      if captionTagMatches and captionTagMatches.index is 0
+        captionTagMatches[1] + "\n" +
           makeCodeblock(text.slice(captionTagMatches[0].length))
-      } else {
-        return makeCodeblock(text)
-      }
-    case "author":
+      else
+        makeCodeblock(text)
+    when "author":
       emailMatch := text.match(/(.+)\s<([-.\w]+@[-.\w]+)>/)
-      if (!emailMatch) return text
-      return `${emailMatch[1]} ${emailMatch[2]}`
-    case "default":
-      return makeCodeblock(text)
-    default:
-      return text
-  }
-}
+      return text unless emailMatch
+
+      `${emailMatch[1]} ${emailMatch[2]}`
+    when "default":
+      makeCodeblock(text)
+    else
+      text

--- a/lsp/source/lib/textRendering.civet
+++ b/lsp/source/lib/textRendering.civet
@@ -7,7 +7,7 @@ type JSDocTagInfo = ts.server.protocol.JSDocTagInfo
 
 export function asPlainText(parts: SymbolDisplayPart[] | string): string {
   if (typeof parts === "string") return parts
-  return parts.map(part => part.text).join('')
+  return parts.map((part) => part.text).join('')
 }
 
 export function asPlainTextWithLinks(parts: SymbolDisplayPart[] | string | undefined): string {
@@ -118,12 +118,12 @@ function getTagBody(tag: JSDocTagInfo): Array<string> | undefined {
     parts := tag.text
     if (parts && typeof parts !== "string") {
       params := parts
-      .filter(p => p.kind === "typeParameterName")
-      .map(p => p.text)
+      .filter((p) => p.kind === "typeParameterName")
+      .map((p) => p.text)
       .join(", ")
       docs := parts
-      .filter(p => p.kind === "text")
-      .map(p => asPlainTextWithLinks(p.text.replace(/^\s*-?\s*/, "")))
+      .filter((p) => p.kind === "text")
+      .map((p) => asPlainTextWithLinks(p.text.replace(/^\s*-?\s*/, "")))
       .join(", ")
       return params ? ["", params, docs] : undefined
     }

--- a/lsp/source/lib/textRendering.civet
+++ b/lsp/source/lib/textRendering.civet
@@ -1,4 +1,4 @@
-import type ts from 'typescript'
+import type ts from typescript
 type SymbolDisplayPart = ts.server.protocol.SymbolDisplayPart
 type FileSpan = ts.server.protocol.FileSpan
 type JSDocTagInfo = ts.server.protocol.JSDocTagInfo
@@ -13,7 +13,7 @@ export function asPlainText(parts: SymbolDisplayPart[] | string): string {
 export function asPlainTextWithLinks(parts: SymbolDisplayPart[] | string | undefined): string {
   if (!parts) return ''
   if (typeof parts === 'string') return parts
-  let out = ""
+  out .= ""
   let currentLink: {
     name?: string
     target?: FileSpan
@@ -94,10 +94,10 @@ function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
     case "extends":
     case "param":
     case "template":
-      const body = getTagBody(tag)
+      body := getTagBody(tag)
       if (body?.length === 3) {
         const [, param, doc] = body
-        const label = `*@${tag.name}* \`${param}\``
+        label := `*@${tag.name}* \`${param}\``
         if (!doc) return label
         return label + (doc.match(/\r\n|\n/g) ? '  \n' + doc : ` \u2014 ${doc}`)
       }
@@ -107,21 +107,21 @@ function getTagDocumentation(tag: JSDocTagInfo): string | undefined {
       if (!tag.text?.length) return undefined
       break
   }
-  const label = `*@${tag.name}*`
-  const text = getTagBodyText(tag)
+  label := `*@${tag.name}*`
+  text := getTagBodyText(tag)
   if (!text) return label
   return label + (text.match(/\r\n|\n/g) ? '  \n' + text : ` \u2014 ${text}`)
 }
 
 function getTagBody(tag: JSDocTagInfo): Array<string> | undefined {
   if (tag.name === "template") {
-    const parts = tag.text
+    parts := tag.text
     if (parts && typeof parts !== "string") {
-      const params = parts
+      params := parts
       .filter(p => p.kind === "typeParameterName")
       .map(p => p.text)
       .join(", ")
-      const docs = parts
+      docs := parts
       .filter(p => p.kind === "text")
       .map(p => asPlainTextWithLinks(p.text.replace(/^\s*-?\s*/, "")))
       .join(", ")
@@ -139,11 +139,11 @@ function getTagBodyText(tag: JSDocTagInfo): string | undefined {
     return '```\n' + text + '\n```';
   }
 
-  let text = asPlainTextWithLinks(tag.text)
+  text .= asPlainTextWithLinks(tag.text)
   switch (tag.name) {
     case "example":
       text = asPlainText(tag.text)
-      const captionTagMatches = text.match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/)
+      captionTagMatches := text.match(/<caption>(.*?)<\/caption>\s*(\r\n|\n)/)
       if (captionTagMatches && captionTagMatches.index === 0) {
         return captionTagMatches[1] + "\n" +
           makeCodeblock(text.slice(captionTagMatches[0].length))
@@ -151,7 +151,7 @@ function getTagBodyText(tag: JSDocTagInfo): string | undefined {
         return makeCodeblock(text)
       }
     case "author":
-      const emailMatch = text.match(/(.+)\s<([-.\w]+@[-.\w]+)>/)
+      emailMatch := text.match(/(.+)\s<([-.\w]+@[-.\w]+)>/)
       if (!emailMatch) return text
       return `${emailMatch[1]} ${emailMatch[2]}`
     case "default":

--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -23,8 +23,8 @@ ts from typescript
 { TextDocument } from vscode-languageserver-textdocument
 
 // Import version from package.json
-import pkg from "../../package.json" with { type: 'json' }
-{ RemoteConsole } from vscode-languageserver
+import pkg from ../../package.json with { type: 'json' }
+{ type RemoteConsole } from vscode-languageserver
 { version } := pkg
 
 // HACK to get __dirname working in tests with ts-node
@@ -33,29 +33,25 @@ import pkg from "../../package.json" with { type: 'json' }
 dir :=
   typeof __dirname !== "undefined" ? __dirname : fileURLToPath(import.meta.url);
 
-interface SourceMap {
+interface SourceMap
   lines?: CivetSourceMap["data"]["lines"]  // New format: direct lines access
   data?: CivetSourceMap["data"]             // Old format: nested in data
-}
 
 // ts doesn't have this key in the type
-interface ResolvedModuleWithFailedLookupLocations extends ts.ResolvedModuleWithFailedLookupLocations {
-  failedLookupLocations: string[];
-}
+interface ResolvedModuleWithFailedLookupLocations extends ts.ResolvedModuleWithFailedLookupLocations
+  failedLookupLocations: string[]
 
-export interface FileMeta {
+export interface FileMeta
   sourcemapLines: SourceMap["lines"] | undefined
   transpiledDoc: TextDocument | undefined
   parseErrors: (Error | ParseError)[] | undefined
   fatal: boolean // whether errors were fatal during compilation, so no doc
-}
 
-interface Host extends LanguageServiceHost {
+interface Host extends LanguageServiceHost
   getMeta(path: string): FileMeta | undefined
   addOrUpdateDocument(doc: TextDocument): void
-}
 
-interface Transpiler {
+interface Transpiler
   extension: string
   /**
    * The target extension of the transpiler (used to force module/commonjs via .mjs, .cjs, .mts, .cts, etc)
@@ -67,11 +63,9 @@ interface Transpiler {
     sourceMap?: SourceMap
     errors?: (Error | ParseError)[]
   } | undefined
-}
 
-interface Plugin {
+interface Plugin
   transpilers?: Transpiler[]
-}
 
 function TSHost(
   compilationSettings: CompilerOptions,
@@ -84,7 +78,7 @@ function TSHost(
   assert(rootDir, "Most have root dir for now")
 
   scriptFileNames: Set<string> := new Set(initialFileNames.map(getCanonicalFileName))
-  fileMetaData: Map<string, FileMeta> := new Map;
+  fileMetaData: Map<string, FileMeta> := new Map
 
   pathMap: Map<string, TextDocument> := new Map
   snapshotMap: Map<string, IScriptSnapshot> := new Map
@@ -96,14 +90,13 @@ function TSHost(
   let self: Host;
 
   return self = Object.assign({}, baseHost, {
-    getDefaultLibFileName(options: ts.CompilerOptions) {
+    getDefaultLibFileName(options: ts.CompilerOptions)
       // TODO: this might not be correct for dev dev/test envs
-      result := path.join(dir, "lib", ts.getDefaultLibFileName(options))
-      return result
-    },
-    getModuleResolutionCache() {
-      return resolutionCache
-    },
+      path.join(dir, "lib", ts.getDefaultLibFileName(options))
+
+    getModuleResolutionCache()
+      resolutionCache
+
     /**
      * This is how TypeScript resolves module names when it finds things like `import { foo } from "bar"`.
      * We need to modify this to make sure that TypeScript can resolve our `.civet` files.
@@ -115,7 +108,7 @@ function TSHost(
       return moduleNames.map((name) => {
         // Try to resolve the module using the standard TypeScript logic
         { resolvedModule } := ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache) as ResolvedModuleWithFailedLookupLocations
-        if (resolvedModule) return resolvedModule
+        return resolvedModule if resolvedModule
 
         // get the transpiler for the extension
         extension := getExtensionFromPath(name)
@@ -137,7 +130,7 @@ function TSHost(
                   break
                 }
               }
-              if (!transpiler) return
+              return unless transpiler
             }
             // Now sys.fileExists(resolved) should be true
             { target } := transpiler
@@ -152,9 +145,9 @@ function TSHost(
           // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts
           // tryLoadModuleUsingOptionalResolutionSettings
           { baseUrl, paths, pathsBasePath } .= compilationSettings
-          if (!isExternalModuleNameRelative(name)) { // absolute
+          if !isExternalModuleNameRelative(name) // absolute
             // tryLoadModuleUsingPathsIfEligible
-            if (paths) {
+            if paths
               // tryLoadModuleUsingPaths
               // getPathsBasePath from
               // https://github.com/microsoft/TypeScript/blob/bbef6a7a31cff1d0d9f94b082996334baca74caa/src/compiler/utilities.ts#L6317-L6320
@@ -164,45 +157,39 @@ function TSHost(
               // https://github.com/microsoft/TypeScript/blob/bbef6a7a31cff1d0d9f94b082996334baca74caa/src/compiler/utilities.ts#L9743-L9745
               best .= ''
               bestPrefix .= ''
-              for (const [pattern, replacements] of Object.entries(paths)) {
-                if (pattern.endsWith("*")) {
+              for [pattern, replacements] of Object.entries(paths)
+                if pattern.endsWith("*")
                   prefix := pattern.slice(0, -1)
-                  if (name.startsWith(prefix)) {
-                    for (const replacement of replacements) {
+                  if name.startsWith(prefix)
+                    for replacement of replacements
                       resolved := path.resolve(pathsBase,
                         replacement.replace('*', name.slice(prefix.length)))
-                      if (exists(resolved) && prefix.length > bestPrefix.length) {
+                      if exists(resolved) and prefix.length > bestPrefix.length
                         best = resolved
                         bestPrefix = prefix
-                      }
-                    }
-                  }
-                } else if (name === pattern) {
-                  for (const replacement of replacements) {
+
+                else if name is pattern
+                  for replacement of replacements
                     resolved := path.resolve(pathsBase, replacement)
-                    if (exists(resolved) && pattern.length > bestPrefix.length) {
+                    if exists(resolved) and pattern.length > bestPrefix.length
                       best = resolved
                       bestPrefix = pattern
-                    }
-                  }
-                }
-              }
-              if (best) return resolvedModule(best)
-            }
+
+              if best return resolvedModule(best)
+
             // tryLoadModuleUsingBaseUrl
-            if (baseUrl) {
+            if baseUrl
               resolved := path.resolve(baseUrl, name)
-              if (exists(resolved)) return resolvedModule(resolved)
-            }
-          } else { // relative
+              return resolvedModule(resolved) if exists(resolved)
+
+          else // relative
             // TODO: tryLoadModuleUsingRootDirs
-          }
 
           // This backup resolver is really just for relative paths.
           // TODO: Implement absolute case from tryResolve
           // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts#L3221
           resolved := path.resolve(path.dirname(containingFile), name)
-          if (exists(resolved)) return resolvedModule(resolved)
+          return resolvedModule(resolved) if exists(resolved)
           // TODO: add to resolution cache?
         }
 
@@ -234,9 +221,7 @@ function TSHost(
 
         transpiledDoc .= pathMap.get(transpiledPath)
 
-        if (!transpiledDoc) {
-          initTranspiledDoc(transpiledPath)
-        }
+        initTranspiledDoc(transpiledPath) unless transpiledDoc
         // Deleting the snapshot will force a new one to be created when requested
         snapshotMap.delete(transpiledPath)
 
@@ -247,88 +232,66 @@ function TSHost(
       }
 
       // Plain non-transpiled document
-      if (!scriptFileNames.has(path)) {
-        scriptFileNames.add(path)
-      }
-
-      if (!pathMap.has(path)) {
-        pathMap.set(path, doc)
-      }
-
-      return
+      scriptFileNames.add(path) unless scriptFileNames.has(path)
+      pathMap.set(path, doc) unless pathMap.has(path)
     },
-    getMeta(path: string) {
+    getMeta(path: string)
       transpiledPath := getTranspiledPath(path)
       // This ensures that the transpiled meta data is created
       getOrCreatePathSnapshot(transpiledPath)
+      fileMetaData.get(path)
 
-      return fileMetaData.get(path)
-    },
-    getProjectVersion() {
-      return projectVersion.toString();
-    },
-    getCompilationSettings() {
-      return compilationSettings;
-    },
+    getProjectVersion()
+      projectVersion.toString()
+
+    getCompilationSettings()
+      compilationSettings
+
+
     /**
      * NOTE: TypeScript likes to pass in paths with only forward slashes regardless of the OS.
      * So we need to normalize them here and in `getScriptVersion`.
      */
-    getScriptSnapshot(path: string) {
+    getScriptSnapshot(path: string)
       path = getCanonicalFileName(path)
-      snap := getOrCreatePathSnapshot(path)
+      getOrCreatePathSnapshot(path)
 
-      return snap
-    },
     /**
      * NOTE: TypeScript likes to pass in paths with only forward slashes regardless of the OS.
      * So we need to normalize them here and in `getScriptSnapshot`.
      */
-    getScriptVersion(path: string) {
+    getScriptVersion(path: string)
       path = getCanonicalFileName(path)
-      version := pathMap.get(path)?.version.toString() || "0"
       // console.log("getScriptVersion", path, version)
-      return version
-    },
-    getScriptFileNames() {
-      return Array.from(scriptFileNames)
-    },
-    writeFile(fileName: string, content: string) {
+      pathMap.get(path)?.version.toString() || "0"
+
+    getScriptFileNames()
+      Array.from(scriptFileNames)
+
+    writeFile(fileName: string, content: string)
       logger.log("write " + fileName + " " + content)
-    }
   });
 
   /**
    * Get the source code for a path.
    * Use the VSCode document if it exists otherwise use the file system.
    */
-  function getPathSource(path: string): string {
+  function getPathSource(path: string): string
     // Open VSCode docs and transpiled files should all be in the pathMap
     doc := pathMap.get(path)
-    if (doc) {
-      return doc.getText()
-    }
+    return doc.getText() if doc
+    return sys.readFile(path)! if sys.fileExists(path)
+    ""
 
-    if (sys.fileExists(path)) {
-      return sys.readFile(path)!
-    }
-
-    return ""
-  }
-
-  function getTranspiledPath(path: string) {
+  function getTranspiledPath(path: string)
     extension := getExtensionFromPath(path)
     transpiler := transpilers.get(extension)
-
-    if (transpiler) {
-      return path + transpiler.target
-    }
-    return path
-  }
+    return path + transpiler.target if transpiler
+    path
 
   function getOrCreatePathSnapshot(path: string) {
     snapshot .= snapshotMap.get(path)
-    if (snapshot) return snapshot
+    return snapshot if snapshot
 
     let transpiler
 
@@ -342,32 +305,25 @@ function TSHost(
       sourcePath := removeExtension(path)
       sourceDoc := pathMap.get(sourcePath)
       transpiledDoc .= pathMap.get(path)
-      if (!transpiledDoc) {
-        transpiledDoc = initTranspiledDoc(path)
-      }
+      transpiledDoc = initTranspiledDoc(path) unless transpiledDoc
 
       let source
       sourceDocVersion .= 0
-      if (!sourceDoc) {
+      if !sourceDoc
         // A source file from the file system
         source = sys.readFile(sourcePath)
-      } else {
+      else
         source = sourceDoc.getText()
         sourceDocVersion = sourceDoc.version
-      }
 
       // The source document is ahead of the transpiled document
       if (source && sourceDocVersion > transpiledDoc.version) {
         transpiledCode := doTranspileAndUpdateMeta(transpiledDoc, sourceDocVersion, transpiler, sourcePath, source)
-        if (transpiledCode !== undefined) {
-          snapshot = Snap(transpiledCode)
-        }
+        snapshot = Snap(transpiledCode) if transpiledCode?
       }
 
-      if (!snapshot) {
-        // Use the old version if there was an error
-        snapshot = Snap(transpiledDoc.getText())
-      }
+      // Use the old version if there was an error
+      snapshot = Snap(transpiledDoc.getText()) unless snapshot
 
       snapshotMap.set(path, snapshot)
       return snapshot
@@ -381,20 +337,12 @@ function TSHost(
 
   function createOrUpdateMeta(path: string, transpiledDoc: TextDocument, sourcemapLines?: SourceMap["lines"], parseErrors?: (Error | ParseError)[], fatal: boolean = false) {
     meta .= fileMetaData.get(path)
-
-    if (!meta) {
-      newMeta: FileMeta := {
-        sourcemapLines,
-        transpiledDoc,
-        parseErrors,
-        fatal,
-      }
-      fileMetaData.set(path, newMeta)
-    } else {
+    if !meta
+      fileMetaData.set(path, { sourcemapLines, transpiledDoc, parseErrors, fatal } as FileMeta)
+    else
       meta.sourcemapLines = sourcemapLines
       meta.parseErrors = parseErrors
       meta.fatal = fatal
-    }
   }
 
   function doTranspileAndUpdateMeta(transpiledDoc: TextDocument, version: number, transpiler: Transpiler, sourcePath: string, sourceCode: string): string | undefined {
@@ -407,18 +355,15 @@ function TSHost(
       return
     }
 
-    if (result) {
-      { code: transpiledCode, sourceMap, errors } := result
-      sourceMapLines := sourceMap?.lines ?? sourceMap?.data?.lines // older Civet
-      createOrUpdateMeta(sourcePath, transpiledDoc, sourceMapLines, errors, false)
-      TextDocument.update(transpiledDoc, [{ text: transpiledCode }], version)
-
-      return transpiledCode
-    }
-    return
+    return unless result
+    { code: transpiledCode, sourceMap, errors } := result
+    sourceMapLines := sourceMap?.lines ?? sourceMap?.data?.lines // older Civet
+    createOrUpdateMeta(sourcePath, transpiledDoc, sourceMapLines, errors, false)
+    TextDocument.update(transpiledDoc, [{ text: transpiledCode }], version)
+    transpiledCode
   }
 
-  function initTranspiledDoc(path: string) {
+  function initTranspiledDoc(path: string)
     // Create an empty document, it will be updated on-demand when `getScriptSnapshot` is called
     // `path` must be the in the format that TypeScript Language Service expects
     uri := URI.file(path).toString()
@@ -427,16 +372,13 @@ function TSHost(
     pathMap.set(path, transpiledDoc)
     // Transpiled doc gets added to scriptFileNames
     scriptFileNames.add(path)
-
-    return transpiledDoc
-  }
+    transpiledDoc
 
   /**
    * Normalize slashes based on the OS.
    */
-  function getCanonicalFileName(fileName: string): string {
-    return path.join(fileName)
-  }
+  function getCanonicalFileName(fileName: string): string
+    path.join(fileName)
 }
 
 async function TSService(projectURL = "./", logger: Console | RemoteConsole = console) {
@@ -575,11 +517,10 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
  * @example
  * getExtension('foo/bar/baz.') // => ''
  */
-function getExtensionFromPath(path: string): string {
+function getExtensionFromPath(path: string): string
   match := path.match(lastExtension)
-  if (!match) return ""
-  return match[0]
-}
+  return "" unless match
+  match[0]
 
 // Regex to match last extension including dot
 lastExtension := /(?:\.(?:[^./]+))?$/
@@ -595,12 +536,10 @@ lastTwoExtensions := /(\.[^./]*)(\.[^./]*)$/
  * @example
  * getLastTwoExtensions('foo/bar/baz.civet.ts') // => ['.civet', '.ts']
  */
-function getTranspiledExtensionsFromPath(path: string): [string, string] | undefined {
+function getTranspiledExtensionsFromPath(path: string): [string, string] | undefined
   match := path.match(lastTwoExtensions)
-  if (!match) return
-
-  return [match[1], match[2]]
-}
+  return unless match
+  [match[1], match[2]]
 
 /**
  * Removes the last extension from a path.
@@ -615,23 +554,16 @@ function getTranspiledExtensionsFromPath(path: string): [string, string] | undef
  * @example
  * removeExtension('foo/bar.js/baz') // => 'foo/bar.js/baz'
  */
-function removeExtension(path: string) {
-  return path.replace(/\.[^\/.]+$/, "")
-}
+function removeExtension(path: string)
+  path.replace(/\.[^\/.]+$/, "")
 
-function remapFileName(fileName: string, transpilers: Map<string, Transpiler>): string {
+function remapFileName(fileName: string, transpilers: Map<string, Transpiler>): string
   [extension, target] := getTranspiledExtensionsFromPath(fileName) || []
-
-  if (!extension) return fileName
+  return fileName unless extension
   transpiler := transpilers.get(extension)
-  if (!transpiler) return fileName
-
-  if (transpiler.target === target) {
-    return removeExtension(fileName)
-  }
-
-  return fileName
-}
+  return fileName unless transpiler
+  return removeExtension(fileName) if transpiler.target === target
+  fileName
 
 // Incremental snapshot example from vue language tools
 // https://github.com/vuejs/language-tools/blob/5607f45835ab85e0b5a0747614a4ed9989a28cec/packages/language-core/src/virtualFile/computedFiles.ts#L218

--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -488,7 +488,7 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   civetPath := "@danielx/civet"
   try {
     projectRequire(`${civetPath}/lsp/package.json`)
-    logger.info("USING DEVELOPMENT VERSION OF CIVET -- BE SURE TO yarn build")
+    logger.info("USING DEVELOPMENT VERSION OF CIVET -- BE SURE TO pnpm build")
   } catch (e) { }
   try {
     Civet = projectRequire(civetPath)

--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -112,7 +112,7 @@ function TSHost(
      * Then TypeScript will call `getScriptSnapshot` with the `.civet` extension and we can do the transpilation there.
      */
     resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, _containingSourceFile?: ts.SourceFile) {
-      return moduleNames.map(name => {
+      return moduleNames.map((name) => {
         // Try to resolve the module using the standard TypeScript logic
         { resolvedModule } := ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache) as ResolvedModuleWithFailedLookupLocations
         if (resolvedModule) return resolvedModule
@@ -473,7 +473,7 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
     extension: ".civet" as const,
     target: ".tsx" as ts.Extension,
     compile: transpileCivet,
-  }].map<[string, Transpiler]>(def => [def.extension, def])
+  }].map<[string, Transpiler]>((def) => [def.extension, def])
 
   transpilers := new Map<string, Transpiler>(transpilerDefinitions)
   // TODO: May want to add transpiled files to fileNames
@@ -526,8 +526,8 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
 
       // One day it would be nice to load plugins that could be transpiled but that is a whole can of worms.
       // VSCode Node versions, esm loaders, etc.
-      pluginFiles := civetFiles.filter(file => file.endsWith("plugin.mjs"))
-        .map(file => URI.file(file).toString())
+      pluginFiles := civetFiles.filter((file) => file.endsWith("plugin.mjs"))
+        .map((file) => URI.file(file).toString())
 
       for (const filePath of pluginFiles) {
         logger.info("Loading plugin " + filePath)
@@ -544,7 +544,7 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
           transpilers.set(transpiler.extension, transpiler)
         })
       })
-      .catch(e => {
+      .catch((e) => {
         logger.error("Error loading plugin " + path + " " + e)
       })
   }

--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -79,7 +79,7 @@ function TSHost(
   logger: Logger = console
 ): Host {
   { rootDir } := compilationSettings
-  assert(rootDir, "Most have root dir for now")
+  assert(rootDir, "Must have root dir for now")
 
   scriptFileNames: Set<string> := new Set(initialFileNames.map(getCanonicalFileName))
   fileMetaData: Map<string, FileMeta> := new Map

--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -10,11 +10,11 @@ ts from typescript
 { type CompilerHost, type CompilerOptions, type IScriptSnapshot, type LanguageServiceHost } from typescript
 
 {
-  createCompilerHost,
-  createLanguageService,
-  parseJsonConfigFileContent,
-  readConfigFile,
-  sys,
+  createCompilerHost
+  createLanguageService
+  parseJsonConfigFileContent
+  readConfigFile
+  sys
 } := ts
 
 { createRequire } from module
@@ -24,14 +24,18 @@ ts from typescript
 
 // Import version from package.json
 import pkg from ../../package.json with { type: 'json' }
-{ type RemoteConsole } from vscode-languageserver
 { version } := pkg
+
+interface Logger
+  log(msg: string): void
+  info(msg: string): void
+  error(msg: string): void
 
 // HACK to get __dirname working in tests with ts-node
 // ts-node needs everything to be modules for .civet files to work
 // and modules don't have __dirname
 dir :=
-  typeof __dirname !== "undefined" ? __dirname : fileURLToPath(import.meta.url);
+  typeof __dirname !== "undefined" ? __dirname : fileURLToPath(import.meta.url)
 
 interface SourceMap
   lines?: CivetSourceMap["data"]["lines"]  // New format: direct lines access
@@ -42,13 +46,13 @@ interface ResolvedModuleWithFailedLookupLocations extends ts.ResolvedModuleWithF
   failedLookupLocations: string[]
 
 export interface FileMeta
-  sourcemapLines: SourceMap["lines"] | undefined
-  transpiledDoc: TextDocument | undefined
-  parseErrors: (Error | ParseError)[] | undefined
+  sourcemapLines: SourceMap["lines"]?
+  transpiledDoc: TextDocument?
+  parseErrors: (Error | ParseError)[]?
   fatal: boolean // whether errors were fatal during compilation, so no doc
 
 interface Host extends LanguageServiceHost
-  getMeta(path: string): FileMeta | undefined
+  getMeta(path: string): FileMeta?
   addOrUpdateDocument(doc: TextDocument): void
 
 interface Transpiler
@@ -59,20 +63,20 @@ interface Transpiler
    */
   target: ts.Extension
   compile(path: string, source: string): {
-    code: string,
+    code: string
     sourceMap?: SourceMap
     errors?: (Error | ParseError)[]
-  } | undefined
+  }?
 
 interface Plugin
   transpilers?: Transpiler[]
 
 function TSHost(
-  compilationSettings: CompilerOptions,
-  initialFileNames: string[],
-  baseHost: CompilerHost,
-  transpilers: Map<string, Transpiler>,
-  logger: Console | RemoteConsole = console,
+  compilationSettings: CompilerOptions
+  initialFileNames: string[]
+  baseHost: CompilerHost
+  transpilers: Map<string, Transpiler>
+  logger: Logger = console
 ): Host {
   { rootDir } := compilationSettings
   assert(rootDir, "Most have root dir for now")
@@ -83,11 +87,11 @@ function TSHost(
   pathMap: Map<string, TextDocument> := new Map
   snapshotMap: Map<string, IScriptSnapshot> := new Map
 
-  projectVersion .= 0;
+  projectVersion .= 0
 
-  resolutionCache: ts.ModuleResolutionCache := ts.createModuleResolutionCache(rootDir, (fileName) => fileName, compilationSettings);
+  resolutionCache: ts.ModuleResolutionCache := ts.createModuleResolutionCache(rootDir, (fileName) => fileName, compilationSettings)
 
-  let self: Host;
+  let self: Host
 
   return self = Object.assign({}, baseHost, {
     getDefaultLibFileName(options: ts.CompilerOptions)
@@ -104,8 +108,8 @@ function TSHost(
      * This requires the `allowNonTsExtensions` option and `allowJs` options to be set to true.
      * Then TypeScript will call `getScriptSnapshot` with the `.civet` extension and we can do the transpilation there.
      */
-    resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, _containingSourceFile?: ts.SourceFile) {
-      return moduleNames.map((name) => {
+    resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, _containingSourceFile?: ts.SourceFile)
+      moduleNames.map (name) =>
         // Try to resolve the module using the standard TypeScript logic
         { resolvedModule } := ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache) as ResolvedModuleWithFailedLookupLocations
         return resolvedModule if resolvedModule
@@ -113,33 +117,30 @@ function TSHost(
         // get the transpiler for the extension
         extension := getExtensionFromPath(name)
         transpiler .= transpilers.get(extension)
-        if (transpiler || !extension) {
+        if transpiler or !extension
           exists := (transpiler ? sys.fileExists : sys.directoryExists).bind(sys)
-          resolvedModule := (resolved: string) => {
+          resolvedModule := (resolved: string) =>
             // Assumes exists(resolved) is true
             // Directories don't yet have a transpiler chosen; try to find one
             // via implicit index file.
             // TODO: Only when state.features & NodeResolutionFeatures.EsmMode
             // TODO: Read package.json as in loadNodeModuleFromDirectoryWorker
-            if (!transpiler) {
-              for (const [_, t] of transpilers) {
-                const index = path.join(resolved, "index" + t.extension)
-                if (sys.fileExists(index)) {
+            if !transpiler
+              for [_, t] of transpilers
+                index := path.join(resolved, "index" + t.extension)
+                if sys.fileExists(index)
                   transpiler = t
                   resolved = index
                   break
-                }
-              }
+
               return unless transpiler
-            }
             // Now sys.fileExists(resolved) should be true
             { target } := transpiler
             return {
-              resolvedFileName: resolved + target,
-              extension: target,
-              isExternalLibraryImport: false,
+              resolvedFileName: resolved + target
+              extension: target
+              isExternalLibraryImport: false
             }
-          }
 
           // Mimic tryResolve from
           // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts
@@ -162,8 +163,10 @@ function TSHost(
                   prefix := pattern.slice(0, -1)
                   if name.startsWith(prefix)
                     for replacement of replacements
-                      resolved := path.resolve(pathsBase,
-                        replacement.replace('*', name.slice(prefix.length)))
+                      resolved := path.resolve
+                        pathsBase
+                        replacement.replace('*', name.slice(prefix.length))
+
                       if exists(resolved) and prefix.length > bestPrefix.length
                         best = resolved
                         bestPrefix = prefix
@@ -175,7 +178,7 @@ function TSHost(
                       best = resolved
                       bestPrefix = pattern
 
-              if best return resolvedModule(best)
+              return resolvedModule(best) if best
 
             // tryLoadModuleUsingBaseUrl
             if baseUrl
@@ -191,17 +194,15 @@ function TSHost(
           resolved := path.resolve(path.dirname(containingFile), name)
           return resolvedModule(resolved) if exists(resolved)
           // TODO: add to resolution cache?
-        }
 
         return undefined
-      });
-    },
+
     /**
      * Add a VSCode TextDocument source file.
      * The VSCode document should keep track of its contents and version.
      * This accepts both `.civet` and `.ts` adding the transpiled targets to `scriptFileNames`.
      */
-    addOrUpdateDocument(doc: TextDocument): void {
+    addOrUpdateDocument(doc: TextDocument): void
       const path = URI.parse(doc.uri).fsPath
       // Clear any cached snapshot for this document
       snapshotMap.delete(path)
@@ -215,7 +216,7 @@ function TSHost(
 
       // console.log("addOrUpdateDocument", path, extension, transpiler)
 
-      if (transpiler) {
+      if transpiler
         { target } := transpiler
         transpiledPath := path + target
 
@@ -229,12 +230,11 @@ function TSHost(
         // Document map is so that the transpiled doc can update when the original changes
         pathMap.set(path, doc)
         return
-      }
 
       // Plain non-transpiled document
       scriptFileNames.add(path) unless scriptFileNames.has(path)
       pathMap.set(path, doc) unless pathMap.has(path)
-    },
+
     getMeta(path: string)
       transpiledPath := getTranspiledPath(path)
       // This ensures that the transpiled meta data is created
@@ -246,7 +246,6 @@ function TSHost(
 
     getCompilationSettings()
       compilationSettings
-
 
     /**
      * NOTE: TypeScript likes to pass in paths with only forward slashes regardless of the OS.
@@ -270,13 +269,13 @@ function TSHost(
 
     writeFile(fileName: string, content: string)
       logger.log("write " + fileName + " " + content)
-  });
+  })
 
   /**
    * Get the source code for a path.
    * Use the VSCode document if it exists otherwise use the file system.
    */
-  function getPathSource(path: string): string
+  function getPathSource(path: string)
     // Open VSCode docs and transpiled files should all be in the pathMap
     doc := pathMap.get(path)
     return doc.getText() if doc
@@ -381,7 +380,7 @@ function TSHost(
     path.join(fileName)
 }
 
-async function TSService(projectURL = "./", logger: Console | RemoteConsole = console) {
+function TSService(projectURL = "./", logger: Logger = console)
   logger.info("CIVET VSCODE PLUGIN " + version)
   logger.info("TYPESCRIPT " + typescriptVersion)
 
@@ -390,21 +389,21 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   { config } := readConfigFile(tsConfigPath, sys.readFile)
 
   existingOptions := {
-    rootDir: projectPath,
+    rootDir: projectPath
     // This is necessary to load .civet files
-    allowNonTsExtensions: true,
+    allowNonTsExtensions: true
     // Better described as "allow non-ts, non-json extensions"
-    allowJs: true,
-    jsx: JsxEmit.Preserve,
+    allowJs: true
+    jsx: JsxEmit.Preserve
   }
 
   parsedConfig := parseJsonConfigFileContent(
-    config,
-    sys,
-    projectPath,
-    existingOptions,
-    tsConfigPath,
-    undefined,
+    config
+    sys
+    projectPath
+    existingOptions
+    tsConfigPath
+    undefined
   )
   logger.info("PARSED TSCONFIG\n " + parsedConfig + " " + "\n\n")
 
@@ -412,9 +411,9 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   baseHost := createCompilerHost(parsedConfig)
 
   transpilerDefinitions := [{
-    extension: ".civet" as const,
-    target: ".tsx" as ts.Extension,
-    compile: transpileCivet,
+    extension: ".civet" as const
+    target: ".tsx" as ts.Extension
+    compile: transpileCivet
   }].map<[string, Transpiler]>((def) => [def.extension, def])
 
   transpilers := new Map<string, Transpiler>(transpilerDefinitions)
@@ -428,40 +427,36 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   Civet .= BundledCivetModule
   CivetConfig .= BundledCivetConfigModule
   civetPath := "@danielx/civet"
-  try {
+  try
     projectRequire(`${civetPath}/lsp/package.json`)
     logger.info("USING DEVELOPMENT VERSION OF CIVET -- BE SURE TO pnpm build")
-  } catch (e) { }
-  try {
+
+  try
     Civet = projectRequire(civetPath)
     CivetConfig = projectRequire(`${civetPath}/config`)
     CivetVersion := projectRequire(`${civetPath}/package.json`).version
     logger.info(`LOADED PROJECT CIVET ${CivetVersion}: ${path.join(projectURL + " " + civetPath)} \n\n`)
-  } catch (e) {
+  catch e
     logger.info("USING BUNDLED CIVET")
-  }
 
   civetConfig: CompileOptions .= {}
-  try {
-    configPath := await CivetConfig.findConfig(projectPath)
-    if (configPath) {
+  try
+    if configPath := await CivetConfig.findConfig(projectPath)
       logger.info("Loading Civet config @ " + configPath)
       config := await CivetConfig.loadConfig(configPath)
       logger.info("Found civet config!")
       civetConfig = config
-    } else {
+    else
       logger.info("No Civet config found")
-    }
-  } catch (e) {
+  catch e
     logger.error("Error loading Civet config " + e)
-  }
 
-  return Object.assign({}, service, {
-    host,
-    getSourceFileName(fileName: string) {
-      return remapFileName(fileName, transpilers)
-    },
-    loadPlugins: async function () {
+  return Object.assign {}, service, {
+    host
+    getSourceFileName(fileName: string)
+      remapFileName(fileName, transpilers)
+
+    loadPlugins: async function ()
       civetFolder := path.join(projectPath, "./.civet/")
       // List files in civet folder
       civetFiles := sys.readDirectory(civetFolder)
@@ -471,14 +466,15 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
       pluginFiles := civetFiles.filter((file) => file.endsWith("plugin.mjs"))
         .map((file) => URI.file(file).toString())
 
-      for (const filePath of pluginFiles) {
+      for filePath of pluginFiles
         logger.info("Loading plugin " + filePath)
         await loadPlugin(filePath)
-      }
-    }
-  })
 
-  async function loadPlugin(path: string) {
+      return
+
+  }
+
+  function loadPlugin(path: string)
     await import(path)
       .then(({ default: plugin }: { default: Plugin }) => {
         logger.info("Loaded plugin " + plugin)
@@ -489,24 +485,21 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
       .catch((e) => {
         logger.error("Error loading plugin " + path + " " + e)
       })
-  }
 
-  function transpileCivet(path: string, source: string) {
+  function transpileCivet(path: string, source: string)
     errors: ParseError[] := []
     // `Civet` may be resolved from the project at runtime, so TS loses `sync: true` narrowing.
     result := Civet.compile(source, {
-      ...civetConfig,
-      filename: path,
-      sourceMap: true,
-      errors,
+      ...civetConfig
+      filename: path
+      sourceMap: true
+      errors
       // We don't process comptime in LSP so don't need async yet
-      sync: true,
-      comptime: false,
+      sync: true
+      comptime: false
     }) as { code: string; sourceMap: CivetSourceMap }
 
-    return { ...result, errors }
-  }
-}
+    { ...result, errors }
 
 /**
  * Returns the extension of the file including the dot.
@@ -567,60 +560,50 @@ function remapFileName(fileName: string, transpilers: Map<string, Transpiler>): 
 
 // Incremental snapshot example from vue language tools
 // https://github.com/vuejs/language-tools/blob/5607f45835ab85e0b5a0747614a4ed9989a28cec/packages/language-core/src/virtualFile/computedFiles.ts#L218
-function fullDiffTextChangeRange(oldText: string, newText: string): ts.TextChangeRange | undefined {
+function fullDiffTextChangeRange(oldText: string, newText: string): ts.TextChangeRange | undefined
   oldTextLength := oldText.length
   newTextLength := newText.length
-  minLength := Math.min(oldTextLength, newTextLength);
+  minLength := Math.min(oldTextLength, newTextLength)
 
-  for (let start = 0; start < minLength; start++) {
-    if (oldText[start] !== newText[start]) {
-      end .= oldTextLength;
-      stop .= minLength - start;
-      for (let i = 0; i < stop; i++) {
-        if (oldText[oldTextLength - i - 1] !== newText[newTextLength - i - 1]) {
-          break;
-        }
-        end--;
-      }
+  for let start = 0; start < minLength; start++
+    if oldText[start] !== newText[start]
+      end .= oldTextLength
+      stop .= minLength - start
+      for let i = 0; i < stop; i++
+        if oldText[oldTextLength - i - 1] !== newText[newTextLength - i - 1]
+          break
+        end--
 
-      length .= end - start;
-      newLength .= length + (newTextLength - oldTextLength);
-      if (newLength < 0) {
-        length -= newLength;
-        newLength = 0;
-      }
+      length .= end - start
+      newLength .= length + (newTextLength - oldTextLength)
+      if newLength < 0
+        length -= newLength
+        newLength = 0
 
       return {
-        span: { start, length },
-        newLength,
-      };
-    }
-  }
-
-  return undefined;
-}
-
-Snap := (newText: string) => {
-  changeRanges := new Map<ts.IScriptSnapshot, ts.TextChangeRange | undefined>();
-
-  snapshot: ts.IScriptSnapshot := {
-    getText: (start, end) => newText.slice(start, end),
-    getLength: () => newText.length,
-    getChangeRange(oldSnapshot) {
-      if (!changeRanges.has(oldSnapshot)) {
-        changeRanges.set(oldSnapshot, undefined);
-        oldText := oldSnapshot.getText(0, oldSnapshot.getLength());
-        changeRange := fullDiffTextChangeRange(oldText, newText);
-        if (changeRange) {
-          changeRanges.set(oldSnapshot, changeRange);
-        }
+        span: { start, length }
+        newLength
       }
 
-      return changeRanges.get(oldSnapshot);
-    },
-  };
+  return undefined
 
-  return snapshot as ts.IScriptSnapshot;
-}
+Snap := (newText: string) =>
+  changeRanges := new Map<ts.IScriptSnapshot, ts.TextChangeRange | undefined>()
+
+  snapshot: ts.IScriptSnapshot := {
+    getText: (start, end) => newText.slice(start, end)
+    getLength: () => newText.length
+    getChangeRange(oldSnapshot)
+      unless changeRanges.has(oldSnapshot)
+        changeRanges.set(oldSnapshot, undefined)
+        oldText := oldSnapshot.getText(0, oldSnapshot.getLength())
+        changeRange := fullDiffTextChangeRange(oldText, newText)
+        if changeRange
+          changeRanges.set(oldSnapshot, changeRange)
+
+      changeRanges.get(oldSnapshot)
+  }
+
+  return snapshot as ts.IScriptSnapshot
 
 export default TSService

--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -1,45 +1,36 @@
-import assert from "assert"
-import path from "path"
+assert from assert
+path from path
 
-import type {
-  SourceMap as CivetSourceMap,
-  CompileOptions,
-  ParseError,
-} from "@danielx/civet"
-import BundledCivetModule from "@danielx/civet"
-import BundledCivetConfigModule from "@danielx/civet/config"
+{ type SourceMap as CivetSourceMap, type CompileOptions, type ParseError } from @danielx/civet
+BundledCivetModule from @danielx/civet
+BundledCivetConfigModule from @danielx/civet/config
 
-import ts from "typescript"
-const { version: typescriptVersion, JsxEmit, isExternalModuleNameRelative } = ts
-import type {
-  CompilerHost,
-  CompilerOptions,
-  IScriptSnapshot,
-  LanguageServiceHost,
-} from "typescript"
+ts from typescript
+{ version: typescriptVersion, JsxEmit, isExternalModuleNameRelative } := ts
+{ type CompilerHost, type CompilerOptions, type IScriptSnapshot, type LanguageServiceHost } from typescript
 
-const {
+{
   createCompilerHost,
   createLanguageService,
   parseJsonConfigFileContent,
   readConfigFile,
   sys,
-} = ts
+} := ts
 
-import { createRequire } from "module"
-import { fileURLToPath } from "url"
-import { URI } from "vscode-uri"
-import { TextDocument } from "vscode-languageserver-textdocument"
+{ createRequire } from module
+{ fileURLToPath } from url
+{ URI } from vscode-uri
+{ TextDocument } from vscode-languageserver-textdocument
 
 // Import version from package.json
 import pkg from "../../package.json" with { type: 'json' }
-import { RemoteConsole } from "vscode-languageserver"
-const { version } = pkg
+{ RemoteConsole } from vscode-languageserver
+{ version } := pkg
 
 // HACK to get __dirname working in tests with ts-node
 // ts-node needs everything to be modules for .civet files to work
 // and modules don't have __dirname
-const dir =
+dir :=
   typeof __dirname !== "undefined" ? __dirname : fileURLToPath(import.meta.url);
 
 interface SourceMap {
@@ -89,25 +80,25 @@ function TSHost(
   transpilers: Map<string, Transpiler>,
   logger: Console | RemoteConsole = console,
 ): Host {
-  const { rootDir } = compilationSettings
+  { rootDir } := compilationSettings
   assert(rootDir, "Most have root dir for now")
 
-  const scriptFileNames: Set<string> = new Set(initialFileNames.map(getCanonicalFileName))
-  const fileMetaData: Map<string, FileMeta> = new Map;
+  scriptFileNames: Set<string> := new Set(initialFileNames.map(getCanonicalFileName))
+  fileMetaData: Map<string, FileMeta> := new Map;
 
-  const pathMap: Map<string, TextDocument> = new Map
-  const snapshotMap: Map<string, IScriptSnapshot> = new Map
+  pathMap: Map<string, TextDocument> := new Map
+  snapshotMap: Map<string, IScriptSnapshot> := new Map
 
-  let projectVersion = 0;
+  projectVersion .= 0;
 
-  const resolutionCache: ts.ModuleResolutionCache = ts.createModuleResolutionCache(rootDir, (fileName) => fileName, compilationSettings);
+  resolutionCache: ts.ModuleResolutionCache := ts.createModuleResolutionCache(rootDir, (fileName) => fileName, compilationSettings);
 
   let self: Host;
 
   return self = Object.assign({}, baseHost, {
     getDefaultLibFileName(options: ts.CompilerOptions) {
       // TODO: this might not be correct for dev dev/test envs
-      const result = path.join(dir, "lib", ts.getDefaultLibFileName(options))
+      result := path.join(dir, "lib", ts.getDefaultLibFileName(options))
       return result
     },
     getModuleResolutionCache() {
@@ -123,15 +114,15 @@ function TSHost(
     resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, _containingSourceFile?: ts.SourceFile) {
       return moduleNames.map(name => {
         // Try to resolve the module using the standard TypeScript logic
-        const { resolvedModule } = ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache) as ResolvedModuleWithFailedLookupLocations
+        { resolvedModule } := ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache) as ResolvedModuleWithFailedLookupLocations
         if (resolvedModule) return resolvedModule
 
         // get the transpiler for the extension
-        const extension = getExtensionFromPath(name)
-        let transpiler = transpilers.get(extension)
+        extension := getExtensionFromPath(name)
+        transpiler .= transpilers.get(extension)
         if (transpiler || !extension) {
-          const exists = (transpiler ? sys.fileExists : sys.directoryExists).bind(sys)
-          const resolvedModule = (resolved: string) => {
+          exists := (transpiler ? sys.fileExists : sys.directoryExists).bind(sys)
+          resolvedModule := (resolved: string) => {
             // Assumes exists(resolved) is true
             // Directories don't yet have a transpiler chosen; try to find one
             // via implicit index file.
@@ -149,7 +140,7 @@ function TSHost(
               if (!transpiler) return
             }
             // Now sys.fileExists(resolved) should be true
-            const { target } = transpiler
+            { target } := transpiler
             return {
               resolvedFileName: resolved + target,
               extension: target,
@@ -160,24 +151,25 @@ function TSHost(
           // Mimic tryResolve from
           // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts
           // tryLoadModuleUsingOptionalResolutionSettings
-          let { baseUrl, paths, pathsBasePath } = compilationSettings
+          { baseUrl, paths, pathsBasePath } .= compilationSettings
           if (!isExternalModuleNameRelative(name)) { // absolute
             // tryLoadModuleUsingPathsIfEligible
             if (paths) {
               // tryLoadModuleUsingPaths
               // getPathsBasePath from
               // https://github.com/microsoft/TypeScript/blob/bbef6a7a31cff1d0d9f94b082996334baca74caa/src/compiler/utilities.ts#L6317-L6320
-              const pathsBase = baseUrl ?? (pathsBasePath as string ||
+              pathsBase := baseUrl ?? (pathsBasePath as string ||
                 (baseHost.getCurrentDirectory?.() ?? '.'))
               // TODO: more closely follow tryParsePatterns from
               // https://github.com/microsoft/TypeScript/blob/bbef6a7a31cff1d0d9f94b082996334baca74caa/src/compiler/utilities.ts#L9743-L9745
-              let best = '', bestPrefix = ''
+              best .= ''
+              bestPrefix .= ''
               for (const [pattern, replacements] of Object.entries(paths)) {
                 if (pattern.endsWith("*")) {
-                  const prefix = pattern.slice(0, -1)
+                  prefix := pattern.slice(0, -1)
                   if (name.startsWith(prefix)) {
                     for (const replacement of replacements) {
-                      const resolved = path.resolve(pathsBase,
+                      resolved := path.resolve(pathsBase,
                         replacement.replace('*', name.slice(prefix.length)))
                       if (exists(resolved) && prefix.length > bestPrefix.length) {
                         best = resolved
@@ -187,7 +179,7 @@ function TSHost(
                   }
                 } else if (name === pattern) {
                   for (const replacement of replacements) {
-                    const resolved = path.resolve(pathsBase, replacement)
+                    resolved := path.resolve(pathsBase, replacement)
                     if (exists(resolved) && pattern.length > bestPrefix.length) {
                       best = resolved
                       bestPrefix = pattern
@@ -199,7 +191,7 @@ function TSHost(
             }
             // tryLoadModuleUsingBaseUrl
             if (baseUrl) {
-              const resolved = path.resolve(baseUrl, name)
+              resolved := path.resolve(baseUrl, name)
               if (exists(resolved)) return resolvedModule(resolved)
             }
           } else { // relative
@@ -209,7 +201,7 @@ function TSHost(
           // This backup resolver is really just for relative paths.
           // TODO: Implement absolute case from tryResolve
           // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts#L3221
-          const resolved = path.resolve(path.dirname(containingFile), name)
+          resolved := path.resolve(path.dirname(containingFile), name)
           if (exists(resolved)) return resolvedModule(resolved)
           // TODO: add to resolution cache?
         }
@@ -231,16 +223,16 @@ function TSHost(
       // Still not too sure exactly how TS uses this. Read `synchronizeHostData` in `typescript/src/sercivces/services.ts` for more info.
       projectVersion++
 
-      const extension = getExtensionFromPath(path)
-      const transpiler = transpilers.get(extension)
+      extension := getExtensionFromPath(path)
+      transpiler := transpilers.get(extension)
 
       // console.log("addOrUpdateDocument", path, extension, transpiler)
 
       if (transpiler) {
-        const { target } = transpiler
-        const transpiledPath = path + target
+        { target } := transpiler
+        transpiledPath := path + target
 
-        let transpiledDoc = pathMap.get(transpiledPath)
+        transpiledDoc .= pathMap.get(transpiledPath)
 
         if (!transpiledDoc) {
           initTranspiledDoc(transpiledPath)
@@ -266,7 +258,7 @@ function TSHost(
       return
     },
     getMeta(path: string) {
-      const transpiledPath = getTranspiledPath(path)
+      transpiledPath := getTranspiledPath(path)
       // This ensures that the transpiled meta data is created
       getOrCreatePathSnapshot(transpiledPath)
 
@@ -284,7 +276,7 @@ function TSHost(
      */
     getScriptSnapshot(path: string) {
       path = getCanonicalFileName(path)
-      const snap = getOrCreatePathSnapshot(path)
+      snap := getOrCreatePathSnapshot(path)
 
       return snap
     },
@@ -294,7 +286,7 @@ function TSHost(
      */
     getScriptVersion(path: string) {
       path = getCanonicalFileName(path)
-      const version = pathMap.get(path)?.version.toString() || "0"
+      version := pathMap.get(path)?.version.toString() || "0"
       // console.log("getScriptVersion", path, version)
       return version
     },
@@ -312,7 +304,7 @@ function TSHost(
    */
   function getPathSource(path: string): string {
     // Open VSCode docs and transpiled files should all be in the pathMap
-    const doc = pathMap.get(path)
+    doc := pathMap.get(path)
     if (doc) {
       return doc.getText()
     }
@@ -325,8 +317,8 @@ function TSHost(
   }
 
   function getTranspiledPath(path: string) {
-    const extension = getExtensionFromPath(path)
-    const transpiler = transpilers.get(extension)
+    extension := getExtensionFromPath(path)
+    transpiler := transpilers.get(extension)
 
     if (transpiler) {
       return path + transpiler.target
@@ -335,7 +327,7 @@ function TSHost(
   }
 
   function getOrCreatePathSnapshot(path: string) {
-    let snapshot = snapshotMap.get(path)
+    snapshot .= snapshotMap.get(path)
     if (snapshot) return snapshot
 
     let transpiler
@@ -343,18 +335,19 @@ function TSHost(
     // path comes in as transformed (transpiler target extension added), check for 2nd to last extension for transpiler
     // ie .coffee.js or .civet.ts or .hera.cjs
 
-    const exts = getTranspiledExtensionsFromPath(path)
+    exts := getTranspiledExtensionsFromPath(path)
     if (exts && (transpiler = transpilers.get(exts[0]))) {
       // this is a possibly transpiled file
 
-      const sourcePath = removeExtension(path)
-      const sourceDoc = pathMap.get(sourcePath)
-      let transpiledDoc = pathMap.get(path)
+      sourcePath := removeExtension(path)
+      sourceDoc := pathMap.get(sourcePath)
+      transpiledDoc .= pathMap.get(path)
       if (!transpiledDoc) {
         transpiledDoc = initTranspiledDoc(path)
       }
 
-      let source, sourceDocVersion = 0
+      let source
+      sourceDocVersion .= 0
       if (!sourceDoc) {
         // A source file from the file system
         source = sys.readFile(sourcePath)
@@ -365,7 +358,7 @@ function TSHost(
 
       // The source document is ahead of the transpiled document
       if (source && sourceDocVersion > transpiledDoc.version) {
-        const transpiledCode = doTranspileAndUpdateMeta(transpiledDoc, sourceDocVersion, transpiler, sourcePath, source)
+        transpiledCode := doTranspileAndUpdateMeta(transpiledDoc, sourceDocVersion, transpiler, sourcePath, source)
         if (transpiledCode !== undefined) {
           snapshot = Snap(transpiledCode)
         }
@@ -387,10 +380,10 @@ function TSHost(
   }
 
   function createOrUpdateMeta(path: string, transpiledDoc: TextDocument, sourcemapLines?: SourceMap["lines"], parseErrors?: (Error | ParseError)[], fatal: boolean = false) {
-    let meta = fileMetaData.get(path)
+    meta .= fileMetaData.get(path)
 
     if (!meta) {
-      const newMeta: FileMeta = {
+      newMeta: FileMeta := {
         sourcemapLines,
         transpiledDoc,
         parseErrors,
@@ -415,8 +408,8 @@ function TSHost(
     }
 
     if (result) {
-      const { code: transpiledCode, sourceMap, errors } = result
-      const sourceMapLines = sourceMap?.lines ?? sourceMap?.data?.lines // older Civet
+      { code: transpiledCode, sourceMap, errors } := result
+      sourceMapLines := sourceMap?.lines ?? sourceMap?.data?.lines // older Civet
       createOrUpdateMeta(sourcePath, transpiledDoc, sourceMapLines, errors, false)
       TextDocument.update(transpiledDoc, [{ text: transpiledCode }], version)
 
@@ -428,8 +421,8 @@ function TSHost(
   function initTranspiledDoc(path: string) {
     // Create an empty document, it will be updated on-demand when `getScriptSnapshot` is called
     // `path` must be the in the format that TypeScript Language Service expects
-    const uri = URI.file(path).toString()
-    const transpiledDoc = TextDocument.create(uri, "none", -1, "")
+    uri := URI.file(path).toString()
+    transpiledDoc := TextDocument.create(uri, "none", -1, "")
     // Add transpiled doc
     pathMap.set(path, transpiledDoc)
     // Transpiled doc gets added to scriptFileNames
@@ -450,11 +443,11 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   logger.info("CIVET VSCODE PLUGIN " + version)
   logger.info("TYPESCRIPT " + typescriptVersion)
 
-  const projectPath = projectURL.startsWith("file:") ? URI.parse(projectURL).fsPath : path.resolve(projectURL)
-  const tsConfigPath = `${projectPath}tsconfig.json`
-  const { config } = readConfigFile(tsConfigPath, sys.readFile)
+  projectPath := projectURL.startsWith("file:") ? URI.parse(projectURL).fsPath : path.resolve(projectURL)
+  tsConfigPath := `${projectPath}tsconfig.json`
+  { config } := readConfigFile(tsConfigPath, sys.readFile)
 
-  const existingOptions = {
+  existingOptions := {
     rootDir: projectPath,
     // This is necessary to load .civet files
     allowNonTsExtensions: true,
@@ -463,7 +456,7 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
     jsx: JsxEmit.Preserve,
   }
 
-  const parsedConfig = parseJsonConfigFileContent(
+  parsedConfig := parseJsonConfigFileContent(
     config,
     sys,
     projectPath,
@@ -474,25 +467,25 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   logger.info("PARSED TSCONFIG\n " + parsedConfig + " " + "\n\n")
 
   //@ts-ignore
-  const baseHost = createCompilerHost(parsedConfig)
+  baseHost := createCompilerHost(parsedConfig)
 
-  const transpilerDefinitions = [{
+  transpilerDefinitions := [{
     extension: ".civet" as const,
     target: ".tsx" as ts.Extension,
     compile: transpileCivet,
   }].map<[string, Transpiler]>(def => [def.extension, def])
 
-  const transpilers = new Map<string, Transpiler>(transpilerDefinitions)
+  transpilers := new Map<string, Transpiler>(transpilerDefinitions)
   // TODO: May want to add transpiled files to fileNames
-  const host = TSHost(parsedConfig.options, parsedConfig.fileNames, baseHost, transpilers, logger)
-  const service = createLanguageService(host)
+  host := TSHost(parsedConfig.options, parsedConfig.fileNames, baseHost, transpilers, logger)
+  service := createLanguageService(host)
 
-  const projectRequire = createRequire(projectURL)
+  projectRequire := createRequire(projectURL)
 
   // Use Civet from the project if present
-  let Civet = BundledCivetModule
-  let CivetConfig = BundledCivetConfigModule
-  const civetPath = "@danielx/civet"
+  Civet .= BundledCivetModule
+  CivetConfig .= BundledCivetConfigModule
+  civetPath := "@danielx/civet"
   try {
     projectRequire(`${civetPath}/lsp/package.json`)
     logger.info("USING DEVELOPMENT VERSION OF CIVET -- BE SURE TO yarn build")
@@ -500,18 +493,18 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   try {
     Civet = projectRequire(civetPath)
     CivetConfig = projectRequire(`${civetPath}/config`)
-    const CivetVersion = projectRequire(`${civetPath}/package.json`).version
+    CivetVersion := projectRequire(`${civetPath}/package.json`).version
     logger.info(`LOADED PROJECT CIVET ${CivetVersion}: ${path.join(projectURL + " " + civetPath)} \n\n`)
   } catch (e) {
     logger.info("USING BUNDLED CIVET")
   }
 
-  let civetConfig: CompileOptions = {}
+  civetConfig: CompileOptions .= {}
   try {
-    const configPath = await CivetConfig.findConfig(projectPath)
+    configPath := await CivetConfig.findConfig(projectPath)
     if (configPath) {
       logger.info("Loading Civet config @ " + configPath)
-      const config = await CivetConfig.loadConfig(configPath)
+      config := await CivetConfig.loadConfig(configPath)
       logger.info("Found civet config!")
       civetConfig = config
     } else {
@@ -527,13 +520,13 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
       return remapFileName(fileName, transpilers)
     },
     loadPlugins: async function () {
-      const civetFolder = path.join(projectPath, "./.civet/")
+      civetFolder := path.join(projectPath, "./.civet/")
       // List files in civet folder
-      const civetFiles = sys.readDirectory(civetFolder)
+      civetFiles := sys.readDirectory(civetFolder)
 
       // One day it would be nice to load plugins that could be transpiled but that is a whole can of worms.
       // VSCode Node versions, esm loaders, etc.
-      const pluginFiles = civetFiles.filter(file => file.endsWith("plugin.mjs"))
+      pluginFiles := civetFiles.filter(file => file.endsWith("plugin.mjs"))
         .map(file => URI.file(file).toString())
 
       for (const filePath of pluginFiles) {
@@ -557,9 +550,9 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
   }
 
   function transpileCivet(path: string, source: string) {
-    const errors: ParseError[] = []
+    errors: ParseError[] := []
     // `Civet` may be resolved from the project at runtime, so TS loses `sync: true` narrowing.
-    const result = Civet.compile(source, {
+    result := Civet.compile(source, {
       ...civetConfig,
       filename: path,
       sourceMap: true,
@@ -583,14 +576,14 @@ async function TSService(projectURL = "./", logger: Console | RemoteConsole = co
  * getExtension('foo/bar/baz.') // => ''
  */
 function getExtensionFromPath(path: string): string {
-  const match = path.match(lastExtension)
+  match := path.match(lastExtension)
   if (!match) return ""
   return match[0]
 }
 
 // Regex to match last extension including dot
-const lastExtension = /(?:\.(?:[^./]+))?$/
-const lastTwoExtensions = /(\.[^./]*)(\.[^./]*)$/
+lastExtension := /(?:\.(?:[^./]+))?$/
+lastTwoExtensions := /(\.[^./]*)(\.[^./]*)$/
 
 /**
  * Returns the last two extensions of a path.
@@ -603,7 +596,7 @@ const lastTwoExtensions = /(\.[^./]*)(\.[^./]*)$/
  * getLastTwoExtensions('foo/bar/baz.civet.ts') // => ['.civet', '.ts']
  */
 function getTranspiledExtensionsFromPath(path: string): [string, string] | undefined {
-  const match = path.match(lastTwoExtensions)
+  match := path.match(lastTwoExtensions)
   if (!match) return
 
   return [match[1], match[2]]
@@ -627,10 +620,10 @@ function removeExtension(path: string) {
 }
 
 function remapFileName(fileName: string, transpilers: Map<string, Transpiler>): string {
-  const [extension, target] = getTranspiledExtensionsFromPath(fileName) || []
+  [extension, target] := getTranspiledExtensionsFromPath(fileName) || []
 
   if (!extension) return fileName
-  const transpiler = transpilers.get(extension)
+  transpiler := transpilers.get(extension)
   if (!transpiler) return fileName
 
   if (transpiler.target === target) {
@@ -643,14 +636,14 @@ function remapFileName(fileName: string, transpilers: Map<string, Transpiler>): 
 // Incremental snapshot example from vue language tools
 // https://github.com/vuejs/language-tools/blob/5607f45835ab85e0b5a0747614a4ed9989a28cec/packages/language-core/src/virtualFile/computedFiles.ts#L218
 function fullDiffTextChangeRange(oldText: string, newText: string): ts.TextChangeRange | undefined {
-  const oldTextLength = oldText.length,
-    newTextLength = newText.length,
-    minLength = Math.min(oldTextLength, newTextLength);
+  oldTextLength := oldText.length
+  newTextLength := newText.length
+  minLength := Math.min(oldTextLength, newTextLength);
 
   for (let start = 0; start < minLength; start++) {
     if (oldText[start] !== newText[start]) {
-      let end = oldTextLength;
-      let stop = minLength - start;
+      end .= oldTextLength;
+      stop .= minLength - start;
       for (let i = 0; i < stop; i++) {
         if (oldText[oldTextLength - i - 1] !== newText[newTextLength - i - 1]) {
           break;
@@ -658,8 +651,8 @@ function fullDiffTextChangeRange(oldText: string, newText: string): ts.TextChang
         end--;
       }
 
-      let length = end - start;
-      let newLength = length + (newTextLength - oldTextLength);
+      length .= end - start;
+      newLength .= length + (newTextLength - oldTextLength);
       if (newLength < 0) {
         length -= newLength;
         newLength = 0;
@@ -675,17 +668,17 @@ function fullDiffTextChangeRange(oldText: string, newText: string): ts.TextChang
   return undefined;
 }
 
-const Snap = (newText: string) => {
-  const changeRanges = new Map<ts.IScriptSnapshot, ts.TextChangeRange | undefined>();
+Snap := (newText: string) => {
+  changeRanges := new Map<ts.IScriptSnapshot, ts.TextChangeRange | undefined>();
 
-  const snapshot: ts.IScriptSnapshot = {
+  snapshot: ts.IScriptSnapshot := {
     getText: (start, end) => newText.slice(start, end),
     getLength: () => newText.length,
     getChangeRange(oldSnapshot) {
       if (!changeRanges.has(oldSnapshot)) {
         changeRanges.set(oldSnapshot, undefined);
-        const oldText = oldSnapshot.getText(0, oldSnapshot.getLength());
-        const changeRange = fullDiffTextChangeRange(oldText, newText);
+        oldText := oldSnapshot.getText(0, oldSnapshot.getLength());
+        changeRange := fullDiffTextChangeRange(oldText, newText);
         if (changeRange) {
           changeRanges.set(oldSnapshot, changeRange);
         }

--- a/lsp/source/lib/util.civet
+++ b/lsp/source/lib/util.civet
@@ -1,12 +1,7 @@
-import ts from 'typescript';
-import type {
-  Diagnostic,
-  NavigationBarItem,
-  NavigationTree,
-  TextSpan,
-} from 'typescript';
-const { DiagnosticCategory, ScriptElementKind, ScriptElementKindModifier } = ts;
-import vs, {
+ts from typescript
+{ type Diagnostic, type NavigationBarItem, type NavigationTree, type TextSpan } from typescript
+{ DiagnosticCategory, ScriptElementKind, ScriptElementKindModifier } := ts
+vs, {
   CompletionItemKind,
   DiagnosticSeverity,
   DocumentSymbol,
@@ -15,15 +10,15 @@ import vs, {
   RemoteConsole,
   SymbolKind,
   SymbolTag,
-} from 'vscode-languageserver';
+} from vscode-languageserver
 
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import assert from 'assert';
-import type { SourceMapping } from '@danielx/civet';
-import {
+{ TextDocument } from vscode-languageserver-textdocument
+assert from assert
+{ type SourceMapping } from @danielx/civet
+{
   flattenDiagnosticMessageText,
   remapRange,
-} from '@danielx/civet/ts-diagnostic';
+} from @danielx/civet/ts-diagnostic
 
 /** Same shape as Civet's source map `lines` table; defined here because the `ts-diagnostic` subpath has no type exports. */
 export type SourcemapLines = SourceMapping[][];
@@ -37,7 +32,7 @@ export {
 
 // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts#L63
 
-const getSymbolKind = (kind: ts.ScriptElementKind): SymbolKind => {
+getSymbolKind := (kind: ts.ScriptElementKind): SymbolKind => {
   switch (kind) {
     case ScriptElementKind.moduleElement: return SymbolKind.Module;
     case ScriptElementKind.classElement: return SymbolKind.Class;
@@ -134,19 +129,19 @@ export function convertNavTree(
   sourcemapLines: SourcemapLines | undefined,
 
 ): boolean {
-  let shouldInclude = shouldIncludeEntry(item);
+  shouldInclude .= shouldIncludeEntry(item);
   if (!shouldInclude && !item.childItems?.length) {
     return false;
   }
 
-  const children = new Set(item.childItems || []);
+  children := new Set(item.childItems || []);
   for (const span of item.spans) {
-    const range = remapRange(rangeFromTextSpan(span, document), sourcemapLines)
-    const symbolInfo = convertSymbol(item, range, document, sourcemapLines);
+    range := remapRange(rangeFromTextSpan(span, document), sourcemapLines)
+    symbolInfo := convertSymbol(item, range, document, sourcemapLines);
 
     for (const child of children) {
       if (child.spans.some(span => !!intersectRanges(range, remapRange(rangeFromTextSpan(span, document), sourcemapLines)))) {
-        const includedChild = convertNavTree(child, symbolInfo.children!, document, sourcemapLines);
+        includedChild := convertNavTree(child, symbolInfo.children!, document, sourcemapLines);
         shouldInclude = shouldInclude || includedChild;
         children.delete(child);
       }
@@ -169,15 +164,19 @@ function convertSymbol(item: NavigationTree, range: Range, document: TextDocumen
     }
   }
 
-  const selectionRange = nameRange || range;
-  let label = item.text
+  selectionRange := nameRange || range;
+  label .= item.text
 
   switch (item.kind) {
-    case ScriptElementKind.memberGetAccessorElement: label = `(get) ${label}`; break;
-    case ScriptElementKind.memberSetAccessorElement: label = `(set) ${label}`; break;
+    case ScriptElementKind.memberGetAccessorElement:
+      label = `(get) ${label}`
+      break
+    case ScriptElementKind.memberSetAccessorElement:
+      label = `(set) ${label}`
+      break
   }
 
-  const symbolInfo = makeDocumentSymbol(
+  symbolInfo := makeDocumentSymbol(
     label,
     '',
     getSymbolKind(item.kind),
@@ -185,7 +184,7 @@ function convertSymbol(item: NavigationTree, range: Range, document: TextDocumen
     containsRange(range, selectionRange) ? selectionRange : range
   );
 
-  const kindModifiers = parseKindModifier(item.kindModifiers);
+  kindModifiers := parseKindModifier(item.kindModifiers);
   if (kindModifiers.has(ScriptElementKindModifier.deprecatedModifier)) {
     symbolInfo.tags = [SymbolTag.Deprecated];
   }
@@ -249,10 +248,10 @@ function makeDocumentSymbol(name: string, detail: string, kind: SymbolKind, rang
  * A intersection of the two ranges.
  */
 export function intersectRanges(a: Range, b: Range): Range | null {
-  let { line: resultStartLineNumber, character: resultStartColumn } = a.start;
-  let { line: resultEndLineNumber, character: resultEndColumn } = a.end;
-  let { line: otherStartLineNumber, character: otherStartColumn } = b.start;
-  let { line: otherEndLineNumber, character: otherEndColumn } = b.end;
+  { line: resultStartLineNumber, character: resultStartColumn } .= a.start;
+  { line: resultEndLineNumber, character: resultEndColumn } .= a.end;
+  { line: otherStartLineNumber, character: otherStartColumn } .= b.start;
+  { line: otherEndLineNumber, character: otherEndColumn } .= b.end;
 
   if (resultStartLineNumber < otherStartLineNumber) {
     resultStartLineNumber = otherStartLineNumber;
@@ -297,7 +296,7 @@ export function containsRange(range: Range, otherRange: Range): boolean {
   return true;
 }
 
-const isFourTuple = (m: SourceMapping): m is [number, number, number, number] => m.length === 4;
+isFourTuple := (m: SourceMapping): m is [number, number, number, number] => m.length === 4;
 /**
  * The normal direction for sourcemapping is reverse, given a position in the generated file it points to a position in the source file.
  *
@@ -314,13 +313,13 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
   assert("line" in position, "position must have line")
   assert("character" in position, "position must have character")
 
-  const { line: origLine, character: origOffset } = position
+  { line: origLine, character: origOffset } := position
 
-  let col = 0
-  let bestLine = -1,
-    bestOffset = -1,
-    foundLine = -1,
-    foundOffset = -1
+  col .= 0
+  bestLine .= -1
+  bestOffset .= -1
+  foundLine .= -1
+  foundOffset .= -1
 
   sourcemapLines.forEach((line: SourcemapLines[number], i: number) => {
     col = 0
@@ -329,7 +328,7 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
 
       if (isFourTuple(mapping)) {
         // find best line without going beyond
-        const [_p, _f, srcLine, srcOffset] = mapping
+        [_p, _f, srcLine, srcOffset] := mapping
         if (srcLine <= origLine) {
           if (srcLine > bestLine && (srcOffset <= origOffset) || srcLine === bestLine && (srcOffset <= origOffset) && (srcOffset >= bestOffset)) {
             bestLine = srcLine
@@ -343,8 +342,8 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
   })
 
   if (foundLine >= 0) {
-    const genLine = foundLine + origLine - bestLine
-    const genOffset = foundOffset + origOffset - bestOffset
+    genLine := foundLine + origLine - bestLine
+    genOffset := foundOffset + origOffset - bestOffset
 
     // console.log(`transformed position ${[origLine, origOffset]} => ${[genLine, genOffset]}`)
 
@@ -364,9 +363,9 @@ export function logTiming<R, A extends unknown[]>(
   fn: (...args: A) => R,
 ) {
   return function (...args: A) {
-    const start = performance.now(),
-      result = fn(...args),
-      end = performance.now();
+    start := performance.now()
+    result := fn(...args)
+    end := performance.now()
     logger.log(`${name.padStart(32)}${(end - start).toFixed(2).padStart(8)}ms`)
 
     return result;
@@ -417,7 +416,7 @@ function diagnosticCategoryToSeverity(
 export function withResolvers<T>() {
   let resolve: (value: T) => void;
   let reject: (reason?: any) => void;
-  const promise = new Promise<T>((res, rej) => {
+  promise := new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
   });

--- a/lsp/source/lib/util.civet
+++ b/lsp/source/lib/util.civet
@@ -7,7 +7,7 @@ vs, {
   DocumentSymbol,
   Position,
   Range,
-  RemoteConsole,
+  type RemoteConsole,
   SymbolKind,
   SymbolTag,
 } from vscode-languageserver
@@ -130,9 +130,7 @@ export function convertNavTree(
 
 ): boolean {
   shouldInclude .= shouldIncludeEntry(item);
-  if (!shouldInclude && !item.childItems?.length) {
-    return false;
-  }
+  return false if !shouldInclude && !item.childItems?.length
 
   children := new Set(item.childItems || []);
   for (const span of item.spans) {
@@ -147,22 +145,17 @@ export function convertNavTree(
       }
     }
 
-    if (shouldInclude) {
-      output.push(symbolInfo);
-    }
+    output.push(symbolInfo) if shouldInclude
   }
 
-  return shouldInclude;
+  shouldInclude
 }
 
 function convertSymbol(item: NavigationTree, range: Range, document: TextDocument, sourcemapLines?: SourcemapLines): DocumentSymbol {
   let nameRange
-  if (item.nameSpan) {
+  if item.nameSpan
     nameRange = rangeFromTextSpan(item.nameSpan, document)
-    if (sourcemapLines) {
-      nameRange = remapRange(nameRange, sourcemapLines)
-    }
-  }
+    nameRange = remapRange(nameRange, sourcemapLines) if sourcemapLines
 
   selectionRange := nameRange || range;
   label .= item.text
@@ -185,30 +178,20 @@ function convertSymbol(item: NavigationTree, range: Range, document: TextDocumen
   );
 
   kindModifiers := parseKindModifier(item.kindModifiers);
-  if (kindModifiers.has(ScriptElementKindModifier.deprecatedModifier)) {
-    symbolInfo.tags = [SymbolTag.Deprecated];
-  }
-
-  return symbolInfo;
+  symbolInfo.tags = [SymbolTag.Deprecated] if kindModifiers.has(ScriptElementKindModifier.deprecatedModifier)
+  symbolInfo
 }
 
-function shouldIncludeEntry(item: NavigationTree | NavigationBarItem): boolean {
-  if (item.kind === ScriptElementKind.alias) {
-    return false;
-  }
-  return !!(item.text && item.text !== '<function>' && item.text !== '<class>');
-}
+function shouldIncludeEntry(item: NavigationTree | NavigationBarItem): boolean
+  return false if item.kind === ScriptElementKind.alias
+  !!(item.text && item.text !== '<function>' && item.text !== '<class>')
 
-export function parseKindModifier(kindModifiers: string): Set<string> {
-  return new Set(kindModifiers.split(/,|\s+/g));
-}
+export function parseKindModifier(kindModifiers: string): Set<string>
+  new Set(kindModifiers.split(/,|\s+/g))
 
-function rangeFromTextSpan(span: TextSpan, document: TextDocument): Range {
-  return {
-    start: document.positionAt(span.start),
-    end: document.positionAt(span.start + span.length),
-  }
-}
+function rangeFromTextSpan(span: TextSpan, document: TextDocument): Range
+  start: document.positionAt(span.start)
+  end: document.positionAt(span.start + span.length)
 
 
 export function makeRange(l1: number, c1: number, l2: number, c2: number) {
@@ -253,50 +236,35 @@ export function intersectRanges(a: Range, b: Range): Range | null {
   { line: otherStartLineNumber, character: otherStartColumn } .= b.start;
   { line: otherEndLineNumber, character: otherEndColumn } .= b.end;
 
-  if (resultStartLineNumber < otherStartLineNumber) {
-    resultStartLineNumber = otherStartLineNumber;
-    resultStartColumn = otherStartColumn;
-  } else if (resultStartLineNumber === otherStartLineNumber) {
-    resultStartColumn = Math.max(resultStartColumn, otherStartColumn);
-  }
+  if resultStartLineNumber < otherStartLineNumber
+    resultStartLineNumber = otherStartLineNumber
+    resultStartColumn = otherStartColumn
+  else if resultStartLineNumber === otherStartLineNumber
+    resultStartColumn = Math.max(resultStartColumn, otherStartColumn)
 
-  if (resultEndLineNumber > otherEndLineNumber) {
-    resultEndLineNumber = otherEndLineNumber;
-    resultEndColumn = otherEndColumn;
-  } else if (resultEndLineNumber === otherEndLineNumber) {
-    resultEndColumn = Math.min(resultEndColumn, otherEndColumn);
-  }
+  if resultEndLineNumber > otherEndLineNumber
+    resultEndLineNumber = otherEndLineNumber
+    resultEndColumn = otherEndColumn
+  else if resultEndLineNumber === otherEndLineNumber
+    resultEndColumn = Math.min(resultEndColumn, otherEndColumn)
 
   // Check if selection is now empty
-  if (resultStartLineNumber > resultEndLineNumber) {
-    return null;
-  }
-  if (resultStartLineNumber === resultEndLineNumber && resultStartColumn > resultEndColumn) {
-    return null;
-  }
-  return makeRange(resultStartLineNumber, resultStartColumn, resultEndLineNumber, resultEndColumn);
+  return null if resultStartLineNumber > resultEndLineNumber
+  return null if resultStartLineNumber === resultEndLineNumber && resultStartColumn > resultEndColumn
+  makeRange(resultStartLineNumber, resultStartColumn, resultEndLineNumber, resultEndColumn)
 }
 
 /**
  * Test if `otherRange` is in `range`. If the ranges are equal, will return true.
  */
-export function containsRange(range: Range, otherRange: Range): boolean {
-  if (otherRange.start.line < range.start.line || otherRange.end.line < range.start.line) {
-    return false;
-  }
-  if (otherRange.start.line > range.end.line || otherRange.end.line > range.end.line) {
-    return false;
-  }
-  if (otherRange.start.line === range.start.line && otherRange.start.character < range.start.character) {
-    return false;
-  }
-  if (otherRange.end.line === range.end.line && otherRange.end.character > range.end.character) {
-    return false;
-  }
-  return true;
-}
+export function containsRange(range: Range, otherRange: Range): boolean
+  return false if otherRange.start.line < range.start.line || otherRange.end.line < range.start.line
+  return false if otherRange.start.line > range.end.line || otherRange.end.line > range.end.line
+  return false if otherRange.start.line === range.start.line && otherRange.start.character < range.start.character
+  return false if otherRange.end.line === range.end.line && otherRange.end.character > range.end.character
+  true
 
-isFourTuple := (m: SourceMapping): m is [number, number, number, number] => m.length === 4;
+isFourTuple := (m: SourceMapping): m is [number, number, number, number] => m.length === 4
 /**
  * The normal direction for sourcemapping is reverse, given a position in the generated file it points to a position in the source file.
  *

--- a/lsp/source/lib/util.civet
+++ b/lsp/source/lib/util.civet
@@ -140,7 +140,7 @@ export function convertNavTree(
     symbolInfo := convertSymbol(item, range, document, sourcemapLines);
 
     for (const child of children) {
-      if (child.spans.some(span => !!intersectRanges(range, remapRange(rangeFromTextSpan(span, document), sourcemapLines)))) {
+      if (child.spans.some((span) => !!intersectRanges(range, remapRange(rangeFromTextSpan(span, document), sourcemapLines)))) {
         includedChild := convertNavTree(child, symbolInfo.children!, document, sourcemapLines);
         shouldInclude = shouldInclude || includedChild;
         children.delete(child);

--- a/lsp/source/lib/util.civet
+++ b/lsp/source/lib/util.civet
@@ -2,63 +2,63 @@ ts from typescript
 { type Diagnostic, type NavigationBarItem, type NavigationTree, type TextSpan } from typescript
 { DiagnosticCategory, ScriptElementKind, ScriptElementKindModifier } := ts
 vs, {
-  CompletionItemKind,
-  DiagnosticSeverity,
-  DocumentSymbol,
-  Position,
-  Range,
-  type RemoteConsole,
-  SymbolKind,
-  SymbolTag,
+  CompletionItemKind
+  DiagnosticSeverity
+  DocumentSymbol
+  Position
+  Range
+  type RemoteConsole
+  SymbolKind
+  SymbolTag
 } from vscode-languageserver
 
 { TextDocument } from vscode-languageserver-textdocument
 assert from assert
 { type SourceMapping } from @danielx/civet
 {
-  flattenDiagnosticMessageText,
-  remapRange,
+  flattenDiagnosticMessageText
+  remapRange
 } from @danielx/civet/ts-diagnostic
 
 /** Same shape as Civet's source map `lines` table; defined here because the `ts-diagnostic` subpath has no type exports. */
-export type SourcemapLines = SourceMapping[][];
-export type { SourceMapping };
+export type SourcemapLines = SourceMapping[][]
+export type { SourceMapping }
 
 export {
-  flattenDiagnosticMessageText,
-  remapPosition,
-  remapRange,
-} from '@danielx/civet/ts-diagnostic';
+  flattenDiagnosticMessageText
+  remapPosition
+  remapRange
+} from '@danielx/civet/ts-diagnostic'
 
 // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts#L63
 
 getSymbolKind := (kind: ts.ScriptElementKind): SymbolKind => {
   switch (kind) {
-    case ScriptElementKind.moduleElement: return SymbolKind.Module;
-    case ScriptElementKind.classElement: return SymbolKind.Class;
-    case ScriptElementKind.enumElement: return SymbolKind.Enum;
-    case ScriptElementKind.interfaceElement: return SymbolKind.Interface;
-    case ScriptElementKind.memberFunctionElement: return SymbolKind.Method;
-    case ScriptElementKind.memberVariableElement: return SymbolKind.Property;
-    case ScriptElementKind.memberGetAccessorElement: return SymbolKind.Property;
-    case ScriptElementKind.memberSetAccessorElement: return SymbolKind.Property;
-    case ScriptElementKind.variableElement: return SymbolKind.Variable;
-    case ScriptElementKind.constElement: return SymbolKind.Variable;
-    case ScriptElementKind.localVariableElement: return SymbolKind.Variable;
-    case ScriptElementKind.functionElement: return SymbolKind.Function;
-    case ScriptElementKind.localFunctionElement: return SymbolKind.Function;
-    case ScriptElementKind.constructSignatureElement: return SymbolKind.Constructor;
-    case ScriptElementKind.constructorImplementationElement: return SymbolKind.Constructor;
+    case ScriptElementKind.moduleElement: return SymbolKind.Module
+    case ScriptElementKind.classElement: return SymbolKind.Class
+    case ScriptElementKind.enumElement: return SymbolKind.Enum
+    case ScriptElementKind.interfaceElement: return SymbolKind.Interface
+    case ScriptElementKind.memberFunctionElement: return SymbolKind.Method
+    case ScriptElementKind.memberVariableElement: return SymbolKind.Property
+    case ScriptElementKind.memberGetAccessorElement: return SymbolKind.Property
+    case ScriptElementKind.memberSetAccessorElement: return SymbolKind.Property
+    case ScriptElementKind.variableElement: return SymbolKind.Variable
+    case ScriptElementKind.constElement: return SymbolKind.Variable
+    case ScriptElementKind.localVariableElement: return SymbolKind.Variable
+    case ScriptElementKind.functionElement: return SymbolKind.Function
+    case ScriptElementKind.localFunctionElement: return SymbolKind.Function
+    case ScriptElementKind.constructSignatureElement: return SymbolKind.Constructor
+    case ScriptElementKind.constructorImplementationElement: return SymbolKind.Constructor
   }
-  return SymbolKind.Variable;
-};
+  return SymbolKind.Variable
+}
 
 // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts
 export function getCompletionItemKind(kind: string): CompletionItemKind {
   switch (kind) {
     case ScriptElementKind.primitiveType:
     case ScriptElementKind.keyword:
-      return CompletionItemKind.Keyword;
+      return CompletionItemKind.Keyword
 
     case ScriptElementKind.constElement:
     case ScriptElementKind.letElement:
@@ -66,53 +66,53 @@ export function getCompletionItemKind(kind: string): CompletionItemKind {
     case ScriptElementKind.localVariableElement:
     case ScriptElementKind.alias:
     case ScriptElementKind.parameterElement:
-      return CompletionItemKind.Variable;
+      return CompletionItemKind.Variable
 
     case ScriptElementKind.memberVariableElement:
     case ScriptElementKind.memberGetAccessorElement:
     case ScriptElementKind.memberSetAccessorElement:
-      return CompletionItemKind.Field;
+      return CompletionItemKind.Field
 
     case ScriptElementKind.functionElement:
     case ScriptElementKind.localFunctionElement:
-      return CompletionItemKind.Function;
+      return CompletionItemKind.Function
 
     case ScriptElementKind.constructSignatureElement:
     case ScriptElementKind.callSignatureElement:
     case ScriptElementKind.indexSignatureElement:
-      return CompletionItemKind.Method;
+      return CompletionItemKind.Method
 
     case ScriptElementKind.enumElement:
-      return CompletionItemKind.Enum;
+      return CompletionItemKind.Enum
 
     case ScriptElementKind.enumMemberElement:
-      return CompletionItemKind.EnumMember;
+      return CompletionItemKind.EnumMember
 
     case ScriptElementKind.moduleElement:
     case ScriptElementKind.externalModuleName:
-      return CompletionItemKind.Module;
+      return CompletionItemKind.Module
 
     case ScriptElementKind.classElement:
     case ScriptElementKind.typeElement:
-      return CompletionItemKind.Class;
+      return CompletionItemKind.Class
 
     case ScriptElementKind.interfaceElement:
-      return CompletionItemKind.Interface;
+      return CompletionItemKind.Interface
 
     case ScriptElementKind.warning:
-      return CompletionItemKind.Text;
+      return CompletionItemKind.Text
 
     case ScriptElementKind.scriptElement:
-      return CompletionItemKind.File;
+      return CompletionItemKind.File
 
     case ScriptElementKind.directory:
-      return CompletionItemKind.Folder;
+      return CompletionItemKind.Folder
 
     case ScriptElementKind.string:
-      return CompletionItemKind.Constant;
+      return CompletionItemKind.Constant
 
     default:
-      return CompletionItemKind.Property;
+      return CompletionItemKind.Property
   }
 }
 
@@ -123,25 +123,25 @@ export function getCompletionItemKind(kind: string): CompletionItemKind {
  * @param item
  */
 export function convertNavTree(
-  item: NavigationTree,
-  output: DocumentSymbol[],
-  document: TextDocument,
-  sourcemapLines: SourcemapLines | undefined,
+  item: NavigationTree
+  output: DocumentSymbol[]
+  document: TextDocument
+  sourcemapLines: SourcemapLines | undefined
 
 ): boolean {
-  shouldInclude .= shouldIncludeEntry(item);
+  shouldInclude .= shouldIncludeEntry(item)
   return false if !shouldInclude && !item.childItems?.length
 
-  children := new Set(item.childItems || []);
+  children := new Set(item.childItems || [])
   for (const span of item.spans) {
     range := remapRange(rangeFromTextSpan(span, document), sourcemapLines)
-    symbolInfo := convertSymbol(item, range, document, sourcemapLines);
+    symbolInfo := convertSymbol(item, range, document, sourcemapLines)
 
     for (const child of children) {
       if (child.spans.some((span) => !!intersectRanges(range, remapRange(rangeFromTextSpan(span, document), sourcemapLines)))) {
-        includedChild := convertNavTree(child, symbolInfo.children!, document, sourcemapLines);
-        shouldInclude = shouldInclude || includedChild;
-        children.delete(child);
+        includedChild := convertNavTree(child, symbolInfo.children!, document, sourcemapLines)
+        shouldInclude = shouldInclude || includedChild
+        children.delete(child)
       }
     }
 
@@ -157,7 +157,7 @@ function convertSymbol(item: NavigationTree, range: Range, document: TextDocumen
     nameRange = rangeFromTextSpan(item.nameSpan, document)
     nameRange = remapRange(nameRange, sourcemapLines) if sourcemapLines
 
-  selectionRange := nameRange || range;
+  selectionRange := nameRange || range
   label .= item.text
 
   switch (item.kind) {
@@ -170,14 +170,14 @@ function convertSymbol(item: NavigationTree, range: Range, document: TextDocumen
   }
 
   symbolInfo := makeDocumentSymbol(
-    label,
-    '',
-    getSymbolKind(item.kind),
-    range,
+    label
+    ''
+    getSymbolKind(item.kind)
+    range
     containsRange(range, selectionRange) ? selectionRange : range
-  );
+  )
 
-  kindModifiers := parseKindModifier(item.kindModifiers);
+  kindModifiers := parseKindModifier(item.kindModifiers)
   symbolInfo.tags = [SymbolTag.Deprecated] if kindModifiers.has(ScriptElementKindModifier.deprecatedModifier)
   symbolInfo
 }
@@ -197,12 +197,12 @@ function rangeFromTextSpan(span: TextSpan, document: TextDocument): Range
 export function makeRange(l1: number, c1: number, l2: number, c2: number) {
   return {
     start: {
-      line: l1,
-      character: c1,
-    },
+      line: l1
+      character: c1
+    }
     end: {
-      line: l2,
-      character: c2,
+      line: l2
+      character: c2
     }
   }
 }
@@ -218,11 +218,11 @@ export function makeRange(l1: number, c1: number, l2: number, c2: number) {
  */
 function makeDocumentSymbol(name: string, detail: string, kind: SymbolKind, range: Range, selectionRange: Range): DocumentSymbol {
   return {
-    name,
-    detail,
-    kind,
-    range,
-    selectionRange,
+    name
+    detail
+    kind
+    range
+    selectionRange
     children: []
   }
 }
@@ -231,10 +231,10 @@ function makeDocumentSymbol(name: string, detail: string, kind: SymbolKind, rang
  * A intersection of the two ranges.
  */
 export function intersectRanges(a: Range, b: Range): Range | null {
-  { line: resultStartLineNumber, character: resultStartColumn } .= a.start;
-  { line: resultEndLineNumber, character: resultEndColumn } .= a.end;
-  { line: otherStartLineNumber, character: otherStartColumn } .= b.start;
-  { line: otherEndLineNumber, character: otherEndColumn } .= b.end;
+  { line: resultStartLineNumber, character: resultStartColumn } .= a.start
+  { line: resultEndLineNumber, character: resultEndColumn } .= a.end
+  { line: otherStartLineNumber, character: otherStartColumn } .= b.start
+  { line: otherEndLineNumber, character: otherEndColumn } .= b.end
 
   if resultStartLineNumber < otherStartLineNumber
     resultStartLineNumber = otherStartLineNumber
@@ -316,7 +316,7 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
     // console.log(`transformed position ${[origLine, origOffset]} => ${[genLine, genOffset]}`)
 
     return {
-      line: genLine,
+      line: genLine
       character: genOffset
     }
   }
@@ -326,9 +326,9 @@ export function forwardMap(sourcemapLines: SourcemapLines, position: Position) {
 }
 
 export function logTiming<R, A extends unknown[]>(
-  logger: Console | RemoteConsole = console,
-  name: string,
-  fn: (...args: A) => R,
+  logger: Console | RemoteConsole = console
+  name: string
+  fn: (...args: A) => R
 ) {
   return function (...args: A) {
     start := performance.now()
@@ -336,31 +336,31 @@ export function logTiming<R, A extends unknown[]>(
     end := performance.now()
     logger.log(`${name.padStart(32)}${(end - start).toFixed(2).padStart(8)}ms`)
 
-    return result;
+    return result
   }
 }
 
 export function convertDiagnostic(
-  diagnostic: Diagnostic,
-  document: TextDocument,
+  diagnostic: Diagnostic
+  document: TextDocument
   sourcemapLines?: SourcemapLines
 ): vs.Diagnostic {
   return {
-    message: flattenDiagnosticMessageText(diagnostic.messageText),
+    message: flattenDiagnosticMessageText(diagnostic.messageText)
     range: remapRange(
       rangeFromTextSpan(
         {
-          start: diagnostic.start || 0,
-          length: diagnostic.length ?? 1,
-        },
+          start: diagnostic.start || 0
+          length: diagnostic.length ?? 1
+        }
         document
-      ),
+      )
       sourcemapLines
-    ),
-    severity: diagnosticCategoryToSeverity(diagnostic.category),
-    code: diagnostic.code,
-    source: diagnostic.source || 'typescript',
-  };
+    )
+    severity: diagnosticCategoryToSeverity(diagnostic.category)
+    code: diagnostic.code
+    source: diagnostic.source || 'typescript'
+  }
 }
 
 function diagnosticCategoryToSeverity(
@@ -368,13 +368,13 @@ function diagnosticCategoryToSeverity(
 ): DiagnosticSeverity {
   switch (category) {
     case DiagnosticCategory.Warning:
-      return DiagnosticSeverity.Warning;
+      return DiagnosticSeverity.Warning
     case DiagnosticCategory.Error:
-      return DiagnosticSeverity.Error;
+      return DiagnosticSeverity.Error
     case DiagnosticCategory.Suggestion:
-      return DiagnosticSeverity.Hint;
+      return DiagnosticSeverity.Hint
     case DiagnosticCategory.Message:
-      return DiagnosticSeverity.Information;
+      return DiagnosticSeverity.Information
   }
 }
 
@@ -382,16 +382,16 @@ function diagnosticCategoryToSeverity(
  * https://github.com/tc39/proposal-promise-with-resolvers
  */
 export function withResolvers<T>() {
-  let resolve: (value: T) => void;
-  let reject: (reason?: any) => void;
+  let resolve: (value: T) => void
+  let reject: (reason?: any) => void
   promise := new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve: resolve!, reject: reject! };
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve: resolve!, reject: reject! }
 }
 export interface WithResolvers<T> {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (reason?: any) => void;
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: any) => void
 }

--- a/lsp/source/server.civet
+++ b/lsp/source/server.civet
@@ -65,47 +65,40 @@ projectPathToServiceMap := new Map<string, ResolvedService>()
 
 let rootUri: string | undefined, rootDir: string | undefined;
 
-getProjectPathFromSourcePath := (sourcePath: string): string => {
+getProjectPathFromSourcePath := (sourcePath: string): string =>
   projPath .= sourcePathToProjectPathMap.get(sourcePath)
-  if (projPath) return projPath
+  return projPath if projPath
 
   // If we're in a node_modules/foo directory, use that as the project path
   dirname .= sourcePath
-  while (dirname.includes("node_modules")) {
-    if (path.basename(path.dirname(dirname)) === "node_modules") {
+  while dirname.includes("node_modules")
+    if path.basename(path.dirname(dirname)) is "node_modules"
       projPath = URI.file(dirname + "/").toString()
       break
-    } else {
+    else
       dirname = path.dirname(dirname) // go up one level
-    }
-  }
 
   // Otherwise, check for ancestor tsconfig
-  if (!projPath) {
+  if !projPath
     tsConfigPath := findConfigFile(sourcePath, tsSys.fileExists, 'tsconfig.json')
-    if (tsConfigPath) {
+    if tsConfigPath
       projPath = URI.file(path.dirname(tsConfigPath) + "/").toString()
-    }
-  }
 
   // Otherwise, check whether we're inside the root
-  if (!projPath) {
-    if (rootDir != null && sourcePath.startsWith(rootDir)) {
+  if !projPath
+    if rootDir and sourcePath.startsWith(rootDir)
       projPath = rootUri ?? pathToFileURL(path.dirname(sourcePath) + "/").toString()
-    } else {
+    else
       projPath = URI.file(path.dirname(sourcePath) + "/").toString()
-    }
-  }
 
   sourcePathToProjectPathMap.set(sourcePath, projPath)
   return projPath
-}
 
 ensureServiceForSourcePath := async (sourcePath: string) => {
   projPath := getProjectPathFromSourcePath(sourcePath)
   await projectPathToPendingPromiseMap.get(projPath)
   service .= projectPathToServiceMap.get(projPath)
-  if (service) return service
+  return service if service
   logger.log("Spawning language server for project path: " + projPath)
   service = await TSService(projPath, connection.console)
   initP := service.loadPlugins()
@@ -174,13 +167,15 @@ connection.onInitialize async (params: InitializeParams) =>
   return result
 
 connection.onInitialized () =>
-  if (hasConfigurationCapability)
+  if hasConfigurationCapability
     // Register for all configuration changes.
-    connection.client.register(DidChangeConfigurationNotification.type, undefined);
+    connection.client.register(DidChangeConfigurationNotification.type, undefined)
 
-  if (hasWorkspaceFolderCapability)
+  if hasWorkspaceFolderCapability
     connection.workspace.onDidChangeWorkspaceFolders (_event) =>
-      logger.log('Workspace folder change event received.');
+      logger.log('Workspace folder change event received.')
+
+  return
 
 updating := (document: { uri: string }) => documentUpdateStatus.get(document.uri)?.promise
 tsSuffix := /\.[cm]?[jt]s$|\.json|\.[jt]sx/
@@ -192,7 +187,7 @@ connection.onHover(async ({ textDocument, position }) => {
   assert(sourcePath)
 
   service := await ensureServiceForSourcePath(sourcePath)
-  if (!service) return
+  return unless service
 
   doc := documents.get(textDocument.uri)
   assert(doc)
@@ -205,16 +200,14 @@ connection.onHover(async ({ textDocument, position }) => {
   } else { // Transpiled
     // need to sourcemap the line/columns
     meta := service.host.getMeta(sourcePath)
-    if (!meta) return
+    return unless meta
     sourcemapLines := meta.sourcemapLines
     transpiledDoc := meta.transpiledDoc
-    if (!transpiledDoc) return
+    return unless transpiledDoc
 
     // Map input hover position into output TS position
     // Don't map for files that don't have a sourcemap (plain .ts for example)
-    if (sourcemapLines) {
-      position = forwardMap(sourcemapLines, position)
-    }
+    position = forwardMap(sourcemapLines, position) if sourcemapLines
 
     // logger.log("onHover2"+ sourcePath+ position)
 
@@ -224,7 +217,7 @@ connection.onHover(async ({ textDocument, position }) => {
     // logger.log("onHover3"+ info)
 
   }
-  if (!info) return
+  return unless info
 
   display := displayPartsToString(info.displayParts);
   // TODO: Replace Previewer
@@ -307,8 +300,8 @@ function resolvePathAliasDir(
   importPath: string,
 ): string | undefined {
   { baseUrl, paths } := compilationSettings
-  if (!paths) return
-  if (!(baseUrl && path.isAbsolute(baseUrl))) return
+  return unless paths
+  return unless (baseUrl && path.isAbsolute(baseUrl))
 
   candidates: { resolvedDir: string, aliasPattern: string }[] := []
 
@@ -361,7 +354,7 @@ function appendClosingQuoteToPathCompletions(
   completions: CompletionItem[],
   closingQuoteSuffix: "'" | '"' | undefined,
 ): CompletionItem[] {
-  if (!closingQuoteSuffix) return completions
+  return completions unless closingQuoteSuffix
 
   for (const completion of completions) {
     if (completion.kind !== CompletionItemKind.File && completion.kind !== CompletionItemKind.Module) {
@@ -468,7 +461,7 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
   service := await ensureServiceForSourcePath(sourcePath)
-  if (!service) return
+  return unless service
 
   logger.log("completion " + sourcePath + " " + (position.line+1) + ":" + position.character)
 
@@ -521,10 +514,12 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
 
   // … Sourcemap the line/columns
   meta := service.host.getMeta(sourcePath)
-  if (!meta) return civetFileCompletions
+  return civetFileCompletions unless meta
   { sourcemapLines, transpiledDoc } := meta
-  if (!transpiledDoc) return civetFileCompletions
-  if (sourcemapLines) { position = forwardMap(sourcemapLines, position); logger.log('remapped') }
+  return civetFileCompletions unless transpiledDoc
+  if sourcemapLines
+    position = forwardMap(sourcemapLines, position)
+    logger.log('remapped')
   p .= transpiledDoc.offsetAt(position)
 
   // … Adjust the cursor position, on a case-per-case basis, to access better completions.
@@ -573,7 +568,7 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
 connection.onCompletionResolve(async (item) => {
   { sourcePath, position, name, source, data } .= item.data
   service := await ensureServiceForSourcePath(sourcePath)
-  if (!service) return item
+  return item unless service
 
   let document
   if (sourcePath.match(tsSuffix)) { // non-transpiled
@@ -582,9 +577,9 @@ connection.onCompletionResolve(async (item) => {
   } else {
     // use transpiled doc; forward source mapping already done
     meta := service.host.getMeta(sourcePath)
-    if (!meta) return item
+    return item unless meta
     { transpiledDoc } := meta
-    if (!transpiledDoc) return item
+    return item unless transpiledDoc
     document = transpiledDoc
     sourcePath = documentToSourcePath(transpiledDoc)
   }
@@ -599,7 +594,7 @@ connection.onCompletionResolve(async (item) => {
     logger.log("Failed to get completion details for " + name)
     logger.log(String(e))
   }
-  if (!detail) return item
+  return item unless detail
 
   // getDetails from https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts
   details: string[] := []
@@ -634,7 +629,7 @@ connection.onDefinition(async ({ textDocument, position }) => {
   sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
   service := await ensureServiceForSourcePath(sourcePath)
-  if (!service) return
+  return unless service
 
   let definitions
 
@@ -648,22 +643,20 @@ connection.onDefinition(async ({ textDocument, position }) => {
   } else {
     // need to sourcemap the line/columns
     meta := service.host.getMeta(sourcePath)
-    if (!meta) return
+    return unless meta
     { sourcemapLines, transpiledDoc } := meta
-    if (!transpiledDoc) return
+    return unless transpiledDoc
 
     // Map input hover position into output TS position
     // Don't map for files that don't have a sourcemap (plain .ts for example)
-    if (sourcemapLines) {
-      position = forwardMap(sourcemapLines, position)
-    }
+    position = forwardMap(sourcemapLines, position) if sourcemapLines
 
     p := transpiledDoc.offsetAt(position)
     transpiledPath := documentToSourcePath(transpiledDoc)
     definitions = service.getDefinitionAtPosition(transpiledPath, p)
   }
 
-  if (!definitions) return
+  return unless definitions
 
   program := service.getProgram()
   assert(program)
@@ -673,7 +666,7 @@ connection.onDefinition(async ({ textDocument, position }) => {
     { fileName, textSpan } .= definition
     // source file as it is known to TSServer
     sourceFile := program.getSourceFile(fileName)
-    if (!sourceFile) return
+    return unless sourceFile
 
     start .= sourceFile.getLineAndCharacterOfPosition(textSpan.start)
     end .= sourceFile.getLineAndCharacterOfPosition(textSpan.start + textSpan.length)
@@ -681,14 +674,11 @@ connection.onDefinition(async ({ textDocument, position }) => {
 
     // Reverse map back to .civet source space if this definition is in a transpiled file
     meta := service.host.getMeta(rawSourceName)
-    if (meta) {
+    if meta
       { sourcemapLines } := meta
-
-      if (sourcemapLines) {
+      if sourcemapLines
         start = remapPosition(start, sourcemapLines)
         end = remapPosition(end, sourcemapLines)
-      }
-    }
 
     return {
       uri: URI.file(rawSourceName).toString(),
@@ -706,7 +696,7 @@ connection.onReferences(async ({ textDocument, position }) => {
   assert(sourcePath)
   service := await ensureServiceForSourcePath(sourcePath)
   // TODO: same source mapping as onDefinition I think...
-  if (!service) return
+  return unless service
 
   let references
 
@@ -719,22 +709,20 @@ connection.onReferences(async ({ textDocument, position }) => {
   } else {
     // need to sourcemap the line/columns
     meta := service.host.getMeta(sourcePath)
-    if (!meta) return
+    return unless meta
     { sourcemapLines, transpiledDoc } := meta
-    if (!transpiledDoc) return
+    return unless transpiledDoc
 
     // Map input hover position into output TS position
     // Don't map for files that don't have a sourcemap (plain .ts for example)
-    if (sourcemapLines) {
-      position = forwardMap(sourcemapLines, position)
-    }
+    position = forwardMap(sourcemapLines, position) if sourcemapLines
 
     p := transpiledDoc.offsetAt(position)
     transpiledPath := documentToSourcePath(transpiledDoc)
     references = service.getReferencesAtPosition(transpiledPath, p)
   }
 
-  if (!references) return
+  return unless references
 
   program := service.getProgram()
   assert(program)
@@ -744,7 +732,7 @@ connection.onReferences(async ({ textDocument, position }) => {
     { fileName, textSpan } .= reference
     // source file as it is known to TSServer
     sourceFile := program.getSourceFile(fileName)
-    if (!sourceFile) return
+    return unless sourceFile
 
     start .= sourceFile.getLineAndCharacterOfPosition(textSpan.start)
     end .= sourceFile.getLineAndCharacterOfPosition(textSpan.start + textSpan.length)
@@ -752,14 +740,11 @@ connection.onReferences(async ({ textDocument, position }) => {
 
     // Reverse map back to .civet source space if this definition is in a transpiled file
     meta := service.host.getMeta(rawSourceName)
-    if (meta) {
+    if meta
       { sourcemapLines } := meta
-
-      if (sourcemapLines) {
+      if sourcemapLines
         start = remapPosition(start, sourcemapLines)
         end = remapPosition(end, sourcemapLines)
-      }
-    }
 
     return {
       uri: URI.file(rawSourceName).toString(),
@@ -776,7 +761,7 @@ connection.onDocumentSymbol(async ({ textDocument }) => {
   assert(sourcePath)
 
   service := await ensureServiceForSourcePath(sourcePath)
-  if (!service) return
+  return unless service
 
   let document, navTree, sourcemapLines
 
@@ -819,7 +804,7 @@ function getRenameSourceDetails(
   isTypeScriptFile := sourcePath.match(tsSuffix)
   if (isTypeScriptFile) {
     document := documents.get(textDocumentId.uri)
-    if (!document) return null
+    return null unless document
     return {
       document,
       position,
@@ -828,11 +813,11 @@ function getRenameSourceDetails(
     }
   } else {
     meta := service.host.getMeta(sourcePath)
-    if (!meta) return null
-    if (!meta.transpiledDoc || !meta.sourcemapLines) return null
+    return null unless meta
+    return null unless meta.transpiledDoc || !meta.sourcemapLines
 
     document := meta.transpiledDoc
-    if (!document) return null
+    return null unless document
 
     mappedPosition := forwardMap(meta.sourcemapLines, position)
 
@@ -900,15 +885,15 @@ connection.onRenameRequest(async ({ textDocument, position, newName }) => {
   assert(sourcePath)
 
   service := await ensureServiceForSourcePath(sourcePath)
-  if (!service) return
+  return unless service
 
   await updating(textDocument)
 
   mapped := getRenameSourceDetails(service, textDocument, sourcePath, position)
-  if (!mapped) return
+  return unless mapped
 
   locations := service.findRenameLocations(mapped.sourcePath, mapped.offset, false, false, {})
-  if (!locations || !locations.length) return
+  return unless locations || !locations.length
 
   program := service.getProgram()
   assert(program)
@@ -977,8 +962,8 @@ async function executeQueue() {
 }
 async function scheduleExecuteQueue() {
   // Schedule executeQueue() if there isn't one already running or scheduled
-  if (executeTimeout) return
-  if (!changeQueue.size) return
+  return if executeTimeout
+  return unless changeQueue.size
   await (executeTimeout = setTimeout(diagnosticsDelay))
   await executeQueue()
 }
@@ -1000,7 +985,7 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
   if (!service) {
     service = await ensureServiceForSourcePath(sourcePath)
   }
-  if (!service) return
+  return unless service
 
   // When called from executeQueue, document is already staged.
   // When called from updateProjectDiagnostics, we need to stage it.
@@ -1123,14 +1108,14 @@ updateProjectDiagnostics := async (
   service: ResolvedService
 ) => {
   program := service.getProgram();
-  if (!program) return;
+  return unless program
 
   // A single, short delay before starting the update for a project.
   await setTimeout(diagnosticsPropagationDelay);
 
   projectFiles := program.getSourceFiles();
   for (const sourceFile of projectFiles) {
-    if (status.isCanceled) return;
+    return if status.isCanceled
 
     // We only need to send diagnostics for files the user has open
     // TypeScript is analyzing all files in memory anyway
@@ -1163,29 +1148,26 @@ function scheduleUpdateDiagnostics(changedDocs: Set<TextDocument>) {
   }
 
   // Trigger updates for each affected project.
-  for (const service of servicesToUpdate) {
+  for service of servicesToUpdate
     // Don't await; let updates for different projects run in parallel.
-    updateProjectDiagnostics(status, service);
-  }
+    updateProjectDiagnostics(status, service)
 }
 
-connection.onDidChangeWatchedFiles((_change) => {
+connection.onDidChangeWatchedFiles (_change) =>
   // Monitored files have change in VSCode
-  logger.log('We received an file change event');
-});
+  logger.log('We received an file change event')
 
 // Make the text document manager listen on the connection
 // for open, change and close text document events
-documents.listen(connection);
+documents.listen(connection)
 
 // Listen on the connection
-connection.listen();
+connection.listen()
 
 // Utils
 
-function documentToSourcePath(textDocument: TextDocumentIdentifier) {
-  return URI.parse(textDocument.uri).fsPath;
-}
+function documentToSourcePath(textDocument: TextDocumentIdentifier)
+  URI.parse(textDocument.uri).fsPath
 
 // https://github.com/typescript-language-server/typescript-language-server/blob/e91bd52a47c05ffd946e0abd27f242eb631b7604/src/completion.ts#L188
 fileExtensionKindModifiers := new Set<string>([
@@ -1205,7 +1187,7 @@ fileExtensionKindModifiers := new Set<string>([
 
 function getFileExtensionModifier(kindModifiers: Set<string>): string {
   for (const modifier of kindModifiers) {
-    if (fileExtensionKindModifiers.has(modifier)) return modifier
+    return modifier if fileExtensionKindModifiers.has(modifier)
   }
   return ''
 }
@@ -1253,10 +1235,9 @@ function convertCompletions(completions: ts.CompletionInfo, document: TextDocume
       { start, length } := entry.replacementSpan
       begin .= document.positionAt(start)
       end .= document.positionAt(start + length)
-      if (sourcemapLines) {
+      if sourcemapLines
         begin = remapPosition(begin, sourcemapLines)
         end = remapPosition(end, sourcemapLines)
-      }
       item.textEdit = {
         range: { start: begin, end },
         newText: entry.insertText!,

--- a/lsp/source/server.civet
+++ b/lsp/source/server.civet
@@ -120,23 +120,17 @@ ensureServiceForSourcePath := async (sourcePath: string) => {
 diagnosticsDelay := 16;  // ms delay for primary updated file
 diagnosticsPropagationDelay := 100;  // ms delay for other files
 
-connection.onInitialize(async (params: InitializeParams) => {
+connection.onInitialize async (params: InitializeParams) =>
   capabilities := params.capabilities;
 
   // Does the client support the `workspace/configuration` request?
   // If not, we fall back using global settings.
   hasConfigurationCapability = !!(
     capabilities.workspace && !!capabilities.workspace.configuration
-  );
+  )
   hasWorkspaceFolderCapability = !!(
     capabilities.workspace && !!capabilities.workspace.workspaceFolders
-  );
-  // hasDiagnosticRelatedInformationCapability = !!(
-  //   capabilities.textDocument &&
-  //   capabilities.textDocument.publishDiagnostics &&
-  //   capabilities.textDocument.publishDiagnostics.relatedInformation
-  // );
-  // Removed unused diagnostic capability check
+  )
 
   result: InitializeResult := {
     capabilities: {
@@ -162,39 +156,31 @@ connection.onInitialize(async (params: InitializeParams) => {
     }
   };
 
-  if (hasWorkspaceFolderCapability) {
-    result.capabilities.workspace = {
-      workspaceFolders: {
+  if hasWorkspaceFolderCapability
+    result.capabilities.workspace =
+      workspaceFolders:
         supported: true
-      }
-    };
-  }
 
   // TODO: currently only using the first workspace folder
   baseDir := params.workspaceFolders?.[0]?.uri.toString()
-  if (!baseDir) {
+  if !baseDir
     logger.log("Warning: No workspace folders")
     rootUri = rootDir = undefined
-  } else {
+  else
     rootUri = baseDir + "/"
     rootDir = URI.parse(rootUri).fsPath
-  }
 
-  logger.log("Init " + rootDir)
-  return result;
-});
+  logger.log "Init " + rootDir
+  return result
 
-connection.onInitialized(() => {
-  if (hasConfigurationCapability) {
+connection.onInitialized () =>
+  if (hasConfigurationCapability)
     // Register for all configuration changes.
     connection.client.register(DidChangeConfigurationNotification.type, undefined);
-  }
-  if (hasWorkspaceFolderCapability) {
-    connection.workspace.onDidChangeWorkspaceFolders(_event => {
+
+  if (hasWorkspaceFolderCapability)
+    connection.workspace.onDidChangeWorkspaceFolders (_event) =>
       logger.log('Workspace folder change event received.');
-    });
-  }
-});
 
 updating := (document: { uri: string }) => documentUpdateStatus.get(document.uri)?.promise
 tsSuffix := /\.[cm]?[jt]s$|\.json|\.[jt]sx/
@@ -288,7 +274,7 @@ function findCivetFilesInDir(searchDir: string): string[] {
   try {
     return tsSys
       .readDirectory(searchDir, [civetFileExtension], undefined, undefined, 1)
-      .map(f => path.basename(f))
+      .map((f) => path.basename(f))
   } catch {
     return []
   }
@@ -973,7 +959,7 @@ async function executeQueue() {
 
   for (const { service, docs } of docsByProject.values()) {
     // Phase 1: Stage all changes within this project.
-    docs.forEach(doc => service.host.addOrUpdateDocument(doc));
+    docs.forEach((doc) => service.host.addOrUpdateDocument(doc));
 
     // Phase 2: Analyze all staged documents within this project.
     for (const doc of docs) {
@@ -1113,7 +1099,7 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
         message,
         source: 'civet'
       }
-    }).filter(x => !!x))
+    }).filter((x) => !!x))
   }
   if (!fatal) {
     diagnostics.push(...getTypeScriptDiagnostics(transpiledPath, transpiledDoc, sourcemapLines))
@@ -1183,7 +1169,7 @@ function scheduleUpdateDiagnostics(changedDocs: Set<TextDocument>) {
   }
 }
 
-connection.onDidChangeWatchedFiles(_change => {
+connection.onDidChangeWatchedFiles((_change) => {
   // Monitored files have change in VSCode
   logger.log('We received an file change event');
 });

--- a/lsp/source/server.civet
+++ b/lsp/source/server.civet
@@ -101,13 +101,16 @@ ensureServiceForSourcePath := (sourcePath: string) =>
   service .= projectPathToServiceMap.get(projPath)
   return service if service
 
+  let resolveInit: () => void
+  initP := new Promise<void> (^resolveInit) =>
+  projectPathToPendingPromiseMap.set(projPath, initP)  // guard set BEFORE await
+
   logger.log("Spawning language server for project path: " + projPath)
   service = await TSService(projPath, connection.console)
-  initP := service.loadPlugins()
-  projectPathToPendingPromiseMap.set(projPath, initP)
-  await initP
+  await service.loadPlugins()
   projectPathToServiceMap.set(projPath, service)
   projectPathToPendingPromiseMap.delete(projPath)
+  resolveInit!()
 
   return service
 
@@ -873,7 +876,7 @@ function createRenameLocationChanges(
   return changes
 }
 
-connection.onRenameRequest(async ({ textDocument, position, newName }) => {
+connection.onRenameRequest ({ textDocument, position, newName }) =>
   sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
 
@@ -886,15 +889,12 @@ connection.onRenameRequest(async ({ textDocument, position, newName }) => {
   return unless mapped
 
   locations := service.findRenameLocations(mapped.sourcePath, mapped.offset, false, false, {})
-  return unless locations || !locations.length
+  return unless locations?#
 
   program := service.getProgram()
   assert(program)
 
-  return {
-    changes: createRenameLocationChanges(service, program, locations, newName)
-  }
-})
+  changes: createRenameLocationChanges(service, program, locations, newName)
 
 // TODO
 documents.onDidClose(({ document }) => {

--- a/lsp/source/server.civet
+++ b/lsp/source/server.civet
@@ -1,4 +1,4 @@
-import {
+{
   createConnection,
   TextDocuments,
   Diagnostic,
@@ -16,61 +16,61 @@ import {
   Location,
   DiagnosticSeverity,
   TextEdit,
-} from 'vscode-languageserver/node';
+} from vscode-languageserver/node
 
-import {
+{
   TextDocument,
   type Position
-} from 'vscode-languageserver-textdocument';
-import TSService from './lib/typescript-service.mjs';
-import * as Previewer from "./lib/previewer.mjs";
-import { convertNavTree, forwardMap, getCompletionItemKind, convertDiagnostic, remapPosition, parseKindModifier, logTiming, WithResolvers, withResolvers, type SourcemapLines } from './lib/util.mjs';
-import { asPlainTextWithLinks, tagsToMarkdown } from './lib/textRendering.mjs';
-import assert from "assert"
-import path from "node:path"
-import ts, {
+} from vscode-languageserver-textdocument
+TSService from ./lib/typescript-service.civet
+* as Previewer from ./lib/previewer.civet
+{ convertNavTree, forwardMap, getCompletionItemKind, convertDiagnostic, remapPosition, parseKindModifier, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
+{ asPlainTextWithLinks, tagsToMarkdown } from ./lib/textRendering.civet
+assert from assert
+path from node:path
+ts, {
   sys as tsSys,
   displayPartsToString,
   GetCompletionsAtPositionOptions,
   findConfigFile,
   ScriptElementKindModifier,
   SemicolonPreference,
-} from 'typescript';
-import { URI } from 'vscode-uri';
-import { setTimeout } from 'timers/promises';
+} from typescript
+{ URI } from vscode-uri
+{ setTimeout } from timers/promises
 
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
-const connection = createConnection(ProposedFeatures.all)
-const logger = connection.console;
+connection := createConnection(ProposedFeatures.all)
+logger := connection.console;
 
 // Create a simple text document manager.
-const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+documents: TextDocuments<TextDocument> := new TextDocuments(TextDocument);
 
-let hasConfigurationCapability = false;
-let hasWorkspaceFolderCapability = false;
+hasConfigurationCapability .= false;
+hasWorkspaceFolderCapability .= false;
 // let hasDiagnosticRelatedInformationCapability = false;
 // comment out unused variable
 
 // Mapping from abs file path -> path of nearest applicable project path (tsconfig.json base)
-const sourcePathToProjectPathMap = new Map<string, string>()
+sourcePathToProjectPathMap := new Map<string, string>()
 
 // Tracks pending promises for tsserver initialization to safeguard
 // against creating multiple tsserver instances for same project path
-const projectPathToPendingPromiseMap = new Map<string, Promise<void>>()
+projectPathToPendingPromiseMap := new Map<string, Promise<void>>()
 
 // Mapping from project path -> TSService instance operating on that base directory
 type ResolvedService = Awaited<ReturnType<typeof TSService>>
-const projectPathToServiceMap = new Map<string, ResolvedService>()
+projectPathToServiceMap := new Map<string, ResolvedService>()
 
 let rootUri: string | undefined, rootDir: string | undefined;
 
-const getProjectPathFromSourcePath = (sourcePath: string): string => {
-  let projPath = sourcePathToProjectPathMap.get(sourcePath)
+getProjectPathFromSourcePath := (sourcePath: string): string => {
+  projPath .= sourcePathToProjectPathMap.get(sourcePath)
   if (projPath) return projPath
 
   // If we're in a node_modules/foo directory, use that as the project path
-  let dirname = sourcePath
+  dirname .= sourcePath
   while (dirname.includes("node_modules")) {
     if (path.basename(path.dirname(dirname)) === "node_modules") {
       projPath = URI.file(dirname + "/").toString()
@@ -82,7 +82,7 @@ const getProjectPathFromSourcePath = (sourcePath: string): string => {
 
   // Otherwise, check for ancestor tsconfig
   if (!projPath) {
-    const tsConfigPath = findConfigFile(sourcePath, tsSys.fileExists, 'tsconfig.json')
+    tsConfigPath := findConfigFile(sourcePath, tsSys.fileExists, 'tsconfig.json')
     if (tsConfigPath) {
       projPath = URI.file(path.dirname(tsConfigPath) + "/").toString()
     }
@@ -101,14 +101,14 @@ const getProjectPathFromSourcePath = (sourcePath: string): string => {
   return projPath
 }
 
-const ensureServiceForSourcePath = async (sourcePath: string) => {
-  const projPath = getProjectPathFromSourcePath(sourcePath)
+ensureServiceForSourcePath := async (sourcePath: string) => {
+  projPath := getProjectPathFromSourcePath(sourcePath)
   await projectPathToPendingPromiseMap.get(projPath)
-  let service = projectPathToServiceMap.get(projPath)
+  service .= projectPathToServiceMap.get(projPath)
   if (service) return service
   logger.log("Spawning language server for project path: " + projPath)
   service = await TSService(projPath, connection.console)
-  const initP = service.loadPlugins()
+  initP := service.loadPlugins()
   projectPathToPendingPromiseMap.set(projPath, initP)
   await initP
   projectPathToServiceMap.set(projPath, service)
@@ -117,11 +117,11 @@ const ensureServiceForSourcePath = async (sourcePath: string) => {
 }
 
 // TODO Propagate this to an extension setting
-const diagnosticsDelay = 16;  // ms delay for primary updated file
-const diagnosticsPropagationDelay = 100;  // ms delay for other files
+diagnosticsDelay := 16;  // ms delay for primary updated file
+diagnosticsPropagationDelay := 100;  // ms delay for other files
 
 connection.onInitialize(async (params: InitializeParams) => {
-  const capabilities = params.capabilities;
+  capabilities := params.capabilities;
 
   // Does the client support the `workspace/configuration` request?
   // If not, we fall back using global settings.
@@ -138,7 +138,7 @@ connection.onInitialize(async (params: InitializeParams) => {
   // );
   // Removed unused diagnostic capability check
 
-  const result: InitializeResult = {
+  result: InitializeResult := {
     capabilities: {
       textDocumentSync: TextDocumentSyncKind.Incremental,
       // Tell the client that this server supports code completion.
@@ -171,7 +171,7 @@ connection.onInitialize(async (params: InitializeParams) => {
   }
 
   // TODO: currently only using the first workspace folder
-  const baseDir = params.workspaceFolders?.[0]?.uri.toString()
+  baseDir := params.workspaceFolders?.[0]?.uri.toString()
   if (!baseDir) {
     logger.log("Warning: No workspace folders")
     rootUri = rootDir = undefined
@@ -196,32 +196,32 @@ connection.onInitialized(() => {
   }
 });
 
-const updating = (document: { uri: string }) => documentUpdateStatus.get(document.uri)?.promise
-const tsSuffix = /\.[cm]?[jt]s$|\.json|\.[jt]sx/
-const civetFileExtension = '.civet'
+updating := (document: { uri: string }) => documentUpdateStatus.get(document.uri)?.promise
+tsSuffix := /\.[cm]?[jt]s$|\.json|\.[jt]sx/
+civetFileExtension := '.civet'
 
 connection.onHover(async ({ textDocument, position }) => {
   // logger.log("hover"+ position)
-  const sourcePath = documentToSourcePath(textDocument)
+  sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
 
-  const service = await ensureServiceForSourcePath(sourcePath)
+  service := await ensureServiceForSourcePath(sourcePath)
   if (!service) return
 
-  const doc = documents.get(textDocument.uri)
+  doc := documents.get(textDocument.uri)
   assert(doc)
 
   let info
   await updating(textDocument)
   if (sourcePath.match(tsSuffix)) { // non-transpiled
-    const p = doc.offsetAt(position)
+    p := doc.offsetAt(position)
     info = service.getQuickInfoAtPosition(sourcePath, p)
   } else { // Transpiled
     // need to sourcemap the line/columns
-    const meta = service.host.getMeta(sourcePath)
+    meta := service.host.getMeta(sourcePath)
     if (!meta) return
-    const sourcemapLines = meta.sourcemapLines
-    const transpiledDoc = meta.transpiledDoc
+    sourcemapLines := meta.sourcemapLines
+    transpiledDoc := meta.transpiledDoc
     if (!transpiledDoc) return
 
     // Map input hover position into output TS position
@@ -232,17 +232,17 @@ connection.onHover(async ({ textDocument, position }) => {
 
     // logger.log("onHover2"+ sourcePath+ position)
 
-    const p = transpiledDoc.offsetAt(position)
-    const transpiledPath = documentToSourcePath(transpiledDoc)
+    p := transpiledDoc.offsetAt(position)
+    transpiledPath := documentToSourcePath(transpiledDoc)
     info = service.getQuickInfoAtPosition(transpiledPath, p)
     // logger.log("onHover3"+ info)
 
   }
   if (!info) return
 
-  const display = displayPartsToString(info.displayParts);
+  display := displayPartsToString(info.displayParts);
   // TODO: Replace Previewer
-  const documentation = Previewer.plain(displayPartsToString(info.documentation));
+  documentation := Previewer.plain(displayPartsToString(info.documentation));
 
   return {
     // TODO: Range
@@ -259,11 +259,11 @@ connection.onHover(async ({ textDocument, position }) => {
 
 // Helpers for completing import paths.
 
-const looksLikeImportContext = /\b(from|import|require)(\s+['"]?)?$/
+looksLikeImportContext := /\b(from|import|require)(\s+['"]?)?$/
 function likelyImportContext(text: string): boolean { return looksLikeImportContext.test(text) }
 
 // … Extract information about an import statement under the cursor
-const importPathExtractor = /\b(?<statement>from|import|require)\b[ \t]*(?:[\(][ \t]*)?(?:(?<qt>')(?<path>[^']*)(?<endqt>'?)|(?<qt>")(?<path>[^"]*)(?<endqt>")?|(?<path>[^;"'\s=>]*))/gd
+importPathExtractor := /\b(?<statement>from|import|require)\b[ \t]*(?:[\(][ \t]*)?(?:(?<qt>')(?<path>[^']*)(?<endqt>'?)|(?<qt>")(?<path>[^"]*)(?<endqt>")?|(?<path>[^;"'\s=>]*))/gd
 
 type ImportPathMatchIterator = RegExpStringIterator< RegExpExecArray & {
   groups: { statement: ('from'|'import'|'require'), path: string, qt: '"'|"'"|undefined , endqt: '"'|"'"|undefined }
@@ -272,7 +272,7 @@ type ImportPathMatchIterator = RegExpStringIterator< RegExpExecArray & {
 
 function extractImportPath(lineText: string, cursorOffset: number) {
   // Get all import|from|require statements in the line
-  const matches = lineText.matchAll(importPathExtractor) as ImportPathMatchIterator
+  matches := lineText.matchAll(importPathExtractor) as ImportPathMatchIterator
 
   // See if there's a match whose path group spans over the cursor
   for (const match of matches) {
@@ -320,20 +320,20 @@ function resolvePathAliasDir(
   compilationSettings: ts.CompilerOptions,
   importPath: string,
 ): string | undefined {
-  const { baseUrl, paths } = compilationSettings
+  { baseUrl, paths } := compilationSettings
   if (!paths) return
   if (!(baseUrl && path.isAbsolute(baseUrl))) return
 
-  const candidates: { resolvedDir: string, aliasPattern: string }[] = []
+  candidates: { resolvedDir: string, aliasPattern: string }[] := []
 
   for (const [pattern, replacements] of Object.entries(paths)) {
     if (pattern.endsWith('*')) {
-      const aliasPrefix = pattern.slice(0, -1)
+      aliasPrefix := pattern.slice(0, -1)
       if (importPath.startsWith(aliasPrefix)) {
-        const pathAfterAlias = importPath.slice(aliasPrefix.length)
+        pathAfterAlias := importPath.slice(aliasPrefix.length)
         for (const replacement of replacements) {
-          const replacementBase = replacement.endsWith('*') ? replacement.slice(0, -1) : replacement
-          const resolvedDir = path.resolve(baseUrl, replacementBase, pathAfterAlias)
+          replacementBase := replacement.endsWith('*') ? replacement.slice(0, -1) : replacement
+          resolvedDir := path.resolve(baseUrl, replacementBase, pathAfterAlias)
           if (tsSys.directoryExists(resolvedDir)) {
             candidates.push({
               aliasPattern: aliasPrefix,
@@ -344,7 +344,7 @@ function resolvePathAliasDir(
       }
     } else if (importPath === pattern) {
       for (const replacement of replacements) {
-        const resolvedDir = path.resolve(baseUrl, replacement)
+        resolvedDir := path.resolve(baseUrl, replacement)
         if (tsSys.directoryExists(resolvedDir)) {
           candidates.push({
             resolvedDir,
@@ -355,20 +355,20 @@ function resolvePathAliasDir(
     }
   }
 
-  const chosenCandidate = candidates
+  chosenCandidate := candidates
     .sort((a, b) => b.aliasPattern.length - a.aliasPattern.length)
     .at(0)
 
   return chosenCandidate?.resolvedDir
 }
 
-const lineEnding = /[\n\r]+$/g
+lineEnding := /[\n\r]+$/g
 /** Get the content of the current line (with the trailing newline removed.) */
 function getCurrentLineText(document: TextDocument, position: Position): string {
   return document.getText({
     start: { character: 0, line: position.line     },
     end:   { character: 0, line: position.line + 1 },
-  }).replace(lineEnding, '');  
+  }).replace(lineEnding, '');
 }
 
 function appendClosingQuoteToPathCompletions(
@@ -403,22 +403,22 @@ function getCivetFileCompletions(
   sourcePath: string,
   position: Position
 ) {
-  const lineText = getCurrentLineText(document, position)
-  let civetFileCompletions: CompletionItem[] = []
-  const show = { 
+  lineText := getCurrentLineText(document, position)
+  civetFileCompletions: CompletionItem[] .= []
+  show := {
     relative:           false, // Civet files from relative paths
     alias:              false, // Civet files from path alias
     otherPaths:         false, // Other files, found by TypeScript
     otherLspCompletions: true, // Other suggestions, including exports
   }
-  let cursorOffsetAdjustment = 0
-  let importPath = ''
+  cursorOffsetAdjustment .= 0
+  importPath .= ''
   let closingQuoteSuffix: "'" | '"' | undefined
-  
-  const extracted = extractImportPath(lineText, position.character)
+
+  extracted := extractImportPath(lineText, position.character)
   // logger.log(JSON.stringify(extracted || { path: '' }))
   if (extracted != null) {
-    const { statement, path: pathText, qt, endqt } = extracted
+    { statement, path: pathText, qt, endqt } := extracted
 
     // require needs quotes to trigger completions
     if (statement !== 'require' || qt) {
@@ -442,60 +442,60 @@ function getCivetFileCompletions(
     }
   }
 
-  let relativeCompletionItems: CompletionItem[] = []
+  relativeCompletionItems: CompletionItem[] .= []
   if (show.relative) {
-    const sourceDir = path.dirname(sourcePath)
-    const searchDir = path.resolve(sourceDir, importPath.substring(0, importPath.lastIndexOf('/')))
-    const relativeCivetFiles = findCivetFilesInDir(searchDir)
+    sourceDir := path.dirname(sourcePath)
+    searchDir := path.resolve(sourceDir, importPath.substring(0, importPath.lastIndexOf('/')))
+    relativeCivetFiles := findCivetFilesInDir(searchDir)
     relativeCompletionItems = createCivetFileCompletions(relativeCivetFiles, sourcePath, position)
   }
-  
-  let pathAliasCompletionItems: CompletionItem[] = []
+
+  pathAliasCompletionItems: CompletionItem[] .= []
   if (show.alias) {
-    const compilationSettings = service.host.getCompilationSettings()
-    const aliasDir = resolvePathAliasDir(compilationSettings, importPath)
-    const pathAliasCivetFiles = !aliasDir ? [] : findCivetFilesInDir(aliasDir)
-    pathAliasCompletionItems = createCivetFileCompletions(pathAliasCivetFiles, sourcePath, position) 
+    compilationSettings := service.host.getCompilationSettings()
+    aliasDir := resolvePathAliasDir(compilationSettings, importPath)
+    pathAliasCivetFiles := !aliasDir ? [] : findCivetFilesInDir(aliasDir)
+    pathAliasCompletionItems = createCivetFileCompletions(pathAliasCivetFiles, sourcePath, position)
   }
 
   civetFileCompletions = relativeCompletionItems.concat(pathAliasCompletionItems)
 
-  const heuristics = { show, cursorOffsetAdjustment }
+  heuristics := { show, cursorOffsetAdjustment }
   return { civetFileCompletions, heuristics, closingQuoteSuffix }
 }
 
 // This handler provides the initial list of the completion items.
 connection.onCompletion(async ({ textDocument, position, context }) => {
 
-  const document = documents.get(textDocument.uri)
+  document := documents.get(textDocument.uri)
   assert(document)
 
   // Fast path for space trigger
-  const linePrefix = getCurrentLineText(document, position).slice(0, position.character)
-  const isLikelyImportContext = likelyImportContext(linePrefix)
+  linePrefix := getCurrentLineText(document, position).slice(0, position.character)
+  isLikelyImportContext := likelyImportContext(linePrefix)
   if (context?.triggerCharacter === ' ' && !isLikelyImportContext) {
     return []
   }
 
   await updating(textDocument)
 
-  const sourcePath = documentToSourcePath(textDocument)
+  sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
-  const service = await ensureServiceForSourcePath(sourcePath)
+  service := await ensureServiceForSourcePath(sourcePath)
   if (!service) return
-  
+
   logger.log("completion " + sourcePath + " " + (position.line+1) + ":" + position.character)
 
-  const { civetFileCompletions, heuristics, closingQuoteSuffix } = getCivetFileCompletions(
+  { civetFileCompletions, heuristics, closingQuoteSuffix } := getCivetFileCompletions(
     service, document, sourcePath, position
   )
 
   // Options for the downstream TS LSP
-  const completionOptions: GetCompletionsAtPositionOptions = {
+  completionOptions: GetCompletionsAtPositionOptions := {
     includeCompletionsForImportStatements: heuristics.show.otherPaths || isLikelyImportContext,
     includeCompletionsForModuleExports:    heuristics.show.otherLspCompletions,
     includeCompletionsWithSnippetText:     heuristics.show.otherLspCompletions,
-    
+
     allowIncompleteCompletions: true,
     includeCompletionsWithInsertText: true,
     useLabelDetailsInCompletionEntries: true,
@@ -512,17 +512,19 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
       completionOptions.triggerCharacter = '"' as ts.CompletionsTriggerCharacter
     }
   }
-  
+
   if (sourcePath.match(tsSuffix)) {
     // Non-transpiled files
-    const p = document.offsetAt(position)
-    const tslCompletions = service.getCompletionsAtPosition(sourcePath, p, completionOptions)
-    const completions = tslCompletions
-      ? convertCompletions(
-        tslCompletions, document, sourcePath, position, 
+    p := document.offsetAt(position)
+    tslCompletions := service.getCompletionsAtPosition(sourcePath, p, completionOptions)
+    completions := if tslCompletions
+      convertCompletions(
+        tslCompletions, document, sourcePath, position,
         undefined, // No sourcemap
         true, // Show file extensions (and use them in path completions)
-      ) : []
+      )
+    else
+      []
 
     return appendClosingQuoteToPathCompletions(
       civetFileCompletions.concat(completions),
@@ -530,15 +532,15 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   }
 
   // Civet files
-  
+
   // … Sourcemap the line/columns
-  const meta = service.host.getMeta(sourcePath)
+  meta := service.host.getMeta(sourcePath)
   if (!meta) return civetFileCompletions
-  const { sourcemapLines, transpiledDoc } = meta
+  { sourcemapLines, transpiledDoc } := meta
   if (!transpiledDoc) return civetFileCompletions
   if (sourcemapLines) { position = forwardMap(sourcemapLines, position); logger.log('remapped') }
-  let p = transpiledDoc.offsetAt(position)
-  
+  p .= transpiledDoc.offsetAt(position)
+
   // … Adjust the cursor position, on a case-per-case basis, to access better completions.
   //  0: Default, when sourcemap cursor position is already perfect.
   // -1: Gets inside closing quotes for import file completion.
@@ -546,12 +548,12 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   if (isLikelyImportContext) {
     // When we type `import` at EOF, sourcemapping is a bit wonky,
     // and we end up to the left of the quotes instead of inside them.
-    const start = transpiledDoc.positionAt(p)
-    const quoteRangeText = transpiledDoc.getText({
+    start := transpiledDoc.positionAt(p)
+    quoteRangeText := transpiledDoc.getText({
       start,
       end: { line: start.line, character: start.character + 3 },
     })
-    const match = quoteRangeText.match(/^( ?)(""|'')/)
+    match := quoteRangeText.match(/^( ?)(""|'')/)
     if (match) p += match[1].length + 1
   }
   // logger.log([
@@ -560,18 +562,20 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   // ].join(`<[${heuristics.cursorOffsetAdjustment}]|>`))
 
   // … Get completions from TS
-  const transpiledPath = documentToSourcePath(transpiledDoc)
-  const tslCompletions = service.getCompletionsAtPosition(
+  transpiledPath := documentToSourcePath(transpiledDoc)
+  tslCompletions := service.getCompletionsAtPosition(
     transpiledPath, p, completionOptions)
-  const completions = tslCompletions 
-    ? convertCompletions(
+  completions := if tslCompletions
+    convertCompletions(
       tslCompletions,
       transpiledDoc,
       sourcePath,
       position,
       sourcemapLines,
       true,
-    ) : []
+    )
+  else
+    []
 
   // … Return.
   return appendClosingQuoteToPathCompletions(
@@ -581,8 +585,8 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
 });
 
 connection.onCompletionResolve(async (item) => {
-  let { sourcePath, position, name, source, data } = item.data
-  const service = await ensureServiceForSourcePath(sourcePath)
+  { sourcePath, position, name, source, data } .= item.data
+  service := await ensureServiceForSourcePath(sourcePath)
   if (!service) return item
 
   let document
@@ -591,14 +595,14 @@ connection.onCompletionResolve(async (item) => {
     assert(document)
   } else {
     // use transpiled doc; forward source mapping already done
-    const meta = service.host.getMeta(sourcePath)
+    meta := service.host.getMeta(sourcePath)
     if (!meta) return item
-    const { transpiledDoc } = meta
+    { transpiledDoc } := meta
     if (!transpiledDoc) return item
     document = transpiledDoc
     sourcePath = documentToSourcePath(transpiledDoc)
   }
-  const p = document.offsetAt(position)
+  p := document.offsetAt(position)
 
   let detail
   try {
@@ -612,7 +616,7 @@ connection.onCompletionResolve(async (item) => {
   if (!detail) return item
 
   // getDetails from https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts
-  const details: string[] = []
+  details: string[] := []
   for (const action of detail.codeActions ?? []) {
     details.push(action.description)
   }
@@ -620,7 +624,7 @@ connection.onCompletionResolve(async (item) => {
   item.detail = details.join("\n\n")
 
   // getDocumentation from https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts
-  const documentations: string[] = []
+  documentations: string[] := []
   if (detail.documentation) {
     documentations.push(asPlainTextWithLinks(detail.documentation))
   }
@@ -641,9 +645,9 @@ connection.onCompletionResolve(async (item) => {
 });
 
 connection.onDefinition(async ({ textDocument, position }) => {
-  const sourcePath = documentToSourcePath(textDocument)
+  sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
-  const service = await ensureServiceForSourcePath(sourcePath)
+  service := await ensureServiceForSourcePath(sourcePath)
   if (!service) return
 
   let definitions
@@ -651,15 +655,15 @@ connection.onDefinition(async ({ textDocument, position }) => {
   await updating(textDocument)
   // Non-transpiled
   if (sourcePath.match(tsSuffix)) {
-    const document = documents.get(textDocument.uri)
+    document := documents.get(textDocument.uri)
     assert(document)
-    const p = document.offsetAt(position)
+    p := document.offsetAt(position)
     definitions = service.getDefinitionAtPosition(sourcePath, p)
   } else {
     // need to sourcemap the line/columns
-    const meta = service.host.getMeta(sourcePath)
+    meta := service.host.getMeta(sourcePath)
     if (!meta) return
-    const { sourcemapLines, transpiledDoc } = meta
+    { sourcemapLines, transpiledDoc } := meta
     if (!transpiledDoc) return
 
     // Map input hover position into output TS position
@@ -668,31 +672,31 @@ connection.onDefinition(async ({ textDocument, position }) => {
       position = forwardMap(sourcemapLines, position)
     }
 
-    const p = transpiledDoc.offsetAt(position)
-    const transpiledPath = documentToSourcePath(transpiledDoc)
+    p := transpiledDoc.offsetAt(position)
+    transpiledPath := documentToSourcePath(transpiledDoc)
     definitions = service.getDefinitionAtPosition(transpiledPath, p)
   }
 
   if (!definitions) return
 
-  const program = service.getProgram()
+  program := service.getProgram()
   assert(program)
 
-  const defs = definitions as readonly ts.DefinitionInfo[]
+  defs := definitions as readonly ts.DefinitionInfo[]
   return defs.map((definition) => {
-    let { fileName, textSpan } = definition
+    { fileName, textSpan } .= definition
     // source file as it is known to TSServer
-    const sourceFile = program.getSourceFile(fileName)
+    sourceFile := program.getSourceFile(fileName)
     if (!sourceFile) return
 
-    let start = sourceFile.getLineAndCharacterOfPosition(textSpan.start)
-    let end = sourceFile.getLineAndCharacterOfPosition(textSpan.start + textSpan.length)
-    const rawSourceName = service.getSourceFileName(fileName)
+    start .= sourceFile.getLineAndCharacterOfPosition(textSpan.start)
+    end .= sourceFile.getLineAndCharacterOfPosition(textSpan.start + textSpan.length)
+    rawSourceName := service.getSourceFileName(fileName)
 
     // Reverse map back to .civet source space if this definition is in a transpiled file
-    const meta = service.host.getMeta(rawSourceName)
+    meta := service.host.getMeta(rawSourceName)
     if (meta) {
-      const { sourcemapLines } = meta
+      { sourcemapLines } := meta
 
       if (sourcemapLines) {
         start = remapPosition(start, sourcemapLines)
@@ -712,9 +716,9 @@ connection.onDefinition(async ({ textDocument, position }) => {
 })
 
 connection.onReferences(async ({ textDocument, position }) => {
-  const sourcePath = documentToSourcePath(textDocument)
+  sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
-  const service = await ensureServiceForSourcePath(sourcePath)
+  service := await ensureServiceForSourcePath(sourcePath)
   // TODO: same source mapping as onDefinition I think...
   if (!service) return
 
@@ -722,15 +726,15 @@ connection.onReferences(async ({ textDocument, position }) => {
 
   await updating(textDocument)
   if (sourcePath.match(tsSuffix)) { // non-transpiled
-    const document = documents.get(textDocument.uri)
+    document := documents.get(textDocument.uri)
     assert(document)
-    const p = document.offsetAt(position)
+    p := document.offsetAt(position)
     references = service.getReferencesAtPosition(sourcePath, p)
   } else {
     // need to sourcemap the line/columns
-    const meta = service.host.getMeta(sourcePath)
+    meta := service.host.getMeta(sourcePath)
     if (!meta) return
-    const { sourcemapLines, transpiledDoc } = meta
+    { sourcemapLines, transpiledDoc } := meta
     if (!transpiledDoc) return
 
     // Map input hover position into output TS position
@@ -739,31 +743,31 @@ connection.onReferences(async ({ textDocument, position }) => {
       position = forwardMap(sourcemapLines, position)
     }
 
-    const p = transpiledDoc.offsetAt(position)
-    const transpiledPath = documentToSourcePath(transpiledDoc)
+    p := transpiledDoc.offsetAt(position)
+    transpiledPath := documentToSourcePath(transpiledDoc)
     references = service.getReferencesAtPosition(transpiledPath, p)
   }
 
   if (!references) return
 
-  const program = service.getProgram()
+  program := service.getProgram()
   assert(program)
 
-  const refs = references as readonly ts.ReferenceEntry[]
+  refs := references as readonly ts.ReferenceEntry[]
   return refs.map((reference) => {
-    let { fileName, textSpan } = reference
+    { fileName, textSpan } .= reference
     // source file as it is known to TSServer
-    const sourceFile = program.getSourceFile(fileName)
+    sourceFile := program.getSourceFile(fileName)
     if (!sourceFile) return
 
-    let start = sourceFile.getLineAndCharacterOfPosition(textSpan.start)
-    let end = sourceFile.getLineAndCharacterOfPosition(textSpan.start + textSpan.length)
-    const rawSourceName = service.getSourceFileName(fileName)
+    start .= sourceFile.getLineAndCharacterOfPosition(textSpan.start)
+    end .= sourceFile.getLineAndCharacterOfPosition(textSpan.start + textSpan.length)
+    rawSourceName := service.getSourceFileName(fileName)
 
     // Reverse map back to .civet source space if this definition is in a transpiled file
-    const meta = service.host.getMeta(rawSourceName)
+    meta := service.host.getMeta(rawSourceName)
     if (meta) {
-      const { sourcemapLines } = meta
+      { sourcemapLines } := meta
 
       if (sourcemapLines) {
         start = remapPosition(start, sourcemapLines)
@@ -782,10 +786,10 @@ connection.onReferences(async ({ textDocument, position }) => {
 });
 
 connection.onDocumentSymbol(async ({ textDocument }) => {
-  const sourcePath = documentToSourcePath(textDocument)
+  sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
 
-  const service = await ensureServiceForSourcePath(sourcePath)
+  service := await ensureServiceForSourcePath(sourcePath)
   if (!service) return
 
   let document, navTree, sourcemapLines
@@ -797,18 +801,18 @@ connection.onDocumentSymbol(async ({ textDocument }) => {
     navTree = service.getNavigationTree(sourcePath)
   } else {
     // Transpiled
-    const meta = service.host.getMeta(sourcePath)
+    meta := service.host.getMeta(sourcePath)
     assert(meta)
-    const { transpiledDoc } = meta
+    { transpiledDoc } := meta
     assert(transpiledDoc)
 
     document = transpiledDoc
-    const transpiledPath = documentToSourcePath(transpiledDoc)
+    transpiledPath := documentToSourcePath(transpiledDoc)
     navTree = service.getNavigationTree(transpiledPath)
     sourcemapLines = meta.sourcemapLines
   }
 
-  const items: DocumentSymbol[] = []
+  items: DocumentSymbol[] := []
 
   // The root represents the file. Ignore this when showing in the UI
   if (navTree.childItems) {
@@ -826,9 +830,9 @@ function getRenameSourceDetails(
   sourcePath: string,
   position: Position
 ) {
-  const isTypeScriptFile = sourcePath.match(tsSuffix)
+  isTypeScriptFile := sourcePath.match(tsSuffix)
   if (isTypeScriptFile) {
-    const document = documents.get(textDocumentId.uri)
+    document := documents.get(textDocumentId.uri)
     if (!document) return null
     return {
       document,
@@ -837,14 +841,14 @@ function getRenameSourceDetails(
       offset: document.offsetAt(position),
     }
   } else {
-    const meta = service.host.getMeta(sourcePath)
+    meta := service.host.getMeta(sourcePath)
     if (!meta) return null
     if (!meta.transpiledDoc || !meta.sourcemapLines) return null
 
-    const document = meta.transpiledDoc
+    document := meta.transpiledDoc
     if (!document) return null
 
-    const mappedPosition = forwardMap(meta.sourcemapLines, position)
+    mappedPosition := forwardMap(meta.sourcemapLines, position)
 
     return {
       document,
@@ -856,11 +860,11 @@ function getRenameSourceDetails(
 }
 
 function remapLocationRename(service: ResolvedService, sourceFile: ts.SourceFile, loc: ts.RenameLocation) {
-  const start = sourceFile.getLineAndCharacterOfPosition(loc.textSpan.start)
-  const end = sourceFile.getLineAndCharacterOfPosition(loc.textSpan.start + loc.textSpan.length)
+  start := sourceFile.getLineAndCharacterOfPosition(loc.textSpan.start)
+  end := sourceFile.getLineAndCharacterOfPosition(loc.textSpan.start + loc.textSpan.length)
 
-  const sourceFileName = service.getSourceFileName(loc.fileName)
-  const meta = service.host.getMeta(sourceFileName)
+  sourceFileName := service.getSourceFileName(loc.fileName)
+  meta := service.host.getMeta(sourceFileName)
 
   if (meta?.sourcemapLines) {
     return {
@@ -869,7 +873,7 @@ function remapLocationRename(service: ResolvedService, sourceFile: ts.SourceFile
       uri: pathToFileURL(sourceFileName).toString(),
     }
   }
-  
+
   return {
     start,
     end,
@@ -883,14 +887,14 @@ function createRenameLocationChanges(
   locations: readonly ts.RenameLocation[],
   newName: string
 ) {
-  const changes: Record<string, TextEdit[]> = {}
+  changes: Record<string, TextEdit[]> := {}
 
   for (const loc of locations) {
-    const sourceFile = program.getSourceFile(loc.fileName)
+    sourceFile := program.getSourceFile(loc.fileName)
     if (!sourceFile) continue
 
-    const { start, end, uri } = remapLocationRename(service, sourceFile, loc)
-    const edit: TextEdit = {
+    { start, end, uri } := remapLocationRename(service, sourceFile, loc)
+    edit: TextEdit := {
       range: { start, end },
       newText: newName,
     };
@@ -902,25 +906,25 @@ function createRenameLocationChanges(
     }
   }
 
-  return changes 
+  return changes
 }
 
 connection.onRenameRequest(async ({ textDocument, position, newName }) => {
-  const sourcePath = documentToSourcePath(textDocument)
+  sourcePath := documentToSourcePath(textDocument)
   assert(sourcePath)
 
-  const service = await ensureServiceForSourcePath(sourcePath)
+  service := await ensureServiceForSourcePath(sourcePath)
   if (!service) return
 
   await updating(textDocument)
 
-  const mapped = getRenameSourceDetails(service, textDocument, sourcePath, position)
+  mapped := getRenameSourceDetails(service, textDocument, sourcePath, position)
   if (!mapped) return
 
-  const locations = service.findRenameLocations(mapped.sourcePath, mapped.offset, false, false, {})
+  locations := service.findRenameLocations(mapped.sourcePath, mapped.offset, false, false, {})
   if (!locations || !locations.length) return
 
-  const program = service.getProgram()
+  program := service.getProgram()
   assert(program)
 
   return {
@@ -938,15 +942,15 @@ documents.onDidOpen(async ({ document }) => {
 })
 
 // Buffer up changes to documents so we don't stack transpilations and become unresponsive
-let changeQueue = new Set<TextDocument>()
+changeQueue .= new Set<TextDocument>()
 let executeTimeout: Promise<void> | undefined
-const documentUpdateStatus = new Map<string, WithResolvers<boolean>>()
+documentUpdateStatus := new Map<string, WithResolvers<boolean>>()
 async function executeQueue() {
   // Cancel any in-flight project-wide diagnostics update to avoid conflicts
   if (runningDiagnosticsUpdate) {
     runningDiagnosticsUpdate.isCanceled = true
   }
-  const changed = Array.from(changeQueue);
+  changed := Array.from(changeQueue);
   changeQueue = new Set();
   if (changed.length === 0) {
     executeTimeout = undefined;
@@ -954,14 +958,14 @@ async function executeQueue() {
   }
   logger.log(`executeQueue: Processing batch of ${changed.length} documents.`);
 
-  const docsByProject = new Map<string, { service: ResolvedService; docs: TextDocument[] }>();
+  docsByProject := new Map<string, { service: ResolvedService; docs: TextDocument[] }>();
 
   // Group documents by their project path to ensure atomic updates per project.
   for (const doc of changed) {
-    const sourcePath = documentToSourcePath(doc);
-    const projPath = getProjectPathFromSourcePath(sourcePath);
+    sourcePath := documentToSourcePath(doc);
+    projPath := getProjectPathFromSourcePath(sourcePath);
     if (!docsByProject.has(projPath)) {
-      const service = await ensureServiceForSourcePath(sourcePath);
+      service := await ensureServiceForSourcePath(sourcePath);
       if (service) docsByProject.set(projPath, { service, docs: [] });
     }
     docsByProject.get(projPath)?.docs.push(doc);
@@ -1004,7 +1008,7 @@ documents.onDidChangeContent(async ({ document }) => {
 
 async function updateDiagnosticsForDoc(document: TextDocument, service?: ResolvedService) {
   logger.log("Updating diagnostics for doc: " + document.uri)
-  const sourcePath = documentToSourcePath(document)
+  sourcePath := documentToSourcePath(document)
   assert(sourcePath)
 
   if (!service) {
@@ -1018,13 +1022,13 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
     service.host.addOrUpdateDocument(document)
   }
 
-  const getTypeScriptDiagnostics = (
+  getTypeScriptDiagnostics := (
     filePath: string,
     diagDocument: TextDocument,
     sourcemapLines?: SourcemapLines,
   ): Diagnostic[] => {
-    const diagnostics: Diagnostic[] = []
-    const diagnosticMethods = [
+    diagnostics: Diagnostic[] := []
+    diagnosticMethods := [
       "getSyntacticDiagnostics",
       "getSemanticDiagnostics",
       "getSuggestionDiagnostics",
@@ -1032,15 +1036,15 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
 
     for (const method of diagnosticMethods) {
       try {
-        const fn = service[method].bind(service)
-        const tsDiagnostics = logTiming(logger, `service.${method}`, fn)(filePath)
+        fn := service[method].bind(service)
+        tsDiagnostics := logTiming(logger, `service.${method}`, fn)(filePath)
         diagnostics.push(...tsDiagnostics.map((diagnostic) =>
           convertDiagnostic(diagnostic, diagDocument, sourcemapLines)))
       } catch (error) {
-        const errorMessage = error instanceof Error
+        errorMessage := error instanceof Error
           ? `${error.name}: ${error.message}`
           : String(error)
-        const message = `TypeScript ${method} failed for ${filePath}: ${errorMessage}`
+        message := `TypeScript ${method} failed for ${filePath}: ${errorMessage}`
         logger.error(message)
         if (error instanceof Error && error.stack) {
           logger.error(error.stack)
@@ -1063,7 +1067,7 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
 
   // Non-transpiled
   if (sourcePath.match(tsSuffix)) {
-    const diagnostics = getTypeScriptDiagnostics(sourcePath, document)
+    diagnostics := getTypeScriptDiagnostics(sourcePath, document)
 
     return connection.sendDiagnostics({
       uri: document.uri,
@@ -1072,19 +1076,19 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
   }
 
   // Transpiled file
-  const meta = service.host.getMeta(sourcePath)
+  meta := service.host.getMeta(sourcePath)
   if (!meta) {
     logger.log("no meta for " + sourcePath)
     return
   }
-  const { sourcemapLines, transpiledDoc, parseErrors, fatal } = meta
+  { sourcemapLines, transpiledDoc, parseErrors, fatal } := meta
   if (!transpiledDoc) {
     logger.log("no transpiledDoc for " + sourcePath)
     return
   }
 
-  const transpiledPath = documentToSourcePath(transpiledDoc)
-  const diagnostics: Diagnostic[] = [];
+  transpiledPath := documentToSourcePath(transpiledDoc)
+  diagnostics: Diagnostic[] := [];
 
   if (parseErrors?.length) {
     diagnostics.push(...parseErrors.map((e: Error & {line?: number, column?: number}) => {
@@ -1128,25 +1132,25 @@ let runningDiagnosticsUpdate: { isCanceled: boolean } | undefined
 
 // Asynchronously update diagnostics for all the documents
 // in a project, based on the service instance.
-const updateProjectDiagnostics = async (
+updateProjectDiagnostics := async (
   status: { isCanceled: boolean },
   service: ResolvedService
 ) => {
-  const program = service.getProgram();
+  program := service.getProgram();
   if (!program) return;
 
   // A single, short delay before starting the update for a project.
   await setTimeout(diagnosticsPropagationDelay);
 
-  const projectFiles = program.getSourceFiles();
+  projectFiles := program.getSourceFiles();
   for (const sourceFile of projectFiles) {
     if (status.isCanceled) return;
 
     // We only need to send diagnostics for files the user has open
     // TypeScript is analyzing all files in memory anyway
-    const rawFileName = service.getSourceFileName(sourceFile.fileName);
-    const docUri = URI.file(rawFileName).toString();
-    const doc = documents.get(docUri);
+    rawFileName := service.getSourceFileName(sourceFile.fileName);
+    docUri := URI.file(rawFileName).toString();
+    doc := documents.get(docUri);
     if (doc) {
       await updateDiagnosticsForDoc(doc, service);
     }
@@ -1158,15 +1162,15 @@ function scheduleUpdateDiagnostics(changedDocs: Set<TextDocument>) {
   if (runningDiagnosticsUpdate) {
     runningDiagnosticsUpdate.isCanceled = true;
   }
-  const status = { isCanceled: false };
+  status := { isCanceled: false };
   runningDiagnosticsUpdate = status;
 
   // Deduplicate by project path to avoid redundant updates.
-  const servicesToUpdate = new Set<ResolvedService>();
+  servicesToUpdate := new Set<ResolvedService>();
   for (const doc of changedDocs) {
-    const sourcePath = documentToSourcePath(doc);
-    const projPath = getProjectPathFromSourcePath(sourcePath);
-    const service = projectPathToServiceMap.get(projPath);
+    sourcePath := documentToSourcePath(doc);
+    projPath := getProjectPathFromSourcePath(sourcePath);
+    service := projectPathToServiceMap.get(projPath);
     if (service) {
       servicesToUpdate.add(service);
     }
@@ -1198,7 +1202,7 @@ function documentToSourcePath(textDocument: TextDocumentIdentifier) {
 }
 
 // https://github.com/typescript-language-server/typescript-language-server/blob/e91bd52a47c05ffd946e0abd27f242eb631b7604/src/completion.ts#L188
-const fileExtensionKindModifiers = new Set<string>([
+fileExtensionKindModifiers := new Set<string>([
   ScriptElementKindModifier.dtsModifier,
   ScriptElementKindModifier.tsModifier,
   ScriptElementKindModifier.tsxModifier,
@@ -1223,14 +1227,14 @@ function getFileExtensionModifier(kindModifiers: Set<string>): string {
 function convertCompletions(completions: ts.CompletionInfo, document: TextDocument, sourcePath: string, position: Position, sourcemapLines?: SourcemapLines, showFileExtensions?: boolean): CompletionItem[] {
   // Partial simulation of MyCompletionItem in
   // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts
-  const { entries } = completions;
+  { entries } := completions;
 
-  const items: CompletionItem[] = [];
+  items: CompletionItem[] := [];
   for (const entry of entries) {
-    const kind = getCompletionItemKind(entry.kind)
+    kind := getCompletionItemKind(entry.kind)
 
     // https://github.com/typescript-language-server/typescript-language-server/blob/e91bd52a47c05ffd946e0abd27f242eb631b7604/src/completion.ts#L106
-    const item: CompletionItem = {
+    item: CompletionItem := {
       label: entry.name || (entry.insertText ?? ''),
       kind,
       data: {
@@ -1260,9 +1264,9 @@ function convertCompletions(completions: ts.CompletionInfo, document: TextDocume
       item.sortText = entry.sortText
     }
     if (entry.replacementSpan) {
-      const { start, length } = entry.replacementSpan
-      let begin = document.positionAt(start)
-      let end = document.positionAt(start + length)
+      { start, length } := entry.replacementSpan
+      begin .= document.positionAt(start)
+      end .= document.positionAt(start + length)
       if (sourcemapLines) {
         begin = remapPosition(begin, sourcemapLines)
         end = remapPosition(end, sourcemapLines)
@@ -1273,9 +1277,9 @@ function convertCompletions(completions: ts.CompletionInfo, document: TextDocume
       }
     }
     if (entry.kindModifiers) {
-      const kindModifiers = parseKindModifier(entry.kindModifiers)
+      kindModifiers := parseKindModifier(entry.kindModifiers)
       if (kind === CompletionItemKind.File && showFileExtensions) {
-        const extension = getFileExtensionModifier(kindModifiers)
+        extension := getFileExtensionModifier(kindModifiers)
         if (!entry.name.toLowerCase().endsWith(extension)) {
           item.label += extension
           item.insertText += extension

--- a/lsp/source/server.civet
+++ b/lsp/source/server.civet
@@ -1,25 +1,25 @@
 {
-  createConnection,
-  TextDocuments,
-  Diagnostic,
-  ProposedFeatures,
-  InitializeParams,
-  DidChangeConfigurationNotification,
-  TextDocumentSyncKind,
-  InitializeResult,
-  MarkupKind,
-  TextDocumentIdentifier,
-  DocumentSymbol,
-  CompletionItem,
-  CompletionItemKind,
-  CompletionItemTag,
-  Location,
-  DiagnosticSeverity,
-  TextEdit,
+  createConnection
+  TextDocuments
+  Diagnostic
+  ProposedFeatures
+  InitializeParams
+  DidChangeConfigurationNotification
+  TextDocumentSyncKind
+  InitializeResult
+  MarkupKind
+  TextDocumentIdentifier
+  DocumentSymbol
+  CompletionItem
+  CompletionItemKind
+  CompletionItemTag
+  Location
+  DiagnosticSeverity
+  TextEdit
 } from vscode-languageserver/node
 
 {
-  TextDocument,
+  TextDocument
   type Position
 } from vscode-languageserver-textdocument
 TSService from ./lib/typescript-service.civet
@@ -28,13 +28,14 @@ TSService from ./lib/typescript-service.civet
 { asPlainTextWithLinks, tagsToMarkdown } from ./lib/textRendering.civet
 assert from assert
 path from node:path
+{ pathToFileURL } from node:url
 ts, {
-  sys as tsSys,
-  displayPartsToString,
-  GetCompletionsAtPositionOptions,
-  findConfigFile,
-  ScriptElementKindModifier,
-  SemicolonPreference,
+  sys as tsSys
+  displayPartsToString
+  GetCompletionsAtPositionOptions
+  findConfigFile
+  ScriptElementKindModifier
+  SemicolonPreference
 } from typescript
 { URI } from vscode-uri
 { setTimeout } from timers/promises
@@ -42,14 +43,14 @@ ts, {
 // Create a connection for the server, using Node's IPC as a transport.
 // Also include all preview / proposed LSP features.
 connection := createConnection(ProposedFeatures.all)
-logger := connection.console;
+logger := connection.console
 
 // Create a simple text document manager.
-documents: TextDocuments<TextDocument> := new TextDocuments(TextDocument);
+documents: TextDocuments<TextDocument> := new TextDocuments(TextDocument)
 
-hasConfigurationCapability .= false;
-hasWorkspaceFolderCapability .= false;
-// let hasDiagnosticRelatedInformationCapability = false;
+hasConfigurationCapability .= false
+hasWorkspaceFolderCapability .= false
+// let hasDiagnosticRelatedInformationCapability = false
 // comment out unused variable
 
 // Mapping from abs file path -> path of nearest applicable project path (tsconfig.json base)
@@ -63,7 +64,7 @@ projectPathToPendingPromiseMap := new Map<string, Promise<void>>()
 type ResolvedService = Awaited<ReturnType<typeof TSService>>
 projectPathToServiceMap := new Map<string, ResolvedService>()
 
-let rootUri: string | undefined, rootDir: string | undefined;
+let rootUri: string | undefined, rootDir: string | undefined
 
 getProjectPathFromSourcePath := (sourcePath: string): string =>
   projPath .= sourcePathToProjectPathMap.get(sourcePath)
@@ -94,11 +95,12 @@ getProjectPathFromSourcePath := (sourcePath: string): string =>
   sourcePathToProjectPathMap.set(sourcePath, projPath)
   return projPath
 
-ensureServiceForSourcePath := async (sourcePath: string) => {
+ensureServiceForSourcePath := (sourcePath: string) =>
   projPath := getProjectPathFromSourcePath(sourcePath)
   await projectPathToPendingPromiseMap.get(projPath)
   service .= projectPathToServiceMap.get(projPath)
   return service if service
+
   logger.log("Spawning language server for project path: " + projPath)
   service = await TSService(projPath, connection.console)
   initP := service.loadPlugins()
@@ -106,15 +108,15 @@ ensureServiceForSourcePath := async (sourcePath: string) => {
   await initP
   projectPathToServiceMap.set(projPath, service)
   projectPathToPendingPromiseMap.delete(projPath)
+
   return service
-}
 
 // TODO Propagate this to an extension setting
 diagnosticsDelay := 16;  // ms delay for primary updated file
 diagnosticsPropagationDelay := 100;  // ms delay for other files
 
 connection.onInitialize async (params: InitializeParams) =>
-  capabilities := params.capabilities;
+  capabilities := params.capabilities
 
   // Does the client support the `workspace/configuration` request?
   // If not, we fall back using global settings.
@@ -127,27 +129,27 @@ connection.onInitialize async (params: InitializeParams) =>
 
   result: InitializeResult := {
     capabilities: {
-      textDocumentSync: TextDocumentSyncKind.Incremental,
+      textDocumentSync: TextDocumentSyncKind.Incremental
       // Tell the client that this server supports code completion.
       completionProvider: {
 
         // TS extension's triggerCharacters: ['.', '"', '\'', '/', '@', '<']
         // We'll also respond to space to handle e.g. `import module`
-        triggerCharacters: ['.', '"', "'", '/', '@', '<', ' '],
+        triggerCharacters: ['.', '"', "'", '/', '@', '<', ' ']
 
-        resolveProvider: true,
-      },
+        resolveProvider: true
+      }
       // documentLinkProvider: {
       //   resolveProvider: true
-      // },
-      documentSymbolProvider: true,
-      definitionProvider: true,
-      hoverProvider: true,
-      referencesProvider: true,
-      renameProvider: true,
+      // }
+      documentSymbolProvider: true
+      definitionProvider: true
+      hoverProvider: true
+      referencesProvider: true
+      renameProvider: true
 
     }
-  };
+  }
 
   if hasWorkspaceFolderCapability
     result.capabilities.workspace =
@@ -219,21 +221,21 @@ connection.onHover(async ({ textDocument, position }) => {
   }
   return unless info
 
-  display := displayPartsToString(info.displayParts);
+  display := displayPartsToString(info.displayParts)
   // TODO: Replace Previewer
-  documentation := Previewer.plain(displayPartsToString(info.documentation));
+  documentation := Previewer.plain(displayPartsToString(info.documentation))
 
   return {
     // TODO: Range
     contents: {
-      kind: MarkupKind.Markdown,
+      kind: MarkupKind.Markdown
       value: [
-        `\`\`\`typescript\n${display}\n\`\`\``,
-        documentation ?? "",
+        `\`\`\`typescript\n${display}\n\`\`\``
+        documentation ?? ""
         ...info.tags?.map(Previewer.getTagDocumentation).filter((t) => !!t) || []
       ].join("\n\n")
     }
-  };
+  }
 })
 
 // Helpers for completing import paths.
@@ -263,41 +265,36 @@ function extractImportPath(lineText: string, cursorOffset: number) {
   return // undefined means no match
 }
 
-function findCivetFilesInDir(searchDir: string): string[] {
-  try {
-    return tsSys
+function findCivetFilesInDir(searchDir: string): string[]
+  try
+    tsSys
       .readDirectory(searchDir, [civetFileExtension], undefined, undefined, 1)
       .map((f) => path.basename(f))
-  } catch {
-    return []
-  }
-}
+  catch
+    []
 
 function createCivetFileCompletions(
-  files: string[],
-  sourcePath: string,
-  position: Position,
-): CompletionItem[] {
-  return files.map((file) => {
-    return {
-      label: file,
-      kind: CompletionItemKind.File,
-      insertText: file,
-      sortText: `${0}_${file}`,
-      data: {
-        sourcePath,
-        position,
-        name: file,
-        source: undefined,
-        data: undefined,
-      }
+  files: string[]
+  sourcePath: string
+  position: Position
+): CompletionItem[]
+  files.map (file) => {
+    label: file
+    kind: CompletionItemKind.File
+    insertText: file
+    sortText: `${0}_${file}`
+    data: {
+      sourcePath
+      position
+      name: file
+      source: undefined
+      data: undefined
     }
-  })
-}
+  }
 
 function resolvePathAliasDir(
-  compilationSettings: ts.CompilerOptions,
-  importPath: string,
+  compilationSettings: ts.CompilerOptions
+  importPath: string
 ): string | undefined {
   { baseUrl, paths } := compilationSettings
   return unless paths
@@ -315,8 +312,8 @@ function resolvePathAliasDir(
           resolvedDir := path.resolve(baseUrl, replacementBase, pathAfterAlias)
           if (tsSys.directoryExists(resolvedDir)) {
             candidates.push({
-              aliasPattern: aliasPrefix,
-              resolvedDir,
+              aliasPattern: aliasPrefix
+              resolvedDir
             })
           }
         }
@@ -326,8 +323,8 @@ function resolvePathAliasDir(
         resolvedDir := path.resolve(baseUrl, replacement)
         if (tsSys.directoryExists(resolvedDir)) {
           candidates.push({
-            resolvedDir,
-            aliasPattern: pattern,
+            resolvedDir
+            aliasPattern: pattern
           })
         }
       }
@@ -345,14 +342,14 @@ lineEnding := /[\n\r]+$/g
 /** Get the content of the current line (with the trailing newline removed.) */
 function getCurrentLineText(document: TextDocument, position: Position): string {
   return document.getText({
-    start: { character: 0, line: position.line     },
-    end:   { character: 0, line: position.line + 1 },
-  }).replace(lineEnding, '');
+    start: { character: 0, line: position.line     }
+    end:   { character: 0, line: position.line + 1 }
+  }).replace(lineEnding, '')
 }
 
 function appendClosingQuoteToPathCompletions(
-  completions: CompletionItem[],
-  closingQuoteSuffix: "'" | '"' | undefined,
+  completions: CompletionItem[]
+  closingQuoteSuffix: "'" | '"' | undefined
 ): CompletionItem[] {
   return completions unless closingQuoteSuffix
 
@@ -377,9 +374,9 @@ function appendClosingQuoteToPathCompletions(
 }
 
 function getCivetFileCompletions(
-  service: ResolvedService,
-  document: TextDocument,
-  sourcePath: string,
+  service: ResolvedService
+  document: TextDocument
+  sourcePath: string
   position: Position
 ) {
   lineText := getCurrentLineText(document, position)
@@ -452,7 +449,7 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   // Fast path for space trigger
   linePrefix := getCurrentLineText(document, position).slice(0, position.character)
   isLikelyImportContext := likelyImportContext(linePrefix)
-  if (context?.triggerCharacter === ' ' && !isLikelyImportContext) {
+  if (context?.triggerCharacter is ' ' && !isLikelyImportContext) {
     return []
   }
 
@@ -471,13 +468,13 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
 
   // Options for the downstream TS LSP
   completionOptions: GetCompletionsAtPositionOptions := {
-    includeCompletionsForImportStatements: heuristics.show.otherPaths || isLikelyImportContext,
-    includeCompletionsForModuleExports:    heuristics.show.otherLspCompletions,
-    includeCompletionsWithSnippetText:     heuristics.show.otherLspCompletions,
+    includeCompletionsForImportStatements: heuristics.show.otherPaths || isLikelyImportContext
+    includeCompletionsForModuleExports:    heuristics.show.otherLspCompletions
+    includeCompletionsWithSnippetText:     heuristics.show.otherLspCompletions
 
-    allowIncompleteCompletions: true,
-    includeCompletionsWithInsertText: true,
-    useLabelDetailsInCompletionEntries: true,
+    allowIncompleteCompletions: true
+    includeCompletionsWithInsertText: true
+    useLabelDetailsInCompletionEntries: true
   }
   if (context?.triggerKind) {
     completionOptions.triggerKind = context.triggerKind
@@ -498,7 +495,7 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
     tslCompletions := service.getCompletionsAtPosition(sourcePath, p, completionOptions)
     completions := if tslCompletions
       convertCompletions(
-        tslCompletions, document, sourcePath, position,
+        tslCompletions, document, sourcePath, position
         undefined, // No sourcemap
         true, // Show file extensions (and use them in path completions)
       )
@@ -506,7 +503,7 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
       []
 
     return appendClosingQuoteToPathCompletions(
-      civetFileCompletions.concat(completions),
+      civetFileCompletions.concat(completions)
       closingQuoteSuffix)
   }
 
@@ -527,18 +524,18 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
   // -1: Gets inside closing quotes for import file completion.
   p += heuristics.cursorOffsetAdjustment
   if (isLikelyImportContext) {
-    // When we type `import` at EOF, sourcemapping is a bit wonky,
+    // When we type `import` at EOF, sourcemapping is a bit wonky
     // and we end up to the left of the quotes instead of inside them.
     start := transpiledDoc.positionAt(p)
     quoteRangeText := transpiledDoc.getText({
-      start,
-      end: { line: start.line, character: start.character + 3 },
+      start
+      end: { line: start.line, character: start.character + 3 }
     })
     match := quoteRangeText.match(/^( ?)(""|'')/)
     if (match) p += match[1].length + 1
   }
   // logger.log([
-  //   transpiledDoc.getText().slice(0, p),
+  //   transpiledDoc.getText().slice(0, p)
   //   transpiledDoc.getText().slice(p)
   // ].join(`<[${heuristics.cursorOffsetAdjustment}]|>`))
 
@@ -548,22 +545,22 @@ connection.onCompletion(async ({ textDocument, position, context }) => {
     transpiledPath, p, completionOptions)
   completions := if tslCompletions
     convertCompletions(
-      tslCompletions,
-      transpiledDoc,
-      sourcePath,
-      position,
-      sourcemapLines,
-      true,
+      tslCompletions
+      transpiledDoc
+      sourcePath
+      position
+      sourcemapLines
+      true
     )
   else
     []
 
   // … Return.
   return appendClosingQuoteToPathCompletions(
-    civetFileCompletions.concat(completions),
+    civetFileCompletions.concat(completions)
     closingQuoteSuffix)
 
-});
+})
 
 connection.onCompletionResolve(async (item) => {
   { sourcePath, position, name, source, data } .= item.data
@@ -588,7 +585,7 @@ connection.onCompletionResolve(async (item) => {
   let detail
   try {
     detail = service.getCompletionEntryDetails(sourcePath, p, name, {
-      semicolons: SemicolonPreference.Remove,
+      semicolons: SemicolonPreference.Remove
     }, source, undefined, data)
   } catch (e) {
     logger.log("Failed to get completion details for " + name)
@@ -614,16 +611,16 @@ connection.onCompletionResolve(async (item) => {
   }
   if (documentations.length) {
     item.documentation = {
-      kind: "markdown",
-      value: documentations.join("\n\n"),
+      kind: "markdown"
+      value: documentations.join("\n\n")
       // @ts-ignore
-      baseUri: document.uri,
-      isTrusted: { enabledCommands: ["_typescript.openJsDocLink"] },
+      baseUri: document.uri
+      isTrusted: { enabledCommands: ["_typescript.openJsDocLink"] }
     }
   }
 
   return item
-});
+})
 
 connection.onDefinition(async ({ textDocument, position }) => {
   sourcePath := documentToSourcePath(textDocument)
@@ -681,10 +678,10 @@ connection.onDefinition(async ({ textDocument, position }) => {
         end = remapPosition(end, sourcemapLines)
 
     return {
-      uri: URI.file(rawSourceName).toString(),
+      uri: URI.file(rawSourceName).toString()
       range: {
-        start,
-        end,
+        start
+        end
       }
     }
   }).filter((d): d is Location => !!d)
@@ -747,14 +744,14 @@ connection.onReferences(async ({ textDocument, position }) => {
         end = remapPosition(end, sourcemapLines)
 
     return {
-      uri: URI.file(rawSourceName).toString(),
+      uri: URI.file(rawSourceName).toString()
       range: {
-        start,
-        end,
+        start
+        end
       }
     }
   }).filter((d): d is Location => !!d)
-});
+})
 
 connection.onDocumentSymbol(async ({ textDocument }) => {
   sourcePath := documentToSourcePath(textDocument)
@@ -796,39 +793,35 @@ connection.onDocumentSymbol(async ({ textDocument }) => {
 })
 
 function getRenameSourceDetails(
-  service: ResolvedService,
-  textDocumentId: TextDocumentIdentifier,
-  sourcePath: string,
+  service: ResolvedService
+  textDocumentId: TextDocumentIdentifier
+  sourcePath: string
   position: Position
-) {
+)
   isTypeScriptFile := sourcePath.match(tsSuffix)
-  if (isTypeScriptFile) {
+  if isTypeScriptFile
     document := documents.get(textDocumentId.uri)
-    return null unless document
+    return unless document
     return {
-      document,
-      position,
-      sourcePath,
-      offset: document.offsetAt(position),
+      document
+      position
+      sourcePath
+      offset: document.offsetAt(position)
     }
-  } else {
+  else
     meta := service.host.getMeta(sourcePath)
-    return null unless meta
-    return null unless meta.transpiledDoc || !meta.sourcemapLines
+    return unless meta
+    { transpiledDoc: document, sourcemapLines } := meta
+    return unless document and sourcemapLines
 
-    document := meta.transpiledDoc
-    return null unless document
-
-    mappedPosition := forwardMap(meta.sourcemapLines, position)
+    mappedPosition := forwardMap(sourcemapLines, position)
 
     return {
-      document,
-      position: mappedPosition,
-      sourcePath: documentToSourcePath(meta.transpiledDoc),
-      offset: document.offsetAt(mappedPosition),
+      document
+      position: mappedPosition
+      sourcePath: documentToSourcePath(document)
+      offset: document.offsetAt(mappedPosition)
     }
-  }
-}
 
 function remapLocationRename(service: ResolvedService, sourceFile: ts.SourceFile, loc: ts.RenameLocation) {
   start := sourceFile.getLineAndCharacterOfPosition(loc.textSpan.start)
@@ -839,23 +832,23 @@ function remapLocationRename(service: ResolvedService, sourceFile: ts.SourceFile
 
   if (meta?.sourcemapLines) {
     return {
-      start: remapPosition(start, meta.sourcemapLines),
-      end: remapPosition(end, meta.sourcemapLines),
-      uri: pathToFileURL(sourceFileName).toString(),
+      start: remapPosition(start, meta.sourcemapLines)
+      end: remapPosition(end, meta.sourcemapLines)
+      uri: pathToFileURL(sourceFileName).toString()
     }
   }
 
   return {
-    start,
-    end,
-    uri: pathToFileURL(loc.fileName).toString(),
+    start
+    end
+    uri: pathToFileURL(loc.fileName).toString()
   }
 }
 
 function createRenameLocationChanges(
-  service: ResolvedService,
-  program: ts.Program,
-  locations: readonly ts.RenameLocation[],
+  service: ResolvedService
+  program: ts.Program
+  locations: readonly ts.RenameLocation[]
   newName: string
 ) {
   changes: Record<string, TextEdit[]> := {}
@@ -866,9 +859,9 @@ function createRenameLocationChanges(
 
     { start, end, uri } := remapLocationRename(service, sourceFile, loc)
     edit: TextEdit := {
-      range: { start, end },
-      newText: newName,
-    };
+      range: { start, end }
+      newText: newName
+    }
 
     if (changes[uri]) {
       changes[uri].push(edit)
@@ -899,14 +892,14 @@ connection.onRenameRequest(async ({ textDocument, position, newName }) => {
   assert(program)
 
   return {
-    changes: createRenameLocationChanges(service, program, locations, newName),
+    changes: createRenameLocationChanges(service, program, locations, newName)
   }
 })
 
 // TODO
 documents.onDidClose(({ document }) => {
   logger.log("close " + document.uri)
-});
+})
 
 documents.onDidOpen(async ({ document }) => {
   logger.log("open " + document.uri)
@@ -921,43 +914,43 @@ async function executeQueue() {
   if (runningDiagnosticsUpdate) {
     runningDiagnosticsUpdate.isCanceled = true
   }
-  changed := Array.from(changeQueue);
-  changeQueue = new Set();
+  changed := Array.from(changeQueue)
+  changeQueue = new Set()
   if (changed.length === 0) {
-    executeTimeout = undefined;
-    return;
+    executeTimeout = undefined
+    return
   }
-  logger.log(`executeQueue: Processing batch of ${changed.length} documents.`);
+  logger.log(`executeQueue: Processing batch of ${changed.length} documents.`)
 
-  docsByProject := new Map<string, { service: ResolvedService; docs: TextDocument[] }>();
+  docsByProject := new Map<string, { service: ResolvedService; docs: TextDocument[] }>()
 
   // Group documents by their project path to ensure atomic updates per project.
   for (const doc of changed) {
-    sourcePath := documentToSourcePath(doc);
-    projPath := getProjectPathFromSourcePath(sourcePath);
+    sourcePath := documentToSourcePath(doc)
+    projPath := getProjectPathFromSourcePath(sourcePath)
     if (!docsByProject.has(projPath)) {
-      service := await ensureServiceForSourcePath(sourcePath);
-      if (service) docsByProject.set(projPath, { service, docs: [] });
+      service := await ensureServiceForSourcePath(sourcePath)
+      if (service) docsByProject.set(projPath, { service, docs: [] })
     }
-    docsByProject.get(projPath)?.docs.push(doc);
+    docsByProject.get(projPath)?.docs.push(doc)
   }
 
   for (const { service, docs } of docsByProject.values()) {
     // Phase 1: Stage all changes within this project.
-    docs.forEach((doc) => service.host.addOrUpdateDocument(doc));
+    docs.forEach((doc) => service.host.addOrUpdateDocument(doc))
 
     // Phase 2: Analyze all staged documents within this project.
     for (const doc of docs) {
-      await updateDiagnosticsForDoc(doc, service);
-      documentUpdateStatus.get(doc.uri)?.resolve(true);
-      Promise.resolve().then(() => documentUpdateStatus.delete(doc.uri));
+      await updateDiagnosticsForDoc(doc, service)
+      documentUpdateStatus.get(doc.uri)?.resolve(true)
+      Promise.resolve().then(() => documentUpdateStatus.delete(doc.uri))
     }
   }
   executeTimeout = undefined
   if (changeQueue.size) {
     scheduleExecuteQueue()
   } else {
-    scheduleUpdateDiagnostics(new Set(changed));
+    scheduleUpdateDiagnostics(new Set(changed))
   }
 }
 async function scheduleExecuteQueue() {
@@ -975,7 +968,7 @@ documents.onDidChangeContent(async ({ document }) => {
   documentUpdateStatus.set(document.uri, withResolvers())
   changeQueue.add(document)
   scheduleExecuteQueue()
-});
+})
 
 async function updateDiagnosticsForDoc(document: TextDocument, service?: ResolvedService) {
   logger.log("Updating diagnostics for doc: " + document.uri)
@@ -994,15 +987,15 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
   }
 
   getTypeScriptDiagnostics := (
-    filePath: string,
-    diagDocument: TextDocument,
-    sourcemapLines?: SourcemapLines,
+    filePath: string
+    diagDocument: TextDocument
+    sourcemapLines?: SourcemapLines
   ): Diagnostic[] => {
     diagnostics: Diagnostic[] := []
     diagnosticMethods := [
-      "getSyntacticDiagnostics",
-      "getSemanticDiagnostics",
-      "getSuggestionDiagnostics",
+      "getSyntacticDiagnostics"
+      "getSemanticDiagnostics"
+      "getSuggestionDiagnostics"
     ] as const
 
     for (const method of diagnosticMethods) {
@@ -1021,13 +1014,13 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
           logger.error(error.stack)
         }
         diagnostics.push({
-          severity: DiagnosticSeverity.Error,
+          severity: DiagnosticSeverity.Error
           range: {
-            start: { line: 0, character: 0 },
-            end: { line: 0, character: 1 },
-          },
-          message,
-          source: 'civet',
+            start: { line: 0, character: 0 }
+            end: { line: 0, character: 1 }
+          }
+          message
+          source: 'civet'
         })
         break
       }
@@ -1041,7 +1034,7 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
     diagnostics := getTypeScriptDiagnostics(sourcePath, document)
 
     return connection.sendDiagnostics({
-      uri: document.uri,
+      uri: document.uri
       diagnostics
     })
   }
@@ -1059,7 +1052,7 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
   }
 
   transpiledPath := documentToSourcePath(transpiledDoc)
-  diagnostics: Diagnostic[] := [];
+  diagnostics: Diagnostic[] := []
 
   if (parseErrors?.length) {
     diagnostics.push(...parseErrors.map((e: Error & {line?: number, column?: number}) => {
@@ -1075,13 +1068,13 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
       }
 
       return {
-        severity: DiagnosticSeverity.Error,
+        severity: DiagnosticSeverity.Error
         // Don't need to transform the range, it's already in the source file coordinates
         range: {
-          start,
-          end,
-        },
-        message,
+          start
+          end
+        }
+        message
         source: 'civet'
       }
     }).filter((x) => !!x))
@@ -1091,7 +1084,7 @@ async function updateDiagnosticsForDoc(document: TextDocument, service?: Resolve
   }
 
   connection.sendDiagnostics({
-    uri: document.uri,
+    uri: document.uri
     diagnostics
   })
 
@@ -1104,26 +1097,26 @@ let runningDiagnosticsUpdate: { isCanceled: boolean } | undefined
 // Asynchronously update diagnostics for all the documents
 // in a project, based on the service instance.
 updateProjectDiagnostics := async (
-  status: { isCanceled: boolean },
+  status: { isCanceled: boolean }
   service: ResolvedService
 ) => {
-  program := service.getProgram();
+  program := service.getProgram()
   return unless program
 
   // A single, short delay before starting the update for a project.
-  await setTimeout(diagnosticsPropagationDelay);
+  await setTimeout(diagnosticsPropagationDelay)
 
-  projectFiles := program.getSourceFiles();
+  projectFiles := program.getSourceFiles()
   for (const sourceFile of projectFiles) {
     return if status.isCanceled
 
     // We only need to send diagnostics for files the user has open
     // TypeScript is analyzing all files in memory anyway
-    rawFileName := service.getSourceFileName(sourceFile.fileName);
-    docUri := URI.file(rawFileName).toString();
-    doc := documents.get(docUri);
+    rawFileName := service.getSourceFileName(sourceFile.fileName)
+    docUri := URI.file(rawFileName).toString()
+    doc := documents.get(docUri)
     if (doc) {
-      await updateDiagnosticsForDoc(doc, service);
+      await updateDiagnosticsForDoc(doc, service)
     }
   }
 }
@@ -1131,19 +1124,19 @@ updateProjectDiagnostics := async (
 // Schedule an update of diagnostics for all projects affected by recent changes.
 function scheduleUpdateDiagnostics(changedDocs: Set<TextDocument>) {
   if (runningDiagnosticsUpdate) {
-    runningDiagnosticsUpdate.isCanceled = true;
+    runningDiagnosticsUpdate.isCanceled = true
   }
-  status := { isCanceled: false };
-  runningDiagnosticsUpdate = status;
+  status := { isCanceled: false }
+  runningDiagnosticsUpdate = status
 
   // Deduplicate by project path to avoid redundant updates.
-  servicesToUpdate := new Set<ResolvedService>();
+  servicesToUpdate := new Set<ResolvedService>()
   for (const doc of changedDocs) {
-    sourcePath := documentToSourcePath(doc);
-    projPath := getProjectPathFromSourcePath(sourcePath);
-    service := projectPathToServiceMap.get(projPath);
+    sourcePath := documentToSourcePath(doc)
+    projPath := getProjectPathFromSourcePath(sourcePath)
+    service := projectPathToServiceMap.get(projPath)
     if (service) {
-      servicesToUpdate.add(service);
+      servicesToUpdate.add(service)
     }
   }
 
@@ -1171,44 +1164,43 @@ function documentToSourcePath(textDocument: TextDocumentIdentifier)
 
 // https://github.com/typescript-language-server/typescript-language-server/blob/e91bd52a47c05ffd946e0abd27f242eb631b7604/src/completion.ts#L188
 fileExtensionKindModifiers := new Set<string>([
-  ScriptElementKindModifier.dtsModifier,
-  ScriptElementKindModifier.tsModifier,
-  ScriptElementKindModifier.tsxModifier,
-  ScriptElementKindModifier.jsModifier,
-  ScriptElementKindModifier.jsxModifier,
-  ScriptElementKindModifier.jsonModifier,
-  ScriptElementKindModifier.dmtsModifier,
-  ScriptElementKindModifier.mtsModifier,
-  ScriptElementKindModifier.mjsModifier,
-  ScriptElementKindModifier.dctsModifier,
-  ScriptElementKindModifier.ctsModifier,
-  ScriptElementKindModifier.cjsModifier,
+  ScriptElementKindModifier.dtsModifier
+  ScriptElementKindModifier.tsModifier
+  ScriptElementKindModifier.tsxModifier
+  ScriptElementKindModifier.jsModifier
+  ScriptElementKindModifier.jsxModifier
+  ScriptElementKindModifier.jsonModifier
+  ScriptElementKindModifier.dmtsModifier
+  ScriptElementKindModifier.mtsModifier
+  ScriptElementKindModifier.mjsModifier
+  ScriptElementKindModifier.dctsModifier
+  ScriptElementKindModifier.ctsModifier
+  ScriptElementKindModifier.cjsModifier
 ])
 
-function getFileExtensionModifier(kindModifiers: Set<string>): string {
-  for (const modifier of kindModifiers) {
+function getFileExtensionModifier(kindModifiers: Set<string>): string
+  for modifier of kindModifiers
     return modifier if fileExtensionKindModifiers.has(modifier)
-  }
+
   return ''
-}
 
 function convertCompletions(completions: ts.CompletionInfo, document: TextDocument, sourcePath: string, position: Position, sourcemapLines?: SourcemapLines, showFileExtensions?: boolean): CompletionItem[] {
   // Partial simulation of MyCompletionItem in
   // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/completions.ts
-  { entries } := completions;
+  { entries } := completions
 
-  items: CompletionItem[] := [];
+  items: CompletionItem[] := []
   for (const entry of entries) {
     kind := getCompletionItemKind(entry.kind)
 
     // https://github.com/typescript-language-server/typescript-language-server/blob/e91bd52a47c05ffd946e0abd27f242eb631b7604/src/completion.ts#L106
     item: CompletionItem := {
-      label: entry.name || (entry.insertText ?? ''),
-      kind,
+      label: entry.name || (entry.insertText ?? '')
+      kind
       data: {
-        sourcePath, position,
-        name: entry.name, source: entry.source, data: entry.data,
-        kindModifiers: entry.kindModifiers,
+        sourcePath, position
+        name: entry.name, source: entry.source, data: entry.data
+        kindModifiers: entry.kindModifiers
       }
     }
 
@@ -1239,8 +1231,8 @@ function convertCompletions(completions: ts.CompletionInfo, document: TextDocume
         begin = remapPosition(begin, sourcemapLines)
         end = remapPosition(end, sourcemapLines)
       item.textEdit = {
-        range: { start: begin, end },
-        newText: entry.insertText!,
+        range: { start: begin, end }
+        newText: entry.insertText!
       }
     }
     if (entry.kindModifiers) {
@@ -1260,7 +1252,7 @@ function convertCompletions(completions: ts.CompletionInfo, document: TextDocume
       }
     }
 
-    items.push(item);
+    items.push(item)
   }
 
   return items

--- a/lsp/test/rendering.civet
+++ b/lsp/test/rendering.civet
@@ -1,0 +1,164 @@
+import assert from assert
+
+{ getTagDocumentation, plain } from ../source/lib/previewer.civet
+{ asPlainText, asPlainTextWithLinks, tagsToMarkdown } from ../source/lib/textRendering.civet
+
+describe "previewer", ->
+  describe "plain", ->
+    it "passes through a plain string", ->
+      assert.equal plain("hello world"), "hello world"
+
+    it "joins SymbolDisplayParts", ->
+      parts := [{text: "foo"}, {text: "bar"}] as any
+      assert.equal plain(parts), "foobar"
+
+    it "converts {@link url} to markdown link", ->
+      result := plain("{@link https://example.com}")
+      assert.equal result, "[https://example.com](https://example.com)"
+
+    it "converts {@linkcode url text} to backtick link", ->
+      result := plain("{@linkcode https://example.com My Link}")
+      assert.equal result, "[`My Link`](https://example.com)"
+
+  describe "getTagDocumentation", ->
+    it "renders @param with doc", ->
+      tag := { name: "param", text: [{kind: "text", text: "x - the value"}] } as any
+      result := getTagDocumentation(tag)
+      assert result?.includes("@param")
+      assert result?.includes("`x`")
+
+    it "renders @param without doc (label only)", ->
+      tag := { name: "param", text: [{kind: "text", text: "x"}] } as any
+      result := getTagDocumentation(tag)
+      assert result?.includes("@param")
+      assert result?.includes("`x`")
+
+    it "renders generic tag with text on same line", ->
+      tag := { name: "since", text: [{kind: "text", text: "1.0.0"}] } as any
+      result := getTagDocumentation(tag)
+      assert.equal result, "*@since* — 1.0.0"
+
+    it "renders generic tag with multiline text", ->
+      tag := { name: "remarks", text: [{kind: "text", text: "line1\nline2"}] } as any
+      result := getTagDocumentation(tag)
+      assert result?.startsWith("*@remarks*  \n")
+
+    it "returns just label when tag has no text", ->
+      tag := { name: "readonly", text: [] } as any
+      result := getTagDocumentation(tag)
+      assert.equal result, "*@readonly*"
+
+    it "renders @example as code block", ->
+      tag := { name: "example", text: [{kind: "text", text: "foo()"}] } as any
+      result := getTagDocumentation(tag)
+      assert result?.includes("```")
+
+    it "renders @author stripping email", ->
+      tag := { name: "author", text: [{kind: "text", text: "Jane Doe <jane@example.com>"}] } as any
+      result := getTagDocumentation(tag)
+      assert result?.includes("Jane Doe")
+      assert !result?.includes("<jane@example.com>")
+
+    it "renders @default as code block", ->
+      tag := { name: "default", text: [{kind: "text", text: "42"}] } as any
+      result := getTagDocumentation(tag)
+      assert result?.includes("```")
+      assert result?.includes("42")
+
+describe "textRendering", ->
+  describe "asPlainText", ->
+    it "returns string as-is", ->
+      assert.equal asPlainText("hello"), "hello"
+
+    it "joins display parts", ->
+      parts := [{text: "number"}, {text: " | "}, {text: "string"}] as any
+      assert.equal asPlainText(parts), "number | string"
+
+  describe "asPlainTextWithLinks", ->
+    it "returns empty string for falsy input", ->
+      assert.equal asPlainTextWithLinks(undefined), ""
+
+    it "returns string input as-is", ->
+      assert.equal asPlainTextWithLinks("hello"), "hello"
+
+    it "joins text parts", ->
+      parts := [
+        {kind: "text", text: "See "}
+        {kind: "text", text: "docs"}
+      ] as any
+      assert.equal asPlainTextWithLinks(parts), "See docs"
+
+    it "passes non-link parts through unchanged", ->
+      parts := [
+        {kind: "text", text: "before "}
+        {kind: "link", text: "{@link "}
+        {kind: "linkName", text: "SomeClass"}
+        {kind: "link", text: "}"}
+        {kind: "text", text: " after"}
+      ] as any
+      result := asPlainTextWithLinks(parts)
+      // Non-link "text" parts are always appended directly
+      assert.ok result.includes("before")
+      assert.ok result.includes("after")
+
+  describe "tagsToMarkdown", ->
+    it "joins multiple tags with separator", ->
+      tags := [
+        { name: "param", text: [{kind: "text", text: "x - first"}] }
+        { name: "param", text: [{kind: "text", text: "y - second"}] }
+      ] as any
+      result := tagsToMarkdown(tags)
+      assert result.includes("@param")
+      assert result.includes("`x`")
+      assert result.includes("`y`")
+
+  // getTagDocumentation is private; test via tagsToMarkdown
+  tagMd := (tag: any) => tagsToMarkdown([tag])
+
+  describe "tag rendering (via tagsToMarkdown)", ->
+    it "renders @param with doc inline", ->
+      tag := { name: "param", text: [{kind: "text", text: "x - the value"}] } as any
+      result := tagMd(tag)
+      assert result.includes("@param") and result.includes("`x`")
+
+    it "renders @returns with text", ->
+      tag := { name: "returns", text: [{kind: "text", text: "the result"}] } as any
+      assert tagMd(tag).includes("@returns")
+
+    it "omits @returns when text is empty", ->
+      tag := { name: "returns", text: [] } as any
+      assert.equal tagMd(tag), ""
+
+    it "renders @template with type params", ->
+      tag := {
+        name: "template"
+        text: [
+          { kind: "typeParameterName", text: "T" }
+          { kind: "text", text: " the type" }
+        ]
+      } as any
+      assert tagMd(tag).includes("T")
+
+    it "renders @example as code block", ->
+      tag := { name: "example", text: [{kind: "text", text: "foo()"}] } as any
+      result := tagMd(tag)
+      assert result.includes("```") and result.includes("foo()")
+
+    it "renders @example with caption", ->
+      tag := { name: "example", text: [{kind: "text", text: "<caption>My Example</caption>\nfoo()"}] } as any
+      result := tagMd(tag)
+      assert result.includes("My Example") and result.includes("foo()")
+
+    it "renders @author stripping angle brackets from email", ->
+      tag := { name: "author", text: [{kind: "text", text: "Jane Doe <jane@example.com>"}] } as any
+      result := tagMd(tag)
+      assert result.includes("Jane Doe") and !result.includes("<jane@example.com>")
+
+    it "renders @author without email as-is", ->
+      tag := { name: "author", text: [{kind: "text", text: "Jane Doe"}] } as any
+      assert tagMd(tag).includes("Jane Doe")
+
+    it "renders @default as code block", ->
+      tag := { name: "default", text: [{kind: "text", text: "42"}] } as any
+      result := tagMd(tag)
+      assert result.includes("```") and result.includes("42")

--- a/lsp/test/service.civet
+++ b/lsp/test/service.civet
@@ -1,38 +1,88 @@
-import TSService from "../source/lib/typescript-service.mjs"
+import TSService from "../source/lib/typescript-service.civet"
 import { pathToFileURL } from "url"
 import { TextDocument } from "vscode-languageserver-textdocument"
 import fs from "fs"
+import path from "path"
 
-{ forwardMap } from ../source/lib/util.mjs
+{ forwardMap } from ../source/lib/util.civet
 
 assert from assert
 
-loadFile := async (service: Awaited<ReturnType<typeof TSService>>, path: string) ->
+loadFile := (service: Awaited<ReturnType<typeof TSService>>, path: string) ->
   document := TextDocument.create(pathToFileURL(path).href, "civet", 0, fs.readFileSync(path, "utf8"))
   service.host.addOrUpdateDocument(document)
+
+projectURL := pathToFileURL("./integration/project-test/").href
+aPath := "./integration/project-test/a.civet"
+bPath := "./integration/project-test/b.civet"
 
 describe "ts service", ->
   @timeout 5000
   it "should launch ts service", async ->
-    service := await TSService(pathToFileURL("./integration/project-test/").href)
+    service := await TSService(projectURL)
     await service.loadPlugins()
 
-    filePath := "./integration/project-test/a.civet"
-    await loadFile(service, filePath)
+    await loadFile(service, aPath)
 
-    diagnostics := service.getSemanticDiagnostics(filePath + ".tsx")
+    diagnostics := service.getSemanticDiagnostics(aPath + ".tsx")
 
     console.log diagnostics
     // console.log service.host.getScriptFileNames()
 
     assert.equal diagnostics.length, 0
 
-    {transpiledDoc, sourcemapLines} := service.host.getMeta(filePath)!
+    {transpiledDoc, sourcemapLines} := service.host.getMeta(aPath)!
 
     position := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {
       line: 0
       character: 0
     })
-    info := service.getQuickInfoAtPosition(filePath + ".tsx", position)
+    info := service.getQuickInfoAtPosition(aPath + ".tsx", position)
 
     assert info
+
+describe "ts service features", ->
+  @timeout 10000
+
+  service .= null as any as Awaited<ReturnType<typeof TSService>>
+
+  before async ->
+    service = await TSService(projectURL)
+    await service.loadPlugins()
+    loadFile(service, aPath)
+    loadFile(service, bPath)
+
+  it "should go to definition cross-file", async ->
+    {transpiledDoc, sourcemapLines} := service.host.getMeta(aPath)!
+    // "b" is at character 0 on line 0 of a.civet: `b, {b as b2} from ./b.civet`
+    offset := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {line: 0, character: 0})
+    defs := service.getDefinitionAtPosition(aPath + ".tsx", offset)
+    assert.ok defs?.length, "expected at least one definition"
+    rawName := service.getSourceFileName(defs![0].fileName)
+    assert rawName.endsWith("b.civet"), `expected definition in b.civet, got ${rawName}`
+
+  it "should return completions at console.", async ->
+    {transpiledDoc, sourcemapLines} := service.host.getMeta(aPath)!
+    src := fs.readFileSync(aPath, "utf8")
+    lines := src.split("\n")
+    consoleLine := lines.findIndex (l) => l.includes("console.log")
+    consoleCol := lines[consoleLine].indexOf("console.") + "console.".length
+    offset := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {line: consoleLine, character: consoleCol})
+    completions := service.getCompletionsAtPosition(aPath + ".tsx", offset, {})
+    assert.ok completions?.entries.some((e) => e.name === "log"), "expected 'log' in console completions"
+
+  it "should detect type errors and map to civet positions", async ->
+    // Use absolute path so addOrUpdateDocument and getMeta agree on the key
+    errorPath := path.resolve("./integration/project-test/error.civet")
+    errorDoc := TextDocument.create(pathToFileURL(errorPath).href, "civet", 0, 'x: number := "not a number"')
+    service.host.addOrUpdateDocument(errorDoc)
+    diagnostics := service.getSemanticDiagnostics(errorPath + ".tsx")
+    assert.ok diagnostics.length > 0, "expected type error diagnostic"
+    // Verify it's the right error
+    msg := typeof diagnostics[0].messageText === "string"
+      ? diagnostics[0].messageText
+      : diagnostics[0].messageText.messageText
+    assert.match msg, /not assignable/
+    // Verify sourcemap lines are populated (needed for diagnostic remapping)
+    {sourcemapLines} := service.host.getMeta(errorPath)!
+    assert.ok sourcemapLines, "expected sourcemap lines"

--- a/lsp/test/service.civet
+++ b/lsp/test/service.civet
@@ -8,6 +8,11 @@ import path from "path"
 
 assert from assert
 
+nullLogger :=
+  log: ->
+  info: ->
+  error: ->
+
 loadFile := (service: Awaited<ReturnType<typeof TSService>>, path: string) ->
   document := TextDocument.create(pathToFileURL(path).href, "civet", 0, fs.readFileSync(path, "utf8"))
   service.host.addOrUpdateDocument(document)
@@ -17,21 +22,18 @@ aPath := "./integration/project-test/a.civet"
 bPath := "./integration/project-test/b.civet"
 
 describe "ts service", ->
-  @timeout 5000
   it "should launch ts service", async ->
-    service := await TSService(projectURL)
+    service := await TSService(projectURL, nullLogger)
     await service.loadPlugins()
 
-    await loadFile(service, aPath)
+    loadFile(service, aPath)
 
     diagnostics := service.getSemanticDiagnostics(aPath + ".tsx")
 
-    console.log diagnostics
-    // console.log service.host.getScriptFileNames()
-
     assert.equal diagnostics.length, 0
 
-    {transpiledDoc, sourcemapLines} := service.host.getMeta(aPath)!
+    { transpiledDoc, sourcemapLines } := service.host.getMeta(aPath)!
+    assert sourcemapLines
 
     position := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {
       line: 0
@@ -42,34 +44,38 @@ describe "ts service", ->
     assert info
 
 describe "ts service features", ->
-  @timeout 10000
-
   service .= null as any as Awaited<ReturnType<typeof TSService>>
 
   before async ->
-    service = await TSService(projectURL)
+    service = await TSService(projectURL, nullLogger)
     await service.loadPlugins()
     loadFile(service, aPath)
     loadFile(service, bPath)
 
   it "should go to definition cross-file", async ->
-    {transpiledDoc, sourcemapLines} := service.host.getMeta(aPath)!
+    { transpiledDoc, sourcemapLines } := service.host.getMeta(aPath)!
+    assert sourcemapLines
+
     // "b" is at character 0 on line 0 of a.civet: `b, {b as b2} from ./b.civet`
     offset := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {line: 0, character: 0})
     defs := service.getDefinitionAtPosition(aPath + ".tsx", offset)
-    assert.ok defs?.length, "expected at least one definition"
+    assert defs?.length
+
     rawName := service.getSourceFileName(defs![0].fileName)
     assert rawName.endsWith("b.civet"), `expected definition in b.civet, got ${rawName}`
 
   it "should return completions at console.", async ->
-    {transpiledDoc, sourcemapLines} := service.host.getMeta(aPath)!
+    { transpiledDoc, sourcemapLines } := service.host.getMeta(aPath)!
+    assert sourcemapLines
+
     src := fs.readFileSync(aPath, "utf8")
     lines := src.split("\n")
     consoleLine := lines.findIndex (l) => l.includes("console.log")
     consoleCol := lines[consoleLine].indexOf("console.") + "console.".length
     offset := transpiledDoc!.offsetAt forwardMap(sourcemapLines, {line: consoleLine, character: consoleCol})
     completions := service.getCompletionsAtPosition(aPath + ".tsx", offset, {})
-    assert.ok completions?.entries.some((e) => e.name === "log"), "expected 'log' in console completions"
+
+    assert completions?.entries.some .name is "log"
 
   it "should detect type errors and map to civet positions", async ->
     // Use absolute path so addOrUpdateDocument and getMeta agree on the key
@@ -77,12 +83,112 @@ describe "ts service features", ->
     errorDoc := TextDocument.create(pathToFileURL(errorPath).href, "civet", 0, 'x: number := "not a number"')
     service.host.addOrUpdateDocument(errorDoc)
     diagnostics := service.getSemanticDiagnostics(errorPath + ".tsx")
-    assert.ok diagnostics.length > 0, "expected type error diagnostic"
+
+    assert diagnostics.length > 0
+
     // Verify it's the right error
-    msg := typeof diagnostics[0].messageText === "string"
+    msg := diagnostics[0].messageText <? "string"
       ? diagnostics[0].messageText
       : diagnostics[0].messageText.messageText
     assert.match msg, /not assignable/
     // Verify sourcemap lines are populated (needed for diagnostic remapping)
-    {sourcemapLines} := service.host.getMeta(errorPath)!
-    assert.ok sourcemapLines, "expected sourcemap lines"
+    { sourcemapLines } := service.host.getMeta(errorPath)!
+
+    assert sourcemapLines
+
+  it "should compute change range when a civet file is updated", ->
+    absPath := path.resolve(aPath)
+    transpiledPath := absPath + ".tsx"
+
+    // First snapshot
+    snap1 := service.host.getScriptSnapshot(transpiledPath)
+    assert snap1, "expected first snapshot"
+
+    // Prepend a comment so the transpiled output differs from the start
+    // (avoids the "prefix-only" case where fullDiffTextChangeRange returns undefined)
+    origContent := fs.readFileSync(absPath, "utf8")
+    updatedDoc := TextDocument.create(pathToFileURL(absPath).href, "civet", 1, "// extra\n" + origContent)
+    service.host.addOrUpdateDocument(updatedDoc)
+
+    // Second snapshot — new Snap instance with updated transpiled text
+    snap2 := service.host.getScriptSnapshot(transpiledPath)
+    assert snap2, "expected second snapshot"
+    assert.notStrictEqual snap2, snap1
+
+    // Exercises fullDiffTextChangeRange and Snap.getChangeRange (also createOrUpdateMeta update branch)
+    changeRange := snap2.getChangeRange(snap1)
+    assert changeRange, "expected a defined change range when content differs from the start"
+    assert.ok changeRange!.span.start >= 0
+    assert.ok changeRange!.newLength >= 0
+
+    // Calling again returns the cached result
+    assert.strictEqual snap2.getChangeRange(snap1), changeRange
+
+  it "should add a non-transpiled ts document without error", ->
+    tsPath := path.resolve("./integration/project-test/t.ts")
+    tsDoc := TextDocument.create(pathToFileURL(tsPath).href, "typescript", 0, "const x = 1")
+    service.host.addOrUpdateDocument(tsDoc)
+    // No transpiler for .ts — exercises the plain-document branch
+
+  it "should return undefined meta for a plain ts path", ->
+    tsPath := path.resolve("./integration/project-test/t.ts")
+    meta := service.host.getMeta(tsPath)
+    // No meta recorded for non-transpiled files — exercises getTranspiledPath fallback
+    assert.equal meta, undefined
+
+  it "should call writeFile without error", ->
+    service.host.writeFile!("out.js", "const x = 1;")
+    // writeFile just delegates to logger.log; no assertion needed beyond no throw
+
+  it "should return original filename when target extension does not match transpiler target", ->
+    // .civet transpiler targets .tsx; passing .civet.js means target (.js) != .tsx
+    // so remapFileName falls through to the final return (line 557)
+    result := service.getSourceFileName("foo.civet.js")
+    assert.equal result, "foo.civet.js"
+
+  it "should return undefined change range when snapshots have identical text", ->
+    // Getting the same cached snapshot and calling getChangeRange on itself
+    // exercises fullDiffTextChangeRange(text, text) → all chars match → return undefined (line 586)
+    transpiledPath := path.resolve(aPath) + ".tsx"
+    snap := service.host.getScriptSnapshot(transpiledPath)
+    assert snap
+
+    result := snap!.getChangeRange(snap!)
+    assert.equal result, undefined
+
+  it "should compute change range when content changes in the middle", ->
+    // Two civet snapshots differing only in the middle (shared prefix and suffix)
+    // exercises the break in the suffix-scan loop (line 572)
+    snapPath := path.resolve("./integration/project-test/snap-test.civet")
+    snapTranspiledPath := snapPath + ".tsx"
+
+    doc1 := TextDocument.create(pathToFileURL(snapPath).href, "civet", 0, "x := 1")
+    service.host.addOrUpdateDocument(doc1)
+    snap1 := service.host.getScriptSnapshot(snapTranspiledPath)
+
+    assert snap1
+
+    doc2 := TextDocument.create(pathToFileURL(snapPath).href, "civet", 1, "x := 2")
+    service.host.addOrUpdateDocument(doc2)
+    snap2 := service.host.getScriptSnapshot(snapTranspiledPath)
+
+    assert snap2
+    assert.notStrictEqual snap1, snap2
+
+    // "const x = 1;" vs "const x = 2;" — common suffix ";" hits break after one match
+    changeRange := snap2!.getChangeRange(snap1!)
+
+    assert changeRange, "expected a change range for middle-of-string diff"
+    assert changeRange!.span.start >= 0
+
+  it "should store fatal parse error in meta when transpiler throws", ->
+    // Null bytes cause Civet.compile to throw rather than returning errors in the array
+    // exercises the catch block in doTranspileAndUpdateMeta (lines 352-355)
+    errorPath := path.resolve("./integration/project-test/throw-test.civet")
+    throwDoc := TextDocument.create(pathToFileURL(errorPath).href, "civet", 0, "\x00invalid")
+    service.host.addOrUpdateDocument(throwDoc)
+    meta := service.host.getMeta(errorPath)
+
+    assert meta, "expected meta to be recorded after a compile throw"
+    assert meta!.fatal, "expected fatal=true when compile throws"
+    assert meta!.parseErrors?.length, "expected parse errors to be recorded"

--- a/lsp/test/util-extra.civet
+++ b/lsp/test/util-extra.civet
@@ -1,0 +1,143 @@
+import assert from assert
+import { TextDocument } from vscode-languageserver-textdocument
+import ts from typescript
+
+{
+  convertNavTree,
+  convertDiagnostic,
+  withResolvers,
+  makeRange,
+  getCompletionItemKind,
+} from ../source/lib/util.civet
+
+import { CompletionItemKind, DiagnosticSeverity } from vscode-languageserver
+import { ScriptElementKind, DiagnosticCategory } from typescript
+
+describe "util (extra)", ->
+  describe "convertNavTree", ->
+    // Minimal TextDocument for offset calculations
+    doc := TextDocument.create("file:///test.ts", "typescript", 0, "const x = 1\nconst y = 2\n")
+
+    it "returns false and skips alias items", ->
+      item := {
+        text: "alias"
+        kind: ScriptElementKind.alias
+        kindModifiers: ""
+        spans: [{ start: 0, length: 5 }]
+        childItems: []
+        indent: 0
+        nameSpan: undefined
+      } as any
+      output: any[] := []
+      result := convertNavTree(item, output, doc, undefined)
+      assert.equal result, false
+      assert.equal output.length, 0
+
+    it "returns false for empty/unnamed items", ->
+      item := {
+        text: ""
+        kind: ScriptElementKind.constElement
+        kindModifiers: ""
+        spans: [{ start: 0, length: 5 }]
+        childItems: []
+        indent: 0
+        nameSpan: undefined
+      } as any
+      output: any[] := []
+      result := convertNavTree(item, output, doc, undefined)
+      assert.equal result, false
+
+    it "includes a named const in output", ->
+      item := {
+        text: "x"
+        kind: ScriptElementKind.constElement
+        kindModifiers: ""
+        spans: [{ start: 6, length: 1 }]
+        childItems: []
+        indent: 0
+        nameSpan: { start: 6, length: 1 }
+      } as any
+      output: any[] := []
+      result := convertNavTree(item, output, doc, undefined)
+      assert.equal result, true
+      assert.equal output.length, 1
+      assert.equal output[0].name, "x"
+
+    it "marks deprecated items with tag", ->
+      item := {
+        text: "oldFn"
+        kind: ScriptElementKind.functionElement
+        kindModifiers: "deprecated"
+        spans: [{ start: 0, length: 5 }]
+        childItems: []
+        indent: 0
+        nameSpan: undefined
+      } as any
+      output: any[] := []
+      convertNavTree(item, output, doc, undefined)
+      assert.equal output[0]?.tags?.[0], 1 // SymbolTag.Deprecated
+
+  describe "convertDiagnostic", ->
+    doc := TextDocument.create("file:///test.civet", "civet", 0, "x := 1\ny := 2\n")
+
+    it "converts an error diagnostic", ->
+      diag := {
+        messageText: "Some error"
+        start: 0
+        length: 1
+        category: DiagnosticCategory.Error
+        code: 2304
+        source: undefined
+      } as any
+      result := convertDiagnostic(diag, doc)
+      assert.equal result.message, "Some error"
+      assert.equal result.severity, DiagnosticSeverity.Error
+      assert.equal result.code, 2304
+      assert.equal result.source, "typescript"
+
+    it "converts a warning diagnostic", ->
+      diag := {
+        messageText: "A warning"
+        start: 0
+        length: 1
+        category: DiagnosticCategory.Warning
+        code: 1001
+        source: "civet"
+      } as any
+      result := convertDiagnostic(diag, doc)
+      assert.equal result.severity, DiagnosticSeverity.Warning
+      assert.equal result.source, "civet"
+
+    it "converts suggestion and message categories", ->
+      suggestion := { messageText: "s", start: 0, length: 1, category: DiagnosticCategory.Suggestion, code: 1, source: undefined } as any
+      message    := { messageText: "m", start: 0, length: 1, category: DiagnosticCategory.Message,    code: 2, source: undefined } as any
+      assert.equal convertDiagnostic(suggestion, doc).severity, DiagnosticSeverity.Hint
+      assert.equal convertDiagnostic(message, doc).severity, DiagnosticSeverity.Information
+
+  describe "withResolvers", ->
+    it "resolves the promise", async ->
+      { promise, resolve } := withResolvers<number>()
+      resolve(42)
+      result := await promise
+      assert.equal result, 42
+
+    it "rejects the promise", async ->
+      { promise, reject } := withResolvers<number>()
+      reject(new Error("boom"))
+      await assert.rejects promise, /boom/
+
+  describe "getCompletionItemKind", ->
+    it "maps keyword to Keyword kind", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.keyword), CompletionItemKind.Keyword
+
+    it "maps function to Function kind", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.functionElement), CompletionItemKind.Function
+
+    it "maps class to Class kind", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.classElement), CompletionItemKind.Class
+
+    it "maps enum to Enum kind", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.enumElement), CompletionItemKind.Enum
+
+    it "defaults unknown to Property kind", ->
+      assert.equal getCompletionItemKind("unknown-kind"), CompletionItemKind.Property

--- a/lsp/test/util-extra.civet
+++ b/lsp/test/util-extra.civet
@@ -1,13 +1,12 @@
 import assert from assert
 import { TextDocument } from vscode-languageserver-textdocument
-import ts from typescript
 
 {
   convertNavTree,
   convertDiagnostic,
   withResolvers,
-  makeRange,
   getCompletionItemKind,
+  logTiming,
 } from ../source/lib/util.civet
 
 import { CompletionItemKind, DiagnosticSeverity } from vscode-languageserver
@@ -77,6 +76,76 @@ describe "util (extra)", ->
       convertNavTree(item, output, doc, undefined)
       assert.equal output[0]?.tags?.[0], 1 // SymbolTag.Deprecated
 
+    it "nests child items whose span overlaps the parent range", ->
+      // exercises lines 141-146: child is moved into parent's children array
+      child := {
+        text: "x"
+        kind: ScriptElementKind.constElement
+        kindModifiers: ""
+        spans: [{ start: 6, length: 1 }]   // inside the parent span
+        childItems: []
+        indent: 1
+        nameSpan: { start: 6, length: 1 }
+      } as any
+      parent := {
+        text: "outer"
+        kind: ScriptElementKind.functionElement
+        kindModifiers: ""
+        spans: [{ start: 0, length: 24 }]   // whole document
+        childItems: [child]
+        indent: 0
+        nameSpan: { start: 0, length: 5 }
+      } as any
+      output: any[] := []
+      convertNavTree(parent, output, doc, undefined)
+      assert.equal output.length, 1
+      assert.equal output[0].name, "outer"
+      assert.equal output[0].children.length, 1
+      assert.equal output[0].children[0].name, "x"
+
+    it "prefixes get/set accessor labels in convertSymbol", ->
+      // exercises lines 165-169 in convertSymbol
+      getItem := {
+        text: "myProp"
+        kind: ScriptElementKind.memberGetAccessorElement
+        kindModifiers: ""
+        spans: [{ start: 0, length: 5 }]
+        childItems: []
+        indent: 0
+        nameSpan: undefined
+      } as any
+      setItem := {
+        text: "myProp"
+        kind: ScriptElementKind.memberSetAccessorElement
+        kindModifiers: ""
+        spans: [{ start: 0, length: 5 }]
+        childItems: []
+        indent: 0
+        nameSpan: undefined
+      } as any
+      getOut: any[] := []
+      setOut: any[] := []
+      convertNavTree(getItem, getOut, doc, undefined)
+      convertNavTree(setItem, setOut, doc, undefined)
+      assert.equal getOut[0].name, "(get) myProp"
+      assert.equal setOut[0].name, "(set) myProp"
+
+    it "returns SymbolKind.Variable for unrecognized kind (getSymbolKind default)", ->
+      // exercises line 53: getSymbolKind falls through to default return
+      unknownItem := {
+        text: "thing"
+        kind: ScriptElementKind.warning   // not in getSymbolKind switch
+        kindModifiers: ""
+        spans: [{ start: 0, length: 5 }]
+        childItems: []
+        indent: 0
+        nameSpan: undefined
+      } as any
+      output: any[] := []
+      convertNavTree(unknownItem, output, doc, undefined)
+      // SymbolKind.Variable = 13; just assert a symbol was produced
+      assert.equal output.length, 1
+
   describe "convertDiagnostic", ->
     doc := TextDocument.create("file:///test.civet", "civet", 0, "x := 1\ny := 2\n")
 
@@ -141,3 +210,53 @@ describe "util (extra)", ->
 
     it "defaults unknown to Property kind", ->
       assert.equal getCompletionItemKind("unknown-kind"), CompletionItemKind.Property
+
+    it "maps variable kinds to Variable", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.variableElement), CompletionItemKind.Variable
+      assert.equal getCompletionItemKind(ScriptElementKind.localVariableElement), CompletionItemKind.Variable
+      assert.equal getCompletionItemKind(ScriptElementKind.alias), CompletionItemKind.Variable
+      assert.equal getCompletionItemKind(ScriptElementKind.parameterElement), CompletionItemKind.Variable
+
+    it "maps member accessor/variable kinds to Field", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.memberVariableElement), CompletionItemKind.Field
+      assert.equal getCompletionItemKind(ScriptElementKind.memberGetAccessorElement), CompletionItemKind.Field
+      assert.equal getCompletionItemKind(ScriptElementKind.memberSetAccessorElement), CompletionItemKind.Field
+
+    it "maps signature kinds to Method", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.constructSignatureElement), CompletionItemKind.Method
+      assert.equal getCompletionItemKind(ScriptElementKind.callSignatureElement), CompletionItemKind.Method
+      assert.equal getCompletionItemKind(ScriptElementKind.indexSignatureElement), CompletionItemKind.Method
+
+    it "maps enumMember to EnumMember", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.enumMemberElement), CompletionItemKind.EnumMember
+
+    it "maps module kinds to Module", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.moduleElement), CompletionItemKind.Module
+      assert.equal getCompletionItemKind(ScriptElementKind.externalModuleName), CompletionItemKind.Module
+
+    it "maps interface to Interface", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.interfaceElement), CompletionItemKind.Interface
+
+    it "maps warning to Text", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.warning), CompletionItemKind.Text
+
+    it "maps script to File", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.scriptElement), CompletionItemKind.File
+
+    it "maps directory to Folder", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.directory), CompletionItemKind.Folder
+
+    it "maps string to Constant", ->
+      assert.equal getCompletionItemKind(ScriptElementKind.string), CompletionItemKind.Constant
+
+  describe "logTiming", ->
+    it "calls the wrapped function and returns its result", ->
+      // exercises lines 328-341
+      calls: string[] := []
+      logger := { log: (msg: string) => calls.push(msg) } as any
+      add := (a: number, b: number) => a + b
+      timedAdd := logTiming(logger, "add", add)
+      result := timedAdd(2, 3)
+      assert.equal result, 5
+      assert.equal calls.length, 1
+      assert.ok calls[0].includes("add")

--- a/lsp/test/util.civet
+++ b/lsp/test/util.civet
@@ -9,6 +9,23 @@ describe "util", ->
     range2 := makeRange(0, 5, 0, 8)
     assert(intersectRanges(range1, range2))
 
+  it "should use b.start when b begins on a later line", ->
+    // exercises lines 240-241: resultStartLineNumber < otherStartLineNumber
+    a := makeRange(0, 0, 5, 0)
+    b := makeRange(2, 3, 5, 0)
+    result := intersectRanges(a, b)
+    assert(result)
+    assert.equal result!.start.line, 2
+    assert.equal result!.start.character, 3
+
+  it "should use b.end when b ends on an earlier line", ->
+    // exercises lines 246-247: resultEndLineNumber > otherEndLineNumber
+    a := makeRange(0, 0, 5, 0)
+    b := makeRange(0, 0, 3, 0)
+    result := intersectRanges(a, b)
+    assert(result)
+    assert.equal result!.end.line, 3
+
   it "should check containsRange", ->
     assert containsRange
 
@@ -36,6 +53,12 @@ describe "util", ->
       line: 1
       character: 1
     }, linesMap), { line: 1, character: 1}
+
+  it "should return original position when no sourcemap mapping found", ->
+    // exercises the fallback return at line 325-326: foundLine stays -1
+    pos := { line: 5, character: 3 }
+    result := forwardMap([], pos)
+    assert.deepEqual result, pos
 
   it "should forward map", ->
     src := '''

--- a/lsp/test/util.civet
+++ b/lsp/test/util.civet
@@ -1,5 +1,5 @@
 // TODO: figure out the magic ts-note/TypeScript config to make this work without destructuring from default import
-{ intersectRanges, containsRange, makeRange, remapPosition, forwardMap } from ../source/lib/util.mjs
+{ intersectRanges, containsRange, makeRange, remapPosition, forwardMap } from ../source/lib/util.civet
 assert from assert
 Civet from @danielx/civet
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@typescript/vfs": "^1.6.4",
     "c8": "^7.12.0",
     "cross-env": "7.0.3",
-    "esbuild": "0.27.5",
+    "esbuild": "^0.28.0",
     "marked": "^4.2.4",
     "mocha": "^10.7.3",
     "prettier": "^3.2.5",
@@ -181,7 +181,7 @@
       "serialize-javascript": "^7.0.3",
       "tmp": "^0.2.5",
       "lodash": "^4.18.0",
-      "esbuild": "^0.27.0",
+      "esbuild": "^0.28.0",
       "diff": "^8.0.3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@typescript/vfs": "^1.6.4",
     "c8": "^7.12.0",
     "cross-env": "7.0.3",
-    "esbuild": "^0.28.0",
+    "esbuild": "^0.27.7",
     "marked": "^4.2.4",
     "mocha": "^10.7.3",
     "prettier": "^3.2.5",
@@ -181,7 +181,7 @@
       "serialize-javascript": "^7.0.3",
       "tmp": "^0.2.5",
       "lodash": "^4.18.0",
-      "esbuild": "^0.28.0",
+      "esbuild": "^0.27.0",
       "diff": "^8.0.3"
     }
   }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@typescript/vfs": "^1.6.4",
     "c8": "^7.12.0",
     "cross-env": "7.0.3",
-    "esbuild": "^0.27.7",
+    "esbuild": "0.27.5",
     "marked": "^4.2.4",
     "mocha": "^10.7.3",
     "prettier": "^3.2.5",
@@ -181,7 +181,7 @@
       "serialize-javascript": "^7.0.3",
       "tmp": "^0.2.5",
       "lodash": "^4.18.0",
-      "esbuild": "^0.27.0",
+      "esbuild": "0.27.5",
       "diff": "^8.0.3"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   serialize-javascript: ^7.0.3
   tmp: ^0.2.5
   lodash: ^4.18.0
-  esbuild: ^0.28.0
+  esbuild: ^0.27.0
   diff: ^8.0.3
 
 importers:
@@ -59,8 +59,8 @@ importers:
         specifier: 7.0.3
         version: 7.0.3
       esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
+        specifier: ^0.27.0
+        version: 0.27.7
       marked:
         specifier: ^4.2.4
         version: 4.3.0
@@ -84,7 +84,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@types/node@22.19.15)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@22.19.15)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
       vitepress:
         specifier: ^1.0.0-alpha.35
         version: 1.6.4(@algolia/client-search@5.50.0)(@types/node@22.19.15)(lightningcss@1.32.0)(postcss@8.5.8)(search-insights@2.17.3)(terser@5.46.1)(typescript@5.8.3)
@@ -200,8 +200,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
+        specifier: ^0.27.0
+        version: 0.27.7
 
   integration/unplugin-examples/farm:
     dependencies:
@@ -223,10 +223,10 @@ importers:
         version: 0.7.8(solid-js@1.9.12)
       vite:
         specifier: 8.0.3
-        version: 8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3))
+        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
 
   integration/unplugin-examples/nextjs:
     dependencies:
@@ -290,7 +290,7 @@ importers:
         version: link:../../..
       webpack:
         specifier: ^5.89.0
-        version: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
+        version: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.105.4)
@@ -326,8 +326,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       esbuild:
-        specifier: ^0.28.0
-        version: 0.28.0
+        specifier: ^0.27.0
+        version: 0.27.7
       esbuild-visualizer:
         specifier: ^0.7.0
         version: 0.7.0
@@ -804,158 +804,158 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3153,8 +3153,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6056,7 +6056,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.28.0
+      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -7057,82 +7057,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.0':
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.0':
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.0':
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.28.0':
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.0':
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.0':
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.0':
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.0':
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.0':
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.0':
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.0':
+  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -8664,17 +8664,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -8814,7 +8814,7 @@ snapshots:
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 2.0.0
-      esbuild: 0.28.0
+      esbuild: 0.27.7
       flattie: 1.1.1
       fontace: 0.4.1
       github-slugger: 2.0.0
@@ -9574,34 +9574,34 @@ snapshots:
       picomatch: 4.0.4
       yargs: 17.7.2
 
-  esbuild@0.28.0:
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -12689,15 +12689,15 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.4.0(esbuild@0.28.0)(webpack@5.105.4):
+  terser-webpack-plugin@5.4.0(esbuild@0.27.7)(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
     optionalDependencies:
-      esbuild: 0.28.0
+      esbuild: 0.27.7
 
   terser@5.46.1:
     dependencies:
@@ -13028,7 +13028,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -13036,14 +13036,14 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3))
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
   vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1):
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.27.7
       postcss: 8.5.8
       rollup: 4.60.1
     optionalDependencies:
@@ -13054,7 +13054,7 @@ snapshots:
 
   vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.8
@@ -13067,7 +13067,7 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
-  vite@8.0.3(@types/node@22.19.15)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3):
+  vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13076,7 +13076,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.15
-      esbuild: 0.28.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       terser: 5.46.1
       yaml: 2.8.3
@@ -13084,7 +13084,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3):
+  vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13093,7 +13093,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.2
-      esbuild: 0.28.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       terser: 5.46.1
       yaml: 2.8.3
@@ -13105,9 +13105,9 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
 
   vitefu@1.1.3(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
@@ -13239,7 +13239,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   webpack-merge@5.10.0:
@@ -13252,7 +13252,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4):
+  webpack@5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -13276,7 +13276,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.28.0)(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(esbuild@0.27.7)(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       '@vscode/vsce':
         specifier: ^2.19.0
         version: 2.32.0
+      c8:
+        specifier: ^10.1.3
+        version: 10.1.3
       esbuild:
         specifier: ^0.27.0
         version: 0.27.5
@@ -331,15 +334,9 @@ importers:
       mocha:
         specifier: ^10.7.3
         version: 10.8.2
-      nyc:
-        specifier: ^15.1.0
-        version: 15.1.0
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
-      ts-node:
-        specifier: ^10.6.0
-        version: 10.9.2(@types/node@18.19.130)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -674,6 +671,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
@@ -2256,10 +2257,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
-
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2326,13 +2323,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  append-transform@2.0.0:
-    resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
-    engines: {node: '>=8'}
-
-  archy@1.0.0:
-    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -2516,6 +2506,16 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  c8@10.1.3:
+    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
+
   c8@7.14.0:
     resolution: {integrity: sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==}
     engines: {node: '>=10.12.0'}
@@ -2528,10 +2528,6 @@ packages:
   cache-content-type@1.0.1:
     resolution: {integrity: sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==}
     engines: {node: '>= 6.0.0'}
-
-  caching-transform@4.0.0:
-    resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
-    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2634,10 +2630,6 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -2656,9 +2648,6 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-
-  cliui@6.0.0:
-    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -2736,9 +2725,6 @@ packages:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
 
-  commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -2753,9 +2739,6 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
-
-  convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2840,10 +2823,6 @@ packages:
       supports-color:
         optional: true
 
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
@@ -2892,10 +2871,6 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
-
-  default-require-extensions@3.0.1:
-    resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
-    engines: {node: '>=8'}
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -3086,9 +3061,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild-visualizer@0.3.1:
     resolution: {integrity: sha512-eNIM6AOfE+7XvRkBFpxZA8V07yPhskwZH6YBBVVrgiCdq1YKatd0Eh/Y0gK8iDnOAvL3Ezz1zDvzX/ssVNLIiA==}
@@ -3366,10 +3338,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3427,9 +3395,6 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-
-  fromentries@1.3.2:
-    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -3556,10 +3521,6 @@ packages:
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
-
-  hasha@5.2.2:
-    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
-    engines: {node: '>=8'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -3707,10 +3668,6 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -3829,9 +3786,6 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
-  is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -3882,14 +3836,6 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  istanbul-lib-hook@3.0.0:
-    resolution: {integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-instrument@4.0.3:
-    resolution: {integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==}
-    engines: {node: '>=8'}
-
   istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
@@ -3897,10 +3843,6 @@ packages:
   istanbul-lib-instrument@6.0.3:
     resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
     engines: {node: '>=10'}
-
-  istanbul-lib-processinfo@2.0.3:
-    resolution: {integrity: sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==}
-    engines: {node: '>=8'}
 
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
@@ -4261,9 +4203,6 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  lodash.flattendeep@4.4.0:
-    resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -4328,10 +4267,6 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
-
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -4674,10 +4609,6 @@ packages:
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
-  node-preload@0.2.1:
-    resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
-    engines: {node: '>=8'}
-
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
@@ -4695,11 +4626,6 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  nyc@15.1.0:
-    resolution: {integrity: sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==}
-    engines: {node: '>=8.9'}
-    hasBin: true
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -4804,10 +4730,6 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
-  p-map@3.0.0:
-    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
-    engines: {node: '>=8'}
-
   p-queue@9.1.1:
     resolution: {integrity: sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig==}
     engines: {node: '>=20'}
@@ -4819,10 +4741,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  package-hash@4.0.0:
-    resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
-    engines: {node: '>=8'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -4968,10 +4886,6 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  process-on-spawn@1.1.0:
-    resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
-    engines: {node: '>=8'}
-
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -5070,10 +4984,6 @@ packages:
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
 
-  release-zalgo@1.0.0:
-    resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
-    engines: {node: '>=4'}
-
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -5104,9 +5014,6 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-
-  require-main-filename@2.0.0:
-    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -5250,9 +5157,6 @@ packages:
     resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
     engines: {node: '>=10'}
 
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -5361,10 +5265,6 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
-
-  spawn-wrap@2.0.0:
-    resolution: {integrity: sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==}
-    engines: {node: '>=8'}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -5536,6 +5436,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -5638,19 +5542,12 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
-    engines: {node: '>=8'}
-
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
-
-  typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
   typescript-eslint@8.58.0:
     resolution: {integrity: sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==}
@@ -6095,9 +5992,6 @@ packages:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
-  which-module@2.0.1:
-    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
-
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
@@ -6135,9 +6029,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  write-file-atomic@3.0.3:
-    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -6169,9 +6060,6 @@ packages:
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
-  y18n@4.0.3:
-    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -6186,10 +6074,6 @@ packages:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
-
-  yargs-parser@18.1.3:
-    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
-    engines: {node: '>=6'}
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -6206,10 +6090,6 @@ packages:
   yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
     engines: {node: '>=10'}
-
-  yargs@15.4.1:
-    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
-    engines: {node: '>=8'}
 
   yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
@@ -6715,6 +6595,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@capsizecss/unpack@4.0.0':
     dependencies:
@@ -7832,13 +7714,17 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tsconfig/node10@1.0.12': {}
+  '@tsconfig/node10@1.0.12':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -8374,15 +8260,11 @@ snapshots:
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
+    optional: true
 
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -8457,13 +8339,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  append-transform@2.0.0:
-    dependencies:
-      default-require-extensions: 3.0.1
-
-  archy@1.0.0: {}
-
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -8739,6 +8616,20 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  c8@10.1.3:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 7.0.2
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+
   c8@7.14.0:
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
@@ -8760,13 +8651,6 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       ylru: 1.4.0
-
-  caching-transform@4.0.0:
-    dependencies:
-      hasha: 5.2.2
-      make-dir: 3.1.0
-      package-hash: 4.0.0
-      write-file-atomic: 3.0.3
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -8876,8 +8760,6 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
-  clean-stack@2.2.0: {}
-
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -8891,12 +8773,6 @@ snapshots:
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
-
-  cliui@6.0.0:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
 
   cliui@7.0.4:
     dependencies:
@@ -8958,8 +8834,6 @@ snapshots:
 
   common-ancestor-path@2.0.0: {}
 
-  commondir@1.0.1: {}
-
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
@@ -8971,8 +8845,6 @@ snapshots:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
-
-  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -9008,7 +8880,8 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-env@7.0.3:
     dependencies:
@@ -9060,8 +8933,6 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
-  decamelize@1.2.0: {}
-
   decamelize@4.0.0: {}
 
   decode-named-character-reference@1.3.0:
@@ -9102,10 +8973,6 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
-
-  default-require-extensions@3.0.1:
-    dependencies:
-      strip-bom: 4.0.0
 
   defaults@1.0.4:
     dependencies:
@@ -9261,8 +9128,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  es6-error@4.1.1: {}
 
   esbuild-visualizer@0.3.1:
     dependencies:
@@ -9574,12 +9439,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -9636,8 +9495,6 @@ snapshots:
       mime-types: 2.1.35
 
   fresh@0.5.2: {}
-
-  fromentries@1.3.2: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -9778,11 +9635,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasha@5.2.2:
-    dependencies:
-      is-stream: 2.0.1
-      type-fest: 0.8.1
 
   hasown@2.0.2:
     dependencies:
@@ -9999,8 +9851,6 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  indent-string@4.0.0: {}
-
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -10104,8 +9954,6 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
-  is-typedarray@1.0.0: {}
-
   is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@1.3.0: {}
@@ -10136,19 +9984,6 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-hook@3.0.0:
-    dependencies:
-      append-transform: 2.0.0
-
-  istanbul-lib-instrument@4.0.3:
-    dependencies:
-      '@babel/core': 7.29.0
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.2
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.29.0
@@ -10168,15 +10003,6 @@ snapshots:
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
-
-  istanbul-lib-processinfo@2.0.3:
-    dependencies:
-      archy: 1.0.0
-      cross-spawn: 7.0.6
-      istanbul-lib-coverage: 3.2.2
-      p-map: 3.0.0
-      rimraf: 3.0.2
-      uuid: 8.3.2
 
   istanbul-lib-report@3.0.1:
     dependencies:
@@ -10744,8 +10570,6 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
-  lodash.flattendeep@4.4.0: {}
-
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -10802,15 +10626,12 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
-
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   make-synchronized@0.4.2: {}
 
@@ -11327,10 +11148,6 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
-  node-preload@0.2.1:
-    dependencies:
-      process-on-spawn: 1.1.0
-
   node-releases@2.0.36: {}
 
   normalize-path@3.0.0: {}
@@ -11346,38 +11163,6 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
-
-  nyc@15.1.0:
-    dependencies:
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.3
-      caching-transform: 4.0.0
-      convert-source-map: 1.9.0
-      decamelize: 1.2.0
-      find-cache-dir: 3.3.2
-      find-up: 4.1.0
-      foreground-child: 2.0.0
-      get-package-type: 0.1.0
-      glob: 7.2.3
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-hook: 3.0.0
-      istanbul-lib-instrument: 4.0.3
-      istanbul-lib-processinfo: 2.0.3
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.2.0
-      make-dir: 3.1.0
-      node-preload: 0.2.1
-      p-map: 3.0.0
-      process-on-spawn: 1.1.0
-      resolve-from: 5.0.0
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      spawn-wrap: 2.0.0
-      test-exclude: 6.0.0
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - supports-color
 
   object-inspect@1.13.4: {}
 
@@ -11509,10 +11294,6 @@ snapshots:
 
   p-map@2.1.0: {}
 
-  p-map@3.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-
   p-queue@9.1.1:
     dependencies:
       eventemitter3: 5.0.4
@@ -11521,13 +11302,6 @@ snapshots:
   p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
-
-  package-hash@4.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      hasha: 5.2.2
-      lodash.flattendeep: 4.4.0
-      release-zalgo: 1.0.0
 
   package-json-from-dist@1.0.1: {}
 
@@ -11665,10 +11439,6 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  process-on-spawn@1.1.0:
-    dependencies:
-      fromentries: 1.3.2
-
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -11787,10 +11557,6 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  release-zalgo@1.0.0:
-    dependencies:
-      es6-error: 4.1.1
-
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -11839,8 +11605,6 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
-
-  require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
 
@@ -12018,8 +11782,6 @@ snapshots:
 
   seroval@1.5.1: {}
 
-  set-blocking@2.0.0: {}
-
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -12195,15 +11957,6 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  spawn-wrap@2.0.0:
-    dependencies:
-      foreground-child: 2.0.0
-      is-windows: 1.0.2
-      make-dir: 3.1.0
-      rimraf: 3.0.2
-      signal-exit: 3.0.7
-      which: 2.0.2
-
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -12377,6 +12130,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.5.0
+      minimatch: 10.2.5
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
@@ -12417,24 +12176,6 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
-
-  ts-node@10.9.2(@types/node@18.19.130)(typescript@5.8.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.130
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 8.0.4
-      make-error: 1.3.6
-      typescript: 5.8.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
 
   ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3):
     dependencies:
@@ -12478,8 +12219,6 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@0.8.1: {}
-
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -12490,10 +12229,6 @@ snapshots:
       qs: 6.15.0
       tunnel: 0.0.6
       underscore: 1.13.8
-
-  typedarray-to-buffer@3.1.5:
-    dependencies:
-      is-typedarray: 1.0.0
 
   typescript-eslint@8.58.0(eslint@9.39.4)(typescript@5.8.3):
     dependencies:
@@ -12626,7 +12361,8 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -12908,8 +12644,6 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
-  which-module@2.0.1: {}
-
   which-pm-runs@1.1.0: {}
 
   which@2.0.2:
@@ -12944,13 +12678,6 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  write-file-atomic@3.0.3:
-    dependencies:
-      imurmurhash: 0.1.4
-      is-typedarray: 1.0.0
-      signal-exit: 3.0.7
-      typedarray-to-buffer: 3.1.5
-
   write-file-atomic@4.0.2:
     dependencies:
       imurmurhash: 0.1.4
@@ -12971,8 +12698,6 @@ snapshots:
 
   xxhash-wasm@1.1.0: {}
 
-  y18n@4.0.3: {}
-
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -12980,11 +12705,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.8.3: {}
-
-  yargs-parser@18.1.3:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
 
   yargs-parser@20.2.9: {}
 
@@ -12998,20 +12718,6 @@ snapshots:
       decamelize: 4.0.0
       flat: 5.0.2
       is-plain-obj: 2.1.0
-
-  yargs@15.4.1:
-    dependencies:
-      cliui: 6.0.0
-      decamelize: 1.2.0
-      find-up: 4.1.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 4.2.3
-      which-module: 2.0.1
-      y18n: 4.0.3
-      yargs-parser: 18.1.3
 
   yargs@16.2.0:
     dependencies:
@@ -13044,7 +12750,8 @@ snapshots:
 
   ylru@1.4.0: {}
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   serialize-javascript: ^7.0.3
   tmp: ^0.2.5
   lodash: ^4.18.0
-  esbuild: ^0.27.0
+  esbuild: ^0.28.0
   diff: ^8.0.3
 
 importers:
@@ -59,8 +59,8 @@ importers:
         specifier: 7.0.3
         version: 7.0.3
       esbuild:
-        specifier: ^0.27.0
-        version: 0.27.5
+        specifier: ^0.28.0
+        version: 0.28.0
       marked:
         specifier: ^4.2.4
         version: 4.3.0
@@ -84,7 +84,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@22.19.15)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
       vitepress:
         specifier: ^1.0.0-alpha.35
         version: 1.6.4(@algolia/client-search@5.50.0)(@types/node@22.19.15)(lightningcss@1.32.0)(postcss@8.5.8)(search-insights@2.17.3)(terser@5.46.1)(typescript@5.8.3)
@@ -200,8 +200,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       esbuild:
-        specifier: ^0.27.0
-        version: 0.27.5
+        specifier: ^0.28.0
+        version: 0.28.0
 
   integration/unplugin-examples/farm:
     dependencies:
@@ -223,10 +223,10 @@ importers:
         version: 0.7.8(solid-js@1.9.12)
       vite:
         specifier: 8.0.3
-        version: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
+        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3))
 
   integration/unplugin-examples/nextjs:
     dependencies:
@@ -290,7 +290,7 @@ importers:
         version: link:../../..
       webpack:
         specifier: ^5.89.0
-        version: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
+        version: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.105.4)
@@ -804,52 +804,16 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
-  '@esbuild/aix-ppc64@0.27.5':
-    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.0':
     resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.5':
-    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.28.0':
     resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.5':
-    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.0':
@@ -858,52 +822,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.5':
-    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.28.0':
     resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.5':
-    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.0':
     resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.5':
-    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
@@ -912,34 +840,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.5':
-    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.0':
     resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.5':
-    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
@@ -948,34 +852,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.5':
-    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.0':
     resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.5':
-    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
@@ -984,34 +864,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.5':
-    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.0':
     resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.5':
-    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
@@ -1020,34 +876,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.5':
-    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.0':
     resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.5':
-    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
@@ -1056,34 +888,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.5':
-    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.0':
     resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.5':
-    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
@@ -1092,52 +900,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.5':
-    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.0':
     resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.5':
-    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.28.0':
     resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.5':
-    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.0':
@@ -1146,34 +918,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.5':
-    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.28.0':
     resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.5':
-    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
@@ -1182,35 +930,11 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.5':
-    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/openharmony-arm64@0.28.0':
     resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.5':
-    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.0':
     resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
@@ -1218,52 +942,16 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.5':
-    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-arm64@0.28.0':
     resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.5':
-    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.0':
     resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.5':
-    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.0':
@@ -3462,16 +3150,6 @@ packages:
 
   esbuild-visualizer@0.7.0:
     resolution: {integrity: sha512-Vz22k+G2WT7GuCo7rbhaQwGbZ26lEhwzsctkEdQlu2SVrshoM4hzQeRpu/3DP596a9+9K2JyYsinuC6AC896Og==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.5:
-    resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6378,7 +6056,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -7379,235 +7057,79 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.5':
-    optional: true
-
-  '@esbuild/aix-ppc64@0.27.7':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.0':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.7':
     optional: true
 
   '@esbuild/android-arm64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm@0.27.5':
-    optional: true
-
-  '@esbuild/android-arm@0.27.7':
-    optional: true
-
   '@esbuild/android-arm@0.28.0':
-    optional: true
-
-  '@esbuild/android-x64@0.27.5':
-    optional: true
-
-  '@esbuild/android-x64@0.27.7':
     optional: true
 
   '@esbuild/android-x64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.7':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.5':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
   '@esbuild/darwin-x64@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.7':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.5':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.7':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.5':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.7':
     optional: true
 
   '@esbuild/linux-arm@0.28.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.5':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.7':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.5':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
   '@esbuild/linux-loong64@0.28.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.5':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.5':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.5':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.0':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.5':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
   '@esbuild/linux-s390x@0.28.0':
     optional: true
 
-  '@esbuild/linux-x64@0.27.5':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
   '@esbuild/linux-x64@0.28.0':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.5':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.5':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.0':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.5':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.5':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
   '@esbuild/win32-arm64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.5':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.5':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@esbuild/win32-x64@0.28.0':
@@ -9142,17 +8664,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -9292,7 +8814,7 @@ snapshots:
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 2.0.0
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       flattie: 1.1.1
       fontace: 0.4.1
       github-slugger: 2.0.0
@@ -10051,64 +9573,6 @@ snapshots:
       open: 8.4.2
       picomatch: 4.0.4
       yargs: 17.7.2
-
-  esbuild@0.27.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.5
-      '@esbuild/android-arm': 0.27.5
-      '@esbuild/android-arm64': 0.27.5
-      '@esbuild/android-x64': 0.27.5
-      '@esbuild/darwin-arm64': 0.27.5
-      '@esbuild/darwin-x64': 0.27.5
-      '@esbuild/freebsd-arm64': 0.27.5
-      '@esbuild/freebsd-x64': 0.27.5
-      '@esbuild/linux-arm': 0.27.5
-      '@esbuild/linux-arm64': 0.27.5
-      '@esbuild/linux-ia32': 0.27.5
-      '@esbuild/linux-loong64': 0.27.5
-      '@esbuild/linux-mips64el': 0.27.5
-      '@esbuild/linux-ppc64': 0.27.5
-      '@esbuild/linux-riscv64': 0.27.5
-      '@esbuild/linux-s390x': 0.27.5
-      '@esbuild/linux-x64': 0.27.5
-      '@esbuild/netbsd-arm64': 0.27.5
-      '@esbuild/netbsd-x64': 0.27.5
-      '@esbuild/openbsd-arm64': 0.27.5
-      '@esbuild/openbsd-x64': 0.27.5
-      '@esbuild/openharmony-arm64': 0.27.5
-      '@esbuild/sunos-x64': 0.27.5
-      '@esbuild/win32-arm64': 0.27.5
-      '@esbuild/win32-ia32': 0.27.5
-      '@esbuild/win32-x64': 0.27.5
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -13225,15 +12689,15 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.5)(webpack@5.105.4):
+  terser-webpack-plugin@5.4.0(esbuild@0.28.0)(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      esbuild: 0.27.5
+      esbuild: 0.28.0
 
   terser@5.46.1:
     dependencies:
@@ -13564,7 +13028,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -13572,14 +13036,14 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
   vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1):
     dependencies:
-      esbuild: 0.27.5
+      esbuild: 0.28.0
       postcss: 8.5.8
       rollup: 4.60.1
     optionalDependencies:
@@ -13590,7 +13054,7 @@ snapshots:
 
   vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.8
@@ -13603,7 +13067,7 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
-  vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3):
+  vite@8.0.3(@types/node@22.19.15)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13612,7 +13076,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.15
-      esbuild: 0.27.5
+      esbuild: 0.28.0
       fsevents: 2.3.3
       terser: 5.46.1
       yaml: 2.8.3
@@ -13620,7 +13084,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3):
+  vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13629,7 +13093,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.2
-      esbuild: 0.27.7
+      esbuild: 0.28.0
       fsevents: 2.3.3
       terser: 5.46.1
       yaml: 2.8.3
@@ -13641,9 +13105,9 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.28.0)(terser@5.46.1)(yaml@2.8.3)
 
   vitefu@1.1.3(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
@@ -13775,7 +13239,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   webpack-merge@5.10.0:
@@ -13788,7 +13252,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4):
+  webpack@5.105.4(esbuild@0.28.0)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -13812,7 +13276,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.5)(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(esbuild@0.28.0)(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   serialize-javascript: ^7.0.3
   tmp: ^0.2.5
   lodash: ^4.18.0
-  esbuild: ^0.27.0
+  esbuild: 0.27.5
   diff: ^8.0.3
 
 importers:
@@ -59,8 +59,8 @@ importers:
         specifier: 7.0.3
         version: 7.0.3
       esbuild:
-        specifier: ^0.27.0
-        version: 0.27.7
+        specifier: 0.27.5
+        version: 0.27.5
       marked:
         specifier: ^4.2.4
         version: 4.3.0
@@ -84,7 +84,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@types/node@22.19.15)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
       vitepress:
         specifier: ^1.0.0-alpha.35
         version: 1.6.4(@algolia/client-search@5.50.0)(@types/node@22.19.15)(lightningcss@1.32.0)(postcss@8.5.8)(search-insights@2.17.3)(terser@5.46.1)(typescript@5.8.3)
@@ -200,8 +200,8 @@ importers:
         specifier: workspace:*
         version: link:../../..
       esbuild:
-        specifier: ^0.27.0
-        version: 0.27.7
+        specifier: 0.27.5
+        version: 0.27.5
 
   integration/unplugin-examples/farm:
     dependencies:
@@ -223,10 +223,10 @@ importers:
         version: 0.7.8(solid-js@1.9.12)
       vite:
         specifier: 8.0.3
-        version: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
+        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3))
 
   integration/unplugin-examples/nextjs:
     dependencies:
@@ -290,7 +290,7 @@ importers:
         version: link:../../..
       webpack:
         specifier: ^5.89.0
-        version: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
+        version: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.105.4)
@@ -326,8 +326,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       esbuild:
-        specifier: ^0.27.0
-        version: 0.27.7
+        specifier: 0.27.5
+        version: 0.27.5
       esbuild-visualizer:
         specifier: ^0.7.0
         version: 0.7.0
@@ -804,158 +804,158 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.27.5':
+    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.27.5':
+    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.27.5':
+    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.27.5':
+    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.27.5':
+    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.27.5':
+    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.27.5':
+    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.27.5':
+    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.27.5':
+    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.27.5':
+    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.27.5':
+    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.27.5':
+    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.27.5':
+    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.27.5':
+    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.27.5':
+    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.27.5':
+    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.27.5':
+    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.27.5':
+    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.27.5':
+    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.27.5':
+    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.27.5':
+    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.27.5':
+    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.27.5':
+    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.27.5':
+    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.27.5':
+    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.27.5':
+    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3153,8 +3153,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.27.5:
+    resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6056,7 +6056,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: 0.27.5
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -7057,82 +7057,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.27.5':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.27.5':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.27.5':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.27.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.27.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.27.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.27.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.27.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.27.5':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.27.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.27.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.27.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.27.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.27.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.27.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.27.5':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.27.5':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.27.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.27.5':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.27.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.27.5':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.27.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.27.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.27.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.27.5':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.27.5':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -8664,17 +8664,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -8814,7 +8814,7 @@ snapshots:
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 2.0.0
-      esbuild: 0.27.7
+      esbuild: 0.27.5
       flattie: 1.1.1
       fontace: 0.4.1
       github-slugger: 2.0.0
@@ -9574,34 +9574,34 @@ snapshots:
       picomatch: 4.0.4
       yargs: 17.7.2
 
-  esbuild@0.27.7:
+  esbuild@0.27.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.27.5
+      '@esbuild/android-arm': 0.27.5
+      '@esbuild/android-arm64': 0.27.5
+      '@esbuild/android-x64': 0.27.5
+      '@esbuild/darwin-arm64': 0.27.5
+      '@esbuild/darwin-x64': 0.27.5
+      '@esbuild/freebsd-arm64': 0.27.5
+      '@esbuild/freebsd-x64': 0.27.5
+      '@esbuild/linux-arm': 0.27.5
+      '@esbuild/linux-arm64': 0.27.5
+      '@esbuild/linux-ia32': 0.27.5
+      '@esbuild/linux-loong64': 0.27.5
+      '@esbuild/linux-mips64el': 0.27.5
+      '@esbuild/linux-ppc64': 0.27.5
+      '@esbuild/linux-riscv64': 0.27.5
+      '@esbuild/linux-s390x': 0.27.5
+      '@esbuild/linux-x64': 0.27.5
+      '@esbuild/netbsd-arm64': 0.27.5
+      '@esbuild/netbsd-x64': 0.27.5
+      '@esbuild/openbsd-arm64': 0.27.5
+      '@esbuild/openbsd-x64': 0.27.5
+      '@esbuild/openharmony-arm64': 0.27.5
+      '@esbuild/sunos-x64': 0.27.5
+      '@esbuild/win32-arm64': 0.27.5
+      '@esbuild/win32-ia32': 0.27.5
+      '@esbuild/win32-x64': 0.27.5
 
   escalade@3.2.0: {}
 
@@ -12689,15 +12689,15 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 3.2.0
 
-  terser-webpack-plugin@5.4.0(esbuild@0.27.7)(webpack@5.105.4):
+  terser-webpack-plugin@5.4.0(esbuild@0.27.5)(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.1
-      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
     optionalDependencies:
-      esbuild: 0.27.7
+      esbuild: 0.27.5
 
   terser@5.46.1:
     dependencies:
@@ -13028,7 +13028,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -13036,14 +13036,14 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
   vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.27.5
       postcss: 8.5.8
       rollup: 4.60.1
     optionalDependencies:
@@ -13054,7 +13054,7 @@ snapshots:
 
   vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.27.5
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.8
@@ -13067,7 +13067,7 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
-  vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3):
+  vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13076,7 +13076,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.15
-      esbuild: 0.27.7
+      esbuild: 0.27.5
       fsevents: 2.3.3
       terser: 5.46.1
       yaml: 2.8.3
@@ -13084,7 +13084,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3):
+  vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -13093,7 +13093,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.2
-      esbuild: 0.27.7
+      esbuild: 0.27.5
       fsevents: 2.3.3
       terser: 5.46.1
       yaml: 2.8.3
@@ -13105,9 +13105,9 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
 
   vitefu@1.1.3(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
@@ -13239,7 +13239,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4)
+      webpack: 5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   webpack-merge@5.10.0:
@@ -13252,7 +13252,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.105.4(esbuild@0.27.7)(webpack-cli@5.1.4):
+  webpack@5.105.4(esbuild@0.27.5)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -13276,7 +13276,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(esbuild@0.27.7)(webpack@5.105.4)
+      terser-webpack-plugin: 5.4.0(esbuild@0.27.5)(webpack@5.105.4)
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 10.8.2
       typescript-eslint:
         specifier: ^8.19.0
-        version: 8.58.0(eslint@9.39.4)(typescript@5.8.3)
+        version: 8.58.0(eslint@9.39.4)(typescript@6.0.2)
 
   integration/eslint/example:
     devDependencies:
@@ -173,19 +173,19 @@ importers:
         version: 7.0.3
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+        version: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       jest-config:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+        version: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
 
   integration/unplugin-examples/astro:
     dependencies:
       '@astrojs/solid-js':
         specifier: ^6.0.1
-        version: 6.0.1(@types/node@22.19.15)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.1)(yaml@2.8.3)
+        version: 6.0.1(@types/node@25.5.2)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.1)(yaml@2.8.3)
       astro:
         specifier: ^6.1.3
-        version: 6.1.3(@azure/identity@4.13.1)(@types/node@22.19.15)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@5.8.3)(yaml@2.8.3)
+        version: 6.1.3(@azure/identity@4.13.1)(@types/node@25.5.2)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@5.8.3)(yaml@2.8.3)
       solid-js:
         specifier: ^1.7.11
         version: 1.9.12
@@ -217,16 +217,16 @@ importers:
         version: 1.0.5
       '@farmfe/core':
         specifier: ^1.6.7
-        version: 1.7.11(@types/node@22.19.15)
+        version: 1.7.11(@types/node@25.5.2)
       solid-refresh:
         specifier: ^0.7.5
         version: 0.7.8(solid-js@1.9.12)
       vite:
         specifier: 8.0.3
-        version: 8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
+        version: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3))
+        version: 2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
 
   integration/unplugin-examples/nextjs:
     dependencies:
@@ -301,53 +301,53 @@ importers:
         specifier: workspace:*
         version: link:..
       vscode-uri:
-        specifier: ^3.0.8
+        specifier: ^3.1.0
         version: 3.1.0
     devDependencies:
       '@danielx/hera':
-        specifier: ^0.7.12
-        version: 0.7.12
+        specifier: ^0.8.20
+        version: 0.8.20
       '@types/mocha':
-        specifier: ^10.0.8
+        specifier: ^10.0.10
         version: 10.0.10
       '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.130
+        specifier: ^25.5.2
+        version: 25.5.2
       '@types/vscode':
-        specifier: ^1.63.0
-        version: 1.110.0
+        specifier: ^1.115.0
+        version: 1.115.0
       '@vscode/test-electron':
-        specifier: ^2.1.2
+        specifier: ^2.5.2
         version: 2.5.2
       '@vscode/vsce':
-        specifier: ^2.19.0
-        version: 2.32.0
+        specifier: ^3.7.1
+        version: 3.7.1
       c8:
-        specifier: ^10.1.3
-        version: 10.1.3
+        specifier: ^11.0.0
+        version: 11.0.0
       esbuild:
-        specifier: ^0.27.0
-        version: 0.27.5
+        specifier: ^0.28.0
+        version: 0.28.0
       esbuild-visualizer:
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.7.0
+        version: 0.7.0
       mocha:
-        specifier: ^10.7.3
-        version: 10.8.2
+        specifier: ^11.7.5
+        version: 11.7.5
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 6.0.2
+        version: 6.0.2
       vscode-languageclient:
-        specifier: ^8.0.2
-        version: 8.1.0
+        specifier: ^9.0.1
+        version: 9.0.1
       vscode-languageserver:
-        specifier: ^8.0.2
-        version: 8.1.0
+        specifier: ^9.0.1
+        version: 9.0.1
       vscode-languageserver-textdocument:
-        specifier: ^1.0.7
+        specifier: ^1.0.12
         version: 1.0.12
 
 packages:
@@ -455,6 +455,12 @@ packages:
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
+  '@azu/format-text@1.0.2':
+    resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
+
+  '@azu/style-format@1.0.1':
+    resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
+
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
     engines: {node: '>=18.0.0'}
@@ -487,16 +493,16 @@ packages:
     resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
     engines: {node: '>=20.0.0'}
 
-  '@azure/msal-browser@5.6.2':
-    resolution: {integrity: sha512-ZgcN9ToRJ80f+wNPBBKYJ+DG0jlW7ktEjYtSNkNsTrlHVMhKB8tKMdI1yIG1I9BJtykkXtqnuOjlJaEMC7J6aw==}
+  '@azure/msal-browser@5.6.3':
+    resolution: {integrity: sha512-sTjMtUm+bJpENU/1WlRzHEsgEHppZDZ1EtNyaOODg/sQBtMxxJzGB+MOCM+T2Q5Qe1fKBrdxUmjyRxm0r7Ez9w==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-common@16.4.0':
-    resolution: {integrity: sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==}
+  '@azure/msal-common@16.4.1':
+    resolution: {integrity: sha512-Bl8f+w37xkXsYh7QRkAKCFGYtWMYuOVO7Lv+BxILrvGz3HbIEF22Pt0ugyj0QPOl6NLrHcnNUQ9yeew98P/5iw==}
     engines: {node: '>=0.8.0'}
 
-  '@azure/msal-node@5.1.1':
-    resolution: {integrity: sha512-71grXU6+5hl+3CL3joOxlj/AW6rmhthuTlG0fRqsTrhPArQBpZuUFzCIlKOGdcafLUa/i1hBdV78ZxJdlvRA+g==}
+  '@azure/msal-node@5.1.2':
+    resolution: {integrity: sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==}
     engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.0':
@@ -758,10 +764,6 @@ packages:
       yaml:
         optional: true
 
-  '@danielx/hera@0.7.12':
-    resolution: {integrity: sha512-YPqnLGZH7EML3t7u8KlBwjg9rv5h0gWIt8Kr3sZYB6rq1bqHgv30yQAyBs0hf1WTB76NQgA0ErJeIRbOuzRahw==}
-    hasBin: true
-
   '@danielx/hera@0.8.20':
     resolution: {integrity: sha512-0bjwD05ZIGZ0w6Jcw06+eOU7a7P52YtLqjIXynLFftg4iV1DYCoDrd4qHp4DT+/nbTvOeX5RV88ldoZfD3X5sQ==}
     hasBin: true
@@ -808,8 +810,32 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.5':
     resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -820,8 +846,32 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.5':
     resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -832,8 +882,32 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.5':
     resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -844,8 +918,32 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.5':
     resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -856,8 +954,32 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.5':
     resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -868,8 +990,32 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.5':
     resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -880,8 +1026,32 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.5':
     resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -892,8 +1062,32 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.5':
     resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -904,8 +1098,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.5':
     resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -916,8 +1134,32 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.5':
     resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -928,8 +1170,32 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.5':
     resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -940,8 +1206,32 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.5':
     resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -952,8 +1242,32 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.5':
     resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1263,6 +1577,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -1714,6 +2032,51 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@secretlint/config-creator@10.2.2':
+    resolution: {integrity: sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/config-loader@10.2.2':
+    resolution: {integrity: sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/core@10.2.2':
+    resolution: {integrity: sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/formatter@10.2.2':
+    resolution: {integrity: sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/node@10.2.2':
+    resolution: {integrity: sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/profiler@10.2.2':
+    resolution: {integrity: sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==}
+
+  '@secretlint/resolver@10.2.2':
+    resolution: {integrity: sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==}
+
+  '@secretlint/secretlint-formatter-sarif@10.2.2':
+    resolution: {integrity: sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==}
+
+  '@secretlint/secretlint-rule-no-dotenv@10.2.2':
+    resolution: {integrity: sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/secretlint-rule-preset-recommend@10.2.2':
+    resolution: {integrity: sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/source-creator@10.2.2':
+    resolution: {integrity: sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==}
+    engines: {node: '>=20.0.0'}
+
+  '@secretlint/types@10.2.2':
+    resolution: {integrity: sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==}
+    engines: {node: '>=20.0.0'}
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1787,6 +2150,10 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -1798,6 +2165,21 @@ packages:
 
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
+
+  '@textlint/ast-node-types@15.5.4':
+    resolution: {integrity: sha512-bVtB6VEy9U9DpW8cTt25k5T+lz86zV5w6ImePZqY1AXzSuPhqQNT77lkMPxonXzUducEIlSvUu3o7sKw3y9+Sw==}
+
+  '@textlint/linter-formatter@15.5.4':
+    resolution: {integrity: sha512-D9qJedKBLmAo+kiudop4UKgSxXMi4O8U86KrCidVXZ9RsK0NSVIw6+r2rlMUOExq79iEY81FRENyzmNVRxDBsg==}
+
+  '@textlint/module-interop@15.5.4':
+    resolution: {integrity: sha512-JyAUd26ll3IFF87LP0uGoa8Tzw5ZKiYvGs6v8jLlzyND1lUYCI4+2oIAslrODLkf0qwoCaJrBQWM3wsw+asVGQ==}
+
+  '@textlint/resolver@15.5.4':
+    resolution: {integrity: sha512-5GUagtpQuYcmhlOzBGdmVBvDu5lKgVTjwbxtdfoidN4OIqblIxThJHHjazU+ic+/bCIIzI2JcOjHGSaRmE8Gcg==}
+
+  '@textlint/types@15.5.4':
+    resolution: {integrity: sha512-mY28j2U7nrWmZbxyKnRvB8vJxJab4AxqOobLfb6iozrLelJbqxcOTvBQednadWPfAk9XWaZVMqUr9Nird3mutg==}
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -1886,14 +2268,17 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
   '@types/object-path@0.11.4':
     resolution: {integrity: sha512-4tgJ1Z3elF/tOMpA8JLVuR9spt9Ynsf7+JjqsQ2IqtiPJtcLoHoXcT6qU4E10cPFqyXX5HDm9QwIzZhBSkLxsw==}
@@ -1905,6 +2290,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/sarif@2.1.7':
+    resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
@@ -1918,8 +2306,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/vscode@1.110.0':
-    resolution: {integrity: sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==}
+  '@types/vscode@1.115.0':
+    resolution: {integrity: sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -1994,8 +2382,8 @@ packages:
     peerDependencies:
       typescript: '*'
 
-  '@typespec/ts-http-runtime@0.3.4':
-    resolution: {integrity: sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==}
+  '@typespec/ts-http-runtime@0.3.5':
+    resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
   '@ungap/structured-clone@1.3.0':
@@ -2060,9 +2448,9 @@ packages:
   '@vscode/vsce-sign@2.0.9':
     resolution: {integrity: sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==}
 
-  '@vscode/vsce@2.32.0':
-    resolution: {integrity: sha512-3EFJfsgrSftIqt3EtdRcAygy/OJ3hstyI1cDmIgkU9CFZW5C+3djr6mfosndCUqcVYuyjmxOK1xmFp/Bq7+NIg==}
-    engines: {node: '>= 16'}
+  '@vscode/vsce@3.7.1':
+    resolution: {integrity: sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   '@vue/compiler-core@3.5.31':
@@ -2292,6 +2680,10 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2299,10 +2691,6 @@ packages:
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-
-  ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -2342,6 +2730,10 @@ packages:
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
   astro@6.1.3:
@@ -2444,6 +2836,10 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  binaryextensions@6.11.0:
+    resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
+    engines: {node: '>=4'}
+
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
@@ -2452,6 +2848,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boundary@2.0.0:
+    resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
   bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
@@ -2506,9 +2905,9 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  c8@10.1.3:
-    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
-    engines: {node: '>=18'}
+  c8@11.0.0:
+    resolution: {integrity: sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==}
+    engines: {node: 20 || >=22}
     hasBin: true
     peerDependencies:
       monocart-coverage-reports: ^2
@@ -2561,10 +2960,6 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
-
-  chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2683,15 +3078,9 @@ packages:
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
-
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -2714,12 +3103,12 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  commander@6.2.1:
-    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
-    engines: {node: '>= 6'}
 
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
@@ -2879,6 +3268,10 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
@@ -2980,6 +3373,10 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  editions@6.22.0:
+    resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
+    engines: {ecmascript: '>= es5', node: '>=4'}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -3020,9 +3417,6 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
-  entities@2.1.0:
-    resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -3039,6 +3433,10 @@ packages:
     resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
     engines: {node: '>=4'}
     hasBin: true
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -3062,13 +3460,23 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
-  esbuild-visualizer@0.3.1:
-    resolution: {integrity: sha512-eNIM6AOfE+7XvRkBFpxZA8V07yPhskwZH6YBBVVrgiCdq1YKatd0Eh/Y0gK8iDnOAvL3Ezz1zDvzX/ssVNLIiA==}
-    engines: {node: '>=10.20'}
+  esbuild-visualizer@0.7.0:
+    resolution: {integrity: sha512-Vz22k+G2WT7GuCo7rbhaQwGbZ26lEhwzsctkEdQlu2SVrshoM4hzQeRpu/3DP596a9+9K2JyYsinuC6AC896Og==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.27.5:
     resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3078,10 +3486,6 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -3476,6 +3880,16 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -3493,6 +3907,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  globby@14.1.0:
+    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
+    engines: {node: '>=18'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3502,10 +3920,6 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
-
-  has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3566,6 +3980,10 @@ packages:
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
+
+  hosted-git-info@7.0.2:
+    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
+    engines: {node: ^16.14.0 || >=18.0.0}
 
   html-entities@2.3.3:
     resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
@@ -3667,6 +4085,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3856,8 +4278,16 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  istextorbinary@9.5.0:
+    resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
+    engines: {node: '>=4'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -4185,8 +4615,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@3.0.3:
-    resolution: {integrity: sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==}
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
@@ -4230,6 +4660,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -4253,6 +4686,10 @@ packages:
 
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -4284,8 +4721,8 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
-  markdown-it@12.3.2:
-    resolution: {integrity: sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==}
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -4345,8 +4782,8 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
-  mdurl@1.0.1:
-    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -4612,6 +5049,14 @@ packages:
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
+  node-sarif-builder@3.4.0:
+    resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
+    engines: {node: '>=20'}
+
+  normalize-package-data@6.0.2:
+    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -4679,9 +5124,9 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
 
   open@9.1.0:
     resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
@@ -4730,6 +5175,10 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
+
   p-queue@9.1.1:
     resolution: {integrity: sha512-yQS1vV2V7Q14MQrgD8jMNY5owPuGgVHVdSK8NqmKpOVajnjbaeMa6uLOzTALPtvJ7Vo4bw0BGsw7qfUT8z24Ig==}
     engines: {node: '>=20'}
@@ -4761,6 +5210,10 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
@@ -4804,9 +5257,17 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  path-type@6.0.0:
+    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
+    engines: {node: '>=18'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -4843,6 +5304,13 @@ packages:
   plugin-error@2.0.1:
     resolution: {integrity: sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==}
     engines: {node: '>=10.13.0'}
+
+  pluralize@2.0.0:
+    resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -4896,6 +5364,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4903,8 +5375,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -4915,6 +5387,9 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  rc-config-loader@4.1.4:
+    resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4931,6 +5406,10 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  read-pkg@9.0.1:
+    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
+    engines: {node: '>=18'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -5130,6 +5609,11 @@ packages:
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
+  secretlint@10.2.2:
+    resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -5196,8 +5680,8 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -5231,6 +5715,14 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
@@ -5268,6 +5760,18 @@ packages:
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   speakingurl@14.0.1:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
@@ -5352,6 +5856,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  structured-source@4.0.0:
+    resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -5369,10 +5876,6 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
-  supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5380,6 +5883,10 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -5392,6 +5899,10 @@ packages:
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
@@ -5410,6 +5921,10 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  terminal-link@4.0.0:
+    resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
+    engines: {node: '>=18'}
 
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
@@ -5436,12 +5951,19 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
+  test-exclude@8.0.0:
+    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
+    engines: {node: 20 || >=22}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  textextensions@6.11.0:
+    resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
+    engines: {node: '>=4'}
 
   through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
@@ -5542,6 +6064,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -5561,12 +6087,17 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
 
-  uc.micro@1.0.6:
-    resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
@@ -5580,15 +6111,23 @@ packages:
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -5727,9 +6266,16 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  version-range@4.15.0:
+    resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
+    engines: {node: '>=4'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -5900,12 +6446,19 @@ packages:
     resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
     engines: {node: '>=14.0.0'}
 
-  vscode-languageclient@8.1.0:
-    resolution: {integrity: sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==}
-    engines: {vscode: ^1.67.0}
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
 
   vscode-languageserver-protocol@3.17.3:
     resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
 
   vscode-languageserver-textdocument@1.0.12:
     resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
@@ -5913,8 +6466,15 @@ packages:
   vscode-languageserver-types@3.17.3:
     resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
 
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
   vscode-languageserver@8.1.0:
     resolution: {integrity: sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==}
+    hasBin: true
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
     hasBin: true
 
   vscode-uri@3.1.0:
@@ -6286,11 +6846,11 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/solid-js@6.0.1(@types/node@22.19.15)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.1)(yaml@2.8.3)':
+  '@astrojs/solid-js@6.0.1(@types/node@25.5.2)(lightningcss@1.32.0)(solid-js@1.9.12)(terser@5.46.1)(yaml@2.8.3)':
     dependencies:
       solid-js: 1.9.12
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
-      vite-plugin-solid: 2.11.11(solid-js@1.9.12)(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite-plugin-solid: 2.11.11(solid-js@1.9.12)(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - '@types/node'
@@ -6317,6 +6877,12 @@ snapshots:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@azu/format-text@1.0.2': {}
+
+  '@azu/style-format@1.0.1':
+    dependencies:
+      '@azu/format-text': 1.0.2
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -6349,7 +6915,7 @@ snapshots:
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
-      '@typespec/ts-http-runtime': 0.3.4
+      '@typespec/ts-http-runtime': 0.3.5
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6361,7 +6927,7 @@ snapshots:
   '@azure/core-util@1.13.1':
     dependencies:
       '@azure/abort-controller': 2.1.2
-      '@typespec/ts-http-runtime': 0.3.4
+      '@typespec/ts-http-runtime': 0.3.5
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -6375,8 +6941,8 @@ snapshots:
       '@azure/core-tracing': 1.3.1
       '@azure/core-util': 1.13.1
       '@azure/logger': 1.3.0
-      '@azure/msal-browser': 5.6.2
-      '@azure/msal-node': 5.1.1
+      '@azure/msal-browser': 5.6.3
+      '@azure/msal-node': 5.1.2
       open: 10.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -6384,20 +6950,20 @@ snapshots:
 
   '@azure/logger@1.3.0':
     dependencies:
-      '@typespec/ts-http-runtime': 0.3.4
+      '@typespec/ts-http-runtime': 0.3.5
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@azure/msal-browser@5.6.2':
+  '@azure/msal-browser@5.6.3':
     dependencies:
-      '@azure/msal-common': 16.4.0
+      '@azure/msal-common': 16.4.1
 
-  '@azure/msal-common@16.4.0': {}
+  '@azure/msal-common@16.4.1': {}
 
-  '@azure/msal-node@5.1.1':
+  '@azure/msal-node@5.1.2':
     dependencies:
-      '@azure/msal-common': 16.4.0
+      '@azure/msal-common': 16.4.1
       jsonwebtoken: 9.0.3
       uuid: 8.3.2
 
@@ -6631,7 +7197,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.30.0(@types/node@22.19.15)':
+  '@changesets/cli@2.30.0(@types/node@25.5.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.0
       '@changesets/assemble-release-plan': 6.0.9
@@ -6647,7 +7213,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.15)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.5.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -6769,8 +7335,6 @@ snapshots:
       typescript: 5.8.3
       yaml: 2.8.3
 
-  '@danielx/hera@0.7.12': {}
-
   '@danielx/hera@0.8.20': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
@@ -6818,79 +7382,235 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.5':
     optional: true
 
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.5':
     optional: true
 
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.5':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.5':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
@@ -6973,7 +7693,7 @@ snapshots:
   '@farmfe/core-win32-x64-msvc@1.7.11':
     optional: true
 
-  '@farmfe/core@1.7.11(@types/node@22.19.15)':
+  '@farmfe/core@1.7.11(@types/node@25.5.2)':
     dependencies:
       '@farmfe/runtime': 0.12.10
       '@farmfe/runtime-plugin-hmr': 3.5.10
@@ -6987,7 +7707,7 @@ snapshots:
       dotenv-expand: 11.0.7
       execa: 7.2.0
       farm-browserslist-generator: 1.0.5
-      farm-plugin-replace-dirname: 0.2.1(@types/node@22.19.15)
+      farm-plugin-replace-dirname: 0.2.1(@types/node@25.5.2)
       fast-glob: 3.3.3
       fs-extra: 11.3.4
       http-proxy-middleware: 3.0.5
@@ -7148,12 +7868,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.15)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.5.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -7163,6 +7883,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/cliui@9.0.0': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -7177,27 +7899,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -7226,7 +7948,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -7244,7 +7966,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -7266,7 +7988,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -7336,7 +8058,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -7587,6 +8309,80 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
+  '@secretlint/config-creator@10.2.2':
+    dependencies:
+      '@secretlint/types': 10.2.2
+
+  '@secretlint/config-loader@10.2.2':
+    dependencies:
+      '@secretlint/profiler': 10.2.2
+      '@secretlint/resolver': 10.2.2
+      '@secretlint/types': 10.2.2
+      ajv: 8.18.0
+      debug: 4.4.3(supports-color@8.1.1)
+      rc-config-loader: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/core@10.2.2':
+    dependencies:
+      '@secretlint/profiler': 10.2.2
+      '@secretlint/types': 10.2.2
+      debug: 4.4.3(supports-color@8.1.1)
+      structured-source: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/formatter@10.2.2':
+    dependencies:
+      '@secretlint/resolver': 10.2.2
+      '@secretlint/types': 10.2.2
+      '@textlint/linter-formatter': 15.5.4
+      '@textlint/module-interop': 15.5.4
+      '@textlint/types': 15.5.4
+      chalk: 5.6.2
+      debug: 4.4.3(supports-color@8.1.1)
+      pluralize: 8.0.0
+      strip-ansi: 7.2.0
+      table: 6.9.0
+      terminal-link: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/node@10.2.2':
+    dependencies:
+      '@secretlint/config-loader': 10.2.2
+      '@secretlint/core': 10.2.2
+      '@secretlint/formatter': 10.2.2
+      '@secretlint/profiler': 10.2.2
+      '@secretlint/source-creator': 10.2.2
+      '@secretlint/types': 10.2.2
+      debug: 4.4.3(supports-color@8.1.1)
+      p-map: 7.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@secretlint/profiler@10.2.2': {}
+
+  '@secretlint/resolver@10.2.2': {}
+
+  '@secretlint/secretlint-formatter-sarif@10.2.2':
+    dependencies:
+      node-sarif-builder: 3.4.0
+
+  '@secretlint/secretlint-rule-no-dotenv@10.2.2':
+    dependencies:
+      '@secretlint/types': 10.2.2
+
+  '@secretlint/secretlint-rule-preset-recommend@10.2.2': {}
+
+  '@secretlint/source-creator@10.2.2':
+    dependencies:
+      '@secretlint/types': 10.2.2
+      istextorbinary: 9.5.0
+
+  '@secretlint/types@10.2.2': {}
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -7698,6 +8494,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@sindresorhus/merge-streams@2.3.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -7713,6 +8511,35 @@ snapshots:
   '@swc/helpers@0.5.20':
     dependencies:
       tslib: 2.8.1
+
+  '@textlint/ast-node-types@15.5.4': {}
+
+  '@textlint/linter-formatter@15.5.4':
+    dependencies:
+      '@azu/format-text': 1.0.2
+      '@azu/style-format': 1.0.1
+      '@textlint/module-interop': 15.5.4
+      '@textlint/resolver': 15.5.4
+      '@textlint/types': 15.5.4
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      js-yaml: 4.1.1
+      lodash: 4.18.1
+      pluralize: 2.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      table: 6.9.0
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@textlint/module-interop@15.5.4': {}
+
+  '@textlint/resolver@15.5.4': {}
+
+  '@textlint/types@15.5.4':
+    dependencies:
+      '@textlint/ast-node-types': 15.5.4
 
   '@tsconfig/node10@1.0.12':
     optional: true
@@ -7772,7 +8599,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7780,7 +8607,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7817,10 +8644,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
@@ -7828,6 +8651,12 @@ snapshots:
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@25.5.2':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/normalize-package-data@2.4.4': {}
 
   '@types/object-path@0.11.4': {}
 
@@ -7839,6 +8668,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sarif@2.1.7': {}
+
   '@types/semver@7.7.1': {}
 
   '@types/stack-utils@2.0.3': {}
@@ -7847,7 +8678,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/vscode@1.110.0': {}
+  '@types/vscode@1.115.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
@@ -7873,6 +8704,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/type-utils': 8.58.0(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.58.0
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.0
@@ -7885,12 +8732,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.4
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.58.0(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.58.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.58.0(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7903,6 +8771,10 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
+  '@typescript-eslint/tsconfig-utils@8.58.0(typescript@6.0.2)':
+    dependencies:
+      typescript: 6.0.2
+
   '@typescript-eslint/type-utils@8.58.0(eslint@9.39.4)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.0
@@ -7912,6 +8784,18 @@ snapshots:
       eslint: 9.39.4
       ts-api-utils: 2.5.0(typescript@5.8.3)
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/type-utils@8.58.0(eslint@9.39.4)(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4)(typescript@6.0.2)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7932,6 +8816,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.58.0(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.58.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/visitor-keys': 8.58.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.58.0(eslint@9.39.4)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
@@ -7940,6 +8839,17 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.8.3)
       eslint: 9.39.4
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.58.0(eslint@9.39.4)(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.58.0
+      '@typescript-eslint/types': 8.58.0
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
+      eslint: 9.39.4
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7955,7 +8865,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typespec/ts-http-runtime@0.3.4':
+  '@typespec/ts-http-runtime@0.3.5':
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -8019,25 +8929,30 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@2.32.0':
+  '@vscode/vsce@3.7.1':
     dependencies:
       '@azure/identity': 4.13.1
+      '@secretlint/node': 10.2.2
+      '@secretlint/secretlint-formatter-sarif': 10.2.2
+      '@secretlint/secretlint-rule-no-dotenv': 10.2.2
+      '@secretlint/secretlint-rule-preset-recommend': 10.2.2
       '@vscode/vsce-sign': 2.0.9
       azure-devops-node-api: 12.5.0
-      chalk: 2.4.2
+      chalk: 4.1.2
       cheerio: 1.2.0
       cockatiel: 3.2.1
-      commander: 6.2.1
+      commander: 12.1.0
       form-data: 4.0.5
-      glob: 7.2.3
+      glob: 11.1.0
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
       leven: 3.1.0
-      markdown-it: 12.3.2
+      markdown-it: 14.1.1
       mime: 1.6.0
       minimatch: 3.1.5
       parse-semver: 1.1.1
       read: 1.0.7
+      secretlint: 10.2.2
       semver: 7.7.4
       tmp: 0.2.5
       typed-rest-client: 1.8.11
@@ -8316,13 +9231,13 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
-
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -8354,7 +9269,9 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  astro@6.1.3(@azure/identity@4.13.1)(@types/node@22.19.15)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@5.8.3)(yaml@2.8.3):
+  astral-regex@2.0.0: {}
+
+  astro@6.1.3(@azure/identity@4.13.1)(@types/node@25.5.2)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@5.8.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -8375,7 +9292,7 @@ snapshots:
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 2.0.0
-      esbuild: 0.27.5
+      esbuild: 0.27.7
       flattie: 1.1.1
       fontace: 0.4.1
       github-slugger: 2.0.0
@@ -8406,8 +9323,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5(@azure/identity@4.13.1)
       vfile: 6.0.3
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
-      vitefu: 1.1.3(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -8550,6 +9467,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  binaryextensions@6.11.0:
+    dependencies:
+      editions: 6.22.0
+
   birpc@2.9.0: {}
 
   bl@4.1.0:
@@ -8559,6 +9480,8 @@ snapshots:
       readable-stream: 3.6.2
 
   boolbase@1.0.0: {}
+
+  boundary@2.0.0: {}
 
   bplist-parser@0.2.0:
     dependencies:
@@ -8616,7 +9539,7 @@ snapshots:
 
   bytes@3.1.2: {}
 
-  c8@10.1.3:
+  c8@11.0.0:
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@istanbuljs/schema': 0.1.3
@@ -8625,7 +9548,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      test-exclude: 7.0.2
+      test-exclude: 8.0.0
       v8-to-istanbul: 9.3.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
@@ -8681,12 +9604,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -8726,7 +9643,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.24.6
+      undici: 7.24.7
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -8804,15 +9721,9 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -8828,9 +9739,9 @@ snapshots:
 
   commander@11.1.0: {}
 
-  commander@2.20.3: {}
+  commander@12.1.0: {}
 
-  commander@6.2.1: {}
+  commander@2.20.3: {}
 
   common-ancestor-path@2.0.0: {}
 
@@ -8865,13 +9776,13 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  create-jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3)):
+  create-jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -8984,6 +9895,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  define-lazy-prop@2.0.0: {}
+
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.6: {}
@@ -9062,6 +9975,10 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  editions@6.22.0:
+    dependencies:
+      version-range: 4.15.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.329: {}
@@ -9098,8 +10015,6 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
-  entities@2.1.0: {}
-
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -9107,6 +10022,8 @@ snapshots:
   entities@7.0.1: {}
 
   envinfo@7.21.0: {}
+
+  environment@1.1.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -9129,11 +10046,11 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild-visualizer@0.3.1:
+  esbuild-visualizer@0.7.0:
     dependencies:
-      nanoid: 3.3.11
-      open: 7.4.2
-      yargs: 16.2.0
+      open: 8.4.2
+      picomatch: 4.0.4
+      yargs: 17.7.2
 
   esbuild@0.27.5:
     optionalDependencies:
@@ -9164,11 +10081,67 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.5
       '@esbuild/win32-x64': 0.27.5
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
-
-  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -9362,9 +10335,9 @@ snapshots:
   farm-plugin-replace-dirname-win32-x64-msvc@0.2.1:
     optional: true
 
-  farm-plugin-replace-dirname@0.2.1(@types/node@22.19.15):
+  farm-plugin-replace-dirname@0.2.1(@types/node@25.5.2):
     dependencies:
-      '@changesets/cli': 2.30.0(@types/node@22.19.15)
+      '@changesets/cli': 2.30.0(@types/node@25.5.2)
       '@farmfe/utils': 0.0.1
       cac: 6.7.14
     optionalDependencies:
@@ -9578,6 +10551,21 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -9606,6 +10594,15 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  globby@14.1.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      path-type: 6.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.3.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -9621,8 +10618,6 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.3
       uncrypto: 0.1.3
-
-  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -9734,6 +10729,10 @@ snapshots:
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
+
+  hosted-git-info@7.0.2:
+    dependencies:
+      lru-cache: 10.4.3
 
   html-entities@2.3.3: {}
 
@@ -9850,6 +10849,8 @@ snapshots:
       resolve-cwd: 3.0.0
 
   imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -10023,11 +11024,21 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  istextorbinary@9.5.0:
+    dependencies:
+      binaryextensions: 6.11.0
+      editions: 6.22.0
+      textextensions: 6.11.0
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -10041,7 +11052,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -10061,16 +11072,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3)):
+  jest-cli@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      create-jest: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -10080,7 +11091,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -10105,8 +11116,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.19.15
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.8.3)
+      '@types/node': 25.5.2
+      ts-node: 10.9.2(@types/node@25.5.2)(typescript@6.0.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -10135,7 +11146,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -10145,7 +11156,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -10184,7 +11195,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -10219,7 +11230,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -10247,7 +11258,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -10293,7 +11304,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10312,7 +11323,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -10321,23 +11332,23 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3)):
+  jest@29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3))
+      jest-cli: 29.7.0(@types/node@25.5.2)(ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10554,9 +11565,9 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@3.0.3:
+  linkify-it@5.0.0:
     dependencies:
-      uc.micro: 1.0.6
+      uc.micro: 2.1.0
 
   loader-runner@4.3.1: {}
 
@@ -10588,6 +11599,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash.truncate@4.4.2: {}
+
   lodash@4.18.1: {}
 
   log-symbols@4.1.0:
@@ -10607,6 +11620,8 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.2.7: {}
+
+  lru-cache@11.3.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -10641,13 +11656,14 @@ snapshots:
 
   mark.js@8.11.1: {}
 
-  markdown-it@12.3.2:
+  markdown-it@14.1.1:
     dependencies:
       argparse: 2.0.1
-      entities: 2.1.0
-      linkify-it: 3.0.3
-      mdurl: 1.0.1
-      uc.micro: 1.0.6
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -10779,7 +11795,7 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mdurl@1.0.1: {}
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -11150,6 +12166,17 @@ snapshots:
 
   node-releases@2.0.36: {}
 
+  node-sarif-builder@3.4.0:
+    dependencies:
+      '@types/sarif': 2.1.7
+      fs-extra: 11.3.4
+
+  normalize-package-data@6.0.2:
+    dependencies:
+      hosted-git-info: 7.0.2
+      semver: 7.7.4
+      validate-npm-package-license: 3.0.4
+
   normalize-path@3.0.0: {}
 
   npm-run-path@4.0.1:
@@ -11221,8 +12248,9 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  open@7.4.2:
+  open@8.4.2:
     dependencies:
+      define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
@@ -11294,6 +12322,8 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-map@7.0.4: {}
+
   p-queue@9.1.1:
     dependencies:
       eventemitter3: 5.0.4
@@ -11323,6 +12353,12 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
 
   parse-latin@7.0.0:
     dependencies:
@@ -11367,7 +12403,14 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.3
+      minipass: 7.1.3
+
   path-type@4.0.0: {}
+
+  path-type@6.0.0: {}
 
   pend@1.2.0: {}
 
@@ -11392,6 +12435,10 @@ snapshots:
   plugin-error@2.0.1:
     dependencies:
       ansi-colors: 1.1.0
+
+  pluralize@2.0.0: {}
+
+  pluralize@8.0.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -11452,11 +12499,13 @@ snapshots:
       once: 1.4.0
     optional: true
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -11465,6 +12514,15 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
+
+  rc-config-loader@4.1.4:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      js-yaml: 4.1.1
+      json5: 2.2.3
+      require-from-string: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   rc@1.2.8:
     dependencies:
@@ -11482,6 +12540,14 @@ snapshots:
   react-is@18.3.1: {}
 
   react@19.2.4: {}
+
+  read-pkg@9.0.1:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 6.0.2
+      parse-json: 8.3.0
+      type-fest: 4.41.0
+      unicorn-magic: 0.1.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -11768,6 +12834,18 @@ snapshots:
 
   search-insights@2.17.3: {}
 
+  secretlint@10.2.2:
+    dependencies:
+      '@secretlint/config-creator': 10.2.2
+      '@secretlint/formatter': 10.2.2
+      '@secretlint/node': 10.2.2
+      '@secretlint/profiler': 10.2.2
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 14.1.0
+      read-pkg: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -11872,7 +12950,7 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -11896,7 +12974,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -11917,6 +12995,14 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
+
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   smol-toml@1.6.1: {}
 
@@ -11961,6 +13047,20 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   speakingurl@14.0.1: {}
 
@@ -12042,6 +13142,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  structured-source@4.0.0:
+    dependencies:
+      boundary: 2.0.0
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -12053,10 +13157,6 @@ snapshots:
     dependencies:
       copy-anything: 4.0.5
 
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -12064,6 +13164,11 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -12078,6 +13183,14 @@ snapshots:
       sax: 1.6.0
 
   tabbable@6.4.0: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tapable@2.3.2: {}
 
@@ -12107,6 +13220,11 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terminal-link@4.0.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      supports-hyperlinks: 3.2.0
+
   terser-webpack-plugin@5.4.0(esbuild@0.27.5)(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -12130,10 +13248,10 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  test-exclude@7.0.2:
+  test-exclude@8.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 10.5.0
+      glob: 13.0.6
       minimatch: 10.2.5
 
   text-decoder@1.2.7:
@@ -12141,6 +13259,12 @@ snapshots:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+
+  text-table@0.2.0: {}
+
+  textextensions@6.11.0:
+    dependencies:
+      editions: 6.22.0
 
   through2@4.0.2:
     dependencies:
@@ -12177,21 +13301,25 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3):
+  ts-api-utils@2.5.0(typescript@6.0.2):
+    dependencies:
+      typescript: 6.0.2
+
+  ts-node@10.9.2(@types/node@25.5.2)(typescript@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
       diff: 8.0.4
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 6.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -12219,6 +13347,8 @@ snapshots:
 
   type-fest@0.21.3: {}
 
+  type-fest@4.41.0: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -12226,7 +13356,7 @@ snapshots:
 
   typed-rest-client@1.8.11:
     dependencies:
-      qs: 6.15.0
+      qs: 6.15.1
       tunnel: 0.0.6
       underscore: 1.13.8
 
@@ -12241,11 +13371,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript-eslint@8.58.0(eslint@9.39.4)(typescript@6.0.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@6.0.2))(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4)(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4)(typescript@6.0.2)
+      eslint: 9.39.4
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.8.3: {}
+
+  typescript@6.0.2: {}
 
   ua-parser-js@1.0.41: {}
 
-  uc.micro@1.0.6: {}
+  uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
 
@@ -12255,11 +13398,15 @@ snapshots:
 
   underscore@1.13.8: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
 
-  undici@7.24.6: {}
+  undici-types@7.18.2: {}
+
+  undici@7.24.7: {}
+
+  unicorn-magic@0.1.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -12370,7 +13517,14 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
   vary@1.1.2: {}
+
+  version-range@4.15.0: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -12397,7 +13551,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -12405,12 +13559,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.11(solid-js@1.9.12)(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -12418,8 +13572,8 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.12
       solid-refresh: 0.6.3(solid-js@1.9.12)
-      vite: 8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
-      vitefu: 1.1.2(vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3))
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+      vitefu: 1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -12434,16 +13588,16 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.46.1
 
-  vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3):
+  vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.5
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.2
       fsevents: 2.3.3
       lightningcss: 1.32.0
       terser: 5.46.1
@@ -12466,17 +13620,34 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      tinyglobby: 0.2.15
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      '@types/node': 25.5.2
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      terser: 5.46.1
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  vitefu@1.1.2(vite@8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 8.0.3(@types/node@22.19.15)(esbuild@0.27.5)(terser@5.46.1)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
-  vitefu@1.1.3(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+  vitefu@1.1.2(vite@8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+      vite: 8.0.3(@types/node@25.5.2)(esbuild@0.27.7)(terser@5.46.1)(yaml@2.8.3)
+
+  vitefu@1.1.3(vite@7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)):
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.5.2)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
   vitepress@1.6.4(@algolia/client-search@5.50.0)(@types/node@22.19.15)(lightningcss@1.32.0)(postcss@8.5.8)(search-insights@2.17.3)(terser@5.46.1)(typescript@5.8.3):
     dependencies:
@@ -12529,24 +13700,37 @@ snapshots:
 
   vscode-jsonrpc@8.1.0: {}
 
-  vscode-languageclient@8.1.0:
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageclient@9.0.1:
     dependencies:
       minimatch: 5.1.9
       semver: 7.7.4
-      vscode-languageserver-protocol: 3.17.3
+      vscode-languageserver-protocol: 3.17.5
 
   vscode-languageserver-protocol@3.17.3:
     dependencies:
       vscode-jsonrpc: 8.1.0
       vscode-languageserver-types: 3.17.3
 
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.17.3: {}
 
+  vscode-languageserver-types@3.17.5: {}
+
   vscode-languageserver@8.1.0:
     dependencies:
       vscode-languageserver-protocol: 3.17.3
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
# PR #1935: LSP Civet Conversion + CI

## Summary

### LSP source converted from TypeScript to Civet

All LSP source files have been rewritten from `.mts` TypeScript to `.civet`:

- `server.mts` → `server.civet`
- `lib/typescript-service.mts` → `lib/typescript-service.civet`
- `lib/util.mts` → `lib/util.civet`
- `lib/previewer.mts` → `lib/previewer.civet`
- `lib/textRendering.mts` → `lib/textRendering.civet`

### E2E test suite added

New end-to-end tests that spin up a real VS Code instance via `@vscode/test-electron` and exercise the LSP over the language client protocol:

- `e2e/completion.test.civet` — completion items
- `e2e/at-completions.test.civet` — `@`-prefixed decorator completions
- `e2e/definition.test.civet` — go-to-definition
- `e2e/hover.test.civet` — hover info
- `e2e/diagnostics.test.civet` — error diagnostics
- `e2e/document-symbols.test.civet` — document symbol outline
- `e2e/references.test.civet` — find references
- `e2e/fixture/` — shared Civet fixture files used by the tests

### Unit test coverage expanded

- `test/service.civet` — significantly expanded TypeScript service tests
- `test/rendering.civet` — new rendering/hover text tests
- `test/util-extra.civet` — new utility function tests
- `lsp/scripts/show-uncovered.mjs` — script for visualizing uncovered code regions

### CI workflow added

`.github/workflows/lsp.yml` — new GitHub Actions workflow that runs `pnpm build && pnpm test && pnpm e2e` in the `lsp/` directory on every push or PR touching `lsp/**`. Builds the root `@danielx/civet` package first so the LSP build can find the `civet` binary.

### Build fix

`lsp/build/build.sh` was updated to use `${CIVET_BIN:-../dist/civet}` instead of a hardcoded `node_modules/.bin/civet` path, which pnpm does not create for workspace-linked packages in CI.

### esbuild pinned to 0.27.5

`pnpm.overrides.esbuild` pinned back to `0.27.5` (from `^0.27.0`) to avoid a regression in esbuild 0.27.7 that breaks the VitePress docs build with a "Transforming destructuring to the configured target environment is not supported yet" error.
