### PR TITLE
Pin properties and pin patterns in arrays use `typeof` typing

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -75,6 +75,7 @@ import {
   skipImplicitArguments,
   stripTrailingImplicitComma,
   trimFirstSpace,
+  typeSuffixForExpression,
   typeOfJSX,
   wrapTypeInPromise,
 } from "./parser/lib.civet"
@@ -2158,18 +2159,21 @@ PinPattern
       type: "PinPattern",
       children: [expression],
       expression,
+      typeSuffix: typeSuffixForExpression(expression),
     }
   Caret SingleLineExpressionWithIndentedApplicationForbidden:expression ->
     return {
       type: "PinPattern",
       children: [expression],
       expression,
+      typeSuffix: typeSuffixForExpression(expression),
     }
   ActualMemberExpression:expression ->
     return {
       type: "PinPattern",
       children: [expression],
       expression,
+      typeSuffix: typeSuffixForExpression(expression),
     }
   # Handle unary numeric in switch patterns
   ([+-] NumericLiteral):expression ->
@@ -2177,6 +2181,7 @@ PinPattern
       type: "PinPattern",
       children: [expression],
       expression,
+      typeSuffix: typeSuffixForExpression(expression),
     }
   # Handle undefined in switch patterns
   Undefined:expression ->
@@ -2184,6 +2189,7 @@ PinPattern
       type: "PinPattern",
       children: [expression],
       expression,
+      typeSuffix: typeSuffixForExpression(expression),
     }
 
 # `name^ pattern` means bind the whole thing to `name`,
@@ -2364,6 +2370,7 @@ BindingProperty
         type: "PinPattern",
         children: [binding],
         expression: binding,
+        typeSuffix: typeSuffixForExpression(binding),
       },
     }
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -161,10 +161,10 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
         if n.type is "PinPattern"
           n.ref = makeRef
             n.expression.type is "Identifier" ? n.expression.name : "pin"
+          n.children = [n.ref]
           // Add `typeof X` type annotation for direct, untyped pin parameters
-          typeSuffix := if n.parent?.type is "Parameter" and not n.parent?.typeSuffix?
-            typeSuffixForExpression n.expression
-          n.children = if typeSuffix? then [n.ref, typeSuffix] else [n.ref]
+          if n.parent?.type is "Parameter" and not n.parent?.typeSuffix? and n.typeSuffix?
+            n.children.push n.typeSuffix
           updateParentPointers n
           thisAssignments.push
             type: "AssignmentExpression"
@@ -243,7 +243,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
           if (prop as BindingProperty).initializer and not typeSuffix.optional
             typeSuffix.children.unshift typeSuffix.optional = "?"
           switch prop.type
-            when "BindingProperty"
+            when "BindingProperty", "PinProperty"
               ws := prop.children[...prop.children.indexOf prop.name]
               [ ...ws, prop.name, typeSuffix, prop.delim ] as Children
             when "AtBindingProperty"

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -162,9 +162,6 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
           n.ref = makeRef
             n.expression.type is "Identifier" ? n.expression.name : "pin"
           n.children = [n.ref]
-          // Add `typeof X` type annotation for direct, untyped pin parameters
-          if n.parent?.type is "Parameter" and not n.parent?.typeSuffix? and n.typeSuffix?
-            n.children.push n.typeSuffix
           updateParentPointers n
           thisAssignments.push
             type: "AssignmentExpression"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -92,6 +92,7 @@ import {
   replaceNodes
   stripTrailingImplicitComma
   trimFirstSpace
+  typeSuffixForExpression
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
@@ -2145,6 +2146,7 @@ export {
   skipImplicitArguments
   stripTrailingImplicitComma
   trimFirstSpace
+  typeSuffixForExpression
   typeOfJSX
   wrapIIFE
   wrapTypeInPromise

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -44,6 +44,7 @@ import {
 } from ./block.civet
 
 import {
+  gatherBindingPatternTypeSuffix
   gatherSubbindings
   gatherBindingCode
   simplifyBindingProperties
@@ -306,6 +307,7 @@ function getPatternBlockPrefix(
   // Gather bindings
   [splices, thisAssignments] .= gatherBindingCode(pattern)
   patternBindings := nonMatcherBindings(pattern)
+  typeSuffix = patternBindings.typeSuffix if "typeSuffix" in patternBindings
   subbindings := gatherSubbindings patternBindings
   simplifyBindingProperties patternBindings
   simplifyBindingProperties subbindings
@@ -407,15 +409,23 @@ function nonMatcherBindings(pattern: ASTNodeObject): ASTNodeObject?
   switch pattern.type
     when "ArrayBindingPattern", "PostRestBindingElements"
       elements := elideMatchersFromArrayBindings pattern.elements
-      makeNode {
+      node := makeNode {
         ...pattern
         elements
         children: pattern.children.map & is pattern.elements ? elements : &
       }
+      typePattern := {
+        ...node
+        typeSuffix: undefined
+        elements: elements.filter (element) => element?.type?
+      }
+      node.typeSuffix = gatherBindingPatternTypeSuffix(typePattern).typeSuffix
+      node
     when "ObjectBindingPattern"
       properties := elideMatchersFromPropertyBindings pattern.properties
-      makeNode {
+      gatherBindingPatternTypeSuffix makeNode {
         ...pattern
+        typeSuffix: undefined
         properties
         children: pattern.children.map & is pattern.properties ? properties : &
       }
@@ -423,6 +433,7 @@ function nonMatcherBindings(pattern: ASTNodeObject): ASTNodeObject?
       bindings := nonMatcherBindings pattern.pattern
       makeNode {
         ...pattern
+        typeSuffix: bindings?.typeSuffix
         subbinding:
           if bindings?.type is like "ArrayBindingPattern", "ObjectBindingPattern", "Identifier"
             [ bindings, " = ", pattern.binding ]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -866,6 +866,7 @@ export type PinPattern
   parent?: Parent
   expression: ExpressionNode
   ref?: ASTRef
+  typeSuffix?: TypeSuffix?
 
 export type NamedBindingPattern
   type: "NamedBindingPattern"

--- a/test/function.civet
+++ b/test/function.civet
@@ -501,7 +501,7 @@ describe "function", ->
       ({^a, b: ^b}) ->
         a
       ---
-      (function({a: a1, b: b1}) {
+      (function({a: a1, b: b1}: {a: typeof a, b: typeof b}) {
         a = a1;
         b = b1;
         return a
@@ -514,7 +514,7 @@ describe "function", ->
       ([^a, ^b]) ->
         a
       ---
-      (function([a1, b1]) {
+      (function([a1, b1]: [typeof a,typeof b]) {
         a = a1;
         b = b1;
         return a

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -750,6 +750,46 @@ describe "[TS] function", ->
     """
 
     testCase """
+      infers tuple types for array binding pattern
+      ---
+      ([^foo, ^bar]) =>
+      ---
+      ([foo1, bar1]: [typeof foo,typeof bar]) => {foo = foo1;bar = bar1;}
+    """
+
+    testCase """
+      combines inferred and explicit tuple types
+      ---
+      ([^x, y:: T]) =>
+      ---
+      ([x1, y]: [typeof x, T]) => {x = x1;}
+    """
+
+    testCase """
+      infers typeof for member expressions in tuple types
+      ---
+      ([^x.y[z], value:: T]) =>
+      ---
+      ([pin, value]: [typeof x.y[z], T]) => {x.y[z] = pin;}
+    """
+
+    testCase """
+      infers object types for object binding pattern
+      ---
+      ({^foo, bar: ^bar}) =>
+      ---
+      ({foo: foo1, bar: bar1}: {foo: typeof foo, bar: typeof bar}) => {foo = foo1;bar = bar1;}
+    """
+
+    testCase """
+      combines inferred and explicit object types
+      ---
+      ({^x, y:: T}) =>
+      ---
+      ({x: x1, y}: {x: typeof x, y: T}) => {x = x1;}
+    """
+
+    testCase """
       no inference when explicit type given
       ---
       function initialize(^options: Options)


### PR DESCRIPTION
Followup to #1942 to handle the general case, not just top-level pins. Also handles mixed cases with `::` like `([^foo, bar:: Type]) =>`.