### PR TITLE
Allow trailing member access after pipeline expressions

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1000,24 +1000,36 @@ ShortCircuitExpression
   BinaryOpExpression
 
 PipelineExpression
-  PipelineAllowed _?:ws PipelineHeadItem:head PipelineExpressionBody:body ->
+  PipelineAllowed _?:ws PipelineHeadItem:head PipelineExpressionBody:body AllowedTrailingCallExpressions?:trailing ->
     if head.type is "ArrowFunction" and head.ampersandBlock
       expressions := [ {
         type: "PipelineExpression",
         children: [ ws, head.block.expressions[0], body ],
       } ]
       block := { ...head.block, expressions, children: [expressions] }
-      return {
+      node := {
         ...head,
         block,
         body: expressions,
         children: [ ...head.children.slice(0, -1), block ],
       }
+      if trailing
+        return processCallMemberExpression({
+          type: "CallExpression",
+          children: [node, ...trailing]
+        })
+      return node
 
-    return {
+    node := {
       type: "PipelineExpression",
       children: [ws, head, body]
     }
+    if trailing
+      return processCallMemberExpression({
+        type: "CallExpression",
+        children: [node, ...trailing]
+      })
+    return node
 
 PipelineExpressionBody
   # First check for properly indented chain of |>s,

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -934,3 +934,30 @@ describe "pipe", ->
       return $ => $.b()
     }})()(y).c()
   """
+
+  testCase """
+    trailing member access on pipeline result
+    ---
+    a
+    |> b
+      .c
+    .d
+    ---
+    b
+      .c(a)
+    .d
+  """
+
+  testCase """
+    trailing member access on multi-step pipeline result
+    ---
+    a
+    |> b
+    |> c
+      .d
+    .e
+    ---
+    c
+      .d(b(a))
+    .e
+  """


### PR DESCRIPTION
When a pipeline ends with an indented tail (e.g. `b\n  .c`), any further member access at the outer indentation level (e.g. `.d`) was incorrectly parsed as a standalone ampersand-shorthand expression (`$ => $.d`).

Fix: add `AllowedTrailingCallExpressions` after `PipelineExpressionBody` in the grammar. When trailing is present, wrap the `PipelineExpression` in a `CallExpression`, so `a |> b\n  .c\n.d` correctly compiles to `b.c(a).d`.

Closes #1724

Generated with [Claude Code](https://claude.ai/code)