### PR TITLE
Dev: Fix eslint typecheck

### DIFF
--- a/integration/eslint/source/default-config.civet
+++ b/integration/eslint/source/default-config.civet
@@ -9,6 +9,7 @@ hasTypeScriptEslint :=
 
 defaultConfig :=
   if hasTypeScriptEslint
+    // @ts-expect-error - ./ts.js is the build output of ./ts.civet, unresolvable at typecheck time
     import civetPlugin from ./ts.js
     [
       ...(civetPlugin.configs.jsRecommended as Linter.FlatConfig[])
@@ -16,6 +17,7 @@ defaultConfig :=
       ...(civetPlugin.configs.stylistic as Linter.FlatConfig[])
     ]
   else
+    // @ts-expect-error - ./index.js is the build output of ./index.civet, unresolvable at typecheck time
     import civetPlugin from ./index.js
     civetPlugin.configs.recommended
 

--- a/integration/eslint/source/index.civet
+++ b/integration/eslint/source/index.civet
@@ -1,5 +1,6 @@
 Civet, { type CompileOptions } from '@danielx/civet'
 civetMeta from '@danielx/civet/package.json' with type: 'json'
+// @ts-expect-error - ts-diagnostic module not included in published types
 { remapPosition } from '@danielx/civet/ts-diagnostic'
 type { ESLint, Linter } from 'eslint'
 js from "@eslint/js"

--- a/integration/eslint/source/ts.civet
+++ b/integration/eslint/source/ts.civet
@@ -21,7 +21,7 @@ export function civet(options: Options = {js: false})
             rules[rule] = plugin.configs.overrides.rules[rule]
         config.rules = { ...config.rules, ...plugin.configs.overrides.rules }
       if "files" in config
-        config.files = [ ...config.files, "**/*.civet" ]
+        config.files = [ ...(config.files ?? []), "**/*.civet" ]
       config
 
   // Rename eslint recommended and all configs to jsRecommended and jsAll

--- a/integration/eslint/tsconfig.json
+++ b/integration/eslint/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "source/**/*.civet"
+  ]
+}


### PR DESCRIPTION
Found when running `pnpm -r test` at root this typecheck was broken.

Added tsconfig and some expect-errors for dynamic imports.