### PR TITLE
Make Import rule express its intent via NonIdContinue

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1082,7 +1082,7 @@ PipelineTailItem
   ( AwaitOp / Return / Throw ) !AccessStart !MaybeParenNestedExpression -> $1
   $( Yield ( _? Star )? ) !AccessStart !MaybeParenNestedExpression ->
     return { $loc, token: $1, type: "Yield" }
-  "import" !AccessStart ->
+  Import !AccessStart ->
     return {
       type: "Identifier",
       children: [ $1 ],
@@ -1637,7 +1637,7 @@ CallExpression
     return dynamizeImportDeclarationExpression([i, iws, imports, fws, from])
   # Dynamic import(), with optional parentheses when not used at top level.
   # (At top level, ImportDeclaration will match first.)
-  "import" ArgumentsWithTrailingCallExpressions:argsWithTrailing CallExpressionRest*:rest ->
+  Import ArgumentsWithTrailingCallExpressions:argsWithTrailing CallExpressionRest*:rest ->
     [args, ...trailing] := argsWithTrailing
     return processCallMemberExpression({
       type: "CallExpression",
@@ -5974,7 +5974,10 @@ ImportDeclaration
       from,
       ts: !!t,
     }
-  Import SameLineOrIndentedFurther ModuleSpecifier:module -> { type: "ImportDeclaration", children: $0, module }
+  # &/\s/ assertion: ModuleSpecifier's UnquotedSpecifier can otherwise eat
+  # the `(` of `import("foo")` or the `.` of `import.meta` as a one-char
+  # specifier, masking the dynamic-import / member-access parse paths.
+  Import:i &/\s/ SameLineOrIndentedFurther:ws ModuleSpecifier:module -> { type: "ImportDeclaration", children: [i, ws, module], module }
   # NOTE: Robust parsing for better LSP completions
   Import:i _?:ws UnclosedSingleLineStringLiteral?:unclosed &EOS ->
     return {
@@ -7082,8 +7085,7 @@ If
     return { $loc, token: $1 }
 
 Import
-  # NOTE: this is a hack so import.meta will parse correctly
-  "import" &/\s/ ->
+  "import" NonIdContinue ->
     return { $loc, token: $1 }
 
 In
@@ -7754,7 +7756,7 @@ InlineJSXCallExpression
         ...rest.flat()
       ],
     })
-  "import" ExplicitArguments:args InlineJSXCallExpressionRest*:rest ->
+  Import ExplicitArguments:args InlineJSXCallExpressionRest*:rest ->
     return processCallMemberExpression({
       type: "CallExpression",
       children: [
@@ -8595,9 +8597,9 @@ TypeIdentifier
     }
 
 ImportType
-  "import" OpenParen __ StringLiteral __ CloseParen ( Dot IdentifierName )? TypeArguments?
+  Import OpenParen __ StringLiteral __ CloseParen ( Dot IdentifierName )? TypeArguments?
   # NOTE: Added implicit import without parens
-  "import" InsertOpenParen Trimmed_? StringLiteral InsertCloseParen
+  Import InsertOpenParen Trimmed_? StringLiteral InsertCloseParen
 
 TypeTuple
   OpenBracket:open AllowAll TypeTupleContent?:elements RestoreAll __:ws CloseBracket:close ->


### PR DESCRIPTION
## Summary

Replace the `"import" &/\s/` "hack" in the `Import` rule with the canonical `"import" NonIdContinue` ("the import keyword, not a longer identifier"). Migrate bare `"import"` literals at the dynamic-import, JSX, type, and pipeline-tail-item sites to use the `Import` rule directly so all import-keyword paths share one matcher and one AST shape.

The whitespace constraint that `&/\s/` was providing moves to exactly the one ImportDeclaration alternative that needs it: `Import SameLineOrIndentedFurther ModuleSpecifier` (line 6018). Without that gate, `UnquotedSpecifier` (`/[^;"'\s=>]+/`) would eat the `(` of `import("foo")` or the `.` of `import.meta` as a one-character module specifier and mask the dynamic-import / member-access parse paths.

## Why now

Defensive cleanup — no behavior change for any pattern on main today. Surfaced while exploring zero-whitespace implicit application in #2036 (unicode identifiers), where loosening `ApplicationStart` made `imports` parse as `import(s)` because the bare `"import"` literal at the dynamic-import call site had no identifier-boundary check. That PR works around the issue with a separate gate; this PR removes the latent fragility entirely.

## Analysis of the other ImportDeclaration alternatives

All other `Import`-using paths are inherently safe because their continuations require specific keywords or structural tokens:

| Alt | RHS after `Import` | Inherent guard |
|---|---|---|
| `Import _ Identifier _? Equals __ "require" …` | `_` requires whitespace |
| `Import SameLineOrIndentedFurther Operator …` | `Operator` is `"operator" NonIdContinue` |
| `Import SameLineOrIndentedFurther (TypeKeyword)? ImportClause __ FromClause` | `ImportClause` needs identifier / `*` / `{` |
| **`Import SameLineOrIndentedFurther ModuleSpecifier`** | **No inherent guard — `&/\s/` added** |
| `Import:i _? UnclosedSingleLineStringLiteral? &EOS` | `&EOS` is strict |
| `FromClause … Import …` (reverse syntax) | `from` keyword required first |

## Test plan
- [x] Full test suite passes (3870 passing, 19 pending).
- [x] Typecheck within baseline (888).
- [x] Smoke tests: `imports = 1`, `import.meta.url`, `import("foo")`, `import x = require("foo")`, `import type { Foo }`, `import operator { add }`, `from "x" import { y }`, `import * as x`, `import { x, y }`, `import x from "foo" with { type: "json" }`.