### PR TITLE
VSCode: support `lang="civet"` in Svelte components

### DIFF
--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -57,6 +57,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.civet": "civet"
         }
+      },
+      {
+        "scopeName": "svelte.civet.injection",
+        "path": "./syntaxes/svelte-injection.json",
+        "injectTo": [
+          "source.svelte"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.svelte": "civet"
+        }
       }
     ],
     "commands": [

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -65,7 +65,7 @@
           "source.svelte"
         ],
         "embeddedLanguages": {
-          "meta.embedded.block.svelte": "civet"
+          "meta.embedded.block.civet": "civet"
         }
       }
     ],

--- a/lsp/vscode/syntaxes/svelte-injection.json
+++ b/lsp/vscode/syntaxes/svelte-injection.json
@@ -1,0 +1,18 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:(meta.script.svelte) (meta.lang.civet) - (meta source)",
+  "patterns": [
+    {
+      "begin": "(?<=>)(?!</)",
+      "end": "(?=</)",
+      "name": "meta.embedded.block.svelte",
+      "contentName": "source.civet",
+      "patterns": [
+        {
+          "include": "source.civet"
+        }
+      ]
+    }
+  ],
+  "scopeName": "svelte.civet.injection"
+}

--- a/lsp/vscode/syntaxes/svelte-injection.json
+++ b/lsp/vscode/syntaxes/svelte-injection.json
@@ -5,7 +5,7 @@
     {
       "begin": "(?<=>)(?=[^\\n]+</(script)[\\s>])",
       "end": "(?=</(script)[\\s>])",
-      "name": "meta.embedded.block.svelte",
+      "name": "meta.embedded.block.civet",
       "contentName": "source.civet",
       "patterns": [
         {
@@ -16,7 +16,7 @@
     {
       "begin": "(?<=>)(?!</)",
       "while": "^(?!\\s*</(script)[\\s>])",
-      "name": "meta.embedded.block.svelte",
+      "name": "meta.embedded.block.civet",
       "contentName": "source.civet",
       "patterns": [
         {

--- a/lsp/vscode/syntaxes/svelte-injection.json
+++ b/lsp/vscode/syntaxes/svelte-injection.json
@@ -3,8 +3,19 @@
   "injectionSelector": "L:(meta.script.svelte) (meta.lang.civet) - (meta source)",
   "patterns": [
     {
+      "begin": "(?<=>)(?=[^\\n]+</(script)[\\s>])",
+      "end": "(?=</(script)[\\s>])",
+      "name": "meta.embedded.block.svelte",
+      "contentName": "source.civet",
+      "patterns": [
+        {
+          "include": "source.civet"
+        }
+      ]
+    },
+    {
       "begin": "(?<=>)(?!</)",
-      "end": "(?=</)",
+      "while": "^(?!\\s*</(script)[\\s>])",
       "name": "meta.embedded.block.svelte",
       "contentName": "source.civet",
       "patterns": [


### PR DESCRIPTION
im too lazy to do zed and allat, i might make more prs later