### PR TITLE
CLI lazy loads unplugin, fix race, allow symlink failure on Windows

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -2,8 +2,6 @@
 type { ASTError, BlockStatement, ParseError, ParseErrors } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
-// unplugin ends up getting installed in the same dist directory
-{rawPlugin} from ./unplugin/unplugin.civet
 type Unplugin =
   buildStart: () => Promise<void>
   buildEnd: (this: {emitFile: (data: {source: string, fileName: string, type: string}) => void}, useConfigFileNames?: boolean) => Promise<void>
@@ -496,6 +494,10 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       }
 
   if options.typescript
+    // unplugin ends up getting installed in the same dist directory.
+    // Defer loading it until we need it.
+    { rawPlugin } from './unplugin/unplugin.civet'
+
     /* c8 ignore start — CJS-only TypeScript fallback; tests load as ESM */
     // In case we're installed globally, allow for co-installed typescript
     unless import.meta.url  // CJS mode only
@@ -672,10 +674,15 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
   process.exitCode = Math.min 255, errors
   if unplugin?
     try
+      pending: Promise<void>[] := []
       await unplugin.buildEnd.call {
-        emitFile({source, fileName})
-          fs.writeFile fileName, source
+        emitFile({source, fileName}): void
+          pending.push async do
+            outputDir := path.dirname fileName
+            await fs.mkdir outputDir, recursive: true unless outputDir is '.'
+            await fs.writeFile fileName, source
       }, not filenames.length
+      await Promise.all pending
     catch error
       if match := (error as Error).message.match /Aborting build because of (\d+) TypeScript diagnostic/
         process.exitCode = Math.min 255, errors + +match[1]

--- a/test/cli-repl.civet
+++ b/test/cli-repl.civet
@@ -62,6 +62,8 @@ function spawnRepl(args: string[] = [], options: {} = {}): ReplHandle
       if pred joined
         outChunks.length = 0
         return joined
+      if proc.exitCode? or proc.killed
+        throw new Error `process exited before match; exitCode: ${proc.exitCode}; captured stdout: ${JSON.stringify joined}; stderr: ${JSON.stringify errChunks.join('')}`
       if Date.now() - start > timeout
         throw new Error `timeout waiting for match; captured stdout: ${JSON.stringify joined}; stderr: ${JSON.stringify errChunks.join('')}`
       await new Promise<void> (r) => setTimeout r, 20

--- a/test/infra/config.civet
+++ b/test/infra/config.civet
@@ -66,7 +66,13 @@ describe "findConfig", ->
     // Exercises the `try`'s catch branch when fs.stat throws on an entry
     // that readdir saw.
     await withTempDir async (dir) ->
-      await fs.symlink join(dir, "does-not-exist"), join(dir, ".config")
+      try
+        await fs.symlink join(dir, "does-not-exist"), join(dir, ".config")
+      catch error
+        // Windows symlink creation can require elevation or Developer Mode.
+        return if process.platform is 'win32' and
+                  (error as NodeJS.ErrnoException).code is 'EPERM'
+        throw error
       await fs.writeFile join(dir, "civetconfig.json"), "{}"
       result := await findConfig(dir)
       assert result, "should fall through after stat failure"
@@ -75,7 +81,13 @@ describe "findConfig", ->
   it "tolerates a dangling config-file symlink (stat failure)", ->
     // Same TOCTOU tolerance for the main configName loop.
     await withTempDir async (dir) ->
-      await fs.symlink join(dir, "does-not-exist"), join(dir, "civetconfig.json")
+      try
+        await fs.symlink join(dir, "does-not-exist"), join(dir, "civetconfig.json")
+      catch error
+        // Windows symlink creation can require elevation or Developer Mode.
+        return if process.platform is 'win32' and
+                  (error as NodeJS.ErrnoException).code is 'EPERM'
+        throw error
       await fs.writeFile join(dir, "civet.config.yaml"), "jsOutput: true\n"
       result := await findInDir(dir)
       assert result, "should fall through to civet.config.yaml"

--- a/test/infra/config.civet
+++ b/test/infra/config.civet
@@ -65,13 +65,13 @@ describe "findConfig", ->
   it "tolerates a dangling .config symlink (stat failure)", ->
     // Exercises the `try`'s catch branch when fs.stat throws on an entry
     // that readdir saw.
-    await withTempDir async (dir) ->
+    await withTempDir async (dir) =>
       try
         await fs.symlink join(dir, "does-not-exist"), join(dir, ".config")
       catch error
         // Windows symlink creation can require elevation or Developer Mode.
-        return if process.platform is 'win32' and
-                  (error as NodeJS.ErrnoException).code is 'EPERM'
+        @skip() if process.platform is 'win32' and
+                   (error as NodeJS.ErrnoException).code is 'EPERM'
         throw error
       await fs.writeFile join(dir, "civetconfig.json"), "{}"
       result := await findConfig(dir)
@@ -80,13 +80,13 @@ describe "findConfig", ->
 
   it "tolerates a dangling config-file symlink (stat failure)", ->
     // Same TOCTOU tolerance for the main configName loop.
-    await withTempDir async (dir) ->
+    await withTempDir async (dir) =>
       try
         await fs.symlink join(dir, "does-not-exist"), join(dir, "civetconfig.json")
       catch error
         // Windows symlink creation can require elevation or Developer Mode.
-        return if process.platform is 'win32' and
-                  (error as NodeJS.ErrnoException).code is 'EPERM'
+        @skip() if process.platform is 'win32' and
+                   (error as NodeJS.ErrnoException).code is 'EPERM'
         throw error
       await fs.writeFile join(dir, "civet.config.yaml"), "jsOutput: true\n"
       result := await findInDir(dir)


### PR DESCRIPTION
Fix some testing for Windows, again...

* CLI had a race where it declared being done before actually emitting files. This caused the "wrote `.d.ts`" test to fail rarely. (This didn't actually happen in practice because the Node process would have waited... but it's good for API access to the CLI.)
* CLI now lazy-loads unplugin only when necessary. Speeds up tests that don't need it.
* Symlinks only work as administrator on Windows. This is fine for CLI but not for normal users. Just skip the tests in those cases.
* Better failure diagnostics