### PR TITLE
Test (CI): reduce Windows mocha flakes via worker cap + warmup hook

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,7 +3,8 @@
     "civet"
   ],
   "require": [
-    "./build/register.js"
+    "./build/register.js",
+    "./build/test-warmup.js"
   ],
   "reporter": "./build/dot-batch-reporter.js",
   "recursive": true,

--- a/build/test-warmup.js
+++ b/build/test-warmup.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Mocha root hook plugin: runs once per worker before any test.
+// Pays cold-start cost (V8 JIT on parser/codegen, Civet register chain,
+// esbuild native binding init) inside a hook timeout instead of inside
+// the first it()'s 5s budget. Without this, the first tiny test in a
+// fresh worker can blow its timeout on Windows CI under scheduling jitter.
+exports.mochaHooks = {
+  async beforeAll() {
+    this.timeout(30000);
+    const { compile } = require('../source/main.civet');
+    const esbuild = require('esbuild');
+    esbuild.transformSync(await compile('1 + 1'), { loader: 'tsx' });
+  },
+};

--- a/build/test.sh
+++ b/build/test.sh
@@ -6,7 +6,15 @@ set -euo pipefail
 # Set CIVET_THREADS=N to override, or CIVET_THREADS=0 to disable.
 # Note: CIVET_THREADS refers to Mocha --parallel workers (separate processes),
 # not Node.js worker_threads, which don't work within Mocha.
-threads="${CIVET_THREADS:-$(node -e 'const cpus = require("os").cpus().length; process.stdout.write(String(Math.min(cpus, 4)))')}"
+# GH-hosted Windows runners have 4 vCPUs; running 4 workers leaves no
+# headroom and produces flaky 5s timeouts on tiny tests under scheduling
+# jitter. Cap to 2 there so each worker has slack. Local Windows boxes
+# with more cores don't have the oversubscription, so gate on $GITHUB_ACTIONS.
+cap=4
+if [[ "${GITHUB_ACTIONS:-}" == "true" && ( "$OSTYPE" == msys* || "$OSTYPE" == cygwin* || "$OSTYPE" == win* ) ]]; then
+  cap=2
+fi
+threads="${CIVET_THREADS:-$(node -e "const cpus = require('os').cpus().length; process.stdout.write(String(Math.min(cpus, $cap)))")}"
 args=""
 if [ "$threads" != "0" ]; then
   args="--parallel -j $threads"


### PR DESCRIPTION
## Summary

Recent Windows `Self-Test` CI runs needed three reruns before passing — each attempt timed out a different small set of tiny tests (`array › empty literal`, `assignment › assignment`, `auto-const › multiple assignment`, `@ -> this › @`) with the generic `Timeout of 5000ms exceeded` error. The pattern (nondeterministic across reruns, always early-alphabetical, never a real assertion failure) points at two compounding causes specific to GH-hosted Windows runners:

1. **Worker oversubscription**: 4 mocha `--parallel` workers on a 4-vCPU runner leaves zero CPU headroom; any scheduling jitter pushes a tiny test past 5s.
2. **Cold-start cost in the first `it()` of each worker**: V8 JIT, the Civet `register` chain, and esbuild's native binding init all land inside the first test's 5s budget when a worker takes its first file.

This PR addresses both:

- `build/test.sh` — cap mocha workers to 2 on GH-hosted Windows runners. Gated on `$GITHUB_ACTIONS=true` so local Windows dev with more cores keeps full parallelism.
- `build/test-warmup.js` (new) — Mocha root hook plugin that runs once per worker and pays cold-start cost in a 30s `beforeAll`, so the first test starts with everything already warm.
- `.mocharc.json` — wires the warmup hook in via `require`, after `register.js` (order matters).

## Why not just bump the timeout?

A timeout bump would paper over the symptom. These tests aren't doing 5s of real work — they need to not be paused for 5s. The two changes here remove the actual sources of stalling instead of widening the budget.

## Test plan

- [ ] Linux/macOS CI still runs with 4 workers (truth-table check passes locally; cap=4 on `linux+ci`, `linux+local`, `win+local`, only drops to 2 on `win+ci`).
- [ ] Windows Self-Test passes without reruns on this PR.
- [ ] Watch the next several Windows runs on `main` and unrelated PRs for residual flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)