### PR TITLE
Allow non-identifier Unicode codepoints as identifiers

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -319,7 +319,8 @@ floor # / 2
 ## ASCII Symbols
 
 Here is a list of ASCII symbols and their various contextual meanings in Civet.
-(There are also more [Unicode symbols](/reference#unicode-operators).)
+(There are also more [Unicode symbols](/reference#unicode-operators)
+and [non-identifier Unicode codepoints in identifiers](/reference#unicode-identifiers).)
 
 | Symbol | Meanings |
 |--------|----------|

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1070,6 +1070,43 @@ N := [1, 2, 3]
 ∀ N
 </Playground>
 
+#### Property keys
+
+When a non-id-unicode identifier appears as a *property key* — in an
+object literal, a destructure, a class member, an `@`-shorthand, or
+a member access — the source name is the emitted property name (so
+JS lookup hits the right key) while the variable side uses the
+mangled form. Member access switches from dot to bracket, since
+`obj.😊` isn't valid JS.
+
+<Playground>
+{ 😊 } := data
+x := { 😊 }
+x := { 😊: 1 }
+data.😊
+data?.😊
+class Foo
+  😊 = 1
+  😊() 2
+function foo(@😊)
+  @😊
+</Playground>
+
+#### Imports and exports
+
+Module-facing names (the side passed to / from another module) use the
+source form; the local-variable side keeps the mangled form. The
+combined `export X := value` declaration splits into a regular
+declaration plus an explicit re-export, since JS doesn't allow
+string-named exports inside `export const`.
+
+<Playground>
+import { 😊 } from "mod"
+import { 😊 as x } from "mod"
+export { 😊 }
+export 😊 := 3
+</Playground>
+
 ## Functions
 
 ### Function Calls

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1037,6 +1037,39 @@ Here is a table of all currently supported:
 
 </div>
 
+### Unicode Identifiers
+
+Identifiers can include non-identifier Unicode codepoints (emoji, dingbats,
+math symbols not in the [Unicode Operators](#unicode-operators) table)
+anywhere in the name, mixed freely with regular identifier characters.
+Each non-id-unicode codepoint is escaped to `u$<HEX>$` (mirroring JS's
+`\u{XXXX}` escape syntax) so the compiled name is a valid JS identifier.
+
+<Playground>
+let △ = 3
+let 😊 = 1
+let pre😊post = 2
+let 😊😔 = 4
+</Playground>
+
+Codepoints already in `\p{ID_Continue}` (letters with diacritics like `é`,
+`ő`, `ω`; digits; combining marks) are valid JS identifier chars and pass
+through unchanged.
+
+<Playground>
+let pokémon = "Pikachu"
+let Erdős = 1
+</Playground>
+
+Implicit function application still requires whitespace, so `∀N` is one
+identifier — write `∀ N` to call.
+
+<Playground>
+function ∀(arr) arr.every (x) => !!x
+N := [1, 2, 3]
+∀ N
+</Playground>
+
 ## Functions
 
 ### Function Calls

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8386,13 +8386,17 @@ EnumDeclaration
           ["let ", id, " = {};\n"],
           ...block.properties.map((property, i) => {
             let init, isString
+            // Use the source string for the property key so the runtime
+            // enum is keyed by the user-visible name (mangled would be
+            // unreachable from `E.😊` style access).
+            propKey := property.name.unicode ?? property.name.name
             if property.initializer
               // Replace references to other enum members.
               // TS further restricts this to past enum members,
               // but we don't need to enforce that here.
               init = replaceNodes(deepCopy(property.initializer),
                 (n) => n.type is "Identifier" and names.has(n.name),
-                (n) => [id, '["', n.name, '"]'])
+                (n) => [id, '["', n.unicode ?? n.name, '"]'])
               value := init[init# - 1]
               isString = value.type is "TemplateLiteral" or
                 (value.type is "Literal" and value.subtype is "StringLiteral")
@@ -8400,17 +8404,18 @@ EnumDeclaration
               // Default initializer is previous property + 1, or 0 if first.
               // TS further restricts this to when previous property is
               // constant, but we don't need to enforce that here.
+              prev := block.properties[i-1]?.name
               init = i is 0 ? " = 0" :
-                [" = ", id, '["', block.properties[i-1].name, '"] + 1']
+                [" = ", id, '["', prev?.unicode ?? prev?.name, '"] + 1']
             // String enums do not get back references
             if isString
               return [
-                id, '["', property.name, '"]', init, ";\n",
+                id, '["', propKey, '"]', init, ";\n",
               ]
             else
               return [
-                id, "[", id, '["', property.name, '"]', init,
-                '] = "', property.name, '";\n',
+                id, "[", id, '["', propKey, '"]', init,
+                '] = "', propKey, '";\n',
               ]
           }),
         ],
@@ -8456,7 +8461,10 @@ EnumProperty
       type: "EnumProperty",
       name,
       initializer,
-      children: $0,
+      // Unicode member: emit `"name" = …` so the TS-form enum has a
+      // string-literal member; runtime emission (in EnumDeclaration) also
+      // uses the source string for the property key.
+      children: [propertyKey(name), ...$0.slice(1)],
     }
 
 TypeProperty

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1529,9 +1529,11 @@ ThisLiteral
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
   AtThis:at $( Hash? IdentifierName ):id ->
-    // `@😊` → `this["😊"]` (matches the binding-side bracket form).
+    // `@😊` → `this["😊"]` (matches the binding-side bracket form), but
+    // private `@#😊` keeps dot access since private fields can't be
+    // string-keyed — emit `this.#u$1F60A$` instead.
     escaped := escapeIdentifier(id)
-    if escaped !== id
+    if escaped !== id and not id.startsWith("#")
       return {
         type: "MemberExpression",
         children: [at, {
@@ -1550,13 +1552,13 @@ ThisLiteral
       type: "MemberExpression",
       children: [at, {
         type: "PropertyAccess",
-        name: id,
+        name: escaped,
         children: [".", {
           $loc: {
             pos: $loc.pos + 1,
             length: $loc# - 1,
           },
-          token: id
+          token: escaped
         }],
       }],
       thisShorthand: true,
@@ -2501,7 +2503,9 @@ BindingProperty
       type: "BindingProperty",
       children,
       name: binding,
-      value: undefined,
+      // Setting value to the binding when expanded keeps the AST shape
+      // consistent (downstream code distinguishes shorthand by `value: undefined`).
+      value: binding.unicode ? binding : undefined,
       typeSuffix,
       initializer,
       names: binding.names,
@@ -4277,13 +4281,16 @@ ClassElementName
 
 PrivateIdentifier
   $(Hash IdentifierName):id ->
+    // Private fields can't be string-keyed, so escape unicode in-place
+    // (`#😊` → `#u$1F60A$`) without setting `unicode` — keeps `#`-dot access.
+    name := escapeIdentifier(id)
     return {
       type: "Identifier",
-      name: id,
-      names: [id],
+      name,
+      names: [name],
       children: [{
         $loc: $loc,
-        token: id,
+        token: name,
       }],
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -57,6 +57,7 @@ import {
   precedenceCustomDefault,
   precedenceStep,
   prepend,
+  propertyKey,
   processAssignmentDeclaration,
   processBinaryOpExpression,
   processCallMemberExpression,
@@ -1491,7 +1492,7 @@ FieldDefinition
         return {
           type: "FieldDefinition",
           id,
-          children: [id, " = ", exp],
+          children: [propertyKey(id), " = ", exp],
         }
     }
 
@@ -1506,14 +1507,14 @@ FieldDefinition
       type: "FieldDefinition",
       id,
       typeSuffix,
-      children: $0,
+      children: [readonly, propertyKey(id), ...$0.slice(2)],
       readonly,
     }
 
   AbstractModifier?:abstract ReadonlyModifier?:readonly ClassElementName:id TypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "FieldDefinition",
-      children: $0,
+      children: [abstract, readonly, propertyKey(id), typeSuffix, initializer],
       ts: abstract ? true : undefined,
       id,
       typeSuffix,
@@ -1527,6 +1528,24 @@ ThisLiteral
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
   AtThis:at $( Hash? IdentifierName ):id ->
+    // For non-id-unicode names (`@😊`), emit `this["😊"]` so the property
+    // name matches what the binding side stores (also bracketed).
+    escaped := escapeIdentifier(id)
+    if escaped !== id
+      return {
+        type: "MemberExpression",
+        children: [at, {
+          type: "Index",
+          children: ["[", {
+            $loc: {
+              pos: $loc.pos + 1,
+              length: $loc# - 1,
+            },
+            token: `"${id}"`
+          }, "]"],
+        }],
+        thisShorthand: true,
+      }
     return {
       type: "MemberExpression",
       children: [at, {
@@ -1932,6 +1951,18 @@ PropertyAccess
     }
 
   AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
+    // Escaped Unicode property `data.😊` becomes `data["😊"]` since the
+    // mangled `u$1F60A$` is a valid JS identifier but not the actual property name.
+    if id.unicode
+      return {
+        type: "Index",
+        children: [
+          adjustIndexAccess(dot),
+          ...comments,
+          propertyKey(id),
+          "]",
+        ],
+      }
     return {
       type: "PropertyAccess",
       name: id.name,
@@ -2219,7 +2250,11 @@ AtIdentifierRef
   ReservedWord:r ->
     return makeRef(`_${r}`, r)
   IdentifierName:id ->
-    return makeRef(id.name)
+    ref := makeRef(id.name)
+    // Carry the source string so binding-side `this.X = X` can emit
+    // bracket access matching the expression-side `this["X"]`.
+    if id.unicode then ref.unicode = id.unicode
+    return ref
 
 PinPattern
   # Forbid ImplicitObjectLiterals such as `x: y` in pinned pattern,
@@ -2404,7 +2439,7 @@ BindingProperty
       }
     return {
       type: "BindingProperty",
-      children: [ws1, name, ws2, colon, ws3, value, initializer],  // omit typeSuffix
+      children: [ws1, propertyKey(name), ws2, colon, ws3, value, initializer],  // omit typeSuffix
       name,
       value,
       typeSuffix,
@@ -2447,7 +2482,7 @@ BindingProperty
 
   # NOTE: name^ means we should bind name, but we do anyway, so allow but ignore
   _?:ws BindingIdentifier:binding Caret?:bind BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
-    children := [ws, binding, initializer]  // omit bind, typeSuffix
+    children .= [ws, binding, initializer]  // omit bind, typeSuffix
 
     if binding.type is "AtBinding"
       return {
@@ -2459,6 +2494,11 @@ BindingProperty
         initializer,
         names: [],
       }
+
+    // Escaped Unicode binding shorthand `{ 😊 }` becomes `{ "😊": u$1F60A$ }`
+    // so the lookup uses the user-visible property name.
+    if binding.unicode
+      children = [ws, propertyKey(binding), ": ", binding, initializer]
 
     return {
       type: "BindingProperty",
@@ -3292,6 +3332,10 @@ IdentifierName
     return {
       type: "Identifier",
       name,
+      // Original source string when escaping changed it, so property-key
+      // sites (object destructuring / literal shorthand / explicit key)
+      // can emit the user-visible name as a quoted string.
+      ...($0 !== name and { unicode: $0 }),
       names: [name],
       children: [{
         $loc: $loc,
@@ -3850,6 +3894,17 @@ PropertyDefinition
         value,
       }
 
+    // Escaped Unicode property shorthand `{ 😊 }` becomes `{ "😊": u$1F60A$ }`
+    // so the resulting object uses the user-visible property name.
+    if id.unicode
+      return {
+        type: "Property",
+        children: [ws, propertyKey(id), ": ", id],
+        name: id,
+        names: id.names,
+        value: id,
+      }
+
     return {
       type: "Property",
       children: [ws, id],
@@ -3980,7 +4035,7 @@ NamedProperty
   PropertyName:name _? Colon PostfixedExpression:exp ->
     return {
       type: "Property",
-      children: $0,
+      children: [propertyKey(name), ...$0.slice(1)],
       name: name,
       names: exp.names || [],
       value: exp,
@@ -3996,7 +4051,7 @@ SnugNamedProperty
       expression = attachPostfixStatementAsExpression(expression, post[0])
     return {
       type: "Property",
-      children: [name, colon, expression],
+      children: [propertyKey(name), colon, expression],
       name,
       names: expression.names || [],
     }
@@ -4208,7 +4263,7 @@ MethodSignature
 
     return {
       type: "MethodSignature",
-      children: [ ...modifier.children, authoredName, ws1, optional, ws2, parameters, returnType ],
+      children: [ ...modifier.children, propertyKey(authoredName), ws1, optional, ws2, parameters, returnType ],
       async: modifier.async,
       generator: modifier.generator,
       name,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1493,7 +1493,7 @@ FieldDefinition
         return {
           type: "FieldDefinition",
           id,
-          children: [propertyKey(id), " = ", exp],
+          children: [id, " = ", exp],
         }
     }
 
@@ -1508,14 +1508,14 @@ FieldDefinition
       type: "FieldDefinition",
       id,
       typeSuffix,
-      children: [readonly, propertyKey(id), ...$0.slice(2)],
+      children: $0,
       readonly,
     }
 
   AbstractModifier?:abstract ReadonlyModifier?:readonly ClassElementName:id TypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "FieldDefinition",
-      children: [abstract, readonly, propertyKey(id), typeSuffix, initializer],
+      children: $0,
       ts: abstract ? true : undefined,
       id,
       typeSuffix,
@@ -2439,7 +2439,7 @@ BindingProperty
       }
     return {
       type: "BindingProperty",
-      children: [ws1, propertyKey(name), ws2, colon, ws3, value, initializer],  // omit typeSuffix
+      children: [ws1, name, ws2, colon, ws3, value, initializer],  // omit typeSuffix
       name,
       value,
       typeSuffix,
@@ -3895,14 +3895,16 @@ PropertyDefinition
         value,
       }
 
-    // `{ 😊 }` → `{ "😊": u$1F60A$ }` so the property uses the source name.
+    // `{ 😊 }` → `{ "😊": u$1F60A$ }`. PropertyName already rewrote `id`'s
+    // children to render the quoted source; `id.identifier` is the original
+    // Identifier whose children render the mangled local-variable reference.
     if id.unicode
       return {
         type: "Property",
-        children: [ws, propertyKey(id), ": ", id],
+        children: [ws, id, ": ", id.identifier],
         name: id,
         names: id.names,
-        value: id,
+        value: id.identifier,
       }
 
     return {
@@ -4035,7 +4037,7 @@ NamedProperty
   PropertyName:name _? Colon PostfixedExpression:exp ->
     return {
       type: "Property",
-      children: [propertyKey(name), ...$0.slice(1)],
+      children: $0,
       name: name,
       names: exp.names || [],
       value: exp,
@@ -4051,7 +4053,7 @@ SnugNamedProperty
       expression = attachPostfixStatementAsExpression(expression, post[0])
     return {
       type: "Property",
-      children: [propertyKey(name), colon, expression],
+      children: [name, colon, expression],
       name,
       names: expression.names || [],
     }
@@ -4069,7 +4071,16 @@ PropertyName
       token: `"${$1}"`,
       $loc,
     }
-  IdentifierName
+  # Unicode `id` renders quoted via children so PropertyName consumers emit
+  # the source name automatically; `id.identifier` carries the original for
+  # shorthand value-side reads.
+  IdentifierName:id ->
+    return id unless id.unicode
+    return {
+      ...id,
+      children: [{$loc: id.children[0].$loc, token: `"${id.unicode}"`}],
+      identifier: id,
+    }
   LengthShorthand
   SymbolElement
 
@@ -4263,7 +4274,7 @@ MethodSignature
 
     return {
       type: "MethodSignature",
-      children: [ ...modifier.children, propertyKey(authoredName), ws1, optional, ws2, parameters, returnType ],
+      children: [ ...modifier.children, authoredName, ws1, optional, ws2, parameters, returnType ],
       async: modifier.async,
       generator: modifier.generator,
       name,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -15,6 +15,7 @@ import {
   blockWithPrefix,
   braceBlock,
   bracedBlock,
+  buildExportSplitClause,
   convertArrowFunctionToMethod,
   convertFunctionToMethod,
   convertNamedImportsToObject,
@@ -6207,17 +6208,27 @@ TypeAndImportSpecifier
 
 # https://262.ecma-international.org/#prod-ImportSpecifier
 ImportSpecifier
-  __ ModuleExportName:source ImportAsToken __ ImportedBinding:binding ObjectPropertyDelimiter ->
+  __:ws1 ModuleExportName:source ImportAsToken:as __:ws2 ImportedBinding:binding ObjectPropertyDelimiter:delim ->
+    // For unicode source `import { 😊 as x }`, quote the module-side name
+    // since the actual export is `"😊"`, not the mangled `u$1F60A$`.
     return {
       source,
       binding,
-      children: $0,
+      children: [ws1, propertyKey(source), as, ws2, binding, delim],
     }
-  __ ImportedBinding:binding ObjectPropertyDelimiter ->
+  __:ws ImportedBinding:binding ObjectPropertyDelimiter:delim ->
+    // Shorthand `import { 😊 }` expands to explicit `"😊" as u$1F60A$` so
+    // the module-side name is the user-visible source string.
+    if binding.unicode
+      return {
+        source: binding,
+        binding,
+        children: [ws, propertyKey(binding), " as ", binding, delim],
+      }
     return {
       source: binding,
       binding,
-      children: $0,
+      children: [ws, binding, delim],
     }
 
 OperatorImportSpecifier
@@ -6349,7 +6360,19 @@ ExportDeclaration
   # NOTE: Declaration and VariableStatement should come before NamedExports
   # so that NamedExports doesn't grab function, async, type, var, etc.
   # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
-  Decorators? Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
+  Decorators?:dec Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
+    // For declarations that bind unicode-named identifiers (`export 😊 := 3`,
+    // `export { 😊 } := data`), JS forbids string-named exports inside the
+    // combined `export const ...` form. Split into `<decl>; export {...}`
+    // so each unicode binding is re-exported under its user-visible name.
+    splitClause := buildExportSplitClause(declaration)
+    if splitClause
+      return {
+        type: "ExportDeclaration",
+        declaration,
+        ts: declaration.ts,
+        children: [dec, declaration, splitClause],  // omit Export keyword + ws
+      }
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
 
 # CoffeeScript style `export x = 3` -> `export var x = 3`
@@ -6380,12 +6403,27 @@ NamedExports
 
 # https://262.ecma-international.org/#prod-ExportSpecifier
 ExportSpecifier
-  __ ( TypeKeyword __ )? ModuleExportName ( __ As __ ModuleExportName )? ObjectPropertyDelimiter ->
-    return $0 unless $2
-    return { ts: true, children: $0 }
+  __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:local ( __ As __ ModuleExportName )?:rename ObjectPropertyDelimiter:delim ->
+    // Local-side keeps its mangled identifier (it's a JS variable reference).
+    // External-side (after `as`, or implicit `as` for shorthand) uses the
+    // user-visible source via propertyKey so the export name matches.
+    children :=
+      if rename
+        [ws1, ts, local, rename[0], rename[1], rename[2], propertyKey(rename[3]), delim]
+      else if local.unicode
+        [ws1, ts, local, " as ", propertyKey(local), delim]
+      else
+        [ws1, ts, local, delim]
+    return children unless ts
+    return { ts: true, children }
 
 ImplicitExportSpecifier
-  !Default ModuleExportName ( __ As __ ModuleExportName )? -> [$2, $3]
+  !Default ModuleExportName:local ( __ As __ ModuleExportName )?:rename ->
+    if rename
+      return [local, rename[0], rename[1], rename[2], propertyKey(rename[3])]
+    if local.unicode
+      return [local, " as ", propertyKey(local)]
+    return [local, rename]
 
 # https://262.ecma-international.org/#prod-Declaration
 Declaration
@@ -8403,7 +8441,7 @@ EnumProperty
     }
 
 TypeProperty
-  ReadonlyModifier? PropertyName
+  ReadonlyModifier?:r PropertyName:n -> [r, propertyKey(n)]
 
 TypeIndexSignature
   # NOTE: QuestionMark will be parsed by following TypeSuffix

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1529,8 +1529,7 @@ ThisLiteral
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
   AtThis:at $( Hash? IdentifierName ):id ->
-    // For non-id-unicode names (`@😊`), emit `this["😊"]` so the property
-    // name matches what the binding side stores (also bracketed).
+    // `@😊` → `this["😊"]` (matches the binding-side bracket form).
     escaped := escapeIdentifier(id)
     if escaped !== id
       return {
@@ -1952,8 +1951,7 @@ PropertyAccess
     }
 
   AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
-    // Escaped Unicode property `data.😊` becomes `data["😊"]` since the
-    // mangled `u$1F60A$` is a valid JS identifier but not the actual property name.
+    // `data.😊` → `data["😊"]` since `u$1F60A$` isn't the real property.
     if id.unicode
       return {
         type: "Index",
@@ -2252,8 +2250,7 @@ AtIdentifierRef
     return makeRef(`_${r}`, r)
   IdentifierName:id ->
     ref := makeRef(id.name)
-    // Carry the source string so binding-side `this.X = X` can emit
-    // bracket access matching the expression-side `this["X"]`.
+    // Propagate so the binding side can emit `this["X"]` matching `@X`.
     if id.unicode then ref.unicode = id.unicode
     return ref
 
@@ -2496,8 +2493,7 @@ BindingProperty
         names: [],
       }
 
-    // Escaped Unicode binding shorthand `{ 😊 }` becomes `{ "😊": u$1F60A$ }`
-    // so the lookup uses the user-visible property name.
+    // `{ 😊 }` → `{ "😊": u$1F60A$ }` so the lookup uses the source name.
     if binding.unicode
       children = [ws, propertyKey(binding), ": ", binding, initializer]
 
@@ -3895,8 +3891,7 @@ PropertyDefinition
         value,
       }
 
-    // Escaped Unicode property shorthand `{ 😊 }` becomes `{ "😊": u$1F60A$ }`
-    // so the resulting object uses the user-visible property name.
+    // `{ 😊 }` → `{ "😊": u$1F60A$ }` so the property uses the source name.
     if id.unicode
       return {
         type: "Property",
@@ -6209,16 +6204,14 @@ TypeAndImportSpecifier
 # https://262.ecma-international.org/#prod-ImportSpecifier
 ImportSpecifier
   __:ws1 ModuleExportName:source ImportAsToken:as __:ws2 ImportedBinding:binding ObjectPropertyDelimiter:delim ->
-    // For unicode source `import { 😊 as x }`, quote the module-side name
-    // since the actual export is `"😊"`, not the mangled `u$1F60A$`.
+    // `import { 😊 as x }` → `"😊" as x` (module-side is the source name).
     return {
       source,
       binding,
       children: [ws1, propertyKey(source), as, ws2, binding, delim],
     }
   __:ws ImportedBinding:binding ObjectPropertyDelimiter:delim ->
-    // Shorthand `import { 😊 }` expands to explicit `"😊" as u$1F60A$` so
-    // the module-side name is the user-visible source string.
+    // `import { 😊 }` → `"😊" as u$1F60A$` (expand shorthand to source name).
     if binding.unicode
       return {
         source: binding,
@@ -6361,10 +6354,8 @@ ExportDeclaration
   # so that NamedExports doesn't grab function, async, type, var, etc.
   # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
   Decorators?:dec Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
-    // For declarations that bind unicode-named identifiers (`export 😊 := 3`,
-    // `export { 😊 } := data`), JS forbids string-named exports inside the
-    // combined `export const ...` form. Split into `<decl>; export {...}`
-    // so each unicode binding is re-exported under its user-visible name.
+    // `export 😊 := 3` → `const u$…$ = 3; export { u$…$ as "😊" }`
+    // (JS forbids string-named exports inside `export const`).
     splitClause := buildExportSplitClause(declaration)
     if splitClause
       return {
@@ -6404,9 +6395,8 @@ NamedExports
 # https://262.ecma-international.org/#prod-ExportSpecifier
 ExportSpecifier
   __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:local ( __ As __ ModuleExportName )?:rename ObjectPropertyDelimiter:delim ->
-    // Local-side keeps its mangled identifier (it's a JS variable reference).
-    // External-side (after `as`, or implicit `as` for shorthand) uses the
-    // user-visible source via propertyKey so the export name matches.
+    // Local stays mangled (JS variable ref); external side uses propertyKey
+    // so the exported name is the user-visible source.
     children :=
       if rename
         [ws1, ts, local, rename[0], rename[1], rename[2], propertyKey(rename[3]), delim]
@@ -7772,11 +7762,9 @@ JSXShorthandString
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeName
 JSXAttributeName
-  # Non-id-unicode attribute name (`<div 😊={x}>`, `<div pre😊post={x}>`):
-  # tried first so it consumes the full identifier (including ASCII parts
-  # adjacent to unicode), then wrapped as a synthetic ComputedPropertyName
-  # so JSXAttribute's existing branch emits `{...{"name": value}}` — valid
-  # JSX since the JSX spec restricts JSXIdentifier to ECMAScript identifiers.
+  # `<div 😊={x}>` — tried first so it claims the whole identifier (incl.
+  # ASCII parts adjacent to unicode); wrapped as a synthetic
+  # ComputedPropertyName so JSXAttribute emits `{...{"😊": value}}`.
   IdentifierName:id ->
     return $skip unless id.unicode
     key := propertyKey(id)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7772,6 +7772,19 @@ JSXShorthandString
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeName
 JSXAttributeName
+  # Non-id-unicode attribute name (`<div 😊={x}>`, `<div pre😊post={x}>`):
+  # tried first so it consumes the full identifier (including ASCII parts
+  # adjacent to unicode), then wrapped as a synthetic ComputedPropertyName
+  # so JSXAttribute's existing branch emits `{...{"name": value}}` — valid
+  # JSX since the JSX spec restricts JSXIdentifier to ECMAScript identifiers.
+  IdentifierName:id ->
+    return $skip unless id.unicode
+    key := propertyKey(id)
+    return {
+      type: "ComputedPropertyName",
+      children: [key],
+      expression: key,
+    }
   # NOTE: Merged JSXIdentifier and JSXNamespacedName
   JSXIdentifierName ( Colon JSXIdentifierName )?
   ComputedPropertyName

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3324,11 +3324,11 @@ SymbolElement
 # JS-valid form.
 Identifier
   # perf: assertion to exit early
-  /(?=\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s\u00F7\u2014\u2016\u2019\u2022\u2025\u2026\u2047\u2192\u21D2\u2208\u2209\u220B\u220C\u2254\u2260\u2261\u2262\u2263\u2264\u2265\u226A\u226B\u22D9\u25B7\u29FA\u2A75\u2A76])/ !ReservedWord IdentifierName:id -> id
+  /(?=\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ !ReservedWord IdentifierName:id -> id
 
 # https://262.ecma-international.org/#prod-IdentifierName
 IdentifierName
-  /(?:\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s\u00F7\u2014\u2016\u2019\u2022\u2025\u2026\u2047\u2192\u21D2\u2208\u2209\u220B\u220C\u2254\u2260\u2261\u2262\u2263\u2264\u2265\u226A\u226B\u22D9\u25B7\u29FA\u2A75\u2A76])(?:\p{ID_Continue}|[\u200C\u200D$]|[^\u0000-\u007F\p{ID_Continue}\s\u00F7\u2014\u2016\u2019\u2022\u2025\u2026\u2047\u2192\u21D2\u2208\u2209\u220B\u220C\u2254\u2260\u2261\u2262\u2263\u2264\u2265\u226A\u226B\u22D9\u25B7\u29FA\u2A75\u2A76])*/ ->
+  /(?:\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ->
     name := escapeIdentifier($0)
     return {
       type: "Identifier",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -25,6 +25,7 @@ import {
   deepCopy,
   dynamizeImportDeclaration,
   dynamizeImportDeclarationExpression,
+  escapeIdentifier,
   expressionizeTypeIf,
   forRange,
   gatherBindingCode,
@@ -3277,20 +3278,24 @@ SymbolElement
   SymbolLiteral -> [ "[", $1, "]" ]
 
 # https://262.ecma-international.org/#prod-Identifier
+# Extended: identifiers may include non-identifier Unicode (emoji, math
+# symbols not claimed as operators); escapeIdentifier converts them to a
+# JS-valid form.
 Identifier
   # perf: assertion to exit early
-  /(?=\p{ID_Start}|[_$])/ !ReservedWord IdentifierName:id -> id
+  /(?=\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s\u00F7\u2014\u2016\u2019\u2022\u2025\u2026\u2047\u2192\u21D2\u2208\u2209\u220B\u220C\u2254\u2260\u2261\u2262\u2263\u2264\u2265\u226A\u226B\u22D9\u25B7\u29FA\u2A75\u2A76])/ !ReservedWord IdentifierName:id -> id
 
 # https://262.ecma-international.org/#prod-IdentifierName
 IdentifierName
-  /(?:\p{ID_Start}|[_$])(?:\p{ID_Continue}|[\u200C\u200D$])*/ ->
+  /(?:\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s\u00F7\u2014\u2016\u2019\u2022\u2025\u2026\u2047\u2192\u21D2\u2208\u2209\u220B\u220C\u2254\u2260\u2261\u2262\u2263\u2264\u2265\u226A\u226B\u22D9\u25B7\u29FA\u2A75\u2A76])(?:\p{ID_Continue}|[\u200C\u200D$]|[^\u0000-\u007F\p{ID_Continue}\s\u00F7\u2014\u2016\u2019\u2022\u2025\u2026\u2047\u2192\u21D2\u2208\u2209\u220B\u220C\u2254\u2260\u2261\u2262\u2263\u2264\u2265\u226A\u226B\u22D9\u25B7\u29FA\u2A75\u2A76])*/ ->
+    name := escapeIdentifier($0)
     return {
       type: "Identifier",
-      name: $0,
-      names: [$0],
+      name,
+      names: [name],
       children: [{
         $loc: $loc,
-        token: $0,
+        token: name,
       }],
     }
 
@@ -6752,14 +6757,15 @@ TemplateBlockCharacters
     return { $loc, token: $0 }
 
 # https://262.ecma-international.org/#sec-comments
+# Keywords sorted longest-first so prefix conflicts (e.g. `instanceof`
+# before `in`) match the longest match first; boundary check via NonIdContinue.
+# `let` added since Civet assumes strict mode.
 ReservedWord
-  /(?:on|off|yes|no)(?!\p{ID_Continue})/ CoffeeBooleansEnabled
-  /(?:isnt)(?!\p{ID_Continue})/ CoffeeIsntEnabled
-  /(?:by)(?!\p{ID_Continue})/ CoffeeForLoopsEnabled
-  /(?:of)(?!\p{ID_Continue})/ CoffeeOfEnabled
-  # NOTE: Added `let`, Civet assumes strict mode
-  /(?:and|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|false|finally|for|function|if|import|in|instanceof|interface|is|let|loop|new|not|null|or|private|protected|public|return|static|super|switch|this|throw|true|try|typeof|unless|until|var|void|while|with|yield)(?!\p{ID_Continue})/
-
+  /(?:off|yes|on|no)/ NonIdContinue CoffeeBooleansEnabled -> $1
+  /isnt/ NonIdContinue CoffeeIsntEnabled -> $1
+  /by/ NonIdContinue CoffeeForLoopsEnabled -> $1
+  /of/ NonIdContinue CoffeeOfEnabled -> $1
+  /(?:instanceof|interface|protected|continue|debugger|function|default|extends|finally|private|delete|export|import|public|return|static|switch|typeof|unless|await|break|catch|class|const|false|super|throw|until|while|yield|case|else|enum|loop|null|this|true|void|with|and|for|let|new|not|try|var|do|if|in|is|or)/ NonIdContinue -> $1
 # https://262.ecma-international.org/#sec-comments
 Comment
   # perf: assertion to exit early
@@ -6875,7 +6881,7 @@ SemicolonDelimiter
     }
 
 NonIdContinue
-  /(?!\p{ID_Continue})/ -> undefined
+  /(?!\p{ID_Continue}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ -> undefined
 
 Loc
   "" ->

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -156,8 +156,7 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
         { ref, at } := n
         { id, unicode } := ref
         atLoc := at?.$loc
-        // For unicode names, store as `this["name"]` so the property name
-        // matches what `@name` (expression side) reads.
+        // Unicode names store as `this["name"]` to match the `@name` read.
         prefix := unicode ? "this[" : "this."
         suffix := unicode ? `"${unicode}"]` : id
         if atLoc

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -154,19 +154,23 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
       // Insert `this` assignments
       if n.type is "AtBinding"
         { ref, at } := n
-        { id } := ref
+        { id, unicode } := ref
         atLoc := at?.$loc
+        // For unicode names, store as `this["name"]` so the property name
+        // matches what `@name` (expression side) reads.
+        prefix := unicode ? "this[" : "this."
+        suffix := unicode ? `"${unicode}"]` : id
         if atLoc
           // Set $loc on ref so populateRefs propagates it to the child
           ref.$loc = { pos: atLoc.pos + 1, length: id.length }
           thisAssignments.push [
-            { $loc: atLoc, token: "this." }
-            { $loc: ref.$loc, token: id }
+            { $loc: atLoc, token: prefix }
+            { $loc: ref.$loc, token: suffix }
             " = "
             ref
           ]
         else
-          thisAssignments.push([`this.${id} = `, ref])
+          thisAssignments.push([`${prefix}${suffix} = `, ref])
         continue
 
       if opts?.assignPins

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -160,8 +160,10 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
         prefix := unicode ? "this[" : "this."
         suffix := unicode ? `"${unicode}"]` : id
         if atLoc
-          // Set $loc on ref so populateRefs propagates it to the child
-          ref.$loc = { pos: atLoc.pos + 1, length: id.length }
+          // Set $loc on ref so populateRefs propagates it to the child.
+          // Length tracks source span (unicode is the raw source; `id` is
+          // the escaped form which can be far wider than the codepoint).
+          ref.$loc = { pos: atLoc.pos + 1, length: (unicode ?? id).length }
           thisAssignments.push [
             { $loc: atLoc, token: prefix }
             { $loc: ref.$loc, token: suffix }

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -1,0 +1,17 @@
+// Escape non-identifier Unicode codepoints to `u$<HEX>$` so the result is
+// a valid JS identifier. The trailing `$` terminates each codepoint so
+// `pre😊post` → `preu$1F60A$post` is unambiguous. `\p{ID_Continue}` chars
+// (letters / digits / combining marks like `é`, `ő`) pass through unchanged.
+function escapeIdentifier(raw: string): string
+  result .= ""
+  for char of raw
+    cp := char.codePointAt(0)!
+    if cp > 0x7F and not /\p{ID_Continue}/u.test(char)
+      result += `u$${cp.toString(16).toUpperCase()}$`
+    else
+      result += char
+  result
+
+export {
+  escapeIdentifier
+}

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -12,6 +12,14 @@ function escapeIdentifier(raw: string): string
       result += char
   result
 
+// In property-key positions (object literal / destructuring keys),
+// emit the user-visible source as a quoted string so the lookup uses the
+// real property name instead of the escaped form.
+function propertyKey(name: any): any
+  return name unless name?.unicode
+  return { $loc: name.children?.[0]?.$loc, token: `"${name.unicode}"` }
+
 export {
   escapeIdentifier
+  propertyKey
 }

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -15,21 +15,17 @@ function escapeIdentifier(raw: string): string
 import { gatherRecursive } from ./traversal.civet
 import type { Identifier } from ./types.civet
 
-// In property-key positions (object literal / destructuring keys),
-// emit the user-visible source as a quoted string so the lookup uses the
-// real property name instead of the escaped form.
+// In property-key positions, emit the source as a quoted string so the
+// lookup uses the user-visible name instead of the escaped form.
 function propertyKey(name: any): any
   return name unless name?.unicode
   return { $loc: name.children?.[0]?.$loc, token: `"${name.unicode}"` }
 
-// For `export <decl>` where any binding has a unicode source: build the
-// `; export { name as "src", … }` clause that re-exports under the user-
-// visible name(s), since JS doesn't allow string-named exports inside a
-// combined `export const {…} = …` declaration. Returns undefined when no
-// binding is unicode.
+// For `export <decl>` where any binding has a unicode source, build a
+// `; export { name as "src", … }` clause to re-export under the source
+// name. Returns undefined when no binding is unicode (or the form isn't
+// declaring new bindings — re-export `export { … } from "…"` is unchanged).
 function buildExportSplitClause(declaration: any): string?
-  // Only split when the export form actually declares new bindings (so
-  // `export { … }` / `export … from "…"` re-exports flow through unchanged).
   return undefined unless Array.isArray(declaration?.names)
   unicodeMap := new Map<string, string>
   for node of gatherRecursive declaration, (n): n is Identifier => n.type is "Identifier" and !!(n as Identifier).unicode

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -12,6 +12,9 @@ function escapeIdentifier(raw: string): string
       result += char
   result
 
+import { gatherRecursive } from ./traversal.civet
+import type { Identifier } from ./types.civet
+
 // In property-key positions (object literal / destructuring keys),
 // emit the user-visible source as a quoted string so the lookup uses the
 // real property name instead of the escaped form.
@@ -19,7 +22,26 @@ function propertyKey(name: any): any
   return name unless name?.unicode
   return { $loc: name.children?.[0]?.$loc, token: `"${name.unicode}"` }
 
+// For `export <decl>` where any binding has a unicode source: build the
+// `; export { name as "src", … }` clause that re-exports under the user-
+// visible name(s), since JS doesn't allow string-named exports inside a
+// combined `export const {…} = …` declaration. Returns undefined when no
+// binding is unicode.
+function buildExportSplitClause(declaration: any): string?
+  // Only split when the export form actually declares new bindings (so
+  // `export { … }` / `export … from "…"` re-exports flow through unchanged).
+  return undefined unless Array.isArray(declaration?.names)
+  unicodeMap := new Map<string, string>
+  for node of gatherRecursive declaration, (n): n is Identifier => n.type is "Identifier" and !!(n as Identifier).unicode
+    unicodeMap.set node.name, node.unicode!
+  return undefined unless unicodeMap.size
+  specs := declaration.names.map (name: string) =>
+    src := unicodeMap.get name
+    src ? `${name} as "${src}"` : name
+  return `; export { ${specs.join(", ")} }`
+
 export {
+  buildExportSplitClause
   escapeIdentifier
   propertyKey
 }

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -1,3 +1,6 @@
+import { gatherRecursive } from ./traversal.civet
+import type { Identifier } from ./types.civet
+
 // Escape non-identifier Unicode codepoints to `u$<HEX>$` so the result is
 // a valid JS identifier. The trailing `$` terminates each codepoint so
 // `pre😊post` → `preu$1F60A$post` is unambiguous. `\p{ID_Continue}` chars
@@ -11,9 +14,6 @@ function escapeIdentifier(raw: string): string
     else
       result += char
   result
-
-import { gatherRecursive } from ./traversal.civet
-import type { Identifier } from ./types.civet
 
 // In property-key positions, emit the source as a quoted string so the
 // lookup uses the user-visible name instead of the escaped form.

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -127,7 +127,7 @@ import {
   processDeclarations
 } from ./declaration.civet
 
-import { escapeIdentifier } from ./identifier.civet
+import { escapeIdentifier, propertyKey } from ./identifier.civet
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
@@ -2176,6 +2176,7 @@ export {
   precedenceCustomDefault
   precedenceStep
   prepend
+  propertyKey
   processAssignmentDeclaration
   processBinaryOpExpression
   processCallMemberExpression

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -127,6 +127,7 @@ import {
   processDeclarations
 } from ./declaration.civet
 
+import { escapeIdentifier } from ./identifier.civet
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
@@ -2137,6 +2138,7 @@ export {
   duplicateBlock
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
+  escapeIdentifier
   expressionizeTypeIf
   forRange
   gatherBindingCode

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -127,7 +127,7 @@ import {
   processDeclarations
 } from ./declaration.civet
 
-import { escapeIdentifier, propertyKey } from ./identifier.civet
+import { buildExportSplitClause, escapeIdentifier, propertyKey } from ./identifier.civet
 import { processPipelineExpressions } from ./pipe.civet
 import { forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
@@ -2127,6 +2127,7 @@ export {
   blockWithPrefix
   braceBlock
   bracedBlock
+  buildExportSplitClause
   convertArrowFunctionToMethod
   convertFunctionToMethod
   convertNamedImportsToObject

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -39,6 +39,10 @@ import {
 } from ./ref.civet
 
 import {
+  propertyKey
+} from ./identifier.civet
+
+import {
   blockWithPrefix
   braceBlock
 } from ./block.civet
@@ -242,8 +246,11 @@ function getPatternConditions(
                 conditions.push([name, " in ", ref])
                 subRef = [ref, "[", name, "]"]
               when "Identifier"
-                conditions.push(["'", name.name, "' in ", ref])
-                subRef = [ref, ".", name.name]
+                key := name.unicode ?? name.name
+                conditions.push(["'", key, "' in ", ref])
+                subRef = name.unicode
+                  ? [ref, "[", `"${name.unicode}"`, "]"]
+                  : [ref, ".", name.name]
 
             getPatternConditions(value, subRef, conditions) if value
 
@@ -372,7 +379,7 @@ function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternConte
               contents = {
                 ...p
                 value: bindings
-                children: [ws, name, bindings && ": ", bindings, p.delim]
+                children: [ws, propertyKey(name), bindings && ": ", bindings, p.delim]
               }
             when "Identifier", undefined
               contents = p
@@ -390,7 +397,7 @@ function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternConte
               // This occurs because the parser expands `{name^: pattern}`
               // into `{name: name^pattern}`
               if p.name is value.binding
-                contents!.children = [ws, name, p.delim]
+                contents!.children = [ws, propertyKey(name), p.delim]
             else // "Literal", "RegularExpressionLiteral", "StringLiteral"
               contents = undefined
           if contents

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -623,6 +623,10 @@ export type Identifier =
   // Source string when escapeIdentifier mangled it (non-id-unicode codepoints
   // like 😊 / △). Property-key sites use this for the user-visible name.
   unicode?: string
+  // Original identifier when PropertyName rewrote children to render a
+  // quoted source string. Shorthand consumers reach this for the value-side
+  // reference (which still needs the mangled local-variable name).
+  identifier?: Identifier
 
 export type ReturnValue = ASTParent &
   type: "ReturnValue"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -536,6 +536,12 @@ export type ASTRef = ASTObject &
    */
   names?: [ASTString]
   children?: [ASTString]
+  /**
+   * Source string when escapeIdentifier mangled the @-binding name; lets
+   * binding-side `this.X = X` emit bracket access matching the expression-
+   * side `this["X"]`.
+   */
+  unicode?: string
 
 export type AtBinding =
   type: "AtBinding"
@@ -614,6 +620,9 @@ export type Identifier =
   names: string[]
   children: Children & [ ASTLeaf | ASTString ]
   parent?: Parent
+  // Source string when escapeIdentifier mangled it (non-id-unicode codepoints
+  // like 😊 / △). Property-key sites use this for the user-visible name.
+  unicode?: string
 
 export type ReturnValue = ASTParent &
   type: "ReturnValue"

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -24,6 +24,8 @@ describe "identifier", ->
   """
 
   describe "unicode", ->
+    // -- Basic mangling: each non-id-unicode codepoint becomes `u$<HEX>$`.
+
     testCase """
       BMP symbol as identifier
       ---
@@ -49,26 +51,14 @@ describe "identifier", ->
     """
 
     testCase """
-      ASCII prefix mixed with unicode
+      ASCII mixed with unicode at every position
       ---
-      let happy😊 = 3
-      ---
-      let happyu$1F60A$ = 3
-    """
-
-    testCase """
-      unicode prefix mixed with ASCII
-      ---
-      let 😊happy = 3
-      ---
-      let u$1F60A$happy = 3
-    """
-
-    testCase """
-      ASCII surrounding unicode
-      ---
+      let happy😊 = 1
+      let 😊happy = 2
       let pre😊post = 3
       ---
+      let happyu$1F60A$ = 1
+      let u$1F60A$happy = 2
       let preu$1F60A$post = 3
     """
 
@@ -90,9 +80,9 @@ describe "identifier", ->
       let u$25B3$ = 3
     """
 
-    // The escaped name is a JS-valid identifier but not the actual property
-    // name — destructuring and object-literal shorthand quote the source so
-    // the property lookup / construction uses the user-visible name.
+    // -- Property-key sites quote the source so the lookup uses the
+    //    user-visible name, not the mangled binding form.
+
     testCase """
       destructuring shorthand with unicode key
       ---
@@ -126,28 +116,15 @@ describe "identifier", ->
     """
 
     testCase """
-      mixed-codepoint identifier as shorthand key
-      ---
-      { pre😊post } := data
-      ---
-      const { "pre😊post": preu$1F60A$post } = data
-    """
-
-    testCase """
-      multi-codepoint identifier as shorthand key
-      ---
-      x := { 😊😔 }
-      ---
-      const x = { "😊😔": u$1F60A$u$1F614$ }
-    """
-
-    testCase """
       ASCII keys still use shorthand alongside unicode
       ---
       { 😊, ascii } := data
       ---
       const { "😊": u$1F60A$, ascii } = data
     """
+
+    // -- Member access: `.😊` → `["😊"]` since dot access requires a
+    //    JS identifier and `u$1F60A$` is the wrong property name.
 
     testCase """
       member access with unicode property
@@ -165,13 +142,7 @@ describe "identifier", ->
       data?.["😊"]
     """
 
-    testCase """
-      mixed-codepoint member access
-      ---
-      data.pre😊post
-      ---
-      data["pre😊post"]
-    """
+    // -- Methods and class fields use the user-visible name as a quoted key.
 
     testCase """
       class method with unicode name
@@ -203,9 +174,8 @@ describe "identifier", ->
       }
     """
 
-    // Both the @-binding (constructor param) and @-expression compile to
-    // bracket access with the user-visible property name, so the property
-    // stored matches the property read.
+    // -- @-binding (constructor param) and @-expression both compile to
+    //    bracket access so the property stored matches the property read.
     testCase """
       this-shorthand with unicode name
       ---
@@ -218,8 +188,8 @@ describe "identifier", ->
       }
     """
 
-    // The TypeScript object type literal should describe the actual runtime
-    // property name (the source string), not the mangled binding form.
+    // -- TS type literal property names match the runtime property.
+
     testCase """
       TS type literal with unicode key
       ---
@@ -236,9 +206,9 @@ describe "identifier", ->
       type T = { readonly "😊": number }
     """
 
-    // Import/export named-specifier shorthand `{ 😊 }` expands to the
-    // explicit `{ "😊" as u$1F60A$ }` form so the module-side name is the
-    // user-visible source string.
+    // -- Import/export specifiers use the user-visible name on the
+    //    module-facing side and the mangled name on the local side.
+
     testCase """
       import shorthand with unicode name
       ---
@@ -272,6 +242,22 @@ describe "identifier", ->
     """
 
     testCase """
+      export explicit with unicode source
+      ---
+      export { 😊 as x }
+      ---
+      export { u$1F60A$ as x }
+    """
+
+    testCase """
+      export explicit with unicode external name
+      ---
+      export { x as 😊 }
+      ---
+      export { x as "😊" }
+    """
+
+    testCase """
       unbraced export with unicode name
       ---
       a := 1
@@ -281,8 +267,8 @@ describe "identifier", ->
       export {u$1F60A$ as "😊", a}
     """
 
-    // The combined `export X := value` form needs to split because JS
-    // doesn't allow string-named exports inside a `export const` clause.
+    // The combined `export X := value` form splits into `<decl>; export {…}`
+    // because JS doesn't allow string-named exports inside `export const`.
     testCase """
       combined export-declaration with unicode name
       ---
@@ -297,14 +283,6 @@ describe "identifier", ->
       export { 😊 } := data
       ---
       const { "😊": u$1F60A$ } = data; export { u$1F60A$ as "😊" }
-    """
-
-    testCase """
-      combined export-declaration with mixed unicode and ASCII
-      ---
-      export { 😊, ascii } := data
-      ---
-      const { "😊": u$1F60A$, ascii } = data; export { u$1F60A$ as "😊", ascii }
     """
 
     testCase """
@@ -323,12 +301,9 @@ describe "identifier", ->
       export const ascii = 3
     """
 
-    // Unicode JSX *attribute* names compile to the spread-with-string-key
-    // form `{...{"name": value}}` — valid JSX that any downstream transform
-    // (esbuild / babel / etc.) accepts. Unicode JSX *tag* names remain
-    // unsupported because the JSX spec restricts JSXIdentifier to ECMAScript
-    // identifiers, and JSX positional tags can't be expressed as a runtime
-    // expression without a Civet-side rewrite of `<Foo />` to a call.
+    // -- Unicode JSX attribute names compile to spread-with-string-key.
+    //    Tag names remain unsupported (JSX spec restricts JSXIdentifier).
+
     testCase """
       JSX attribute with unicode name
       ---
@@ -353,21 +328,8 @@ describe "identifier", ->
       <div {...{"😊": true}} />
     """
 
-    testCase """
-      export explicit with unicode source
-      ---
-      export { 😊 as x }
-      ---
-      export { u$1F60A$ as x }
-    """
-
-    testCase """
-      export explicit with unicode external name
-      ---
-      export { x as 😊 }
-      ---
-      export { x as "😊" }
-    """
+    // -- Pattern matching: existence checks and nested property access
+    //    use the user-visible name on the runtime side.
 
     testCase """
       pattern match object shorthand with unicode key
@@ -413,6 +375,8 @@ describe "identifier", ->
       }
     """
 
+    // -- Pass-through: ID_Continue letters are already valid JS identifiers.
+
     testCase """
       ID_Continue letters pass through unchanged
       ---
@@ -423,7 +387,8 @@ describe "identifier", ->
       let Erdős = 3
     """
 
-    // Use case from discussion #1034
+    // -- Use case from discussion #1034.
+
     testCase """
       define and call as function
       ---
@@ -434,16 +399,6 @@ describe "identifier", ->
       function u$2200$(arr) { return arr.every((x) => !!x) }
       const N = [1,2,3]
       u$2200$(N)
-    """
-
-    testCase """
-      implicit application with space
-      ---
-      function ∀(x) !!x
-      console.log ∀ 5
-      ---
-      function u$2200$(x) { return !!x }
-      console.log(u$2200$(5))
     """
 
     testCase """
@@ -464,7 +419,9 @@ describe "identifier", ->
       u$2200$N()
     """
 
-    // ID_Continue chars are valid mid-identifier but not at the start.
+    // -- Combining marks and non-ASCII digits are valid mid-identifier
+    //    (\p{ID_Continue}) but reject as identifier starts.
+
     throws """
       standalone combining mark rejects
       ---
@@ -482,7 +439,7 @@ describe "identifier", ->
     """
 
     // Drift guard: any non-ASCII codepoint in parser grammar must be in
-    // the operator-exclusion list — else a future operator silently parses
+    // the operator-exclusion list, else a future operator silently parses
     // as part of an identifier.
     it "every non-ASCII codepoint in parser.hera grammar is in the operator-exclusion list", ->
       src := fs.readFileSync("source/parser.hera", "utf8")

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -419,6 +419,21 @@ describe "identifier", ->
       u$2200$N()
     """
 
+    // Civet labels are `:label` (colon on the left) — unicode names
+    // mangle to JS-valid labels via the standard identifier path.
+    testCase """
+      labeled loop with unicode label
+      ---
+      :😊
+      for x of arr
+        break :😊
+      ---
+      u$1F60A$:
+      for (const x of arr) {
+        break u$1F60A$
+      }
+    """
+
     // -- Combining marks and non-ASCII digits are valid mid-identifier
     //    (\p{ID_Continue}) but reject as identifier starts.
 

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -90,6 +90,178 @@ describe "identifier", ->
       let u$25B3$ = 3
     """
 
+    // The escaped name is a JS-valid identifier but not the actual property
+    // name — destructuring and object-literal shorthand quote the source so
+    // the property lookup / construction uses the user-visible name.
+    testCase """
+      destructuring shorthand with unicode key
+      ---
+      { 😊 } := data
+      ---
+      const { "😊": u$1F60A$ } = data
+    """
+
+    testCase """
+      object literal shorthand with unicode key
+      ---
+      x := { 😊 }
+      ---
+      const x = { "😊": u$1F60A$ }
+    """
+
+    testCase """
+      destructuring with explicit unicode key
+      ---
+      { 😊: x } := data
+      ---
+      const { "😊": x } = data
+    """
+
+    testCase """
+      object literal with explicit unicode key
+      ---
+      x := { 😊: y }
+      ---
+      const x = { "😊": y }
+    """
+
+    testCase """
+      mixed-codepoint identifier as shorthand key
+      ---
+      { pre😊post } := data
+      ---
+      const { "pre😊post": preu$1F60A$post } = data
+    """
+
+    testCase """
+      multi-codepoint identifier as shorthand key
+      ---
+      x := { 😊😔 }
+      ---
+      const x = { "😊😔": u$1F60A$u$1F614$ }
+    """
+
+    testCase """
+      ASCII keys still use shorthand alongside unicode
+      ---
+      { 😊, ascii } := data
+      ---
+      const { "😊": u$1F60A$, ascii } = data
+    """
+
+    testCase """
+      member access with unicode property
+      ---
+      data.😊
+      ---
+      data["😊"]
+    """
+
+    testCase """
+      optional member access with unicode property
+      ---
+      data?.😊
+      ---
+      data?.["😊"]
+    """
+
+    testCase """
+      mixed-codepoint member access
+      ---
+      data.pre😊post
+      ---
+      data["pre😊post"]
+    """
+
+    testCase """
+      class method with unicode name
+      ---
+      class Foo
+        😊() 1
+      ---
+      class Foo {
+        "😊"() { return 1 }
+      }
+    """
+
+    testCase """
+      object literal method shorthand with unicode name
+      ---
+      x := { 😊() 1 }
+      ---
+      const x = { "😊"() { return 1 } }
+    """
+
+    testCase """
+      class field with unicode name
+      ---
+      class Foo
+        😊 = 1
+      ---
+      class Foo {
+        "😊" = 1
+      }
+    """
+
+    // Both the @-binding (constructor param) and @-expression compile to
+    // bracket access with the user-visible property name, so the property
+    // stored matches the property read.
+    testCase """
+      this-shorthand with unicode name
+      ---
+      function foo(@😊)
+        @😊
+      ---
+      function foo(u$1F60A$) {
+        this["😊"] = u$1F60A$;
+        return this["😊"]
+      }
+    """
+
+    testCase """
+      pattern match object shorthand with unicode key
+      ---
+      switch x
+        { 😊 } then 😊
+        else 0
+      ---
+      if(typeof x === 'object' && x != null && '😊' in x) {const { "😊": u$1F60A$ } = x; u$1F60A$}
+      else  { 0 }
+    """
+
+    testCase """
+      pattern match object explicit unicode key
+      ---
+      switch x
+        { 😊: y } then y
+        else 0
+      ---
+      if(typeof x === 'object' && x != null && '😊' in x) {const { "😊": y } = x; y}
+      else  { 0 }
+    """
+
+    testCase """
+      pattern match nested unicode key
+      ---
+      switch x
+        { 😊: { y } } then y
+        else 0
+      ---
+      if(typeof x === 'object' && x != null && '😊' in x && typeof x["😊"] === 'object' && x["😊"] != null && 'y' in x["😊"]) {const { "😊": { y } } = x; y}
+      else  { 0 }
+    """
+
+    testCase """
+      if-let with unicode key
+      ---
+      if { 😊 } := data
+        console.log 😊
+      ---
+      if ((data) && typeof data === 'object' && '😊' in data) {const { "😊": u$1F60A$ } = data;
+        console.log(u$1F60A$)
+      }
+    """
+
     testCase """
       ID_Continue letters pass through unchanged
       ---

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -218,6 +218,127 @@ describe "identifier", ->
       }
     """
 
+    // The TypeScript object type literal should describe the actual runtime
+    // property name (the source string), not the mangled binding form.
+    testCase """
+      TS type literal with unicode key
+      ---
+      type T = { 😊: number }
+      ---
+      type T = { "😊": number }
+    """
+
+    testCase """
+      TS readonly type property with unicode key
+      ---
+      type T = { readonly 😊: number }
+      ---
+      type T = { readonly "😊": number }
+    """
+
+    // Import/export named-specifier shorthand `{ 😊 }` expands to the
+    // explicit `{ "😊" as u$1F60A$ }` form so the module-side name is the
+    // user-visible source string.
+    testCase """
+      import shorthand with unicode name
+      ---
+      import { 😊 } from "mod"
+      ---
+      import { "😊" as u$1F60A$ } from "mod"
+    """
+
+    testCase """
+      import explicit with unicode source
+      ---
+      import { 😊 as x } from "mod"
+      ---
+      import { "😊" as x } from "mod"
+    """
+
+    testCase """
+      import explicit with unicode local
+      ---
+      import { x as 😊 } from "mod"
+      ---
+      import { x as u$1F60A$ } from "mod"
+    """
+
+    testCase """
+      export shorthand with unicode name
+      ---
+      export { 😊 }
+      ---
+      export { u$1F60A$ as "😊" }
+    """
+
+    testCase """
+      unbraced export with unicode name
+      ---
+      a := 1
+      export 😊, a
+      ---
+      const a = 1
+      export {u$1F60A$ as "😊", a}
+    """
+
+    // The combined `export X := value` form needs to split because JS
+    // doesn't allow string-named exports inside a `export const` clause.
+    testCase """
+      combined export-declaration with unicode name
+      ---
+      export 😊 := 3
+      ---
+      const u$1F60A$ = 3; export { u$1F60A$ as "😊" }
+    """
+
+    testCase """
+      combined export-declaration with destructured unicode
+      ---
+      export { 😊 } := data
+      ---
+      const { "😊": u$1F60A$ } = data; export { u$1F60A$ as "😊" }
+    """
+
+    testCase """
+      combined export-declaration with mixed unicode and ASCII
+      ---
+      export { 😊, ascii } := data
+      ---
+      const { "😊": u$1F60A$, ascii } = data; export { u$1F60A$ as "😊", ascii }
+    """
+
+    testCase """
+      combined export-declaration with multiple unicode and ASCII interleaved
+      ---
+      export { 😊, ascii, 😔 } := data
+      ---
+      const { "😊": u$1F60A$, ascii, "😔": u$1F614$ } = data; export { u$1F60A$ as "😊", ascii, u$1F614$ as "😔" }
+    """
+
+    testCase """
+      combined export-declaration without unicode unchanged
+      ---
+      export ascii := 3
+      ---
+      export const ascii = 3
+    """
+
+    testCase """
+      export explicit with unicode source
+      ---
+      export { 😊 as x }
+      ---
+      export { u$1F60A$ as x }
+    """
+
+    testCase """
+      export explicit with unicode external name
+      ---
+      export { x as 😊 }
+      ---
+      export { x as "😊" }
+    """
+
     testCase """
       pattern match object shorthand with unicode key
       ---

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -50,6 +50,25 @@ describe "identifier", ->
       let u$1F60A$u$1F614$ = 3
     """
 
+    // ZWJ-joined emoji (family) and modifier-extended emoji (skin tone)
+    // are sequences of distinct codepoints — each codepoint mangles
+    // independently, with ZWJ (U+200D, in \p{ID_Continue}) passing through.
+    testCase """
+      ZWJ-sequence emoji as identifier
+      ---
+      let 👨‍👩‍👧‍👦 = "family"
+      ---
+      let u$1F468$‍u$1F469$‍u$1F467$‍u$1F466$ = "family"
+    """
+
+    testCase """
+      modifier-extended emoji as identifier
+      ---
+      let 👍🏾 = "thumbs"
+      ---
+      let u$1F44D$u$1F3FE$ = "thumbs"
+    """
+
     testCase """
       ASCII mixed with unicode at every position
       ---
@@ -171,6 +190,45 @@ describe "identifier", ->
       ---
       class Foo {
         "😊" = 1
+      }
+    """
+
+    // Private fields can't be string-keyed, so unicode in `#name` mangles
+    // the IdentifierName part and keeps `#`-dot access throughout.
+    testCase """
+      private class field with unicode name
+      ---
+      class Foo
+        #😊 = 1
+      ---
+      class Foo {
+        #u$1F60A$ = 1
+      }
+    """
+
+    testCase """
+      private member access with unicode name
+      ---
+      class Foo
+        #😊 = 1
+        get(obj) obj.#😊
+      ---
+      class Foo {
+        #u$1F60A$ = 1
+        get(obj) { return obj.#u$1F60A$ }
+      }
+    """
+
+    testCase """
+      private this-shorthand with unicode name
+      ---
+      class Foo
+        #😊 = 1
+        get() @#😊
+      ---
+      class Foo {
+        #u$1F60A$ = 1
+        get() { return this.#u$1F60A$ }
       }
     """
 

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -1,4 +1,6 @@
-{testCase} from ./helper.civet
+{testCase, throws} from ./helper.civet
+fs from fs
+assert from assert
 
 describe "identifier", ->
   testCase """
@@ -20,3 +22,158 @@ describe "identifier", ->
     __ = 3
     _  = 2
   """
+
+  describe "unicode", ->
+    testCase """
+      BMP symbol as identifier
+      ---
+      let △ = 3
+      ---
+      let u$25B3$ = 3
+    """
+
+    testCase """
+      astral emoji as identifier
+      ---
+      let 😊 = 3
+      ---
+      let u$1F60A$ = 3
+    """
+
+    testCase """
+      multi-codepoint unicode identifier
+      ---
+      let 😊😔 = 3
+      ---
+      let u$1F60A$u$1F614$ = 3
+    """
+
+    testCase """
+      ASCII prefix mixed with unicode
+      ---
+      let happy😊 = 3
+      ---
+      let happyu$1F60A$ = 3
+    """
+
+    testCase """
+      unicode prefix mixed with ASCII
+      ---
+      let 😊happy = 3
+      ---
+      let u$1F60A$happy = 3
+    """
+
+    testCase """
+      ASCII surrounding unicode
+      ---
+      let pre😊post = 3
+      ---
+      let preu$1F60A$post = 3
+    """
+
+    testCase """
+      reference unicode identifier
+      ---
+      let △ = 3
+      console.log △
+      ---
+      let u$25B3$ = 3
+      console.log(u$25B3$)
+    """
+
+    testCase """
+      hand-written mangled name still works
+      ---
+      let u$25B3$ = 3
+      ---
+      let u$25B3$ = 3
+    """
+
+    testCase """
+      ID_Continue letters pass through unchanged
+      ---
+      let pokémon = 3
+      let Erdős = 3
+      ---
+      let pokémon = 3
+      let Erdős = 3
+    """
+
+    // Use case from discussion #1034
+    testCase """
+      define and call as function
+      ---
+      function ∀(arr) arr.every (x) => !!x
+      N := [1,2,3]
+      ∀ N
+      ---
+      function u$2200$(arr) { return arr.every((x) => !!x) }
+      const N = [1,2,3]
+      u$2200$(N)
+    """
+
+    testCase """
+      implicit application with space
+      ---
+      function ∀(x) !!x
+      console.log ∀ 5
+      ---
+      function u$2200$(x) { return !!x }
+      console.log(u$2200$(5))
+    """
+
+    testCase """
+      operator codepoints still parse as operators
+      ---
+      a ≤ b
+      ---
+      a <= b
+    """
+
+    testCase """
+      adjoined without whitespace is one identifier
+      ---
+      function u$2200$N() 1
+      u$2200$N()
+      ---
+      function u$2200$N() { return 1 }
+      u$2200$N()
+    """
+
+    // ID_Continue chars are valid mid-identifier but not at the start.
+    throws """
+      standalone combining mark rejects
+      ---
+      let ̀ = 3
+      ---
+      ParseError
+    """
+
+    throws """
+      standalone non-ASCII digit rejects
+      ---
+      let ٠ = 3
+      ---
+      ParseError
+    """
+
+    // Drift guard: any non-ASCII codepoint in parser grammar must be in
+    // the operator-exclusion list — else a future operator silently parses
+    // as part of an identifier.
+    it "every non-ASCII codepoint in parser.hera grammar is in the operator-exclusion list", ->
+      src := fs.readFileSync("source/parser.hera", "utf8")
+      stripped := src
+        .replace(/\/\*[\s\S]*?\*\//g, "")    // /* block */ comments
+        .replace(/^[ \t]*#.*$/gm, "")        // hera # line comments
+        .replace(/^[ \t]*\/\/.*$/gm, "")     // JS // line comments
+      operatorChars := /[÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶]/u
+      seen := new Set<string>
+      for ch of stripped
+        cp := ch.codePointAt(0)
+        continue unless cp? and cp > 0x7F
+        seen.add(ch)
+      for ch of seen
+        cp := ch.codePointAt(0)!
+        assert.match ch, operatorChars,
+          `Non-ASCII U+${cp.toString(16).toUpperCase()} ('${ch}') in parser.hera grammar missing from operator-exclusion list — add to [÷—‖…] in IdentifierName, ReservedWord, NonIdContinue regexes.`

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -323,6 +323,36 @@ describe "identifier", ->
       export const ascii = 3
     """
 
+    // Unicode JSX *attribute* names compile to the spread-with-string-key
+    // form `{...{"name": value}}` — valid JSX that any downstream transform
+    // (esbuild / babel / etc.) accepts. Unicode JSX *tag* names remain
+    // unsupported because the JSX spec restricts JSXIdentifier to ECMAScript
+    // identifiers, and JSX positional tags can't be expressed as a runtime
+    // expression without a Civet-side rewrite of `<Foo />` to a call.
+    testCase """
+      JSX attribute with unicode name
+      ---
+      <div 😊={x} />
+      ---
+      <div {...{"😊": x}} />
+    """
+
+    testCase """
+      JSX attribute with mixed-codepoint unicode name
+      ---
+      <div pre😊post={x} />
+      ---
+      <div {...{"pre😊post": x}} />
+    """
+
+    testCase """
+      JSX bare unicode attribute defaults to true
+      ---
+      <div 😊 />
+      ---
+      <div {...{"😊": true}} />
+    """
+
     testCase """
       export explicit with unicode source
       ---

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -232,6 +232,36 @@ describe "identifier", ->
       }
     """
 
+    // Enum members with unicode keys emit the user-visible name as a
+    // string-literal member (TS form) and as the runtime key (JS form),
+    // so `E.😊` lookups work at runtime. Cross-references between members
+    // (`X = 😊 + 1` or `X = E.😊 + 1`) also resolve to the source key.
+    testCase """
+      TS enum with unicode member
+      ---
+      enum E
+        😊 = 1
+        ascii = 2
+      ---
+      enum E {
+        "😊" = 1,
+        ascii = 2,
+      }
+    """
+
+    testCase.js """
+      JS enum with unicode member uses source key
+      ---
+      enum E
+        😊 = 1
+        X = 😊 + 1
+      ---
+      let E = {};
+      E[E["😊"] = 1] = "😊";
+      E[E["X"] = E["😊"] + 1] = "X";
+
+    """
+
     // -- @-binding (constructor param) and @-expression both compile to
     //    bracket access so the property stored matches the property read.
     testCase """


### PR DESCRIPTION
## Summary

Identifiers can now mix standard JS identifier chars (`\p{ID_Start}` / `\p{ID_Continue}`, `_`, `$`, ZWNJ, ZWJ) with non-identifier Unicode codepoints (emoji, dingbats, math symbols not claimed as operators). Non-id-unicode codepoints are escaped to a JS-safe `u$<HEX>$` form (mirrors the `\u{XXXX}` escape syntax) so the resulting name is a valid JS identifier:

- `△` → `u$25B3$`
- `😊` → `u$1F60A$`  *(astral codepoint — surrogate pair handled correctly)*
- `😊😔` → `u$1F60A$u$1F614$`  *(multi-codepoint identifier)*
- `pre😊post` → `preu$1F60A$post`  *(mixed with ASCII)*

The trailing `$` terminates each codepoint so adjacent ASCII parts stay unambiguous. ID_Continue letters (`é`, `ő`, `ω`) are already valid in JS and pass through unchanged — `pokémon` and `Erdős` are unaffected.

This is the smallest viable foothold for the design space in:
- discussion #1034 — Unicode non-letter functions/operators
- #555 — Unicode operator support (mentions emoji-in-identifiers)
- #1382 — Non-identifier operators (Swift-style with name mangling)

Anchors a concrete implementation for further design discussion in those threads — not closing them.

## Design choices

- **Multi-codepoint identifiers** allowed (e.g. `😊😔`) — IdentifierName extended to admit non-id-unicode chars in both start and continue positions, mirroring how JS already admits `\p{ID_Start}` / `\p{ID_Continue}`.
- **Mangling: `u$<HEX>$`** by codepoint (not UTF-16 code unit), no zero-padding. Trailing `$` terminates the codepoint so codepoints can sit adjacent to ASCII id chars without ambiguity. Surrogate pairs handled via codepoint-iterating `for…of` and `u`-flag regex.
- **`escapeIdentifier`** lives in `source/parser/identifier.civet`.
- **Operator-table wins**: codepoints already claimed by the operator/punctuation grammar (`÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶`) are excluded from the non-id-unicode char class, so `a ≤ b` still parses as `a <= b`. A drift-guard test scans `parser.hera` and asserts every non-ASCII grammar codepoint is in the operator-exclusion list — future operator additions can't silently regress to identifiers.
- **`ApplicationStart` unchanged**: implicit application still requires whitespace. `∀N` is one identifier (`u$2200$N`), not `∀(N)`. To call, write `∀ N`.
- **`\p{ID_Continue}` precision**: standalone combining marks (`̀`), non-ASCII digits (`٠`), and modifier letters reject at identifier start (since they're in ID_Continue but not ID_Start, and excluded from non-id-unicode).
- **`ReservedWord` keywords sorted longest-first** within each alternation so prefix conflicts (`instanceof` / `interface` before `in`) match correctly, letting the boundary check delegate to a `NonIdContinue` rule call instead of an inline `(?!...)` per regex.
- **Hand-written `u$25B3$` keeps working** as a normal `$`-prefixed identifier. We accept that hand-written and escape-mangled forms collide; demangling in hover/stack traces is best-effort.

## Deferred follow-ups

- LSP / stack-trace demangling so users see `△` instead of `u$25B3$`.

## Test plan
- [x] New test cases in `test/identifier.civet`: BMP symbol, astral emoji, multi-codepoint, ASCII-prefix-with-unicode, unicode-prefix-with-ASCII, ASCII-surrounding-unicode, reference, hand-written escape form, ID_Continue letters (`pokémon` / `Erdős`), ∀-as-function with space, operator codepoints stay as operators, adjoined-without-whitespace as one identifier, combining-mark / non-ASCII-digit rejection, drift-guard.
- [x] Full test suite: 3886 passing.
- [x] Coverage gate at 100% statements / branches / functions / lines.
- [x] Typecheck within baseline (888).
- [x] Smoke test: `△`, `😊`, `😊😔`, `pre😊post`, `pokémon`, `Erdős`, `imports`, `import.meta.url`, `a ≤ b`, `∀ N` all behave correctly.
