### PR TITLE
Remove unnecessary boolean checks

### DIFF
--- a/source/parser/traversal.civet
+++ b/source/parser/traversal.civet
@@ -7,7 +7,6 @@ import type {
 import { isFunction } from ./util.civet
 
 export type Predicate<T extends ASTNodeObject> = (arg: ASTNodeObject) => arg is T
-type TraversableNode = ASTNode | boolean
 
 function gatherRecursiveWithinFunction<T extends ASTNodeObject>(
   node: ASTNode
@@ -77,19 +76,18 @@ function findAncestor<T extends ASTNodeParent>(
 // without recursing into nested blocks/for loops
 
 function gatherNodes<T extends ASTNodeObject>(
-  node: TraversableNode
+  node: ASTNode
   predicate: Predicate<T>
 ): T[]
 function gatherNodes(
-  node: TraversableNode
+  node: ASTNode
   predicate: (arg: ASTNodeObject) => boolean
 ): ASTNodeObject[]
 function gatherNodes<T extends ASTNodeObject>(
-  node: TraversableNode,
+  node: ASTNode,
   predicate: (arg: ASTNodeObject) => boolean
 ): (T | ASTNodeObject)[]
-  // Hera 0.9.0: `&`/`!` assertions now emit `true` into child arrays; skip them.
-  return [] if not node? or node <? "string" or node <? "boolean"
+  return [] if not node? or node <? "string"
 
   if Array.isArray(node)
     return node.flatMap((n) => gatherNodes(n, predicate))
@@ -116,22 +114,21 @@ function gatherNodes<T extends ASTNodeObject>(
 // Gather nodes that match a predicate recursing into all unmatched children
 // i.e. if the predicate matches a node it is not recursed into further
 function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = never>(
-  node: TraversableNode
+  node: ASTNode
   predicate: Predicate<T>
   skipPredicate?: Predicate<S>
 ): Exclude<T, S>[]
 function gatherRecursive(
-  node: TraversableNode
+  node: ASTNode
   predicate: (arg: ASTNodeObject) => boolean
   skipPredicate?: (arg: ASTNodeObject) => boolean
 ): ASTNodeObject[]
 function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = never>(
-  node: TraversableNode
+  node: ASTNode
   predicate: (arg: ASTNodeObject) => boolean
   skipPredicate?: (arg: ASTNodeObject) => boolean
 ): (ASTNodeObject | Exclude<T, S>)[]
-  // Hera 0.9.0: `&`/`!` assertions now emit `true` into child arrays; skip them.
-  return [] if not node? or node <? "string" or node <? "boolean"
+  return [] if not node? or node <? "string"
 
   if Array.isArray node
     return node.flatMap gatherRecursive(., predicate, skipPredicate)
@@ -147,19 +144,18 @@ function gatherRecursive<T extends ASTNodeObject, S extends ASTNodeObject = neve
     skipPredicate
 
 function gatherRecursiveAll<T extends ASTNodeObject>(
-  node: TraversableNode
+  node: ASTNode
   predicate: Predicate<T>
 ): T[]
 function gatherRecursiveAll(
-  node: TraversableNode
+  node: ASTNode
   predicate: (arg: ASTNodeObject) => boolean
 ): ASTNodeObject[]
 function gatherRecursiveAll<T extends ASTNodeObject>(
-  node: TraversableNode
+  node: ASTNode
   predicate: (arg: ASTNodeObject) => boolean
 ): (T | ASTNodeObject)[]
-  // Hera 0.9.0: `&`/`!` assertions now emit `true` into child arrays; skip them.
-  return [] if not node? or node <? "string" or node <? "boolean"
+  return [] if not node? or node <? "string"
 
   if Array.isArray node
     return node.flatMap (n) => gatherRecursiveAll n, predicate


### PR DESCRIPTION
Followup to #2006 - the changes to `traversal.civet` are no longer needed, as suggested by @STRd6 