### PR TITLE
feat: object shorthand optional properties

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -192,6 +192,18 @@ headers :=
   Content-Encoding: "gzip"
 </Playground>
 
+### Optional Properties
+
+Braced object literals support `?` shorthand for properties
+that get included only when the value is non-null:
+
+<Playground>
+options := { filename?, data?: getData() }
+</Playground>
+
+This is especially helpful for satisfying TypeScript's
+[`exactOptionalPropertyTypes` mode](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes).
+
 ### Object Globs
 
 Inspired by

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -51,6 +51,7 @@ import {
   maybeRefAssignment,
   modifyString,
   negateCondition,
+  parenthesizeExpression,
   precedenceCustomDefault,
   precedenceStep,
   prepend,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3839,6 +3839,14 @@ PropertyDefinition
     // Private name becomes public
     if name[0] is "#" then name = name.slice(1)
 
+    // { y? } → { ...((y != null) && {y}) }
+    if not pre# and post?.token is "?" and value.type is "Identifier"
+      return {
+        type: "SpreadProperty",
+        children: [ws, "...((", value, " != null) && {", name, "})"],
+        names: value.names,
+      }
+
     return {
       type: "Property",
       children: [ws, name, ": ", processUnaryExpression(pre, value, post)],
@@ -3852,6 +3860,15 @@ PropertyDefinition
   #  return prepend(ws, id)
 
 NamedProperty
+  # NOTE: Optional named property { y?: value } → { ...(value != null ? {y: value} : {}) }
+  PropertyName:name "?" _? Colon _? PostfixedExpression:exp ->
+    { ref, refAssignment } := maybeRefAssignment(exp)
+    checkExp := refAssignment ? ["(", refAssignment, ")"] : exp
+    return {
+      type: "SpreadProperty",
+      children: ["...(", checkExp, " != null ? {", name, ": ", ref, "} : {})"],
+      names: exp.names || [],
+    }
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser
   # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
   PropertyName:name _? Colon PostfixedExpression:exp ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3863,7 +3863,7 @@ NamedProperty
   # NOTE: Optional named property { y?: value } → { ...(value != null ? {y: value} : {}) }
   PropertyName:name "?" _? Colon _? PostfixedExpression:exp ->
     { ref, refAssignment } := maybeRefAssignment(exp)
-    checkExp := refAssignment ? ["(", refAssignment, ")"] : exp
+    checkExp := refAssignment ? parenthesizeExpression(refAssignment) : exp
     return {
       type: "SpreadProperty",
       children: ["...(", checkExp, " != null ? {", name, ": ", ref, "} : {})"],

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3842,10 +3842,14 @@ PropertyDefinition
 
     // { y? } → { ...((y != null) && {y}) }
     if not pre# and post?.token is "?" and value.type is "Identifier"
+      dots := { $loc, token: "..." }
+      paren := parenthesizeExpression({ children: ["(", value, " != null) && {", name, "}"] })
       return {
         type: "SpreadProperty",
-        children: [ws, "...((", value, " != null) && {", name, "})"],
+        children: [ws, dots, paren],
         names: value.names,
+        dots,
+        value: paren,
       }
 
     return {
@@ -3865,10 +3869,15 @@ NamedProperty
   PropertyName:name "?" _? Colon _? PostfixedExpression:exp ->
     { ref, refAssignment } := maybeRefAssignment(exp)
     checkExp := refAssignment ? parenthesizeExpression(refAssignment) : exp
+    dots := { $loc, token: "..." }
+    paren := parenthesizeExpression({ children: [checkExp, " != null ? {", name, ": ", ref, "} : {}"] })
+
     return {
       type: "SpreadProperty",
-      children: ["...(", checkExp, " != null ? {", name, ": ", ref, "} : {})"],
+      children: [dots, paren],
       names: exp.names || [],
+      dots,
+      value: paren,
     }
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser
   # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -85,6 +85,7 @@ import {
   makeNode
   maybeWrap
   maybeUnwrap
+  parenthesizeExpression
   parenthesizeType
   prepend
   replaceNode
@@ -2119,6 +2120,7 @@ export {
   maybeRefAssignment
   modifyString
   negateCondition
+  parenthesizeExpression
   precedenceCustomDefault
   precedenceStep
   prepend

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -954,6 +954,14 @@ export type ObjectExpression
   properties: (Property | SpreadProperty | MethodDefinition | ASTError)[]
   parent?: Parent
 
+export type SpreadProperty
+  type: "SpreadProperty"
+  children: Children
+  parent?: Parent
+  names: string[]
+  dots: ASTNode
+  value?: ASTNode
+
 export type Property
   type: "Property"
   children: Children

--- a/test/object.civet
+++ b/test/object.civet
@@ -139,6 +139,62 @@ describe "object", ->
   """
 
   testCase """
+    optional shorthand inline
+    ---
+    {a, y?, b}
+    ---
+    ({a, ...((y != null) && {y}), b})
+  """
+
+  testCase """
+    optional shorthand only
+    ---
+    {y?}
+    ---
+    ({...((y != null) && {y})})
+  """
+
+  testCase """
+    optional shorthand multiline
+    ---
+    {
+      a
+      y?
+      b
+    }
+    ---
+    ({
+      a,
+      ...((y != null) && {y}),
+      b
+    })
+  """
+
+  testCase """
+    optional named property
+    ---
+    {y?: value}
+    ---
+    ({...(value != null ? {y: value} : {})})
+  """
+
+  testCase """
+    optional named property with space
+    ---
+    { y?: value }
+    ---
+    ({ ...(value != null ? {y: value} : {}) })
+  """
+
+  testCase """
+    optional named property with complex expression
+    ---
+    {y?: getValue()}
+    ---
+    let ref;({...((ref = getValue()) != null ? {y: ref} : {})})
+  """
+
+  testCase """
     flagging shorthand inline
     ---
     {+x, -y, !z}

--- a/test/object.civet
+++ b/test/object.civet
@@ -195,6 +195,14 @@ describe "object", ->
   """
 
   testCase """
+    optional computed property name
+    ---
+    {[key]?: getValue()}
+    ---
+    let ref;({...((ref = getValue()) != null ? {[key]: ref} : {})})
+  """
+
+  testCase """
     flagging shorthand inline
     ---
     {+x, -y, !z}


### PR DESCRIPTION
Implements object shorthand optional properties as described in #1883.

`{ y? }` now compiles to `{ ...((y != null) && {y}) }` instead of `{ y: (y != null) }`, meaning "maybe put y in the object".

Also adds value form: `{ y?: value }` compiles to `{ ...(value != null ? {y: value} : {}) }`.

Closes #1883

Generated with [Claude Code](https://claude.ai/code)