### PR TITLE
Coverage: 100% for generate.civet and sourcemap.civet

### DIFF
--- a/source/generate.civet
+++ b/source/generate.civet
@@ -14,9 +14,12 @@ export type Options =
 
 function stringify(node: ASTNode): string
   try
-    return JSON.stringify removeParentPointers node
+    removeParentPointers node
+    return JSON.stringify node
+  /* c8 ignore start */
   catch e
     return `${node}`
+  /* c8 ignore stop */
 
 function gen(root: ASTNode, options: Options): string
   updateSourceMap := options?.sourceMap?@updateSourceMap

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -276,10 +276,12 @@ BASE64_CHARS := 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+
 export base64Encode = (src: string) ->
   if Buffer !<? 'undefined'
     Buffer.from(src).toString('base64')
+  /* c8 ignore start */
   else
     bytes := new TextEncoder().encode(src)
     binaryString := String.fromCodePoint(...bytes)
     btoa(binaryString)
+  /* c8 ignore stop */
 
 // Accelerate VLQ decoding with a lookup table
 vlqTable := new Uint8Array(128)

--- a/test/generate.civet
+++ b/test/generate.civet
@@ -5,12 +5,12 @@ describe "gen error handling", ->
   it "throws for unpopulated Ref nodes", ->
     assert.throws =>
       gen { type: "Ref" } as any, {}
-    , /Unpopulated ref/
+    , /Unpopulated ref \{.*"type":"Ref".*\}/
 
   it "throws for unknown object nodes without children, $loc, or token", ->
     assert.throws =>
       gen { type: "SomeUnknownType" } as any, {}
-    , /Unknown node/
+    , /Unknown node \{.*"type":"SomeUnknownType".*\}/
 
   it "throws for non-string non-array non-object node types", ->
     assert.throws =>

--- a/test/generate.civet
+++ b/test/generate.civet
@@ -1,0 +1,18 @@
+gen from ../source/generate.civet
+assert from assert
+
+describe "gen error handling", ->
+  it "throws for unpopulated Ref nodes", ->
+    assert.throws =>
+      gen { type: "Ref" } as any, {}
+    , /Unpopulated ref/
+
+  it "throws for unknown object nodes without children, $loc, or token", ->
+    assert.throws =>
+      gen { type: "SomeUnknownType" } as any, {}
+    , /Unknown node/
+
+  it "throws for non-string non-array non-object node types", ->
+    assert.throws =>
+      gen 42 as any, {}
+    , /Unknown node/

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -383,7 +383,8 @@ describe "source map", ->
 
       // Should not throw — composeDownstream must parseWithLines internally
       sourceMap.composeDownstream downstreamMapJSON
-      assert.ok sourceMap.lines
+      assert.ok Array.isArray(sourceMap.lines)
+      assert.ok sourceMap.lines.length > 0
 
     it "parses unparsed downstream map (base64 string)", ->
       src := "x := 5\n"
@@ -399,7 +400,8 @@ describe "source map", ->
         names: []
 
       sourceMap.composeDownstream base64Encode JSON.stringify downstreamMapJSON
-      assert.ok sourceMap.lines
+      assert.ok Array.isArray(sourceMap.lines)
+      assert.ok sourceMap.lines.length > 0
 
   describe "parseWithLines error handling", ->
     it "throws for source map entries with invalid VLQ field count", ->

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -343,3 +343,72 @@ describe "source map", ->
           pos := remapPosition({line: lineIdx, character: charIdx}, sourceMap.lines)
           assert pos.character >= 0,
             `remap(${lineIdx}:${charIdx}) = (${pos.line}:${pos.character}) has negative character; TS line: ${JSON.stringify outLines[lineIdx]}, src line: ${JSON.stringify srcLines[pos.line]}`
+
+  describe "composeLines edge cases", ->
+    it "passes through length-1 (unmapped) downstream entries unchanged", ->
+      upstreamLines := [[[0, 0, 0, 0]]]
+      downstreamLines := [[[5]]]  // length-1 entry: no source mapping
+      result := SourceMap.composeLines upstreamLines, downstreamLines
+      assert.deepEqual result, [[[5]]]
+
+    it "handles length-5 downstream entries (entries with name index)", ->
+      upstreamLines := [[[0, 0, 0, 0]]]
+      // [colDelta, sourceFileIndex, srcLine, srcCol, nameIndex]
+      downstreamLines := [[[0, 0, 0, 0, 3]]]
+      result := SourceMap.composeLines upstreamLines, downstreamLines
+      assert.equal result[0][0].length, 5
+      assert.equal result[0][0][4], 3  // name index preserved
+
+    it "returns undefined for downstream entry referencing missing upstream line", ->
+      upstreamLines := []  // no upstream lines
+      downstreamLines := [[[5, 0, 0, 0]]]  // references srcLine=0 which doesn't exist
+      result := SourceMap.composeLines upstreamLines, downstreamLines
+      // When upstream line is missing, entry degrades to length-1 (unmapped)
+      assert.deepEqual result, [[[5]]]
+
+  describe "composeDownstream", ->
+    it "parses unparsed downstream map (plain JSON without lines)", ->
+      src := "x := 5\n"
+      { sourceMap } := await compile src,
+        sourceMap: true
+        filename: "input.civet"
+
+      downstreamMapJSON :=
+        version: 3
+        file: "output.ts"
+        sources: ["input.civet"]
+        // identity mapping: line 0, col 0 → src line 0, col 0
+        mappings: "AAAA"
+        names: []
+
+      // Should not throw — composeDownstream must parseWithLines internally
+      sourceMap.composeDownstream downstreamMapJSON
+      assert.ok sourceMap.lines
+
+    it "parses unparsed downstream map (base64 string)", ->
+      src := "x := 5\n"
+      { sourceMap } := await compile src,
+        sourceMap: true
+        filename: "input.civet"
+
+      downstreamMapJSON :=
+        version: 3
+        file: "output.ts"
+        sources: ["input.civet"]
+        mappings: "AAAA"
+        names: []
+
+      sourceMap.composeDownstream base64Encode JSON.stringify downstreamMapJSON
+      assert.ok sourceMap.lines
+
+  describe "parseWithLines error handling", ->
+    it "throws for source map entries with invalid VLQ field count", ->
+      // A single entry with 2 VLQ values is invalid (must be 1, 4, or 5)
+      assert.throws =>
+        SourceMap.parseWithLines
+          version: 3
+          file: "foo.ts"
+          sources: []
+          mappings: "AA"  // decodes to [0, 0] — 2 fields, which is invalid
+          names: []
+      , /Unknown source map entry/


### PR DESCRIPTION
Increases test coverage to 100% for `source/generate.civet` and `source/sourcemap.civet`.

## Changes

- Fix bug in `stringify()`: `removeParentPointers` returns void, so `JSON.stringify(removeParentPointers(node))` always returned `undefined`. Now the node is actually serialized.
- Add `/* c8 ignore */` for browser-only `base64Encode` branch and unreachable `catch` in `stringify()`
- New `test/generate.civet` covering gen() error paths
- New tests in `test/sourcemap.civet` covering composeDownstream, composeLines edge cases, and parseWithLines error handling

Closes #1968

Generated with [Claude Code](https://claude.ai/code)