### PR TITLE
Unicode escape sequences `\uXXXX` in identifiers

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1531,9 +1531,10 @@ ThisLiteral
   AtThis:at $( Hash? IdentifierName ):id ->
     // `@😊` → `this["😊"]` (matches the binding-side bracket form), but
     // private `@#😊` keeps dot access since private fields can't be
-    // string-keyed — emit `this.#u$1F60A$` instead.
-    escaped := escapeIdentifier(id)
-    if escaped !== id and not id.startsWith("#")
+    // string-keyed — emit `this.#u$1F60A$` instead. IdentifierName's
+    // own action already filtered out-of-range `\u` escapes via $skip.
+    escaped := escapeIdentifier(id)!
+    if escaped.token !== id and not id.startsWith("#")
       return {
         type: "MemberExpression",
         children: [at, {
@@ -1552,13 +1553,13 @@ ThisLiteral
       type: "MemberExpression",
       children: [at, {
         type: "PropertyAccess",
-        name: escaped,
+        name: escaped.name,
         children: [".", {
           $loc: {
             pos: $loc.pos + 1,
             length: $loc# - 1,
           },
-          token: escaped
+          token: escaped.token
         }],
       }],
       thisShorthand: true,
@@ -3329,18 +3330,24 @@ Identifier
 # https://262.ecma-international.org/#prod-IdentifierName
 IdentifierName
   /(?:\p{ID_Start}|[_$]|\\u\{[\dA-Fa-f]+\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|\\u\{[\dA-Fa-f]+\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ->
-    name := escapeIdentifier($0)
+    escaped := escapeIdentifier($0)
+    // Out-of-range codepoint (e.g. `\u{110000}`) — reject so the parser
+    // backtracks and reports a ParseError instead of crashing later.
+    return $skip unless escaped
+    { name, token } := escaped
     return {
       type: "Identifier",
       name,
-      // Original source string when escaping changed it, so property-key
-      // sites (object destructuring / literal shorthand / explicit key)
-      // can emit the user-visible name as a quoted string.
-      ...($0 !== name and { unicode: $0 }),
+      // Original source string when emission differs from source (mangling
+      // happened), so property-key sites (object destructuring / literal
+      // shorthand / explicit key) emit the user-visible name as a quoted
+      // string. `\u`-escapes for valid id chars pass through verbatim and
+      // don't need this indirection.
+      ...(token !== $0 and { unicode: $0 }),
       names: [name],
       children: [{
         $loc: $loc,
-        token: name,
+        token,
       }],
     }
 
@@ -4293,8 +4300,11 @@ ClassElementName
 PrivateIdentifier
   $(Hash IdentifierName):id ->
     // Private fields can't be string-keyed, so escape unicode in-place
-    // (`#😊` → `#u$1F60A$`) without setting `unicode` — keeps `#`-dot access.
-    name := escapeIdentifier(id)
+    // (`#😊` → `#u$1F60A$`) without setting `unicode` — keeps `#`-dot
+    // access. IdentifierName's action already filtered out-of-range
+    // escapes; we always emit the canonical/mangled name since `#`-dot
+    // access can't reference the verbatim escape form anyway.
+    name := escapeIdentifier(id)!.name
     return {
       type: "Identifier",
       name,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3324,11 +3324,11 @@ SymbolElement
 # JS-valid form.
 Identifier
   # perf: assertion to exit early
-  /(?=\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ !ReservedWord IdentifierName:id -> id
+  /(?=\p{ID_Start}|[_$\\]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ !ReservedWord IdentifierName:id -> id
 
 # https://262.ecma-international.org/#prod-IdentifierName
 IdentifierName
-  /(?:\p{ID_Start}|[_$]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ->
+  /(?:\p{ID_Start}|[_$]|\\u\{[\dA-Fa-f]+\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|\\u\{[\dA-Fa-f]+\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ->
     name := escapeIdentifier($0)
     return {
       type: "Identifier",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1529,11 +1529,9 @@ ThisLiteral
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
   AtThis:at $( Hash? IdentifierName ):id ->
-    // `@😊` → `this["😊"]` (matches the binding-side bracket form), but
-    // private `@#😊` keeps dot access since private fields can't be
-    // string-keyed — emit `this.#u$1F60A$` instead. IdentifierName's
-    // own action already filtered out-of-range `\u` escapes via $skip.
-    escaped := escapeIdentifier(id)!
+    // `@😊` → `this["😊"]` to match the binding-side bracket form, but
+    // `@#😊` → `this.#u$1F60A$` since private fields can't be string-keyed.
+    escaped := escapeIdentifier(id)
     if escaped.token !== id and not id.startsWith("#")
       return {
         type: "MemberExpression",
@@ -3328,21 +3326,19 @@ Identifier
   /(?=\p{ID_Start}|[_$\\]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ !ReservedWord IdentifierName:id -> id
 
 # https://262.ecma-international.org/#prod-IdentifierName
+# Two sequential char-class groups (start, then continue*). Each alternates
+# between ID_Start/ID_Continue, `_$` (plus ZWJ/ZWNJ in continue), `\uXXXX`
+# / `\u{X+}` escapes capped at 0x10FFFF, and non-ASCII non-id codepoints
+# not claimed by Civet operators (the long inline exclusion list).
 IdentifierName
-  /(?:\p{ID_Start}|[_$]|\\u\{[\dA-Fa-f]+\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|\\u\{[\dA-Fa-f]+\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ->
-    escaped := escapeIdentifier($0)
-    // Out-of-range codepoint (e.g. `\u{110000}`) — reject so the parser
-    // backtracks and reports a ParseError instead of crashing later.
-    return $skip unless escaped
-    { name, token } := escaped
+  /(?:\p{ID_Start}|[_$]|\\u\{0*(?:[\dA-Fa-f]{1,5}|10[\dA-Fa-f]{4})\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|\\u\{0*(?:[\dA-Fa-f]{1,5}|10[\dA-Fa-f]{4})\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ->
+    { name, token } := escapeIdentifier($0)
     return {
       type: "Identifier",
       name,
-      // Original source string when emission differs from source (mangling
-      // happened), so property-key sites (object destructuring / literal
-      // shorthand / explicit key) emit the user-visible name as a quoted
-      // string. `\u`-escapes for valid id chars pass through verbatim and
-      // don't need this indirection.
+      // Source string when emission was mangled, so property-key sites
+      // (destructuring / shorthand / explicit key) can requote with the
+      // user-visible name. Verbatim `\u`-escapes don't need it.
       ...(token !== $0 and { unicode: $0 }),
       names: [name],
       children: [{
@@ -4299,12 +4295,9 @@ ClassElementName
 
 PrivateIdentifier
   $(Hash IdentifierName):id ->
-    // Private fields can't be string-keyed, so escape unicode in-place
-    // (`#😊` → `#u$1F60A$`) without setting `unicode` — keeps `#`-dot
-    // access. IdentifierName's action already filtered out-of-range
-    // escapes; we always emit the canonical/mangled name since `#`-dot
-    // access can't reference the verbatim escape form anyway.
-    name := escapeIdentifier(id)!.name
+    // Private fields can't be string-keyed, so emit the mangled name
+    // directly (`#😊` → `#u$1F60A$`); no `unicode` indirection.
+    name := escapeIdentifier(id).name
     return {
       type: "Identifier",
       name,

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -1,23 +1,38 @@
 import { gatherRecursive } from ./traversal.civet
 import type { Identifier } from ./types.civet
 
-// Escape non-identifier Unicode codepoints to `u$<HEX>$` so the result is
-// a valid JS identifier. The trailing `$` terminates each codepoint so
+// Compute canonical `name` (for binding / ref resolution) and emitted JS
+// `token` from an identifier source string. Non-identifier Unicode
+// codepoints (emoji, math symbols not claimed as operators) are mangled to
+// `u$<HEX>$` for both — the trailing `$` terminates each codepoint so
 // `pre😊post` → `preu$1F60A$post` is unambiguous. `\p{ID_Continue}` chars
-// (letters / digits / combining marks like `é`, `ő`) pass through unchanged.
-// Unicode escape sequences (`\uXXXX` and `\u{X+}`) are decoded first so
-// e.g. `a` and `a` produce the same name.
-function escapeIdentifier(raw: string): string
-  decoded := raw.replace /\\u\{([\dA-Fa-f]+)\}|\\u([\dA-Fa-f]{4})/g, (_, braces, simple) =>
-    String.fromCodePoint parseInt(braces ?? simple, 16)
-  result .= ""
-  for char of decoded
-    cp := char.codePointAt(0)!
-    if cp > 0x7F and not /\p{ID_Continue}/u.test(char)
-      result += `u$${cp.toString(16).toUpperCase()}$`
+// (letters / digits / combining marks like `é`, `ő`) pass through.
+// `\uXXXX` and `\u{X+}` escapes are decoded into `name` so `a` and
+// `a` resolve to the same binding; in `token` they pass through verbatim
+// when they spell a valid JS identifier char (JS treats `a` ≡ `a`),
+// and are mangled to `u$<HEX>$` only when they decode to a non-ID char.
+// Returns `undefined` if any escape decodes to a codepoint > 0x10FFFF
+// (invalid per ECMAScript) so the caller can reject the match.
+function escapeIdentifier(raw: string): { name: string, token: string } | undefined
+  name .= ""
+  token .= ""
+  for m of raw.matchAll /\\u\{([\dA-Fa-f]+)\}|\\u([\dA-Fa-f]{4})|[\s\S]/gu
+    [unit, brace, simple] := m
+    cp .= 0
+    if brace? or simple?
+      cp = parseInt (brace ?? simple)!, 16
+      return undefined if cp > 0x10FFFF
     else
-      result += char
-  result
+      cp = unit.codePointAt(0)!
+    char := String.fromCodePoint cp
+    if cp > 0x7F and not /\p{ID_Continue}/u.test(char)
+      mangled := `u$${cp.toString(16).toUpperCase()}$`
+      name += mangled
+      token += mangled
+    else
+      name += char
+      token += unit
+  { name, token }
 
 // In property-key positions, emit the source as a quoted string so the
 // lookup uses the user-visible name instead of the escaped form.

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -1,29 +1,22 @@
 import { gatherRecursive } from ./traversal.civet
 import type { Identifier } from ./types.civet
 
-// Compute canonical `name` (for binding / ref resolution) and emitted JS
-// `token` from an identifier source string. Non-identifier Unicode
-// codepoints (emoji, math symbols not claimed as operators) are mangled to
-// `u$<HEX>$` for both — the trailing `$` terminates each codepoint so
-// `pre😊post` → `preu$1F60A$post` is unambiguous. `\p{ID_Continue}` chars
-// (letters / digits / combining marks like `é`, `ő`) pass through.
-// `\uXXXX` and `\u{X+}` escapes are decoded into `name` so `a` and
-// `a` resolve to the same binding; in `token` they pass through verbatim
-// when they spell a valid JS identifier char (JS treats `a` ≡ `a`),
-// and are mangled to `u$<HEX>$` only when they decode to a non-ID char.
-// Returns `undefined` if any escape decodes to a codepoint > 0x10FFFF
-// (invalid per ECMAScript) so the caller can reject the match.
-function escapeIdentifier(raw: string): { name: string, token: string } | undefined
+// Returns canonical `name` (for binding lookup) and emitted JS `token`.
+// Non-id-continue codepoints (emoji, non-operator math symbols) mangle to
+// `u$<HEX>$` in both — trailing `$` keeps `pre😊post` → `preu$1F60A$post`
+// unambiguous. `\uXXXX` / `\u{X+}` escapes decode for `name` (so `a`
+// binds to `a`); `token` keeps them verbatim when they spell a valid id
+// char (JS treats `a` ≡ `a`), mangling otherwise.
+// IdentifierName bounds `\u{X}` to ≤ 0x10FFFF, so `fromCodePoint` is safe.
+function escapeIdentifier(raw: string): { name: string, token: string }
   name .= ""
   token .= ""
   for m of raw.matchAll /\\u\{([\dA-Fa-f]+)\}|\\u([\dA-Fa-f]{4})|[\s\S]/gu
     [unit, brace, simple] := m
-    cp .= 0
-    if brace? or simple?
-      cp = parseInt (brace ?? simple)!, 16
-      return undefined if cp > 0x10FFFF
+    cp := if brace? or simple?
+      parseInt (brace ?? simple)!, 16
     else
-      cp = unit.codePointAt(0)!
+      unit.codePointAt(0)!
     char := String.fromCodePoint cp
     if cp > 0x7F and not /\p{ID_Continue}/u.test(char)
       mangled := `u$${cp.toString(16).toUpperCase()}$`

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -11,7 +11,7 @@ import type { Identifier } from ./types.civet
 function escapeIdentifier(raw: string): { name: string, token: string }
   name .= ""
   token .= ""
-  for m of raw.matchAll /\\u\{([\dA-Fa-f]+)\}|\\u([\dA-Fa-f]{4})|[\s\S]/gu
+  for m of raw.matchAll /\\u\{([\dA-Fa-f]+)\}|\\u([\dA-Fa-f]{4})|./gsu
     [unit, brace, simple] := m
     cp := if brace? or simple?
       parseInt (brace ?? simple)!, 16

--- a/source/parser/identifier.civet
+++ b/source/parser/identifier.civet
@@ -5,9 +5,13 @@ import type { Identifier } from ./types.civet
 // a valid JS identifier. The trailing `$` terminates each codepoint so
 // `pre😊post` → `preu$1F60A$post` is unambiguous. `\p{ID_Continue}` chars
 // (letters / digits / combining marks like `é`, `ő`) pass through unchanged.
+// Unicode escape sequences (`\uXXXX` and `\u{X+}`) are decoded first so
+// e.g. `a` and `a` produce the same name.
 function escapeIdentifier(raw: string): string
+  decoded := raw.replace /\\u\{([\dA-Fa-f]+)\}|\\u([\dA-Fa-f]{4})/g, (_, braces, simple) =>
+    String.fromCodePoint parseInt(braces ?? simple, 16)
   result .= ""
-  for char of raw
+  for char of decoded
     cp := char.codePointAt(0)!
     if cp > 0x7F and not /\p{ID_Continue}/u.test(char)
       result += `u$${cp.toString(16).toUpperCase()}$`

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -522,14 +522,11 @@ describe "identifier", ->
       }
     """
 
-    // -- Unicode escape sequences (\\uXXXX and \\u{X+}) in identifiers are
-    //    valid per ECMAScript and resolve to the same binding as the
-    //    decoded character form. JS treats the escape and direct spellings
-    //    as the same identifier, so we emit them verbatim — only the
-    //    binding side decodes for ref resolution.
+    // -- `\\uXXXX` / `\\u{X+}` escapes bind canonically (so `\\u0061` and
+    //    `a` are the same) but emit verbatim — JS treats them as one.
 
     testCase """
-      hex escape in identifier start preserved verbatim
+      hex escape in identifier start
       ---
       let \\u0061 = 10
       ---
@@ -537,7 +534,7 @@ describe "identifier", ->
     """
 
     testCase """
-      braced hex escape in identifier start preserved verbatim
+      braced hex escape in identifier start
       ---
       let \\u{61} = 10
       ---
@@ -555,7 +552,7 @@ describe "identifier", ->
     """
 
     testCase """
-      escape mid-identifier preserved verbatim
+      escape mid-identifier
       ---
       let a\\u0030 = 1
       ---
@@ -580,11 +577,8 @@ describe "identifier", ->
       console.log(u$1F60A$)
     """
 
-    // -- Out-of-range braced codepoints (> 0x10FFFF) rejected — without the
-    //    guard, escapeIdentifier would crash on String.fromCodePoint. JS's
-    //    own reserved-word check on the decoded SV catches escape-spelled
-    //    keywords like `\\u0069\\u0066` (= `if`) at runtime, so Civet
-    //    passes them through verbatim and lets JS reject the output.
+    // -- Codepoints > 0x10FFFF are invalid per ECMAScript; the grammar
+    //    rejects them so `String.fromCodePoint` never crashes.
 
     throws """
       out-of-range braced codepoint rejects

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -524,22 +524,24 @@ describe "identifier", ->
 
     // -- Unicode escape sequences (\\uXXXX and \\u{X+}) in identifiers are
     //    valid per ECMAScript and resolve to the same binding as the
-    //    decoded character form.
+    //    decoded character form. JS treats the escape and direct spellings
+    //    as the same identifier, so we emit them verbatim — only the
+    //    binding side decodes for ref resolution.
 
     testCase """
-      hex escape in identifier start
+      hex escape in identifier start preserved verbatim
       ---
       let \\u0061 = 10
       ---
-      let a = 10
+      let \\u0061 = 10
     """
 
     testCase """
-      braced hex escape in identifier start
+      braced hex escape in identifier start preserved verbatim
       ---
       let \\u{61} = 10
       ---
-      let a = 10
+      let \\u{61} = 10
     """
 
     testCase """
@@ -548,16 +550,16 @@ describe "identifier", ->
       let \\u0061 = 5
       console.log a
       ---
-      let a = 5
+      let \\u0061 = 5
       console.log(a)
     """
 
     testCase """
-      escape mid-identifier
+      escape mid-identifier preserved verbatim
       ---
       let a\\u0030 = 1
       ---
-      let a0 = 1
+      let a\\u0030 = 1
     """
 
     testCase """
@@ -576,6 +578,20 @@ describe "identifier", ->
       ---
       let u$1F60A$ = 3
       console.log(u$1F60A$)
+    """
+
+    // -- Out-of-range braced codepoints (> 0x10FFFF) rejected — without the
+    //    guard, escapeIdentifier would crash on String.fromCodePoint. JS's
+    //    own reserved-word check on the decoded SV catches escape-spelled
+    //    keywords like `\\u0069\\u0066` (= `if`) at runtime, so Civet
+    //    passes them through verbatim and lets JS reject the output.
+
+    throws """
+      out-of-range braced codepoint rejects
+      ---
+      let \\u{110000} = 1
+      ---
+      ParseError
     """
 
     // -- Combining marks and non-ASCII digits are valid mid-identifier

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -522,6 +522,62 @@ describe "identifier", ->
       }
     """
 
+    // -- Unicode escape sequences (\\uXXXX and \\u{X+}) in identifiers are
+    //    valid per ECMAScript and resolve to the same binding as the
+    //    decoded character form.
+
+    testCase """
+      hex escape in identifier start
+      ---
+      let \\u0061 = 10
+      ---
+      let a = 10
+    """
+
+    testCase """
+      braced hex escape in identifier start
+      ---
+      let \\u{61} = 10
+      ---
+      let a = 10
+    """
+
+    testCase """
+      escape and direct name refer to same binding
+      ---
+      let \\u0061 = 5
+      console.log a
+      ---
+      let a = 5
+      console.log(a)
+    """
+
+    testCase """
+      escape mid-identifier
+      ---
+      let a\\u0030 = 1
+      ---
+      let a0 = 1
+    """
+
+    testCase """
+      astral escape mangles like the codepoint
+      ---
+      let \\u{1F60A} = 3
+      ---
+      let u$1F60A$ = 3
+    """
+
+    testCase """
+      reference astral escape resolves to mangled binding
+      ---
+      let 😊 = 3
+      console.log \\u{1F60A}
+      ---
+      let u$1F60A$ = 3
+      console.log(u$1F60A$)
+    """
+
     // -- Combining marks and non-ASCII digits are valid mid-identifier
     //    (\p{ID_Continue}) but reject as identifier starts.
 


### PR DESCRIPTION
Per ECMAScript, identifiers may include \uXXXX and \u{X+} escape sequences. Extend the IdentifierName regex to accept them and decode in escapeIdentifier so the escape and direct-character spellings resolve to the same binding.

Fixes #2039

Generated with [Claude Code](https://claude.ai/code)