### PR TITLE
Semantic tokens for comments, fixing `coffeeComment` syntax highlighting

### DIFF
--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@danielx/civet-language-server",
   "description": "Civet Language Server (standalone, editor-agnostic)",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "repository": {
     "type": "git",
     "url": "https://github.com/DanielXMoore/civet.git"

--- a/lsp/server/source/lib/typescript-service.civet
+++ b/lsp/server/source/lib/typescript-service.civet
@@ -4,6 +4,7 @@ path from path
 { type SourceMap as CivetSourceMap, type CompileOptions, type ParseError } from @danielx/civet
 BundledCivetModule from @danielx/civet
 BundledCivetConfigModule from @danielx/civet/config
+BundledCivetPackage from @danielx/civet/package.json with type: 'json'
 { getCanonicalFileName } from ./util.civet
 
 ts from typescript
@@ -477,6 +478,7 @@ function TSService(projectURL = "./", logger: Logger = console)
   // Use Civet from the project if present
   Civet .= BundledCivetModule
   CivetConfig .= BundledCivetConfigModule
+  CivetVersion .= BundledCivetPackage.version
   civetPath := "@danielx/civet"
   try
     projectRequire(`${civetPath}/lsp/package.json`)
@@ -484,11 +486,16 @@ function TSService(projectURL = "./", logger: Logger = console)
 
   try
     Civet = projectRequire(civetPath)
-    CivetConfig = projectRequire(`${civetPath}/config`)
-    CivetVersion := projectRequire(`${civetPath}/package.json`).version
+    ProjectVersion := projectRequire(`${civetPath}/package.json`).version
+    try
+      CivetConfig = projectRequire(`${civetPath}/config`)
+    catch e
+      logger.info `BUNDLED CIVET ${ProjectVersion} IS MISSING CONFIG MODULE`
+      throw e
+    CivetVersion = ProjectVersion
     logger.info(`LOADED PROJECT CIVET ${CivetVersion}: ${path.join(projectURL + " " + civetPath)} \n\n`)
   catch e
-    logger.info("USING BUNDLED CIVET")
+    logger.info(`USING BUNDLED CIVET ${CivetVersion}`)
 
   civetConfig: CompileOptions .= {}
   try

--- a/lsp/server/source/lib/typescript-service.civet
+++ b/lsp/server/source/lib/typescript-service.civet
@@ -51,6 +51,7 @@ interface ResolvedModuleWithFailedLookupLocations extends ts.ResolvedModuleWithF
 export interface FileMeta
   sourcemapLines: SourceMap["lines"]?
   transpiledDoc: TextDocument?
+  commentRanges: { pos: number, length: number }[]?
   parseErrors: (Error | ParseError)[]?
   fatal: boolean // whether errors were fatal during compilation, so no doc
 
@@ -70,6 +71,7 @@ interface Transpiler
   compile(path: string, source: string): {
     code: string
     sourceMap?: SourceMap
+    commentRanges?: { pos: number, length: number }[]
     errors?: (Error | ParseError)[]
   }?
 
@@ -388,16 +390,13 @@ function TSHost(
     return snapshot
   }
 
-  function createOrUpdateMeta(path: string, transpiledDoc: TextDocument, sourcemapLines?: SourceMap["lines"], parseErrors?: (Error | ParseError)[], fatal: boolean = false) {
+  function createOrUpdateMeta(path: string, update: FileMeta & { transpiledDoc: TextDocument }) {
     path = getCanonicalFileName path
     meta .= fileMetaData.get(path)
     if !meta
-      fileMetaData.set(path, { sourcemapLines, transpiledDoc, parseErrors, fatal } as FileMeta)
+      fileMetaData.set(path, update)
     else
-      meta.transpiledDoc = transpiledDoc
-      meta.sourcemapLines = sourcemapLines
-      meta.parseErrors = parseErrors
-      meta.fatal = fatal
+      Object.assign(meta, update)
   }
 
   function doTranspileAndUpdateMeta(transpiledDoc: TextDocument, version: number, transpiler: Transpiler, sourcePath: string, sourceCode: string): string | undefined {
@@ -406,14 +405,26 @@ function TSHost(
       var result = transpiler.compile(sourcePath, sourceCode)
     } catch (e: unknown) {
       // Add parse errors to meta
-      createOrUpdateMeta(sourcePath, transpiledDoc, undefined, [e as Error], true)
+      createOrUpdateMeta(sourcePath, {
+        transpiledDoc
+        sourcemapLines: undefined
+        commentRanges: undefined
+        parseErrors: [e as Error]
+        fatal: true
+      })
       return
     }
 
     return unless result
-    { code: transpiledCode, sourceMap, errors } := result
-    sourceMapLines := sourceMap?.lines
-    createOrUpdateMeta(sourcePath, transpiledDoc, sourceMapLines, errors, false)
+    { code: transpiledCode, sourceMap, commentRanges, errors } := result
+    sourcemapLines := sourceMap?.lines
+    createOrUpdateMeta(sourcePath, {
+      transpiledDoc
+      sourcemapLines
+      commentRanges
+      parseErrors: errors
+      fatal: false
+    })
     TextDocument.update(transpiledDoc, [{ text: transpiledCode }], version)
     transpiledCode
   }
@@ -546,18 +557,43 @@ function TSService(projectURL = "./", logger: Logger = console)
 
   function transpileCivet(path: string, source: string)
     errors: ParseError[] := []
-    // `Civet` may be resolved from the project at runtime, so TS loses `sync: true` narrowing.
-    result := Civet.compile(source, {
+    options: CompileOptions & { sync: true } := {}
       ...civetConfig
       filename: path
-      sourceMap: true
       errors
       // We don't process comptime in LSP so don't need async yet
       sync: true
-      comptime: false
-    }) as { code: string; sourceMap: CivetSourceMap }
+      parseOptions: {}
+        ...civetConfig.parseOptions
+        comptime: false
 
-    { ...result, errors }
+    // Civet 0.9.4 introduced `new SourceMap` API
+    [major, minor, patch] := CivetVersion.split(".").map(Number)
+    if major is 0 and (minor < 9 or minor is 9 and patch < 4)
+      result := Civet.compile source, { ...options, sourceMap: true }
+      return { ...result, errors }
+
+    // Re-use the single parse for both code generation and comment extraction.
+    options.ast = true
+    ast := Civet.compile source, options
+    sourceMap := new Civet.SourceMap source, path
+    code := Civet.generate ast, {}
+      ...options
+      sourceMap
+    commentRanges := collectCommentRanges(ast)
+
+    {
+      code
+      sourceMap
+      commentRanges
+      errors
+    }
+
+  function collectCommentRanges(ast: unknown)
+    comments := Civet.lib.gatherRecursiveAll(ast, (node: any) =>
+      node?.type is "Comment" and node.$loc?.length > 0
+    ) as { $loc: { pos: number, length: number } }[]
+    comments.map (comment) => comment.$loc
 
 /**
  * Returns the extension of the file including the dot.

--- a/lsp/server/source/lib/typescript-service.civet
+++ b/lsp/server/source/lib/typescript-service.civet
@@ -509,7 +509,7 @@ function TSService(projectURL = "./", logger: Logger = console)
     try
       CivetConfig = projectRequire(`${civetPath}/config`)
     catch e
-      logger.info `BUNDLED CIVET ${ProjectVersion} IS MISSING CONFIG MODULE`
+      logger.info `PROJECT CIVET ${ProjectVersion} IS MISSING CONFIG MODULE`
       throw e
     CivetVersion = ProjectVersion
     logger.info(`LOADED PROJECT CIVET ${CivetVersion}: ${path.join(projectURL + " " + civetPath)} \n\n`)

--- a/lsp/server/source/lib/typescript-service.civet
+++ b/lsp/server/source/lib/typescript-service.civet
@@ -1,7 +1,7 @@
 assert from assert
 path from path
 
-{ type SourceMap as CivetSourceMap, type CompileOptions, type ParseError } from @danielx/civet
+{ type SourceMap as CivetSourceMap, type CompileOptions, type ParseError, lib as BundledCivetLib } from @danielx/civet
 BundledCivetModule from @danielx/civet
 BundledCivetConfigModule from @danielx/civet/config
 BundledCivetPackage from @danielx/civet/package.json with type: 'json'
@@ -77,6 +77,9 @@ interface Transpiler
 
 interface Plugin
   transpilers?: Transpiler[]
+
+interface CivetTraversalLib
+  gatherRecursiveAll(ast: unknown, predicate: (node: unknown) => boolean): unknown[]
 
 function TSHost(
   compilationSettings: CompilerOptions
@@ -488,6 +491,7 @@ function TSService(projectURL = "./", logger: Logger = console)
 
   // Use Civet from the project if present
   Civet .= BundledCivetModule
+  CivetLib: CivetTraversalLib .= BundledCivetLib
   CivetConfig .= BundledCivetConfigModule
   CivetVersion .= BundledCivetPackage.version
   civetPath := "@danielx/civet"
@@ -497,6 +501,10 @@ function TSService(projectURL = "./", logger: Logger = console)
 
   try
     Civet = projectRequire(civetPath)
+    if Civet.lib?
+      CivetLib = Civet.lib
+    else
+      logger.error `PROJECT CIVET ${civetPath} IS MISSING lib EXPORT; USING BUNDLED lib`
     ProjectVersion := projectRequire(`${civetPath}/package.json`).version
     try
       CivetConfig = projectRequire(`${civetPath}/config`)
@@ -590,7 +598,7 @@ function TSService(projectURL = "./", logger: Logger = console)
     }
 
   function collectCommentRanges(ast: unknown)
-    comments := Civet.lib.gatherRecursiveAll(ast, (node: any) =>
+    comments := CivetLib.gatherRecursiveAll(ast, (node: any) =>
       node?.type is "Comment" and node.$loc?.length > 0
     ) as { $loc: { pos: number, length: number } }[]
     comments.map (comment) => comment.$loc

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -70,7 +70,10 @@ semanticTokenTypes := [
   "property"       // 9
   "function"       // 10
   "member"         // 11
+  "comment"        // 12 (custom Civet token; TS classifier does not emit comments)
 ] as const
+
+commentSemanticTokenType := semanticTokenTypes.indexOf("comment")
 
 // TS 2020 semantic classification token modifiers (order must match TypeScript's internal TokenModifier enum)
 semanticTokenModifiers := [
@@ -1146,6 +1149,7 @@ connection.onRequest SemanticTokensRequest.type, (params) =>
   let transpiledPath: string
   let sourcemapLines: SourcemapLines | undefined
   let transpiledDoc: TextDocument | undefined
+  commentRanges: { pos: number, length: number }[] .= []
   if sourcePath.match(tsSuffix)
     // Non-transpiled TS/JS file
     transpiledPath = sourcePath
@@ -1154,6 +1158,7 @@ connection.onRequest SemanticTokensRequest.type, (params) =>
     return { data: [] } unless meta?.transpiledDoc
     transpiledDoc = meta.transpiledDoc
     sourcemapLines = meta.sourcemapLines
+    commentRanges = meta.commentRanges ?? []
     transpiledPath = documentToSourcePath(transpiledDoc)
 
   try
@@ -1194,6 +1199,8 @@ connection.onRequest SemanticTokensRequest.type, (params) =>
 
       remapped.push { line: pos.line, character: pos.character, length, tokenType, tokenModifiers }
 
+    remapped.push ...collectCommentTokens doc, commentRanges
+
     // Sort by position (required for valid delta encoding)
     remapped.sort (a, b) => a.line - b.line or a.character - b.character
 
@@ -1230,6 +1237,38 @@ documents.listen(connection)
 connection.listen()
 
 // Utils
+
+function collectCommentTokens(
+  doc: TextDocument
+  commentRanges: { pos: number, length: number }[]
+)
+  sourceText := doc.getText()
+  tokens: { line: number, character: number, length: number, tokenType: number, tokenModifiers: number }[] := []
+
+  for { pos, length } of commentRanges
+    start .= Math.max(0, pos)
+    end .= Math.min(sourceText.length, pos + length)
+    while start < end
+      tokenEnd .= start
+      while tokenEnd < end and sourceText[tokenEnd] is not '\r' and sourceText[tokenEnd] is not '\n'
+        tokenEnd++
+
+      if length := tokenEnd - start
+        tokenPos := doc.positionAt start
+        tokens.push {
+          tokenPos.{line,character}
+          length
+          tokenType: commentSemanticTokenType
+          tokenModifiers: 0
+        }
+
+      break if tokenEnd >= end
+      if sourceText[tokenEnd] is '\r' and sourceText[tokenEnd + 1] is '\n'
+        start = tokenEnd + 2
+      else
+        start = tokenEnd + 1
+
+  tokens
 
 function documentToSourcePath(textDocument: TextDocumentIdentifier)
   URI.parse(textDocument.uri).fsPath

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -26,13 +26,14 @@ initializeClient := (client: LspClient, opts: { workspaceFolders?: any, capabili
     opts.workspaceFolders
   else
     [{ uri: rootUri, name: "project-test" }]
-  await client.request "initialize", {
+  result := await client.request "initialize", {
     processId: process.pid
     rootUri: folders?.[0]?.uri ?? null
     capabilities: opts.capabilities ?? {}
     workspaceFolders: folders
   }
   client.notify "initialized", {}
+  result
 
 // Helper to wait for diagnostics matching the given uri predicate with a
 // coverage-friendly timeout.  Defined outside the describe so Civet parses it
@@ -46,11 +47,12 @@ describe "LSP features (shared project server)", ->
   @timeout 60000
 
   let client: LspClient
+  let init: any
   before ->
     client = spawnLspServer()
     // Enable workspaceFolders capability so the workspace-folder change test
     // can exercise the matching listener without a dedicated server.
-    await initializeClient client,
+    init = await initializeClient client,
       capabilities:
         workspace:
           configuration: true
@@ -123,6 +125,61 @@ describe "LSP features (shared project server)", ->
     assert tokens, "expected semantic tokens response"
     assert Array.isArray(tokens.data), "expected tokens.data to be an array"
     assert tokens.data.length > 0, "expected at least one token"
+
+  it "semantic tokens marks civet comments as comments", ->
+    uri := docUri path.join(projectRoot, "semtok-coffee-comment.civet")
+    text := '''
+      "civet coffeeComment"
+      ### coffee block
+      still block ###
+      /* js block
+      still js block */
+      # coffee line
+      value := 1 // trailing js
+    '''
+    lines := text.split "\n"
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    commentIndex := init.capabilities.semanticTokensProvider.legend.tokenTypes.indexOf("comment")
+    assert commentIndex >= 0, 'expected "comment" in semantic token legend'
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    expectedComments := [
+      { text: '### coffee block', character: 0 }
+      { text: 'still block ###', character: 0 }
+      { text: '/* js block', character: 0 }
+      { text: 'still js block */', character: 0 }
+      { text: '# coffee line', character: 0 }
+      { text: '// trailing js', character: lines.find((line) => line.includes('// trailing js'))!.indexOf('//') }
+    ]
+
+    for expected of expectedComments
+      lineIndex := lines.findIndex (line) => line.includes expected.text
+      token := decoded.find (token) =>
+        token.line is lineIndex and token.character is expected.character and token.tokenType is commentIndex
+      assert token, `expected a comment token for '${expected.text}' at ${lineIndex}:${expected.character}`
 
   it "completion resolve returns details for a symbol", ->
     uri := docUri path.join(projectRoot, "complete-resolve.civet")

--- a/lsp/server/test/service.civet
+++ b/lsp/server/test/service.civet
@@ -15,6 +15,9 @@ nullLogger :=
   info: ->
   error: ->
 
+bundledCivetMain := path.resolve("../../dist/main.js")
+bundledCivetConfig := path.resolve("../../dist/config.js")
+
 loadFile := (service: Awaited<ReturnType<typeof TSService>>, path: string) ->
   document := TextDocument.create(pathToFileURL(path).href, "civet", 0, fs.readFileSync(path, "utf8"))
   service.host.addOrUpdateDocument(document)
@@ -371,3 +374,96 @@ describe "ts service without civet dependencies", ->
         `expected config error, got: ${errors.join(" | ")}`
     finally
       rmSync(badConfigDir, { recursive: true, force: true })
+
+describe "ts service with partial project civet packages", ->
+  tmpDirs: string[] := []
+
+  after ->
+    for tmpDir of tmpDirs
+      rmSync tmpDir, { recursive: true, force: true }
+
+  writeFakeProjectCivet := (options: { version: string, includeLib?: boolean, includeConfig?: boolean }) ->
+    tmpDir := mkdtempSync path.join tmpdir(), 'civet-lsp-partial-project-'
+    tmpDirs.push tmpDir
+
+    writeFileSync path.join(tmpDir, 'tsconfig.json'),
+      '{"compilerOptions":{"target":"es2020"}}'
+    samplePath := path.join tmpDir, 'sample.civet'
+    writeFileSync samplePath, '// comment\nx := 1\n'
+
+    packageDir := path.join tmpDir, 'node_modules', '@danielx', 'civet'
+    fs.mkdirSync packageDir, recursive: true
+    exports: Record<string, string> :=
+      '.': './index.cjs'
+      './package.json': './package.json'
+    exports['./config'] = './config.js' if options.includeConfig ?? true
+    writeFileSync path.join(packageDir, 'package.json'), JSON.stringify {}
+      name: '@danielx/civet'
+      version: options.version
+      main: 'index.cjs'
+      exports
+
+    if options.includeConfig ?? true
+      writeFileSync path.join(packageDir, 'config.js'),
+        `module.exports = require(${JSON.stringify bundledCivetConfig});\n`
+
+    if options.includeLib ?? true
+      writeFileSync path.join(packageDir, 'index.cjs'),
+        `module.exports = require(${JSON.stringify bundledCivetMain});\n`
+    else
+      writeFileSync path.join(packageDir, 'index.cjs'), ```
+        const real = require(${JSON.stringify bundledCivetMain});
+        const { lib, ...rest } = real;
+        module.exports = rest;
+      ```
+
+    { tmpDir, samplePath }
+
+  it "falls back to bundled lib when project civet is missing lib export", async ->
+    { tmpDir, samplePath } := writeFakeProjectCivet
+      version: '0.11.7'
+      includeLib: false
+
+    errors: string[] := []
+    capturingLogger :=
+      log: ->
+      info: ->
+      error: (msg: string) => errors.push msg
+
+    service := await TSService(pathToFileURL(tmpDir + path.sep).href, capturingLogger)
+    loadFile(service, samplePath)
+    meta := service.host.getMeta(samplePath)
+
+    assert meta?.commentRanges?.length, 'expected bundled lib fallback to collect comment ranges'
+    assert errors.some((msg) => msg.includes('MISSING lib EXPORT')),
+      `expected missing lib warning, got: ${errors.join(' | ')}`
+
+  it "logs the missing config module when project civet is missing config module", async ->
+    { tmpDir } := writeFakeProjectCivet
+      version: '0.11.7'
+      includeConfig: false
+
+    infos: string[] := []
+    capturingLogger :=
+      log: ->
+      info: (msg: string) => infos.push msg
+      error: ->
+
+    service := await TSService(pathToFileURL(tmpDir + path.sep).href, capturingLogger)
+    await service.loadPlugins()
+
+    assert service
+    assert infos.some((msg) => msg.includes('PROJECT CIVET 0.11.7 IS MISSING CONFIG MODULE')),
+      `expected missing config log, got: ${infos.join(' | ')}`
+
+  it "uses the legacy compile path when project civet predates 0.9.4", async ->
+    { tmpDir, samplePath } := writeFakeProjectCivet
+      version: '0.9.3'
+
+    service := await TSService(pathToFileURL(tmpDir + path.sep).href, nullLogger)
+    loadFile(service, samplePath)
+    meta := service.host.getMeta(samplePath)
+
+    assert meta?.sourcemapLines, 'expected legacy compile path to populate sourcemap lines'
+    assert.equal meta?.commentRanges, undefined,
+      'legacy compile path should not collect comment ranges even when the input contains comments'

--- a/lsp/vscode/e2e/fixture/coffee-comment.civet
+++ b/lsp/vscode/e2e/fixture/coffee-comment.civet
@@ -1,0 +1,7 @@
+"civet coffeeComment"
+### coffee block
+still block ###
+/* js block
+still js block */
+# coffee line
+value := 1 // trailing js

--- a/lsp/vscode/e2e/semantic-tokens.test.civet
+++ b/lsp/vscode/e2e/semantic-tokens.test.civet
@@ -142,3 +142,51 @@ suite 'Semantic Tokens', =>
       remaining := lineText.length - token.character
       assert token.length <= remaining,
         `Token at ${token.line}:${token.character} (type: ${token.tokenType}) has length ${token.length} but only ${remaining} chars remain on line: "${lineText}"`
+
+  test 'Marks Civet comments as semantic comments', async =>
+    docUri := getDocUri('coffee-comment.civet')
+    await activate(docUri)
+    sourceDoc := await vscode.workspace.openTextDocument(docUri)
+    lines := sourceDoc.getText().split('\n')
+
+    legend := await commands.executeCommand('vscode.provideDocumentSemanticTokensLegend', docUri) as SemanticTokensLegend | undefined
+    tokens := await poll
+      () => commands.executeCommand('vscode.provideDocumentSemanticTokens', docUri) as Promise<SemanticTokens | undefined>
+      (v) => (v?.data?.length or 0) > 0
+
+    assert legend, 'Expected semantic tokens legend'
+    assert tokens, 'Expected semantic tokens'
+
+    commentIndex := legend.tokenTypes.indexOf('comment')
+    assert commentIndex >= 0, 'Expected "comment" in token types legend'
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    trailingLine := lines.find (line) => line.includes('// trailing js')
+    expectedComments := [
+      { text: '### coffee block', character: 0 }
+      { text: 'still block ###', character: 0 }
+      { text: '/* js block', character: 0 }
+      { text: 'still js block */', character: 0 }
+      { text: '# coffee line', character: 0 }
+      { text: '// trailing js', character: trailingLine?.indexOf('//') ?? -1 }
+    ]
+
+    for expected of expectedComments
+      lineIndex := lines.findIndex (line) => line.includes expected.text
+      token := decoded.find (token) =>
+        token.line is lineIndex and token.character is expected.character and token.tokenType is commentIndex
+      assert token, `Expected a semantic comment token for "${expected.text}" at ${lineIndex}:${expected.character}`

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "publisher": "DanielX",
   "repository": {
     "type": "git",


### PR DESCRIPTION
TypeScript's semantic tokens, which #1881 recently added support for, sadly do not include comments. This PR adds such semantic tokens manually.  As a result, `coffeeComment` comments are finally highlighted correctly:

<img width="1422" height="679" alt="image" src="https://github.com/user-attachments/assets/b4c20f95-0bb6-4565-b06f-837133442c16" />

It works only on Civet 0.9.4+. Before that, the `SourceMap` interface was different, and I didn't feel like backporting further. But at least the VSCode plugin doesn't crash in this scenario; it falls back to not looking for `{ type: "Comment" }` nodes.

Minor LSP improvements, which surfaced when testing on an old repo of mine that had `coffeeComments` enabled:
* Old Civet didn't have `/config` module; add helpful logs in that case
* Output bundled Civet version number when it's used