### PR TITLE
Lift `&` past `for` body in `when` clause

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5112,6 +5112,10 @@ ForStatementControlWithWhen
           type: "IfStatement",
           then: block,
           children: ["if (!", makeLeftHandSideExpression(trimFirstSpace(condition)), ") ", block],
+          // & placeholders in the condition came from outside the for-body,
+          // so they should lift past it (otherwise `continue` ends up trapped
+          // inside an arrow function — issue #1788).
+          implicitLift: true,
         }, ";"]
       ],
     }

--- a/test/for.civet
+++ b/test/for.civet
@@ -1414,6 +1414,19 @@ describe "for", ->
     bigSquares = (()=>{const results=[];for (const x of y) { if (!(x > 5)) continue;results.push(x*x) }return results})()
   """
 
+  // #1788: & placeholder in when clause must lift past the for-body block
+  // so that `continue` stays inside the loop.
+  testCase """
+    when with & placeholder
+    ---
+    for x of arr when &.test(x)
+      console.log x
+    ---
+    $ => { const results=[];for (const x of arr) {if (!$.test(x)) continue;
+      results.push(console.log(x))
+    };return results;}
+  """
+
   testCase """
     generator suffix with when
     ---


### PR DESCRIPTION
## Summary
- `for x of arr when &.test(x)` was wrapping the synthetic `if (!…) continue` in an arrow function, putting `continue` outside the loop and producing a syntax error.
- The arrow came from the `&` placeholder walker treating the for-body `BlockStatement` as the nearest lift target. Mark the synthetic `IfStatement` with `implicitLift: true` so the walker skips the for-body and lifts to the enclosing scope — same place an `&` in the for clause already lifts to.
- Fixes #1788.

## Test plan
- [x] New regression test in `test/for.civet` ("when with & placeholder")
- [x] `pnpm test` — 3925 passing
- [x] `pnpm typecheck --max-errors 888` — within baseline
- [x] Manually verified the issue's exact input produces the expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)