### PR TITLE
Fix implicit return of `abstract class` mixin body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Typecheck
         if: runner.os == 'Linux'
         run: |
-          pnpm typecheck --max-errors 889
+          pnpm typecheck --max-errors 888
 
       - uses: actions/cache/save@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,33 @@ your branch tip.  If `main` has changed a file your PR doesn't touch, CI's
 happens, `git fetch && git merge origin/main` first — once `md5sum dist/main.js`
 matches CI's, the failure reproduces locally and you can fix it properly.
 
+## Typecheck
+
+CI gates type errors against a baseline (`pnpm typecheck --max-errors N` in
+[`.github/workflows/build.yml`](.github/workflows/build.yml)).  A PR must not
+introduce new errors — fix them at the source rather than bumping the
+baseline.  Identifying what's new can be tricky because adding code shifts
+line numbers, so a naive `diff` flags every shifted preexisting error as
+"new".  Use the diff helper instead:
+
+```sh
+git stash && git checkout origin/main -- '*.civet' '*.hera'
+pnpm build
+CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/before.log
+git checkout HEAD -- '*.civet' '*.hera' && git stash pop
+pnpm build
+CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/after.log
+civet scripts/typecheck-diff.civet /tmp/before.log /tmp/after.log
+```
+
+`typecheck-diff` matches by `(file, code, message)` ignoring line/column, so
+shifted-but-otherwise-identical errors don't show as drift — only genuinely
+new diagnostics appear under "Regressions".  Once those are at zero, no
+baseline bump is needed.
+
+For a one-off summary of where errors live, `bash scripts/typecheck-summary.sh`
+prints per-file and per-error-code counts.
+
 ## Debugging
 
 A useful trick is to add a `debugger` statement inside a rule handler in

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -6,15 +6,18 @@
  *   - errors present in <new> but not in <old>  (regressions)
  *   - errors present in <old> but not in <new>  (fixed)
  *
- * Diagnostics are matched by (file, line, column, code, message).  Line
- * numbers can shift across edits, so we also fuzz-match by (file, code,
- * message) — if an error with the same code+message exists for the same
- * file in both logs, it's considered "moved" and not reported.
+ * This is the right tool for "did my PR add type errors?" — naive line-by-line
+ * diffs flag every shifted preexisting error as new.  Diagnostics here are
+ * matched by (file, code, message), ignoring line/column, so a moved-but-
+ * otherwise-identical error doesn't show as drift.
  *
- * Usage:
- *   pnpm typecheck &>/tmp/before.log
- *   ...edit...
- *   pnpm typecheck &>/tmp/after.log
+ * Typical workflow (full version in CONTRIBUTING.md "Typecheck"):
+ *   git stash && git checkout origin/main -- '*.civet' '*.hera'
+ *   pnpm build
+ *   CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/before.log
+ *   git checkout HEAD -- '*.civet' '*.hera' && git stash pop
+ *   pnpm build
+ *   CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/after.log
  *   civet scripts/typecheck-diff.civet /tmp/before.log /tmp/after.log
  *
  * (`&>` captures both stdout and stderr — diagnostics go to stderr.)

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -12,6 +12,7 @@ import type {
   BreakStatement
   CallExpression
   Children
+  ClassExpression
   Declaration
   ForStatement
   FunctionNode
@@ -83,6 +84,7 @@ import {
   isFunction
   isLoopStatement
   isStatement
+  isToken
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
   makeNode
@@ -384,10 +386,12 @@ function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
 // Ensure an `abstract class` expression has a name, generating a ref if it
 // doesn't, so it can be emitted as a class declaration. Returns the
 // identifier/ref to use for referring to the class afterwards.
-function nameAbstractClass(exp: ASTNodeObject): ASTNode
-  return exp.name if exp.name
+function nameAbstractClass(exp: ClassExpression): ASTNode
+  // ClassExpression `id` includes any leading whitespace from the source;
+  // strip it so `wrapWithReturn`'s `"return "` prefix doesn't double up.
+  return trimFirstSpace(exp.id) if exp.id
   ref := makeRef "Class"
-  classKwIdx := exp.children.findIndex &?.token is "class"
+  classKwIdx := exp.children.findIndex (c) => isToken(c) and c.token is "class"
   assert.notEqual classKwIdx, -1, "Could not find class keyword in ClassExpression children"
   exp.children.splice classKwIdx+1, 0, " ", ref
   return ref
@@ -419,7 +423,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   return if isExit exp
 
   exp = exp as ASTNodeObject
-  outer .= exp
+  outer := exp
   if exp.type is "LabelledStatement"
     exp = exp.statement
 
@@ -428,11 +432,9 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   if exp.type is "ParenthesizedExpression" and
      exp.expression?.type is "ClassExpression" and
      exp.expression.abstract
-    inner := exp.expression as ASTNodeObject
-    inner.parent = outer.parent
-    if outer is exp
-      node[1] = inner
-      outer = inner
+    inner := exp.expression
+    inner.parent = exp.parent
+    node[1] = inner if outer is exp
     exp = inner
 
   switch exp.type
@@ -562,7 +564,7 @@ function insertReturn(node: ASTNode): void
   return if semi?.type is "SemicolonDelimiter"
   assert exp, "insertReturn: statement tuple missing expression"
 
-  outer .= exp
+  outer := exp
   if exp.type is "LabelledStatement"
     exp = exp.statement
 
@@ -571,11 +573,9 @@ function insertReturn(node: ASTNode): void
   if exp.type is "ParenthesizedExpression" and
      exp.expression?.type is "ClassExpression" and
      exp.expression.abstract
-    inner := exp.expression as ASTNodeObject
-    inner.parent = outer.parent
-    if outer is exp
-      node[1] = inner
-      outer = inner
+    inner := exp.expression
+    inner.parent = exp.parent
+    node[1] = inner if outer is exp
     exp = inner
 
   switch exp.type
@@ -620,14 +620,17 @@ function insertReturn(node: ASTNode): void
       // `abstract class` is only valid as a declaration in TS, not an expression,
       // so emit it as a declaration followed by `return ClassName`
       if exp.abstract
-        parent := outer.parent as BlockStatement?
-        index := findChildIndex parent?.expressions, outer
+        parent := exp.parent as BlockStatement?
+        assert parent, "ClassExpression has no parent"
+        // exp may have been unwrapped from a ParenthesizedExpression above,
+        // so search by tuple-position rather than by `outer` reference.
+        index := parent.expressions.findIndex (t) => t[1] is exp
         assert.notEqual index, -1, "Could not find class declaration in parent"
         returnId := nameAbstractClass exp
-        parent!.expressions.splice index+1, 0, ["",
+        parent.expressions.splice index+1, 0, ["",
           wrapWithReturn returnId, exp, true
         ]
-        braceBlock parent!
+        braceBlock parent
         return
       break
     when "ForStatement", "IterationStatement", "DoStatement", "ComptimeStatement"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -381,6 +381,17 @@ function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
       when "Identifier", "AtBinding"
         bindings.push pattern
 
+// Ensure an `abstract class` expression has a name, generating a ref if it
+// doesn't, so it can be emitted as a class declaration. Returns the
+// identifier/ref to use for referring to the class afterwards.
+function nameAbstractClass(exp: ASTNodeObject): ASTNode
+  return exp.name if exp.name
+  ref := makeRef "Class"
+  classKwIdx := exp.children.findIndex &?.token is "class"
+  assert.notEqual classKwIdx, -1, "Could not find class keyword in ClassExpression children"
+  exp.children.splice classKwIdx+1, 0, " ", ref
+  return ref
+
 // NOTE: this is almost the same as insertReturn but doesn't remove `breaks` in `when` and
 // does construct an else clause pushing undefined in if statements that lack them
 // and adds to the beginning and the end of the expression's children.
@@ -408,9 +419,21 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   return if isExit exp
 
   exp = exp as ASTNodeObject
-  outer := exp
+  outer .= exp
   if exp.type is "LabelledStatement"
     exp = exp.statement
+
+  // Anonymous abstract classes get wrapped in parens by ClassDeclaration; unwrap
+  // so the ClassExpression case below can emit a class declaration.
+  if exp.type is "ParenthesizedExpression" and
+     exp.expression?.type is "ClassExpression" and
+     exp.expression.abstract
+    inner := exp.expression as ASTNodeObject
+    inner.parent = outer.parent
+    if outer is exp
+      node[1] = inner
+      outer = inner
+    exp = inner
 
   switch exp.type
     when "DebuggerStatement", "EmptyStatement"
@@ -435,6 +458,17 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
       /* c8 ignore next 3 */
       // This is currently never hit because anonymous FunctionExpressions are already wrapped in parens by this point
       // Add return in normal way for functions without ids
+      break
+    when "ClassExpression"
+      // `abstract class` is only valid as a declaration in TS, not an expression,
+      // so emit it as a declaration followed by `;<collect ClassName>`
+      if exp.abstract
+        id := nameAbstractClass exp
+        exp.children.push [
+          "", [";", collect(id)]
+        ]
+        updateParentPointers exp
+        return
       break
     when "ForStatement", "IterationStatement", "DoStatement", "ComptimeStatement"
       wrapIterationReturningResults exp, collect
@@ -528,9 +562,21 @@ function insertReturn(node: ASTNode): void
   return if semi?.type is "SemicolonDelimiter"
   assert exp, "insertReturn: statement tuple missing expression"
 
-  outer := exp
+  outer .= exp
   if exp.type is "LabelledStatement"
     exp = exp.statement
+
+  // Anonymous abstract classes get wrapped in parens by ClassDeclaration; unwrap
+  // so the ClassExpression case below can emit a class declaration.
+  if exp.type is "ParenthesizedExpression" and
+     exp.expression?.type is "ClassExpression" and
+     exp.expression.abstract
+    inner := exp.expression as ASTNodeObject
+    inner.parent = outer.parent
+    if outer is exp
+      node[1] = inner
+      outer = inner
+    exp = inner
 
   switch exp.type
     when "DebuggerStatement", "EmptyStatement", "ReturnStatement", "ThrowStatement"
@@ -573,12 +619,13 @@ function insertReturn(node: ASTNode): void
     when "ClassExpression"
       // `abstract class` is only valid as a declaration in TS, not an expression,
       // so emit it as a declaration followed by `return ClassName`
-      if exp.abstract and exp.name
+      if exp.abstract
         parent := outer.parent as BlockStatement?
         index := findChildIndex parent?.expressions, outer
         assert.notEqual index, -1, "Could not find class declaration in parent"
+        returnId := nameAbstractClass exp
         parent!.expressions.splice index+1, 0, ["",
-          wrapWithReturn exp.name, exp, true
+          wrapWithReturn returnId, exp, true
         ]
         braceBlock parent!
         return

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -570,6 +570,19 @@ function insertReturn(node: ASTNode): void
       // This is currently never hit because anonymous FunctionExpressions are already wrapped in parens by this point
       // Add return in normal way for functions without ids
       break
+    when "ClassExpression"
+      // `abstract class` is only valid as a declaration in TS, not an expression,
+      // so emit it as a declaration followed by `return ClassName`
+      if exp.abstract and exp.name
+        parent := outer.parent as BlockStatement?
+        index := findChildIndex parent?.expressions, outer
+        assert.notEqual index, -1, "Could not find class declaration in parent"
+        parent!.expressions.splice index+1, 0, ["",
+          wrapWithReturn exp.name, exp, true
+        ]
+        braceBlock parent!
+        return
+      break
     when "ForStatement", "IterationStatement", "DoStatement", "ComptimeStatement"
       wrapIterationReturningResults exp
       return

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1008,6 +1008,7 @@ export type ClassExpression = ASTParent &
   type: "ClassExpression"
   name: string
   id: Identifier
+  abstract?: ASTNode
   heritage: ASTNode
   body: ClassBody
   binding: [BindingIdentifier, TypeParameters]

--- a/test/class.civet
+++ b/test/class.civet
@@ -1142,6 +1142,20 @@ describe "class", ->
     }
   """
 
+  testCase """
+    abstract class as implicit return of mixin function
+    ---
+    Mixin := <T extends Constructor>(S: T) ->
+      abstract class Mixin extends S
+        mix: string = "mix"
+    ---
+    const Mixin = function<T extends Constructor>(S: T) {
+      abstract class Mixin extends S {
+        mix: string = "mix"
+      };return Mixin
+    }
+  """
+
   throws """
     readonly shorthand forbids bare comma expressions
     ---

--- a/test/class.civet
+++ b/test/class.civet
@@ -1156,6 +1156,48 @@ describe "class", ->
     }
   """
 
+  testCase """
+    anonymous abstract class as implicit return of mixin function
+    ---
+    Mixin := <T extends Constructor>(S: T) ->
+      abstract class extends S
+        mix: string = "mix"
+    ---
+    const Mixin = function<T extends Constructor>(S: T) {
+      abstract class Class extends S {
+        mix: string = "mix"
+      };return Class
+    }
+  """
+
+  testCase """
+    abstract class as result of for loop
+    ---
+    mixins := for S of bases
+      abstract class Mixin extends S
+        mix: string = "mix"
+    ---
+    const results=[];for (const S of bases) {
+      abstract class Mixin extends S {
+        mix: string = "mix"
+      };results.push(Mixin)
+    };const mixins =results
+  """
+
+  testCase """
+    anonymous abstract class as result of for loop
+    ---
+    mixins := for S of bases
+      abstract class extends S
+        mix: string = "mix"
+    ---
+    const results=[];for (const S of bases) {
+      abstract class Class extends S {
+        mix: string = "mix"
+      };results.push(Class)
+    };const mixins =results
+  """
+
   throws """
     readonly shorthand forbids bare comma expressions
     ---

--- a/test/class.civet
+++ b/test/class.civet
@@ -1198,6 +1198,20 @@ describe "class", ->
     };const mixins =results
   """
 
+  testCase """
+    non-abstract named class as result of for loop
+    ---
+    classes := for S of bases
+      class Foo extends S
+        foo: string = "foo"
+    ---
+    const results=[];for (const S of bases) {
+      results.push(class Foo extends S {
+        foo: string = "foo"
+      })
+    };const classes =results
+  """
+
   throws """
     readonly shorthand forbids bare comma expressions
     ---


### PR DESCRIPTION
Closes #2019

When a function's implicit-return body was a single named `abstract class`, Civet emitted `return abstract class X { ... }`, which is invalid TypeScript (`abstract` is only allowed on class *declarations*, not class expressions).

The fix mirrors the existing `FunctionExpression`-with-id handling in `insertReturn`: when the implicit-return expression is a `ClassExpression` with `abstract` set and a name, emit the class as a statement and splice in a separate `;return ClassName`. Non-abstract class expressions are unchanged.

Generated with [Claude Code](https://claude.ai/code)