### PR TITLE
CI tests on Windows too

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
+# force LF line endings on all systems
+*.civet text eol=lf
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
 # excluded from language stats
 civet.dev/public/*.html linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,5 @@
 # force LF line endings on all systems
-*.civet text eol=lf
-*.sh text eol=lf
-*.yml text eol=lf
-*.yaml text eol=lf
+* text=auto eol=lf
 
 # excluded from language stats
 civet.dev/public/*.html linguist-vendored

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
         id: cache
         with:
           path: .cache
-          key: ${{ runner.os }}-${{ github.ref_name }}-${{ steps.month.outputs.ym }}
+          key: ${{ github.ref_name }}-${{ steps.month.outputs.ym }}
           restore-keys: |
-            ${{ runner.os }}-main-${{ steps.month.outputs.ym }}
+            main-${{ steps.month.outputs.ym }}
 
       - name: Cache VS Code download
         uses: actions/cache@v4
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/cache/save@v4
         with:
           path: .cache
-          key: ${{ runner.os }}-${{ github.ref_name }}-${{ steps.month.outputs.ym }}
+          key: ${{ github.ref_name }}-${{ steps.month.outputs.ym }}
 
       - uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,19 @@ env:
 
 jobs:
   build:
-    name: Build and Test
-    runs-on: ubuntu-latest
+    name: Build and Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      npm_config_script_shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -35,9 +46,9 @@ jobs:
         id: cache
         with:
           path: .cache
-          key: ${{ github.ref_name }}-${{ steps.month.outputs.ym }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-${{ steps.month.outputs.ym }}
           restore-keys: |
-            main-${{ steps.month.outputs.ym }}
+            ${{ runner.os }}-main-${{ steps.month.outputs.ym }}
 
       - name: Cache VS Code download
         uses: actions/cache@v4
@@ -64,21 +75,34 @@ jobs:
       - uses: actions/cache/save@v4
         with:
           path: .cache
-          key: ${{ github.ref_name }}-${{ steps.month.outputs.ym }}
+          key: ${{ runner.os }}-${{ github.ref_name }}-${{ steps.month.outputs.ym }}
 
       - uses: actions/upload-artifact@v4
+        if: runner.os == 'Linux'
         with:
           name: browser.js
           path: dist/browser.js
 
       - name: Coveralls GitHub Action
+        if: runner.os == 'Linux'
         uses: coverallsapp/github-action@v2
         with:
           file: coverage/lcov.info
 
   self-test:
-    name: Self-Test
-    runs-on: ubuntu-latest
+    name: Self-Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    defaults:
+      run:
+        shell: bash
+    env:
+      npm_config_script_shell: bash
     steps:
       - uses: actions/checkout@v4
 

--- a/lsp/scripts/merge-coverage.civet
+++ b/lsp/scripts/merge-coverage.civet
@@ -2,11 +2,12 @@
 // then runs `c8 report` over the combined set.
 { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 { resolve, join } from 'path'
+{ fileURLToPath } from 'url'
 { execFileSync } from 'child_process'
 
 root := typeof __dirname !== "undefined" ?
   join(__dirname, '..') :
-  new URL('..', import.meta.url).pathname
+  fileURLToPath new URL('..', import.meta.url)
 unitTmp := join root, 'coverage/tmp'
 e2eTmp := join root, 'coverage/e2e-tmp'
 

--- a/lsp/scripts/merge-coverage.civet
+++ b/lsp/scripts/merge-coverage.civet
@@ -37,5 +37,5 @@ console.log `Merged ${copied} e2e coverage file(s) into ${unitTmp}`
 // weren't executed: Civet files aren't valid JS, so v8-to-istanbul falls back
 // to line-level (1 statement per line), which then merges incorrectly with the
 // real remapped bundle coverage and inflates everything to 100%.
-c8 := resolve root, '../node_modules/.bin/c8'
-execFileSync c8, ['report', '--no-all', '--exclude-after-remap', '--reporter', 'text'], { cwd: root, stdio: 'inherit' }
+c8 := resolve root, '../node_modules/c8/bin/c8.js'
+execFileSync process.execPath, [c8, 'report', '--no-all', '--exclude-after-remap', '--reporter', 'text'], { cwd: root, stdio: 'inherit' }

--- a/test/infra/unplugin.civet
+++ b/test/infra/unplugin.civet
@@ -405,7 +405,7 @@ describe "unplugin: file system", ->
       assert errored
 
     it "emitDeclaration: true emits .d.ts files", ->
-      @timeout 5000
+      @timeout 10000
       plugin := rawPlugin {
         ts: 'tsc'
         config: false

--- a/test/infra/unplugin.civet
+++ b/test/infra/unplugin.civet
@@ -20,6 +20,8 @@ nullContext: UnpluginBuildContext & UnpluginContext := {
 
 // Minimal meta object required by rawPlugin
 minMeta := { framework: 'rollup' as const }
+testOutDir := path.join tmpdir(), 'civet-unplugin-test-out'
+testViteRoot := path.join tmpdir(), 'civet-unplugin-vite-root'
 
 describe "unplugin: slash()", ->
   it "returns the same string when no backslashes", ->
@@ -383,7 +385,7 @@ describe "unplugin: file system", ->
       }, { framework: 'esbuild' }
       ctx := { ...nullContext, ...plugin }
 
-      plugin.esbuild.config { outdir: '/tmp/test-out' }
+      plugin.esbuild.config { outdir: testOutDir }
 
       tscErrors: string[] .= []
       origError := console.error
@@ -413,7 +415,7 @@ describe "unplugin: file system", ->
       }, { framework: 'esbuild' }
       ctx := { ...nullContext, ...plugin }
 
-      plugin.esbuild.config { outdir: '/tmp/test-out' }
+      plugin.esbuild.config { outdir: testOutDir }
 
       fileWithDeclaration := await makeCivetTempFile "x: number := 5\n"
 
@@ -446,14 +448,14 @@ describe "unplugin: esbuild framework hook", ->
     //@ts-expect-error build context
     await plugin.buildStart()
     assert plugin.esbuild?.config, "esbuild.config exists"
-    plugin.esbuild.config { outdir: '/tmp/test-out' }
+    plugin.esbuild.config { outdir: testOutDir }
     // just checking it doesn't throw
 
   it "esbuild.config sets outDir from outfile dirname", ->
     plugin := rawPlugin { ts: 'civet', config: false }, { framework: 'esbuild' }
     //@ts-expect-error build context
     await plugin.buildStart()
-    plugin.esbuild.config { outfile: '/tmp/test-out/bundle.js' }
+    plugin.esbuild.config { outfile: path.join testOutDir, 'bundle.js' }
     // just checking it doesn't throw
 
 describe "unplugin: vite framework hook", ->
@@ -462,7 +464,7 @@ describe "unplugin: vite framework hook", ->
     //@ts-expect-error build context
     await plugin.buildStart()
     assert plugin.vite?.config, "vite.config exists"
-    viteConfig: any := { root: '/tmp', build: { outDir: 'dist' }, resolve: { extensions: ['.js'] } }
+    viteConfig: any := { root: testViteRoot, build: { outDir: 'dist' }, resolve: { extensions: ['.js'] } }
     //@ts-expect-error context
     plugin.vite.config viteConfig
     assert viteConfig.resolve.extensions.includes('.civet'), ".civet added to extensions"
@@ -471,7 +473,7 @@ describe "unplugin: vite framework hook", ->
     plugin := rawPlugin { ts: 'civet', config: false, implicitExtension: true }, { framework: 'vite' }
     //@ts-expect-error context
     await plugin.buildStart()
-    viteConfig: any := { root: '/tmp', build: {} }
+    viteConfig: any := { root: testViteRoot, build: {} }
     //@ts-expect-error context
     plugin.vite.config viteConfig
     assert viteConfig.resolve?.extensions?.includes('.civet'), ".civet added to extensions"


### PR DESCRIPTION
~~This is currently built on top of #1937 for testing purposes. Should wait for #1937 to merge first.~~ (now merged)

~~The LSP tests are also expected to fail on Windows until #1939 gets merged.~~ (now merged)

* Run CI tests on Windows in addition to Linux, to prevent future regressions
* Force LF line endings so tests work correctly
* Increase timeout for slow Windows
* Fix path handling in merge-coverage script