### PR TITLE
Fix `case` list with newline before comma

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5355,7 +5355,7 @@ CaseExpressionList
     result := rest.map(([ws, _comma, exp, col]) => {
       exp = trimFirstSpace(exp)
 
-      if ws# then return [insertTrimmingSpace("case ", ws), exp, col]
+      if ws# then return [ws, "case ", exp, col]
       return ["case ", exp, col]
     })
     result./**/unshift(first)

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -305,6 +305,21 @@ describe "switch", ->
   """
 
   testCase """
+    case with multiple expressions with newline before comma
+    ---
+    switch x
+      case 1
+      , 2
+        console.log y
+    ---
+    switch(x) {
+      case 1:
+      case 2:
+        console.log(y)
+    }
+  """
+
+  testCase """
     when skips break if unnecessary
     ---
     switch x


### PR DESCRIPTION
Fixes #1990.

When a case expression list is split with a newline before the comma, the ws array was being passed as the string replacement argument to `insertTrimmingSpace`, causing the array to be coerced to `[object Object]`. The fix emits `[ws, "case ", exp, col]` directly, preserving the whitespace tokens.

Generated with [Claude Code](https://claude.ai/code)