### PR TITLE
`esCompat` turns off implicit returns, no longer affects `->`

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -71,7 +71,7 @@ Like `coffeeCompat`, this is useful for gradually converting an existing codebas
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
 | [`esCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
-| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; disables implicit `=> x` zero-argument arrow functions |
+| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1` and `x -> x+1` as shorthand for `(x) -> x+1`; disables implicit `=> x` and `-> x` zero-argument arrow functions |
 
 We also have the following related options:
 

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -67,17 +67,13 @@ The `esCompat` compatibility flag modifies Civet to be
 closer to pure ECMAScript, removing some
 [places where Civet is not a superset of ECMAScript](comparison).
 Like `coffeeCompat`, this is useful for gradually converting an existing codebase.
+You can also turn on/off individual compatibility features.
 
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
 | [`esCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
 | [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; does not affect `->` |
-
-We also have the following related options:
-
-| Configuration       | What it enables |
-|---------------------|---------------------------------------|
-| [`-implicit-returns`](reference#no-implicit-returns) | turn off implicit return of last value in functions |
+| [`-implicit-returns`](reference#no-implicit-returns) | turn off implicit return of last value in functions, except in one-line `=>` |
 
 ## CoffeeScript Compatibility
 

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -71,7 +71,7 @@ Like `coffeeCompat`, this is useful for gradually converting an existing codebas
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
 | [`esCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
-| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1` and `x -> x+1` as shorthand for `(x) -> x+1`; disables implicit `=> x` and `-> x` zero-argument arrow functions |
+| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; disables implicit `=> x` zero-argument arrow functions; does not affect `->` |
 
 We also have the following related options:
 

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -71,7 +71,7 @@ Like `coffeeCompat`, this is useful for gradually converting an existing codebas
 | Configuration       | What it enables |
 |---------------------|---------------------------------------|
 | [`esCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
-| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; disables implicit `=> x` zero-argument arrow functions; does not affect `->` |
+| [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; does not affect `->` |
 
 We also have the following related options:
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1125,8 +1125,8 @@ function add(a: number, b: number): number
 ### Arrow Functions
 
 ::: info
-Unlike ECMAScript, zero-argument arrows do not need a `()` prefix,
-but one-argument arrows do need parentheses around the argument.
+Unlike ECMAScript, zero-parameter arrows do not need a `()` prefix,
+but one-parameter arrows do need parentheses around the argument.
 :::
 
 <Playground>
@@ -3739,13 +3739,23 @@ You can increase JavaScript compatibility with the following options:
 ### No Implicit Returns
 
 To disable [implicit returns from functions](#function),
-use the directive `"civet -implicitReturns"`:
+use the directive `"civet -implicitReturns"`.
 
 <Playground>
 "civet -implicitReturns"
 function processAll(array)
   for item of array
     process item
+</Playground>
+
+One-line `=>` arrow functions still have implicit returns,
+like in JavaScript, but one-line `->` and `function` do not.
+
+<Playground>
+"civet -implicitReturns"
+=> "returned"
+-> "not returned"
+function() "not returned"
 </Playground>
 
 ### Strict Mode

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3504,25 +3504,68 @@ link := <a href="https://civet.dev/">Civet
 
 ## ECMAScript Compatibility
 
-Turn on full ECMAScript compatibility mode
+By default, Civet aims to be mostly compatible with JavaScript and TypeScript,
+so that most JavaScript/TypeScript code is valid Civet code.
+See [comparison](comparison) for the few exceptions.
+
+To bring Civet closer to JavaScript/TypeScript,
+you can turn on full ECMAScript compatibility mode
 with a `"civet esCompat"` directive at the top of your file,
 or use more specific directive(s) as listed below.
 This is useful for gradually converting an existing JavaScript codebase to Civet.
+
+### No Implicit Returns
+
+To disable [implicit returns from functions](#function),
+use the directive `"civet -implicitReturns"` (or `"civet esCompat"`):
+
+<Playground>
+"civet -implicitReturns"
+function processAll(array)
+  for item of array
+    process item
+</Playground>
+
+One-line `=>` arrow functions still have implicit returns,
+like in JavaScript, but one-line `->` and `function` do not.
+
+<Playground>
+"civet -implicitReturns"
+=> "returned"
+-> "not returned"
+function() "not returned"
+</Playground>
 
 ### Single-Argument Arrow Functions
 
 By default, Civet requires parentheses around a single arrow function parameter:
 `(x) => x + 1`.
-With `esArrowFunction`, you can write `x => x + 1` as in ECMAScript.
+With `"civet esArrowFunction"` (or `"civet esCompat"`),
+you can write `x => x + 1` as in ECMAScript.
 If not preceded by an identifier,
 `=> body` still works as a zero-parameter arrow function.
-The behavior of `->` also remains unchanged.
+The behavior of `->` remains unchanged.
 
 <Playground>
 "civet esArrowFunction"
 double := x => x * 2
 greet := (name) => `Hello, ${name}!`
 noArgs := => console.log "Hello, world!"
+</Playground>
+
+### Strict Mode
+
+Output from Civet runs by default in JavaScript's sloppy mode,
+unless it is loaded as an ECMAScript module.
+To turn on
+[JavaScript's strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode),
+add the directive `"use strict"` as usual, or the Civet directive
+`"civet strict"`. The latter is useful because it can be specified in
+[Civet configuration files](config).
+
+<Playground>
+"civet strict"
+x = 5 // invalid
 </Playground>
 
 ## [CoffeeScript](https://coffeescript.org/) Compatibility
@@ -3728,47 +3771,3 @@ This behavior is usually helpful in a REPL context: it lets you attempt to
 correct a previous declaration.
 It also matches Chrome's console behavior (but not NodeJS's CLI behavior).
 :::
-
-## JavaScript Compatibility
-
-Civet aims to be mostly compatible with JavaScript and TypeScript,
-so that most JavaScript/TypeScript code is valid Civet code.
-See [comparison](comparison) for the few exceptions.
-You can increase JavaScript compatibility with the following options:
-
-### No Implicit Returns
-
-To disable [implicit returns from functions](#function),
-use the directive `"civet -implicitReturns"`.
-
-<Playground>
-"civet -implicitReturns"
-function processAll(array)
-  for item of array
-    process item
-</Playground>
-
-One-line `=>` arrow functions still have implicit returns,
-like in JavaScript, but one-line `->` and `function` do not.
-
-<Playground>
-"civet -implicitReturns"
-=> "returned"
--> "not returned"
-function() "not returned"
-</Playground>
-
-### Strict Mode
-
-Output from Civet runs by default in JavaScript's sloppy mode,
-unless it is loaded as an ECMAScript module.
-To turn on
-[JavaScript's strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode),
-add the directive `"use strict"` as usual, or the Civet directive
-`"civet strict"`. The latter is useful because it can be specified in
-[Civet configuration files](config).
-
-<Playground>
-"civet strict"
-x = 5 // invalid
-</Playground>

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3516,12 +3516,13 @@ By default, Civet requires parentheses around a single arrow function parameter:
 With `esArrowFunction`, you can write `x => x + 1` as in ECMAScript.
 Note that this disables Civet's implicit zero-argument arrow functions (`=> body`);
 use explicit `() => body` instead.
-The same behavior applies to `->` arrow functions.
+The behavior of `->` remains unchanged.
 
 <Playground>
 "civet esArrowFunction"
 double := x => x * 2
 greet := (name) => `Hello, ${name}!`
+noArgs := -> console.log "Hello, world!"
 </Playground>
 
 ## [CoffeeScript](https://coffeescript.org/) Compatibility

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3514,15 +3514,15 @@ This is useful for gradually converting an existing JavaScript codebase to Civet
 By default, Civet requires parentheses around a single arrow function parameter:
 `(x) => x + 1`.
 With `esArrowFunction`, you can write `x => x + 1` as in ECMAScript.
-Note that this disables Civet's implicit zero-argument arrow functions (`=> body`);
-use explicit `() => body` instead.
-The behavior of `->` remains unchanged.
+If not preceded by an identifier,
+`=> body` still works as a zero-parameter arrow function.
+The behavior of `->` also remains unchanged.
 
 <Playground>
 "civet esArrowFunction"
 double := x => x * 2
 greet := (name) => `Hello, ${name}!`
-noArgs := -> console.log "Hello, world!"
+noArgs := => console.log "Hello, world!"
 </Playground>
 
 ## [CoffeeScript](https://coffeescript.org/) Compatibility

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3516,6 +3516,7 @@ By default, Civet requires parentheses around a single arrow function parameter:
 With `esArrowFunction`, you can write `x => x + 1` as in ECMAScript.
 Note that this disables Civet's implicit zero-argument arrow functions (`=> body`);
 use explicit `() => body` instead.
+The same behavior applies to `->` arrow functions.
 
 <Playground>
 "civet esArrowFunction"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2023,11 +2023,17 @@ ShortArrowParameters
   ( ObjectBindingPattern / ArrayBindingPattern ):binding ->
     // Based on ParameterElement
     { typeSuffix } := binding
+    parameter := {
+      type: "Parameter"
+      children: [ binding, typeSuffix ]
+      names: binding.names
+      typeSuffix
+    }
+    parameters := [ parameter ]
     return {
-      type: "Parameter",
-      children: [ binding, typeSuffix ],
-      names: binding.names,
-      typeSuffix,
+      type: "Parameters"
+      children: ["(", parameters, ")"]
+      parameters
     }
 
 # In esArrowFunction mode, allow single bare identifier as arrow parameter (ES-style: x => ...)
@@ -2062,18 +2068,18 @@ ImplicitArrowParameters
       implicit: true,
     }
 
+# Parameters before =>
 ArrowParameters
   # In esArrowFunction mode, try single bare identifier first (before implicit empty params)
   ESArrowIdentifierParameters
-  ShortArrowParameters ->
-    parameters := [ $1 ]
-    return {
-      type: "Parameters",
-      children: ["(", parameters, ")"],
-      parameters,
-    }
+  ShortArrowParameters
   NonEmptyParameters
   ImplicitArrowParameters
+
+# Parameters before ->
+ThinArrowParameters
+  ShortArrowParameters
+  Parameters
 
 NonEmptyParameters
   TypeParameters?:tp OpenParen:open ParameterList:parameters ( __ CloseParen ):close ->
@@ -2793,7 +2799,7 @@ OperatorAssociativity
     return { assoc }
 
 ThinArrowFunction
-  ( Async _ )?:async ArrowParameters:parameters ReturnTypeSuffix?:returnType _?:ws ThinArrow:arrow ( BracedObjectSingleLineStatements / NoCommaBracedOrEmptyBlock ):block ->
+  ( Async _ )?:async ThinArrowParameters:parameters ReturnTypeSuffix?:returnType _?:ws ThinArrow:arrow ( BracedObjectSingleLineStatements / NoCommaBracedOrEmptyBlock ):block ->
     async = [] unless async
     generator := []
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2033,19 +2033,20 @@ ShortArrowParameters
 # In esArrowFunction mode, allow single bare identifier as arrow parameter (ES-style: x => ...)
 ESArrowIdentifierParameters
   ESArrowFunctionEnabled Identifier:id ->
-    const parameter = {
-      type: "Parameter",
-      children: [id],
-      names: id.names,
-      binding: id,
-      typeSuffix: undefined,
-      initializer: undefined,
-      delim: undefined,
+    parameter := {
+      type: "Parameter"
+      children: [id]
+      id.names
+      binding: id
+      typeSuffix: undefined
+      initializer: undefined
+      delim: undefined
     }
+    parameters := [ parameter ]
     return {
-      type: "Parameters",
-      children: ["(", [parameter], ")"],
-      parameters: [parameter],
+      type: "Parameters"
+      children: ["(", parameters, ")"]
+      parameters
     }
 
 # Implicit (zero-argument) arrow parameters, disabled in esArrowFunction mode

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2055,26 +2055,13 @@ ESArrowIdentifierParameters
       parameters
     }
 
-# Implicit (zero-argument) arrow parameters, disabled in esArrowFunction mode
-ImplicitArrowParameters
-  !ESArrowFunctionEnabled TypeParameters?:tp Loc:p ->
-    const parameters = []
-    return {
-      type: "Parameters",
-      children: [tp, {$loc: p.$loc, token: "("}, parameters, ")"],
-      tp,
-      parameters,
-      names: [],
-      implicit: true,
-    }
-
 # Parameters before =>
 ArrowParameters
-  # In esArrowFunction mode, try single bare identifier first (before implicit empty params)
+  # In esArrowFunction mode, try single bare identifier first
+  # (before implicit empty params allowed by Parameters)
   ESArrowIdentifierParameters
   ShortArrowParameters
-  NonEmptyParameters
-  ImplicitArrowParameters
+  Parameters
 
 # Parameters before ->
 ThinArrowParameters

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -9290,6 +9290,7 @@ Reset
         ]) {
           config[option] = b
         }
+        config.implicitReturns = !b
         return
       }
     })

--- a/test/compat/es-arrow-function.civet
+++ b/test/compat/es-arrow-function.civet
@@ -1,4 +1,4 @@
-{testCase, throws} from ../helper.civet
+{testCase} from ../helper.civet
 
 describe "esArrowFunction", ->
   testCase """
@@ -59,7 +59,7 @@ describe "esArrowFunction", ->
   """
 
   testCase """
-    explicit zero-arg still works
+    explicit zero-parameter still works
     ---
     "civet esArrowFunction"
     f = () => 5
@@ -67,18 +67,22 @@ describe "esArrowFunction", ->
     f = () => 5
   """
 
-  throws """
-    implicit zero-arg disabled
+  testCase """
+    implicit zero-parameter still works
     ---
     "civet esArrowFunction"
     f = => 5
+    ---
+    f = () => 5
   """
 
-  throws """
-    implicit async zero-arg disabled
+  testCase """
+    implicit async zero-parameter still works
     ---
     "civet esArrowFunction"
     f = async => 5
+    ---
+    f = async () => 5
   """
 
   testCase """

--- a/test/compat/es-arrow-function.civet
+++ b/test/compat/es-arrow-function.civet
@@ -91,12 +91,12 @@ describe "esArrowFunction", ->
   """
 
   testCase """
-    thin arrow single identifier parameter
+    thin arrow remains implicit call syntax
     ---
     "civet esArrowFunction"
-    f = x -> x + 1
+    f = x -> 5
     ---
-    f = function(x) { return x + 1 }
+    f = x(function() { return 5 })
   """
 
 describe "esCompat enables esArrowFunction", ->

--- a/test/compat/implicit-returns.civet
+++ b/test/compat/implicit-returns.civet
@@ -1,0 +1,89 @@
+{testCase} from ../helper.civet
+
+describe "-implicitReturns", ->
+  testCase """
+    disable via -implicitReturns
+    ---
+    "civet -implicitReturns"
+    => "one line still returns"
+    =>
+      notReturned()
+    -> notReturned()
+    ->
+      notReturned()
+    function() notReturned()
+    function()
+      notReturned()
+    function()
+      if x
+        notReturned()
+      else
+        notReturned()
+    ---
+    () => "one line still returns";
+    () => {
+      notReturned()
+    };
+    (function() { notReturned() });
+    (function() {
+      notReturned()
+    });
+    (function() { notReturned() });
+    (function() {
+      notReturned()
+    });
+    (function() {
+      if (x) {
+        notReturned()
+      }
+      else {
+        notReturned()
+      }
+    })
+  """
+
+  testCase """
+    parenthesized if/else if/else expression implicit return
+    ---
+    "civet -implicitReturns"
+    o = (
+      if x
+        "a"
+      else if y
+        "b"
+      else
+        "c"
+    )
+    ---
+    o = (
+      (()=>{if (x) {
+        return "a"
+      }
+      else if (y) {
+        return "b"
+      }
+      else {
+        return "c"
+      }})()
+    )
+  """
+
+describe "esCompat disables implicit returns", ->
+  testCase """
+    disables block implicit returns but keeps expression-body arrows
+    ---
+    "civet esCompat"
+    function f
+      value
+    g := () =>
+      value
+    h := () => value
+    ---
+    function f() {
+      value
+    }
+    const g = () => {
+      value
+    }
+    const h = () => value
+  """

--- a/test/function.civet
+++ b/test/function.civet
@@ -2348,47 +2348,6 @@ describe "function", ->
       }
     """
 
-    testCase """
-      disable via -implicitReturns
-      ---
-      "civet -implicitReturns"
-      => "one line still returns"
-      =>
-        notReturned()
-      -> notReturned()
-      ->
-        notReturned()
-      function() notReturned()
-      function()
-        notReturned()
-      function()
-        if x
-          notReturned()
-        else
-          notReturned()
-      ---
-      () => "one line still returns";
-      () => {
-        notReturned()
-      };
-      (function() { notReturned() });
-      (function() {
-        notReturned()
-      });
-      (function() { notReturned() });
-      (function() {
-        notReturned()
-      });
-      (function() {
-        if (x) {
-          notReturned()
-        }
-        else {
-          notReturned()
-        }
-      })
-    """
-
   describe "return.value", ->
     testCase """
       return =

--- a/test/if.civet
+++ b/test/if.civet
@@ -1179,32 +1179,6 @@ describe "if", ->
       )
     """
 
-    testCase """
-      parenthesized if/else if/else expression implicit return
-      ---
-      "civet -implicitReturns"
-      o = (
-        if x
-          "a"
-        else if y
-          "b"
-        else
-          "c"
-      )
-      ---
-      o = (
-        (()=>{if (x) {
-          return "a"
-        }
-        else if (y) {
-          return "b"
-        }
-        else {
-          return "c"
-        }})()
-      )
-    """
-
   describe "return if expression", ->
     testCase """
       one line

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -22,6 +22,8 @@ declare module "@danielx/civet" {
     coffeePrototype: boolean
     coffeeRange: boolean
     defaultElement: string
+    esCompat: boolean
+    esArrowFunction: boolean
     globals: string[]
     implicitReturns: boolean
     jsxCode: boolean


### PR DESCRIPTION
Followup to #1949 to improve `esCompat` in a bunch of ways:

* `esArrowFunction` no longer changes the behavior of `->`
* `esArrowFunction` no longer disables parameterless `=> foo`. I think there are many cases where this would be handy without an identifier before it, especially once we add a flag to disable implicit function calls.
* `esCompat` now implies `-implicitReturns`. This already behaved just like JS.
* Documentation improvements. In particular, we had both JavaScript and ECMAScript Compatibility sections. 😮 
* Add missing types for new options
* Potential bug fix: `esArrowFunction` handler code wasn't aliasing the AST in the way we normally do
