### PR TITLE
Fix `typeof` types consuming top-level assignments

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8531,7 +8531,9 @@ TypePrimary
   # NOTE: typeof takes a unary expression, as in
   # https://github.com/microsoft/TypeScript/blob/ae27e55b027c66bf5b80f596da866f8485ac491d/src/compiler/parser.ts#L5666-L5669
   # (binary expression can accidentally grab closing ">" of type arguments)
-  _? Typeof _? UnaryExpression:expression ->
+  # Excludes top-level assignments so `const x: typeof foo = foo` parses
+  # the `= foo` as a variable initializer, not part of the typeof argument.
+  _? Typeof _? UnaryWithoutParenthesizedAssignment:expression ->
     return {
       type: "TypeTypeof",
       children: $0,

--- a/test/types/type-declaration.civet
+++ b/test/types/type-declaration.civet
@@ -397,6 +397,14 @@ describe "[TS] type declaration", ->
   """
 
   testCase """
+    typeof does not consume assignment
+    ---
+    const x: typeof foo = foo
+    ---
+    const x: typeof foo = foo
+  """
+
+  testCase """
     typeof accepts non-type expressions: prototype
     ---
     "civet coffeePrototype"


### PR DESCRIPTION
Fixes #2016

Switches typeof's argument from `UnaryExpression` to `UnaryWithoutParenthesizedAssignment` so that `const x: typeof foo = foo` parses the `= foo` as a variable initializer rather than as part of the typeof argument (`typeof (foo = foo)`).

Adds a regression test in `test/types/type-declaration.civet`.

Generated with [Claude Code](https://claude.ai/code)