### PR TITLE
LSP fixes for path casing (e.g. Windows) and ts documents

### DIFF
--- a/lsp/source/lib/typescript-service.civet
+++ b/lsp/source/lib/typescript-service.civet
@@ -203,7 +203,7 @@ function TSHost(
      * This accepts both `.civet` and `.ts` adding the transpiled targets to `scriptFileNames`.
      */
     addOrUpdateDocument(doc: TextDocument): void
-      const path = URI.parse(doc.uri).fsPath
+      const path = getCanonicalFileName URI.parse(doc.uri).fsPath
       // Clear any cached snapshot for this document
       snapshotMap.delete(path)
 
@@ -233,9 +233,10 @@ function TSHost(
 
       // Plain non-transpiled document
       scriptFileNames.add(path) unless scriptFileNames.has(path)
-      pathMap.set(path, doc) unless pathMap.has(path)
+      pathMap.set(path, doc)
 
     getMeta(path: string)
+      path = getCanonicalFileName path
       transpiledPath := getTranspiledPath(path)
       // This ensures that the transpiled meta data is created
       getOrCreatePathSnapshot(transpiledPath)
@@ -252,7 +253,7 @@ function TSHost(
      * So we need to normalize them here and in `getScriptVersion`.
      */
     getScriptSnapshot(path: string)
-      path = getCanonicalFileName(path)
+      path = getCanonicalFileName path
       getOrCreatePathSnapshot(path)
 
     /**
@@ -260,7 +261,7 @@ function TSHost(
      * So we need to normalize them here and in `getScriptSnapshot`.
      */
     getScriptVersion(path: string)
-      path = getCanonicalFileName(path)
+      path = getCanonicalFileName path
       // console.log("getScriptVersion", path, version)
       pathMap.get(path)?.version.toString() || "0"
 
@@ -276,6 +277,7 @@ function TSHost(
    * Use the VSCode document if it exists otherwise use the file system.
    */
   function getPathSource(path: string)
+    path = getCanonicalFileName path
     // Open VSCode docs and transpiled files should all be in the pathMap
     doc := pathMap.get(path)
     return doc.getText() if doc
@@ -283,12 +285,14 @@ function TSHost(
     ""
 
   function getTranspiledPath(path: string)
+    path = getCanonicalFileName path
     extension := getExtensionFromPath(path)
     transpiler := transpilers.get(extension)
     return path + transpiler.target if transpiler
     path
 
   function getOrCreatePathSnapshot(path: string) {
+    path = getCanonicalFileName path
     snapshot .= snapshotMap.get(path)
     return snapshot if snapshot
 
@@ -335,10 +339,12 @@ function TSHost(
   }
 
   function createOrUpdateMeta(path: string, transpiledDoc: TextDocument, sourcemapLines?: SourceMap["lines"], parseErrors?: (Error | ParseError)[], fatal: boolean = false) {
+    path = getCanonicalFileName path
     meta .= fileMetaData.get(path)
     if !meta
       fileMetaData.set(path, { sourcemapLines, transpiledDoc, parseErrors, fatal } as FileMeta)
     else
+      meta.transpiledDoc = transpiledDoc
       meta.sourcemapLines = sourcemapLines
       meta.parseErrors = parseErrors
       meta.fatal = fatal
@@ -363,6 +369,7 @@ function TSHost(
   }
 
   function initTranspiledDoc(path: string)
+    path = getCanonicalFileName path
     // Create an empty document, it will be updated on-demand when `getScriptSnapshot` is called
     // `path` must be the in the format that TypeScript Language Service expects
     uri := URI.file(path).toString()
@@ -377,7 +384,9 @@ function TSHost(
    * Normalize slashes based on the OS.
    */
   function getCanonicalFileName(fileName: string): string
-    path.join(fileName)
+    fileName = path.normalize fileName
+    fileName = fileName.toLowerCase() unless sys.useCaseSensitiveFileNames
+    fileName
 }
 
 function TSService(projectURL = "./", logger: Logger = console)


### PR DESCRIPTION
~~This is currently built on top of #1937 for testing purposes. Should wait for #1937 to merge first.~~

- Fixed `lsp` test failures on Windows by canonicalizing TypeScript host paths consistently before using them as document, snapshot, and metadata keys. This should fix any non-case-sensitive system.
- Updated the host to replace stored TypeScript / non-transpiled document entries and refresh `transpiledDoc` metadata on recompiles, preventing stale snapshots and metadata from being reused.
- Verified the fix by running #4309's `pnpm test` in `lsp`, with all tests passing on my Windows 11 machine.