### PR TITLE
Pin parameters `^name` gain `typeof` type inference 

### DIFF
--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -161,7 +161,10 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
         if n.type is "PinPattern"
           n.ref = makeRef
             n.expression.type is "Identifier" ? n.expression.name : "pin"
-          n.children = [n.ref]
+          // Add `typeof X` type annotation for direct, untyped pin parameters
+          typeSuffix := if n.parent?.type is "Parameter" and not n.parent?.typeSuffix?
+            typeSuffixForExpression n.expression
+          n.children = if typeSuffix? then [n.ref, typeSuffix] else [n.ref]
           updateParentPointers n
           thisAssignments.push
             type: "AssignmentExpression"

--- a/test/function.civet
+++ b/test/function.civet
@@ -479,7 +479,7 @@ describe "function", ->
       ---
       (^a, ^b) ->
       ---
-      (function(a1, b1) {a = a1;b = b1;})
+      (function(a1: typeof a, b1: typeof b) {a = a1;b = b1;})
     """
 
     testCase """
@@ -488,7 +488,7 @@ describe "function", ->
       (^a, ^b.c) ->
         a++
       ---
-      (function(a1, pin) {
+      (function(a1: typeof a, pin: typeof b.c) {
         a = a1;
         b.c = pin;
         return a++
@@ -526,7 +526,7 @@ describe "function", ->
       ---
       (^a) => 1
       ---
-      (a1) => {a = a1;return  1}
+      (a1: typeof a) => {a = a1;return  1}
     """
 
     testCase """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -739,3 +739,41 @@ describe "[TS] function", ->
         return await x
       }
     """
+
+  describe "^pin params", ->
+    testCase """
+      infers typeof for identifier
+      ---
+      (^downloadPattern) =>
+      ---
+      (downloadPattern1: typeof downloadPattern) => {downloadPattern = downloadPattern1;}
+    """
+
+    testCase """
+      infers typeof for member expression
+      ---
+      (^a, ^b.c) ->
+      ---
+      (function(a1: typeof a, pin: typeof b.c) {a = a1;b.c = pin;})
+    """
+
+    testCase """
+      no inference when explicit type given
+      ---
+      function initialize(^options: Options)
+      ---
+      function initialize(options1: Options){options = options1;}
+    """
+
+    testCase """
+      no inference in destructuring
+      ---
+      ({^a, b: ^b}) ->
+        a
+      ---
+      (function({a: a1, b: b1}) {
+        a = a1;
+        b = b1;
+        return a
+      })
+    """

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -750,30 +750,9 @@ describe "[TS] function", ->
     """
 
     testCase """
-      infers typeof for member expression
-      ---
-      (^a, ^b.c) ->
-      ---
-      (function(a1: typeof a, pin: typeof b.c) {a = a1;b.c = pin;})
-    """
-
-    testCase """
       no inference when explicit type given
       ---
       function initialize(^options: Options)
       ---
       function initialize(options1: Options){options = options1;}
-    """
-
-    testCase """
-      no inference in destructuring
-      ---
-      ({^a, b: ^b}) ->
-        a
-      ---
-      (function({a: a1, b: b1}) {
-        a = a1;
-        b = b1;
-        return a
-      })
     """


### PR DESCRIPTION
When a pin `^` argument has no explicit type annotation, automatically infer `typeof X` as the parameter type so that TypeScript can type-check assignments correctly. Only applies to direct (non-destructured) parameters without an existing explicit type.

Fixes #1866

Generated with [Claude Code](https://claude.ai/code)