### PR TITLE
VSCode basic syntax highlighting for `type`/`interface`

### DIFF
--- a/lsp/vscode/syntaxes/civet.json
+++ b/lsp/vscode/syntaxes/civet.json
@@ -192,6 +192,48 @@
       "name": "keyword.control.civet"
     },
     {
+      "captures": {
+        "1": {
+          "name": "keyword.control.civet"
+        },
+        "2": {
+          "name": "keyword.control.civet"
+        },
+        "3": {
+          "name": "storage.modifier.civet"
+        },
+        "4": {
+          "name": "storage.type.type.civet"
+        },
+        "5": {
+          "name": "entity.name.type.alias.civet"
+        }
+      },
+      "match": "^\\s*(?:(export)\\s+(?:(default)\\s+)?)?(?:(declare)\\s+)?(type)\\s+([a-zA-Z_$][\\w$]*)\\b",
+      "name": "meta.type.declaration.civet"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "keyword.control.civet"
+        },
+        "2": {
+          "name": "keyword.control.civet"
+        },
+        "3": {
+          "name": "storage.modifier.civet"
+        },
+        "4": {
+          "name": "storage.type.interface.civet"
+        },
+        "5": {
+          "name": "entity.name.type.interface.civet"
+        }
+      },
+      "match": "^\\s*(?:(export)\\s+(?:(default)\\s+)?)?(?:(declare)\\s+)?(interface)\\s+([a-zA-Z_$][\\w$]*)\\b",
+      "name": "meta.interface.civet"
+    },
+    {
       "match": "\\b(?<![\\.\\$])(break|by|case|catch|continue|else|finally|for|in|of|if|return|switch|then|throw|try|unless|when|while|until|loop|do|export|import|default|from|as|yield|async|await)(?!\\s*:)\\b",
       "name": "keyword.control.civet"
     },


### PR DESCRIPTION
Basic support for syntax highlighting of TypeScript type declaration features.

Like our current `class` support, this just highlights the first line; doesn't attempt to recognize the block. It might be difficult to recognize blocks by indentation in TextMate.

It's definitely not perfect, but it's an improvement:

<img width="1314" height="521" alt="image" src="https://github.com/user-attachments/assets/0fea28d7-0445-4feb-a50e-ab9e07dfc466" />

<img width="1198" height="298" alt="image" src="https://github.com/user-attachments/assets/786c5ae6-fca1-4ed9-993b-920a38ca0df9" />
