### PR TITLE
Reforbid comma in `:=` shorthand

### DIFF
--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -1027,7 +1027,8 @@ function updateDiagnosticsForDoc(document: TextDocument, service?: ResolvedServi
 
   if parseErrors?#
     diagnostics.push ...parseErrors.map (e) =>
-      start := { line: 0, character: 0 }, end = { line: 0, character: 10 }
+      start := { line: 0, character: 0 }
+      end := { line: 0, character: 10 }
       message .= e.message
 
       if e <? ParseError

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1454,7 +1454,7 @@ FieldDefinition
     }
 
   # NOTE: Added readonly semantic equivalent of const field assignment
-  InsertReadonly:readonly ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedPostfixedCommaExpression ->
+  InsertReadonly:readonly ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedPostfixedExpressionOrCommaLoop ->
     // Adjust position to space before assignment to make TypeScript remapping happier
     readonly.children[0].$loc = {
       pos: ca.$loc.pos - 1,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4632,13 +4632,23 @@ PostfixedExpression
     return attachPostfixStatementAsExpression(expression, post)
   Expression
 
+# Outside contexts where commas are too important (e.g. parameters/arguments),
+# postfixed loops can have comma expressions and spreads to accumulate multiple
+# items in the body, such as `pt.x, pt.y for pt of pts`
+CommaLoop
+  CommaExpressionSpread:expression _?:ws !IfClause PostfixStatement:post ->
+    return attachPostfixStatementAsExpression(expression, [ws, post])
+
+PostfixedExpressionOrCommaLoop
+  CommaLoop
+  PostfixedExpression
+
 # Expression with postfixes *or* comma operators (mixing seems ambiguous)
 # Note that postfixed loops do allow commas though, for accumulating multiple
 # items per iteration
 PostfixedCommaExpression
   # Loops allow commas and spreads before the postfix
-  CommaExpressionSpread:expression _?:ws !IfClause PostfixStatement:post ->
-    return attachPostfixStatementAsExpression(expression, [ws, post])
+  CommaLoop
   # Ifs just allow expressions
   Expression:expression ( _? PostfixStatement ):post ->
     return attachPostfixStatementAsExpression(expression, post)
@@ -5813,6 +5823,18 @@ MaybeNestedPostfixedExpression
     return $skip unless expression
     return expression
 
+MaybeNestedPostfixedExpressionOrCommaLoop
+  # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
+  # the second case, where they get checked by PrimaryExpression,
+  # which then allows for trailing binary operators etc.
+  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested PostfixedExpressionOrCommaLoop )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
+    return $skip unless expression
+    return expression unless trailing
+    return [ expression, trailing ]
+  ForbidImplicitFragment PostfixedExpressionOrCommaLoop?:expression RestoreImplicitFragment ->
+    return $skip unless expression
+    return expression
+
 MaybeNestedPostfixedCommaExpression
   # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
   # the second case, where they get checked by PrimaryExpression,
@@ -6200,7 +6222,7 @@ ExportDeclaration
     ]
   # NOTE: This covers all forms that can be directly export defaulted in TS.
   # NOTE: Using Expression to allow If/Switch expressions
-  Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration / MaybeNestedPostfixedExpression ):declaration ->
+  Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration / MaybeNestedPostfixedExpressionOrCommaLoop ):declaration ->
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
   Export __ ExportFromClause:exports __ FromClause ->
     return { type: "ExportDeclaration", ts: exports.ts, children: $0 }
@@ -6300,7 +6322,7 @@ LexicalDeclaration
   # NOTE: Added const/let shorthands
   # NOTE: Using Expression to allow for If/SwitchExpressions
   # NOTE: Using PostfixExpression to allow postfix if/unless/for
-  Loc:loc ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix NotDedented:ws ( ConstAssignment / LetAssignment ):assign MaybeNestedPostfixedCommaExpression:e ->
+  Loc:loc ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix NotDedented:ws ( ConstAssignment / LetAssignment ):assign MaybeNestedPostfixedExpressionOrCommaLoop:e ->
     return processAssignmentDeclaration(
       { $loc: loc, token: assign.decl }, // like InsertConst or InsertLet
       pattern, typeSuffix, ws, assign, e
@@ -6506,7 +6528,7 @@ TripleSingleStringCharacters
     return { $loc, token: $0 }
 
 CoffeeStringSubstitution
-  CoffeeSubstitutionStart AllowAll ( PostfixedExpression __ CloseBrace )? RestoreAll ->
+  CoffeeSubstitutionStart AllowAll ( PostfixedExpressionOrCommaLoop __ CloseBrace )? RestoreAll ->
     return $skip unless $3
     return [$1, ...$3]
 
@@ -6663,7 +6685,7 @@ _TemplateLiteral
 
 # NOTE: Simplified grammar
 TemplateSubstitution
-  SubstitutionStart AllowAll ( PostfixedExpression __ CloseBrace )? RestoreAll ->
+  SubstitutionStart AllowAll ( PostfixedExpressionOrCommaLoop __ CloseBrace )? RestoreAll ->
     return $skip unless $3
     return [$1, ...$3]
 
@@ -7587,7 +7609,7 @@ JSXShorthandString
   # NOTE: TemplateLiteral must be before StringLiteral,
   # so that CoffeeScript interpolated strings get checked first.
   StringLiteral
-  OpenBrace PostfixedExpression __ CloseBrace
+  OpenBrace PostfixedExpressionOrCommaLoop __ CloseBrace
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeName
 JSXAttributeName
@@ -7608,8 +7630,8 @@ JSXAttributeInitializer
 JSXAttributeValue
   # https://facebook.github.io/jsx/#prod-JSXDoubleStringCharacters
   # https://facebook.github.io/jsx/#prod-JSXSingleStringCharacters
-  # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
-  OpenBrace PostfixedExpression __ CloseBrace
+  # NOTE: Using PostfixedExpressionOrCommaLoop to allow If/Switch expressions and postfixes
+  OpenBrace PostfixedExpressionOrCommaLoop __ CloseBrace
   JSXElement
   JSXFragment
   InsertInlineOpenBrace:open InlineJSXAttributeValue:value InsertCloseBrace:close &JSXAttributeSpace ->
@@ -7893,8 +7915,8 @@ JSXChildExpression
       d.children.push(...d.splices)
     d.children.push(",void 0")
     return d
-  # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
-  Whitespace? ( DotDotDot Whitespace? )? PostfixedExpression
+  # NOTE: Using PostfixedExpressionOrCommaLoop to allow If/Switch expressions and postfixes
+  Whitespace? ( DotDotDot Whitespace? )? PostfixedExpressionOrCommaLoop
 
 IndentedJSXChildExpression
   PushIndent NestedJSXChildExpression? PopIndent ->

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -244,7 +244,7 @@ describe "assignment", ->
     ---
     x := 1, y = 2
     ---
-    ParseError
+    ParseError: unknown:1:14 Failed to parse
   """
 
   testCase """

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -239,6 +239,22 @@ describe "assignment", ->
     const {c, d} = a
   """
 
+  throws """
+    const assignment shorthand forbids comma expressions
+    ---
+    x := 1, y = 2
+    ---
+    ParseError
+  """
+
+  testCase """
+    const assignment shorthand allows parenthesized comma expressions
+    ---
+    x := (1, y = 2)
+    ---
+    const x = (1, y = 2)
+  """
+
   testCase """
     const assignment with postfix
     ---
@@ -246,6 +262,12 @@ describe "assignment", ->
     ---
     const x =(()=>{const results=[];for (let i = 0; i <= 9; ++i) { const y = i;results.push( y*2) }return results})()
   """
+
+  evalsTo """
+    pairs := [[1, 2], [3, 4]]
+    x := a, b for [a, b] of pairs
+    x
+  """, [1, 2, 3, 4]
 
   testCase """
     let assignment shorthand

--- a/test/class.civet
+++ b/test/class.civet
@@ -1069,6 +1069,37 @@ describe "class", ->
     }
   """
 
+  throws """
+    readonly shorthand forbids bare comma expressions
+    ---
+    class Foo
+      x := 1, y = 2
+    ---
+    ParseError: unknown:2:16 Failed to parse
+  """
+
+  testCase """
+    readonly shorthand allows parenthesized comma expressions
+    ---
+    class Foo
+      x := (1, y = 2)
+    ---
+    class Foo {
+      readonly x = (1, y = 2)
+    }
+  """
+
+  testCase """
+    readonly shorthand allows postfix comma loops
+    ---
+    class Foo
+      x := a, b for [a, b] of pairs
+    ---
+    class Foo {
+      readonly x =(()=>{const results=[];for (const [a, b] of pairs) { results.push( a, b) }return results})()
+    }
+  """
+
   testCase """
     interspersed comments
     ---

--- a/test/export.civet
+++ b/test/export.civet
@@ -73,6 +73,14 @@ describe "export", ->
     export default () => {}
   """
 
+  testCase """
+    export default with postfix comma loop
+    ---
+    export default a, b for [a, b] of pairs
+    ---
+    export default (()=>{const results=[];for (const [a, b] of pairs) { results.push(a, b) }return results})()
+  """
+
   describe "export default extensions", ->
     testCase """
       export default const

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -84,6 +84,14 @@ describe "braced JSX attributes", ->
   """
 
   testCase """
+    postfix comma loop in braced attribute
+    ---
+    <Component points={a, b for [a, b] of pairs} />
+    ---
+    <Component points={(()=>{const results=[];for (const [a, b] of pairs) { results.push(a, b) }return results})()} />
+  """
+
+  testCase """
     attribute access
     ---
     <Component x=a.b.c()?.d[e]?() />

--- a/test/jsx/test.civet
+++ b/test/jsx/test.civet
@@ -86,6 +86,14 @@ describe "JSX", ->
   """
 
   testCase """
+    postfix comma loop expression
+    ---
+    <h1>{a, b for [a, b] of pairs}</h1>
+    ---
+    <h1>{(()=>{const results=[];for (const [a, b] of pairs) { results.push(a, b) }return results})()}</h1>
+  """
+
+  testCase """
     extended expression attributes
     ---
     <h1 title={if x < 10 then "Hello" else "Goodbye"}/>

--- a/test/strings.civet
+++ b/test/strings.civet
@@ -20,6 +20,15 @@ describe "strings", ->
   """
 
   testCase """
+    CoffeeScript interpolation postfix comma loop
+    ---
+    "civet coffeeInterpolation"
+    x = "#{a, b for [a, b] of pairs}"
+    ---
+    x = `${(()=>{const results=[];for (const [a, b] of pairs) { results.push(a, b) }return results})()}`
+  """
+
+  testCase """
     a
     ---
     x = "a"

--- a/test/template-literal.civet
+++ b/test/template-literal.civet
@@ -46,6 +46,14 @@ describe "template literal", ->
   """
 
   testCase """
+    postfix comma loop substitution
+    ---
+    `${a, b for [a, b] of pairs}`
+    ---
+    `${(()=>{const results=[];for (const [a, b] of pairs) { results.push(a, b) }return results})()}`
+  """
+
+  testCase """
     $$$
     ---
     `$$$`


### PR DESCRIPTION
#1849 accidentally added `x := 1, y = 2` as shorthand for `const x = 1, y = 2`, but actually parsed as `const x = (1, y = 2)` which is not how it executes in JavaScript. This is at the least buggy: Civet doesn't understand that `y` gets declared. I think it's also safer to go back to forbidding this, as the comma could have different meanings.

This PR reforbids `x := 1, y = 2` while preserving `x := a, b for ...` notation from #1849. It also allows `a, b for ...` in a few more locations, as described in the tests.