### PR TITLE
Zed: point extension grammar repo to GitHub URL

### DIFF
--- a/lsp/zed/extension.toml
+++ b/lsp/zed/extension.toml
@@ -7,7 +7,7 @@ authors = ["Daniel X Moore"]
 repository = "https://github.com/DanielXMoore/Civet"
 
 [grammars.civet]
-repository = "file:///home/daniel/apps/Civet"
+repository = "https://github.com/DanielXMoore/Civet"
 rev = "5ae580bdbcaa984ec14297d21b8c03027f45b9a9"
 path = "lsp/tree-sitter"
 


### PR DESCRIPTION
### Summary

* This change should fix the Zed Extension integration by pointing to the Github url for the Civet grammars.