### PR TITLE
Fix `asserts` in interface call signature return type

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8139,7 +8139,7 @@ NestedInterfaceProperty
 
 InterfaceProperty
   BasicInterfaceProperty
-  NonEmptyParameters TypeSuffix InterfacePropertyDelimiter
+  NonEmptyParameters ReturnTypeSuffix InterfacePropertyDelimiter
   MethodSignature InterfacePropertyDelimiter
 
 BasicInterfaceProperty

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -242,6 +242,51 @@ describe "[TS] function", ->
   """
 
   testCase """
+    call signature asserts
+    ---
+    assert: {
+      <T>(a: T, msg: string): asserts a
+    } :=
+      (a, msg): void =>
+        throw new Error(`Assertion failed [${msg}]`) unless a
+    ---
+    const assert: {
+      <T>(a: T, msg: string): asserts a
+    } =
+      (a, msg): void => {
+        if (!a) { throw new Error(`Assertion failed [${msg}]`) }
+      }
+  """
+
+  testCase """
+    call signature asserts predicate
+    ---
+    x: {
+      (a: unknown): asserts a is string
+    } :=
+      (a) => {}
+    ---
+    const x: {
+      (a: unknown): asserts a is string
+    } =
+      (a) =>( {})
+  """
+
+  testCase """
+    call signature type predicate
+    ---
+    x: {
+      (a: unknown): a is string
+    } :=
+      (a) => {}
+    ---
+    const x: {
+      (a: unknown): a is string
+    } =
+      (a) =>( {})
+  """
+
+  testCase """
     type predicate
     ---
     isCat = (animal: Cat | Dog): animal is Cat ->


### PR DESCRIPTION
Fixes #1993

The call-signature rule in `InterfaceProperty` was using `TypeSuffix`, which does not recognize `asserts` or type predicates. Switched it to `ReturnTypeSuffix` so unnamed call signatures behave like named `MethodSignature`s and correctly parse `asserts a` and `a is T` in the return type.

Generated with [Claude Code](https://claude.ai/code)