### PR TITLE
LSP: fix `@` completion in implicit return context

### DIFF
--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@danielx/civet-language-server",
   "description": "Civet Language Server (standalone, editor-agnostic)",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "repository": {
     "type": "git",
     "url": "https://github.com/DanielXMoore/civet.git"

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -412,6 +412,8 @@ connection.onCompletion ({ textDocument, position, context }) =>
   // Civet files
 
   // … Sourcemap the line/columns
+  // Keep the original source cursor; `position` is remapped below.
+  sourcePosition := position
   meta := service.host.getMeta(sourcePath)
   return civetFileCompletions unless meta
   { sourcemapLines, transpiledDoc } := meta
@@ -431,6 +433,10 @@ connection.onCompletion ({ textDocument, position, context }) =>
   // member completions, and ask as if `.` triggered the completion.
   if context?.triggerCharacter is '@'
     text := transpiledDoc.getText()
+    if sourcemapLines
+      sourceOffset := document.offsetAt(sourcePosition)
+      if sourceOffset > 0 and document.getText()[sourceOffset - 1] is '@'
+        p = transpiledDoc.offsetAt(forwardMap(sourcemapLines, document.positionAt(sourceOffset - 1)))
     searchStart := Math.max(0, p - 3)
     aroundP := text.slice(searchStart, p + 4)
     thisIdx := aroundP.lastIndexOf('this')

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -261,6 +261,38 @@ describe "LSP features (shared project server)", ->
     bar := list.find (i: any) => i.label is "bar"
     assert bar, "expected bar member completion"
 
+  it "returns member completions for bare @ after an implicit return", ->
+    uri := docUri path.join(projectRoot, "at-completion-after-return.civet")
+    text := """
+      class Fetcher
+        cache = new Map<number, string>
+        has(id: number): boolean
+          @cache.has id
+          @
+        get(id: number): string?
+          @cache.get id
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    lines := text.split "\n"
+    atLine := lines.findIndex (l) => l.trim() is "@"
+    result := await client.request "textDocument/completion", {
+      textDocument: { uri }
+      position: { line: atLine, character: lines[atLine].indexOf("@") + 1 }
+      context: { triggerKind: 2, triggerCharacter: "@" }
+    }
+    list := result?.items ?? result
+    assert Array.isArray(list), `expected completion items array, got ${JSON.stringify(result)}`
+    assert result?.isIncomplete, "expected @ completions to be incomplete"
+
+    cache := list.find (i: any) => i.label is "cache"
+    assert cache, "expected cache member completion"
+    insertText2 := cache.insertText <? "string" ? cache.insertText : cache.insertText?.value ?? ""
+    assert !insertText2.includes("this."), `cache completion should not insert this.: ${insertText2}`
+
   it "emits diagnostics for a parse error with a civet syntax error", ->
     uri := docUri path.join(projectRoot, "parse-error.civet")
     client.notify "textDocument/didOpen", {

--- a/lsp/vscode/e2e/at-completions.test.civet
+++ b/lsp/vscode/e2e/at-completions.test.civet
@@ -61,3 +61,24 @@ suite '@foo completions', =>
     insertText := getInsertText name
     assert !insertText.includes 'this.',
       `Completion 'name' has insertText containing 'this.': ${insertText}`
+
+  test 'Returns member completions after an implicit return', async =>
+    // fetcher-bare-at.civet has a bare `@` that compiles to `return this`
+    // and used to map the completion cursor past `this`.
+    docUri := getDocUri 'fetcher-bare-at.civet'
+    await activate docUri
+
+    completions := await poll
+      => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position 4, 5
+        '@'
+      ) as Promise<CompletionList>
+      (list) => list?.items.some (item) => getLabel(item) is 'cache'
+
+    cache := completions.items.find (item) => getLabel(item) is 'cache'
+    assert cache, 'Expected cache member completion for bare @'
+    insertText := getInsertText cache
+    assert !insertText.includes('this.'),
+      `Completion 'cache' has insertText containing 'this.': ${insertText}`

--- a/lsp/vscode/e2e/fixture/fetcher-bare-at.civet
+++ b/lsp/vscode/e2e/fixture/fetcher-bare-at.civet
@@ -1,0 +1,7 @@
+class Fetcher
+  cache = new Map<number, string>
+  has(id: number): boolean
+    @cache.has id
+    @
+  get(id: number): string?
+    @cache.get id

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "publisher": "DanielX",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I noticed that `@` wasn't completing to attributes at all when used at the beginning of a line at the end of a method, i.e., in an implicit `return` context. This PR fixes that by broadening the search-for-`@` heuristic slightly.