### PR TITLE
Rename LSP test script names

### DIFF
--- a/lsp/package.json
+++ b/lsp/package.json
@@ -83,11 +83,13 @@
     "build-dev": "bash ./build/build.sh development",
     "package": "bash ./build/build.sh && vsce package --no-dependencies",
     "vsce-publish": "bash ./build/build.sh && vsce publish --no-dependencies",
-    "test": "mocha --config .mocharc.json",
-    "test:coverage": "c8 mocha --config .mocharc.json && pnpm e2e:coverage && ../dist/civet scripts/merge-coverage.civet",
+    "test": "pnpm test:unit && pnpm test:e2e",
+    "test:coverage": "pnpm test:unit:coverage && pnpm test:e2e:coverage && ../dist/civet scripts/merge-coverage.civet",
     "coverage:show": "../dist/civet scripts/show-uncovered.civet",
-    "e2e": "node e2e/dist/runTest",
-    "e2e:coverage": "pnpm build-dev && rm -rf coverage/e2e-tmp && NODE_V8_COVERAGE=coverage/e2e-tmp node e2e/dist/runTest",
+    "test:unit": "mocha --config .mocharc.json",
+    "test:unit:coverage": "c8 mocha --config .mocharc.json",
+    "test:e2e": "node e2e/dist/runTest",
+    "test:e2e:coverage": "pnpm build-dev && rm -rf coverage/e2e-tmp && NODE_V8_COVERAGE=coverage/e2e-tmp node e2e/dist/runTest",
     "watch": "node build.mjs --watch"
   },
   "c8": {

--- a/lsp/scripts/merge-coverage.civet
+++ b/lsp/scripts/merge-coverage.civet
@@ -14,7 +14,7 @@ e2eTmp := join root, 'coverage/e2e-tmp'
 mkdirSync unitTmp, { recursive: true }
 
 unless existsSync e2eTmp
-  console.error `No e2e coverage found at ${e2eTmp} — run 'pnpm e2e:coverage' first`
+  console.error `No e2e coverage found at ${e2eTmp} — run 'pnpm test:e2e:coverage' first`
   process.exit 1
 
 // Copy e2e coverage JSON files into the unit-test temp dir so c8 sees them all.


### PR DESCRIPTION
I feel like these names are more accurate. In particular, `test:coverage` runs both test suites before and after, so I think `test` should too. And `e2e` renamed to `test:e2e`.