### PR TITLE
Test (CLI): add coverage for piped stdin, --config, --typecheck

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -4,7 +4,7 @@ type { ASTError, BlockStatement, ParseError, ParseErrors } from ./main.civet
 
 // unplugin ends up getting installed in the same dist directory
 {rawPlugin} from ./unplugin/unplugin.civet
-let unplugin:
+type Unplugin =
   buildStart: () => Promise<void>
   buildEnd: (this: {emitFile: (data: {source: string, fileName: string, type: string}) => void}, useConfigFileNames?: boolean) => Promise<void>
   load: (this: {addWatchFile: (filename: string) => void}, filename: string) => Promise<{code: string, map: unknown}>
@@ -414,6 +414,7 @@ export function repl(args: string[], options: Options)
 
 export function cli(args = process.argv[2..])
   // process.argv gets overridden when running scripts, but gets saved here
+  let unplugin: Unplugin | undefined
 
   {filenames, scriptArgs, options} .= await parseArgs args
 

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -629,3 +629,95 @@ describe "CLI file tests", ->
 
       assert.equal exitCode, 1
       assert stdErr.toLowerCase().includes('invalid'), "stderr mentions invalid argument: " + stdErr
+
+describe "CLI piped stdin", ->
+  it "compiles Civet code read from piped stdin to stdout", ->
+    origStdin := process.stdin
+    try
+      async function* gen()
+        yield "wPiped := 7\n"
+      mockStdin :=
+        isTTY: false
+        setEncoding: (_enc: string) => undefined
+        [Symbol.asyncIterator]: => gen()
+      Object.defineProperty process, 'stdin',
+        value: mockStdin
+        configurable: true
+      { stdOut } := await captureProcess =>
+        await cli ['-c', '--no-config', '-']
+      assert stdOut.includes('wPiped'), "piped stdin output contains variable: " + stdOut
+    finally
+      Object.defineProperty process, 'stdin',
+        value: origStdin
+        configurable: true
+
+
+describe "CLI --config", ->
+  let tmpDir: string
+  fileNum .= 0
+  before ->
+    tmpDir = path.join tmpdir(), "civet-cli-config-test-" + Math.random().toString(36).substring(2, 15)
+    await mkdir tmpDir, { recursive: true }
+  after ->
+    await rm tmpDir, { recursive: true, force: true }
+
+  it "loads --config JSON file with parseOptions", ->
+    configPath := path.join tmpDir, "config-${fileNum++}.json"
+    await writeFile configPath, JSON.stringify({parseOptions: {autoLet: true}})
+    { stdOut } := await captureProcess =>
+      await cli ['-c', '--config', configPath, '-e', 'x = 1']
+    assert stdOut.includes('let'), "autoLet from config applied: " + stdOut
+
+  it "deep merges --config parseOptions with --civet flag", ->
+    configPath := path.join tmpDir, "config-${fileNum++}.json"
+    await writeFile configPath, JSON.stringify({parseOptions: {autoLet: true}})
+    // Use --civet to supply an additional parseOption; config's autoLet should remain
+    { stdOut, exitCode } := await captureProcess =>
+      await cli ['-c', '--config', configPath, '--civet', 'tab=2', '-e', 'x = 1']
+    assert.equal exitCode, 0, "merged config + --civet succeeded"
+    assert stdOut.includes('let'), "autoLet from config still applied after merge: " + stdOut
+
+  it "auto-discovers config when neither --config nor --no-config given", ->
+    // Put a config in tmpDir and cd there
+    configPath := path.join tmpDir, "civetconfig.json"
+    await writeFile configPath, JSON.stringify({parseOptions: {autoLet: true}})
+    origCwd := process.cwd()
+    try
+      process.chdir tmpDir
+      { stdOut, exitCode } := await captureProcess =>
+        await cli ['-c', '-e', 'x = 1']
+      assert.equal exitCode, 0
+      assert stdOut.includes('let'), "auto-discovered config applied autoLet: " + stdOut
+    finally
+      process.chdir origCwd
+
+describe "CLI --typecheck", ->
+  let tmpDir: string
+  fileNum .= 0
+  before ->
+    // Place tmp files inside the project so TypeScript's rootDir accepts them
+    tmpDir = path.join process.cwd(), "test", "infra", "tmp-cli-typecheck-" + Math.random().toString(36).substring(2, 15)
+    await mkdir tmpDir, { recursive: true }
+  after ->
+    await rm tmpDir, { recursive: true, force: true }
+
+  function makeCivetTempFile(content: string): string
+    filePath := path.join tmpDir, `input-${fileNum++}.civet`
+    await writeFile filePath, content
+    filePath
+
+  it "typechecks a valid .civet file without errors", :any ->
+    @timeout 30000
+    inputFile := await makeCivetTempFile "x: number := 42\n"
+    { exitCode, stdErr } := await captureProcess =>
+      await cli ['--typecheck', '--no-config', inputFile]
+    assert.equal exitCode ?? 0, 0, "valid file typechecks cleanly; stderr: " + stdErr
+
+  it "reports TypeScript diagnostics for type errors", :any ->
+    @timeout 30000
+    inputFile := await makeCivetTempFile 'x: number := "not a number"\n'
+    { exitCode } := await captureProcess =>
+      await cli ['--typecheck', '--no-config', inputFile]
+    // Non-zero exit due to TS diagnostics
+    assert exitCode? and exitCode > 0, "typecheck reported errors via exitCode: " + exitCode
+


### PR DESCRIPTION
Adds tests exercising previously-uncovered CLI paths: piped stdin, --config (load, deep-merge, auto-discovery), and --typecheck (valid file and error branch). Also fixes a latent bug where a module-level `unplugin` variable persisted across programmatic `cli()` invocations.

Coverage for `source/cli.civet`: 51.19% → 58.56% statements, 90.62% → 92.75% branches, 63.63% → 72.72% functions.

Refs #1979

Generated with [Claude Code](https://claude.ai/code)