### PR TITLE
Add esCompat flag with esArrowFunction option

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -63,10 +63,17 @@ Template literals and other computed specifiers are left unchanged.
 
 ## ECMAScript Compatibility
 
-Eventually, we plan a `jsCompat` compatibility flag to modify Civet to be
-closer to pure ECMAScript, removing the
-[few places where Civet is not a superset of ECMAScript](comparison).
-For now, we have the following related options:
+The `jsCompat` compatibility flag modifies Civet to be
+closer to pure ECMAScript, removing some
+[places where Civet is not a superset of ECMAScript](comparison).
+Like `coffeeCompat`, this is useful for gradually converting an existing codebase.
+
+| Configuration       | What it enables |
+|---------------------|---------------------------------------|
+| [`jsCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
+| [`jsArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; disables implicit `=> x` zero-argument arrow functions |
+
+We also have the following related options:
 
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -63,15 +63,15 @@ Template literals and other computed specifiers are left unchanged.
 
 ## ECMAScript Compatibility
 
-The `jsCompat` compatibility flag modifies Civet to be
+The `esCompat` compatibility flag modifies Civet to be
 closer to pure ECMAScript, removing some
 [places where Civet is not a superset of ECMAScript](comparison).
 Like `coffeeCompat`, this is useful for gradually converting an existing codebase.
 
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
-| [`jsCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
-| [`jsArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; disables implicit `=> x` zero-argument arrow functions |
+| [`esCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
+| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; disables implicit `=> x` zero-argument arrow functions |
 
 We also have the following related options:
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3490,6 +3490,27 @@ and/or the server:
 link := <a href="https://civet.dev/">Civet
 </Playground>
 
+## ECMAScript Compatibility
+
+Turn on full ECMAScript compatibility mode
+with a `"civet esCompat"` directive at the top of your file,
+or use more specific directive(s) as listed below.
+This is useful for gradually converting an existing JavaScript codebase to Civet.
+
+### Single-Argument Arrow Functions
+
+By default, Civet requires parentheses around a single arrow function parameter:
+`(x) => x + 1`.
+With `esArrowFunction`, you can write `x => x + 1` as in ECMAScript.
+Note that this disables Civet's implicit zero-argument arrow functions (`=> body`);
+use explicit `() => body` instead.
+
+<Playground>
+"civet esArrowFunction"
+double := x => x * 2
+greet := (name) => `Hello, ${name}!`
+</Playground>
+
 ## [CoffeeScript](https://coffeescript.org/) Compatibility
 
 Turn on full [CoffeeScript](https://coffeescript.org/) compatibility mode

--- a/source/main.civet
+++ b/source/main.civet
@@ -91,6 +91,8 @@ export type CompilerOptions
     coffeeCompat?: boolean
     comptime?: boolean
     globals?: string[]
+    jsArrowFunction?: boolean
+    jsCompat?: boolean
     operators?: string[] | Record<string, string>
     symbols?: string[]
   /** Specifying an empty array will prevent ParseErrors from being thrown */

--- a/source/main.civet
+++ b/source/main.civet
@@ -91,8 +91,8 @@ export type CompilerOptions
     coffeeCompat?: boolean
     comptime?: boolean
     globals?: string[]
-    jsArrowFunction?: boolean
-    jsCompat?: boolean
+    esArrowFunction?: boolean
+    esCompat?: boolean
     operators?: string[] | Record<string, string>
     symbols?: string[]
   /** Specifying an empty array will prevent ParseErrors from being thrown */

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2066,8 +2066,7 @@ ShortArrowParameters
 
 # In esArrowFunction mode, allow single bare identifier as arrow parameter (ES-style: x => ...)
 ESArrowIdentifierParameters
-  Identifier:id ->
-    if (!config.esArrowFunction) return $skip
+  ESArrowFunctionEnabled Identifier:id ->
     const parameter = {
       type: "Parameter",
       children: [id],
@@ -2085,8 +2084,7 @@ ESArrowIdentifierParameters
 
 # Implicit (zero-argument) arrow parameters, disabled in esArrowFunction mode
 ImplicitArrowParameters
-  TypeParameters?:tp Loc:p ->
-    if (config.esArrowFunction) return $skip
+  !ESArrowFunctionEnabled TypeParameters?:tp Loc:p ->
     const parameters = []
     return {
       type: "Parameters",
@@ -9293,6 +9291,11 @@ CoffeeOfEnabled
 CoffeePrototypeEnabled
   "" ->
     if(config.coffeePrototype) return
+    return $skip
+
+ESArrowFunctionEnabled
+  "" ->
+    if(config.esArrowFunction) return
     return $skip
 
 JSXCodeNestedEnabled

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2064,10 +2064,10 @@ ShortArrowParameters
       typeSuffix,
     }
 
-# In jsArrowFunction mode, allow single bare identifier as arrow parameter (JS-style: x => ...)
-JSArrowIdentifierParameters
+# In esArrowFunction mode, allow single bare identifier as arrow parameter (ES-style: x => ...)
+ESArrowIdentifierParameters
   Identifier:id ->
-    if (!config.jsArrowFunction) return $skip
+    if (!config.esArrowFunction) return $skip
     const parameter = {
       type: "Parameter",
       children: [id],
@@ -2083,10 +2083,10 @@ JSArrowIdentifierParameters
       parameters: [parameter],
     }
 
-# Implicit (zero-argument) arrow parameters, disabled in jsArrowFunction mode
+# Implicit (zero-argument) arrow parameters, disabled in esArrowFunction mode
 ImplicitArrowParameters
   TypeParameters?:tp Loc:p ->
-    if (config.jsArrowFunction) return $skip
+    if (config.esArrowFunction) return $skip
     const parameters = []
     return {
       type: "Parameters",
@@ -2098,8 +2098,8 @@ ImplicitArrowParameters
     }
 
 ArrowParameters
-  # In jsArrowFunction mode, try single bare identifier first (before implicit empty params)
-  JSArrowIdentifierParameters
+  # In esArrowFunction mode, try single bare identifier first (before implicit empty params)
+  ESArrowIdentifierParameters
   ShortArrowParameters ->
     const parameters = [ $1 ]
     return {
@@ -9362,7 +9362,7 @@ Reset
       globals: [],
       iife: false,
       implicitReturns: true,
-      jsArrowFunction: false,
+      esArrowFunction: false,
       jsxCode: false,
       objectIs: false,
       react: false,
@@ -9417,11 +9417,11 @@ Reset
       }
     })
 
-    // Expand setting jsCompat to the individual options
-    Object.defineProperty(config, "jsCompat", {
+    // Expand setting esCompat to the individual options
+    Object.defineProperty(config, "esCompat", {
       set(b) {
         for (const option of [
-          "jsArrowFunction",
+          "esArrowFunction",
         ]) {
           config[option] = b
         }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2064,7 +2064,42 @@ ShortArrowParameters
       typeSuffix,
     }
 
+# In jsArrowFunction mode, allow single bare identifier as arrow parameter (JS-style: x => ...)
+JSArrowIdentifierParameters
+  Identifier:id ->
+    if (!config.jsArrowFunction) return $skip
+    const parameter = {
+      type: "Parameter",
+      children: [id],
+      names: id.names,
+      binding: id,
+      typeSuffix: undefined,
+      initializer: undefined,
+      delim: undefined,
+    }
+    return {
+      type: "Parameters",
+      children: ["(", [parameter], ")"],
+      parameters: [parameter],
+    }
+
+# Implicit (zero-argument) arrow parameters, disabled in jsArrowFunction mode
+ImplicitArrowParameters
+  TypeParameters?:tp Loc:p ->
+    if (config.jsArrowFunction) return $skip
+    const parameters = []
+    return {
+      type: "Parameters",
+      children: [tp, {$loc: p.$loc, token: "("}, parameters, ")"],
+      tp,
+      parameters,
+      names: [],
+      implicit: true,
+    }
+
 ArrowParameters
+  # In jsArrowFunction mode, try single bare identifier first (before implicit empty params)
+  JSArrowIdentifierParameters
   ShortArrowParameters ->
     const parameters = [ $1 ]
     return {
@@ -2072,7 +2107,8 @@ ArrowParameters
       children: ["(", parameters, ")"],
       parameters,
     }
-  Parameters
+  NonEmptyParameters
+  ImplicitArrowParameters
 
 NonEmptyParameters
   TypeParameters?:tp OpenParen:open ParameterList:parameters ( __ CloseParen ):close ->
@@ -9326,6 +9362,7 @@ Reset
       globals: [],
       iife: false,
       implicitReturns: true,
+      jsArrowFunction: false,
       jsxCode: false,
       objectIs: false,
       react: false,
@@ -9375,6 +9412,18 @@ Reset
         }
         if (b) {
           config.objectIs = false
+        }
+        return
+      }
+    })
+
+    // Expand setting jsCompat to the individual options
+    Object.defineProperty(config, "jsCompat", {
+      set(b) {
+        for (const option of [
+          "jsArrowFunction",
+        ]) {
+          config[option] = b
         }
         return
       }

--- a/test/compat/es-arrow-function.civet
+++ b/test/compat/es-arrow-function.civet
@@ -74,6 +74,13 @@ describe "esArrowFunction", ->
     f = => 5
   """
 
+  throws """
+    implicit async zero-arg disabled
+    ---
+    "civet esArrowFunction"
+    f = async => 5
+  """
+
   testCase """
     async single identifier parameter
     ---

--- a/test/compat/es-arrow-function.civet
+++ b/test/compat/es-arrow-function.civet
@@ -1,10 +1,10 @@
 {testCase, throws} from ../helper.civet
 
-describe "jsArrowFunction", ->
+describe "esArrowFunction", ->
   testCase """
     single identifier parameter
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     x => x + 1
     ---
     (x) => x + 1
@@ -13,7 +13,7 @@ describe "jsArrowFunction", ->
   testCase """
     single identifier parameter assigned
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = x => x + 1
     ---
     f = (x) => x + 1
@@ -22,7 +22,7 @@ describe "jsArrowFunction", ->
   testCase """
     single identifier with body block
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = x =>
       x + 1
     ---
@@ -34,7 +34,7 @@ describe "jsArrowFunction", ->
   testCase """
     parens still work
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = (x) => x + 1
     ---
     f = (x) => x + 1
@@ -43,7 +43,7 @@ describe "jsArrowFunction", ->
   testCase """
     multiple params with parens still work
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = (x, y) => x + y
     ---
     f = (x, y) => x + y
@@ -52,7 +52,7 @@ describe "jsArrowFunction", ->
   testCase """
     destructuring still works
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = {x, y} => x + y
     ---
     f = ({x, y}) => x + y
@@ -61,7 +61,7 @@ describe "jsArrowFunction", ->
   testCase """
     explicit zero-arg still works
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = () => 5
     ---
     f = () => 5
@@ -70,14 +70,14 @@ describe "jsArrowFunction", ->
   throws """
     implicit zero-arg disabled
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = => 5
   """
 
   testCase """
     async single identifier parameter
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = async x => x + 1
     ---
     f = async (x) => x + 1
@@ -86,17 +86,17 @@ describe "jsArrowFunction", ->
   testCase """
     thin arrow single identifier parameter
     ---
-    "civet jsArrowFunction"
+    "civet esArrowFunction"
     f = x -> x + 1
     ---
     f = function(x) { return x + 1 }
   """
 
-describe "jsCompat enables jsArrowFunction", ->
+describe "esCompat enables esArrowFunction", ->
   testCase """
     single identifier parameter
     ---
-    "civet jsCompat"
+    "civet esCompat"
     x => x + 1
     ---
     (x) => x + 1

--- a/test/compat/js-arrow-function.civet
+++ b/test/compat/js-arrow-function.civet
@@ -1,0 +1,103 @@
+{testCase, throws} from ../helper.civet
+
+describe "jsArrowFunction", ->
+  testCase """
+    single identifier parameter
+    ---
+    "civet jsArrowFunction"
+    x => x + 1
+    ---
+    (x) => x + 1
+  """
+
+  testCase """
+    single identifier parameter assigned
+    ---
+    "civet jsArrowFunction"
+    f = x => x + 1
+    ---
+    f = (x) => x + 1
+  """
+
+  testCase """
+    single identifier with body block
+    ---
+    "civet jsArrowFunction"
+    f = x =>
+      x + 1
+    ---
+    f = (x) => {
+      return x + 1
+    }
+  """
+
+  testCase """
+    parens still work
+    ---
+    "civet jsArrowFunction"
+    f = (x) => x + 1
+    ---
+    f = (x) => x + 1
+  """
+
+  testCase """
+    multiple params with parens still work
+    ---
+    "civet jsArrowFunction"
+    f = (x, y) => x + y
+    ---
+    f = (x, y) => x + y
+  """
+
+  testCase """
+    destructuring still works
+    ---
+    "civet jsArrowFunction"
+    f = {x, y} => x + y
+    ---
+    f = ({x, y}) => x + y
+  """
+
+  testCase """
+    explicit zero-arg still works
+    ---
+    "civet jsArrowFunction"
+    f = () => 5
+    ---
+    f = () => 5
+  """
+
+  throws """
+    implicit zero-arg disabled
+    ---
+    "civet jsArrowFunction"
+    f = => 5
+  """
+
+  testCase """
+    async single identifier parameter
+    ---
+    "civet jsArrowFunction"
+    f = async x => x + 1
+    ---
+    f = async (x) => x + 1
+  """
+
+  testCase """
+    thin arrow single identifier parameter
+    ---
+    "civet jsArrowFunction"
+    f = x -> x + 1
+    ---
+    f = function(x) { return x + 1 }
+  """
+
+describe "jsCompat enables jsArrowFunction", ->
+  testCase """
+    single identifier parameter
+    ---
+    "civet jsCompat"
+    x => x + 1
+    ---
+    (x) => x + 1
+  """


### PR DESCRIPTION
Adds an `esCompat` meta-flag and `esArrowFunction` option to make Civet closer to ECMAScript compatibility:

- `esArrowFunction: true` allows single bare identifier as fat/thin arrow parameter without parentheses: `x => x + 1` → `(x) => x + 1`
- In esArrowFunction mode, implicit zero-argument arrow functions without parens (`=> body`) are disabled
- `esCompat` enables `esArrowFunction` (and future flags)

Closes #270

Generated with [Claude Code](https://claude.ai/code)