### PR TITLE
Honor autoConst/autoLet for `export x = …`, allow `export` destructuring

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6374,7 +6374,8 @@ ExportDeclaration
   # NOTE: Declaration and VariableStatement should come before NamedExports
   # so that NamedExports doesn't grab function, async, type, var, etc.
   # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
-  Decorators?:dec Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
+  # NOTE: NamedExportsNotAssigned defers `export {a} = obj` to ExportVarDec (#1321)
+  Decorators?:dec Export __ ( Declaration / VariableStatement / NamedExportsNotAssigned / ExportVarDec ):declaration ->
     // `export 😊 := 3` → `const u$…$ = 3; export { u$…$ as "😊" }`
     // (JS forbids string-named exports inside `export const`).
     splitClause := buildExportSplitClause(declaration)
@@ -6387,12 +6388,24 @@ ExportDeclaration
       }
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
 
+# Like TypeAndNamedExports, but only when not followed by `=` so that
+# `export {a} = obj` falls through to ExportVarDec (#1321).
+NamedExportsNotAssigned
+  TypeAndNamedExports:exports !( __ Equals ) ->
+    return exports
+
 # CoffeeScript style `export x = 3` -> `export var x = 3`
+# Respect autoConst/autoLet so `export x = 3` becomes `export const x = 3`
+# or `export let x = 3` accordingly (#1321).  `autoExport` flags the
+# declaration so auto-dec.civet can split it into `<assign>; export {names}`
+# when any name is already declared (avoiding TDZ/redeclaration errors).
 ExportVarDec
   InsertVar VariableDeclarationList ->
+    token := config.autoConst ? "const " : config.autoLet ? "let " : "var "
     return {
       ...$2,
-      children: [$1, ...$2.children]
+      children: [{...$1, token}, ...$2.children]
+      autoExport: true
     }
 
 # https://262.ecma-international.org/#prod-ExportFromClause

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6374,8 +6374,7 @@ ExportDeclaration
   # NOTE: Declaration and VariableStatement should come before NamedExports
   # so that NamedExports doesn't grab function, async, type, var, etc.
   # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
-  # NOTE: NamedExportsNotAssigned defers `export {a} = obj` to ExportVarDec (#1321)
-  Decorators?:dec Export __ ( Declaration / VariableStatement / NamedExportsNotAssigned / ExportVarDec ):declaration ->
+  Decorators?:dec Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
     // `export 😊 := 3` → `const u$…$ = 3; export { u$…$ as "😊" }`
     // (JS forbids string-named exports inside `export const`).
     splitClause := buildExportSplitClause(declaration)
@@ -6387,12 +6386,6 @@ ExportDeclaration
         children: [dec, declaration, splitClause],  // omit Export keyword + ws
       }
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
-
-# Like TypeAndNamedExports, but only when not followed by `=` so that
-# `export {a} = obj` falls through to ExportVarDec (#1321).
-NamedExportsNotAssigned
-  TypeAndNamedExports:exports !( __ Equals ) ->
-    return exports
 
 # CoffeeScript style `export x = 3` -> `export var x = 3`
 # Respect autoConst/autoLet so `export x = 3` becomes `export const x = 3`
@@ -6414,10 +6407,12 @@ ExportFromClause
   TypeAndNamedExports
 
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
+# `!( __ Equals )` defers `export {a} = obj` to ExportVarDec (#1321);
+# the only other caller (ExportFromClause) is always followed by `from`.
 TypeAndNamedExports
-  ( TypeKeyword __ )? NamedExports ->
+  ( TypeKeyword __ )? NamedExports !( __ Equals ) ->
     return $2 unless $1
-    return { ts: true, children: $0 }
+    return { ts: true, children: [$1, $2] }
 
 # https://262.ecma-international.org/#prod-NamedExports
 NamedExports

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6391,7 +6391,8 @@ ExportDeclaration
 # Respect autoConst/autoLet so `export x = 3` becomes `export const x = 3`
 # or `export let x = 3` accordingly (#1321).  `autoExport` flags the
 # declaration so auto-dec.civet can split it into `<assign>; export {names}`
-# when any name is already declared (avoiding TDZ/redeclaration errors).
+# when any name is already declared, pre-declaring any new ones with `let`
+# (avoiding TDZ/redeclaration errors).
 ExportVarDec
   InsertVar VariableDeclarationList ->
     token := config.autoConst ? "const " : config.autoLet ? "let " : "var "

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -17,6 +17,10 @@ import {
   getIndent
 } from ./block.civet
 
+import {
+  buildExportSplitClause
+} from ./identifier.civet
+
 { getConfig } from "../parser.hera"
 
 function findDecs(statements: ASTNode)
@@ -63,8 +67,33 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
   fnNodes := gatherNodes statements, isFunction
   forNodes := gatherNodes statements, .type is "ForStatement"
 
+  // `export x = …` from ExportVarDec under autoConst/autoLet would emit
+  // `export let x = …`, which collides if `x` is already declared. Rewrite
+  // such statements to `x = …; export {x}` so the prior binding is reused.
+  function splitAutoExport(statement): boolean
+    exportDec := statement[1]
+    return false unless exportDec?.type is "ExportDeclaration"
+    innerDecl := exportDec.declaration
+    return false unless innerDecl?.autoExport
+    declNames := innerDecl.names
+    return false unless declNames?# and declNames.every hasDec
+
+    bareDeclChildren := innerDecl.children.slice(1)
+    needsParens := !!innerDecl.bindings?.some (b) =>
+      b.pattern?.type is "ObjectBindingPattern"
+    splitClause := buildExportSplitClause(innerDecl) ?? `; export { ${declNames.join(", ")} }`
+    exportDec.children =
+      if needsParens
+        ["(", bareDeclChildren, ")", splitClause]
+      else
+        [bareDeclChildren, splitClause]
+    return true
+
   targetStatements: StatementTuple[] .= []
   for each statement of statements
+    if splitAutoExport statement
+      targetStatements.push statement
+      continue
     nodes := gatherBlockOrOther statement
     undeclaredIdentifiers .= []
     for each node of nodes

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -71,23 +71,30 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
   // `export x = …` from ExportVarDec under autoConst/autoLet would emit
   // `export let x = …`, which collides if `x` is already declared. Rewrite
   // such statements to `x = …; export {x}` so the prior binding is reused.
+  // For destructuring exports where only some names are already declared,
+  // pre-declare the rest with `let` so the assignment binds them all.
   function splitAutoExport(statement: any): boolean
     exportDec := statement[1]
     return false unless exportDec?.type is "ExportDeclaration"
     innerDecl := exportDec.declaration
     return false unless innerDecl?.autoExport
     declNames := innerDecl.names
-    return false unless declNames?# and declNames.every hasDec
+    return false unless declNames?# and declNames.some hasDec
 
+    newNames := declNames.filter (n: string) => not hasDec n
     bareDeclChildren := innerDecl.children.slice(1)
     needsParens := !!innerDecl.bindings?.some (b: Binding) =>
       b.pattern?.type is "ObjectBindingPattern"
     splitClause := buildExportSplitClause(innerDecl) ?? `; export { ${declNames.join(", ")} }`
+    preDecl := newNames# ? [`let ${newNames.join(", ")}; `] : []
     exportDec.children =
       if needsParens
-        ["(", bareDeclChildren, ")", splitClause]
+        [...preDecl, "(", bareDeclChildren, ")", splitClause]
       else
-        [bareDeclChildren, splitClause]
+        [...preDecl, bareDeclChildren, splitClause]
+
+    for each name of newNames
+      currentScope.add name
     return true
 
   targetStatements: StatementTuple[] .= []

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -1,5 +1,6 @@
 import type {
   ASTNode
+  Binding
   BlockStatement
 } from ./types.civet
 
@@ -79,7 +80,7 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
     return false unless declNames?# and declNames.every hasDec
 
     bareDeclChildren := innerDecl.children.slice(1)
-    needsParens := !!innerDecl.bindings?.some (b: any) =>
+    needsParens := !!innerDecl.bindings?.some (b: Binding) =>
       b.pattern?.type is "ObjectBindingPattern"
     splitClause := buildExportSplitClause(innerDecl) ?? `; export { ${declNames.join(", ")} }`
     exportDec.children =

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -70,7 +70,7 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
   // `export x = …` from ExportVarDec under autoConst/autoLet would emit
   // `export let x = …`, which collides if `x` is already declared. Rewrite
   // such statements to `x = …; export {x}` so the prior binding is reused.
-  function splitAutoExport(statement): boolean
+  function splitAutoExport(statement: any): boolean
     exportDec := statement[1]
     return false unless exportDec?.type is "ExportDeclaration"
     innerDecl := exportDec.declaration
@@ -79,7 +79,7 @@ function createConstLetDecs(statements, scopes, letOrConst: "let" | "const"): vo
     return false unless declNames?# and declNames.every hasDec
 
     bareDeclChildren := innerDecl.children.slice(1)
-    needsParens := !!innerDecl.bindings?.some (b) =>
+    needsParens := !!innerDecl.bindings?.some (b: any) =>
       b.pattern?.type is "ObjectBindingPattern"
     splitClause := buildExportSplitClause(innerDecl) ?? `; export { ${declNames.join(", ")} }`
     exportDec.children =

--- a/test/auto-const.civet
+++ b/test/auto-const.civet
@@ -482,6 +482,15 @@ describe "auto-const", ->
   """
 
   testCase """
+    export from is unaffected
+    ---
+    "civet auto-const"
+    export {x} from "./mod"
+    ---
+    export {x} from "./mod"
+  """
+
+  testCase """
     const dec inside block
     ---
     "civet auto-const"

--- a/test/auto-const.civet
+++ b/test/auto-const.civet
@@ -428,16 +428,57 @@ describe "auto-const", ->
   """
 
 
-  // This case is disabled because the 'export var' cannot be detected due to the var token is not in declaration.
   testCase """
     export implicit const dec
     ---
     "civet auto-const"
-    a = 1
     export a = 2
     ---
-    a = 1
-    export var a = 2
+    export const a = 2
+  """
+
+  testCase """
+    export implicit const arrow function (#1321)
+    ---
+    "civet auto-const"
+    export func = =>
+    ---
+    export const func = () => {}
+  """
+
+  testCase """
+    export implicit const destructuring (#1321)
+    ---
+    "civet auto-const"
+    str = "string"
+    export {length} = str
+    ---
+    const str = "string"
+    export const {length} = str
+  """
+
+  testCase """
+    export splits when name already declared
+    ---
+    "civet auto-const"
+    let a = 1
+    export a = 2
+    ---
+    let a = 1
+    a = 2; export { a }
+  """
+
+  testCase """
+    export splits destructuring when names already declared
+    ---
+    "civet auto-const"
+    let length = 0
+    str = "string"
+    export {length} = str
+    ---
+    let length = 0
+    const str = "string";
+    ({length} = str); export { length }
   """
 
   testCase """

--- a/test/auto-const.civet
+++ b/test/auto-const.civet
@@ -482,6 +482,17 @@ describe "auto-const", ->
   """
 
   testCase """
+    export splits destructuring when only some names already declared
+    ---
+    "civet auto-const"
+    let a = 1
+    export {a, b} = obj
+    ---
+    let a = 1
+    let b; ({a, b} = obj); export { a, b }
+  """
+
+  testCase """
     export from is unaffected
     ---
     "civet auto-const"

--- a/test/auto-let.civet
+++ b/test/auto-let.civet
@@ -428,16 +428,33 @@ describe "auto-let", ->
   """
 
 
-  // This case is disabled because the 'export var' cannot be detected due to the var token is not in declaration.
   testCase """
     export implicit let dec
+    ---
+    "civet auto-let"
+    export a = 2
+    ---
+    export let a = 2
+  """
+
+  testCase """
+    export implicit let destructuring
+    ---
+    "civet auto-let"
+    export {a, b} = obj
+    ---
+    export let {a, b} = obj
+  """
+
+  testCase """
+    export splits when name already assigned
     ---
     "civet auto-let"
     a = 1
     export a = 2
     ---
-    a = 1
-    export var a = 2
+    let a = 1
+    a = 2; export { a }
   """
 
   testCase """

--- a/test/export.civet
+++ b/test/export.civet
@@ -203,6 +203,22 @@ describe "export", ->
   """
 
   testCase """
+    export implicit var destructuring (#1321)
+    ---
+    export {a, b} = obj
+    ---
+    export var {a, b} = obj
+  """
+
+  testCase """
+    export implicit var arrow (#1321)
+    ---
+    export func = =>
+    ---
+    export var func = () => {}
+  """
+
+  testCase """
     implicit braces from
     ---
     export a, b, c from "./cool.js"


### PR DESCRIPTION
Fixes #1321.

## Cause

Two separate bugs under `"civet autoConst"`:

- `export {a} = obj` failed to parse — `TypeAndNamedExports` matched `{a}` as a re-export clause before `ExportVarDec` could try the initializer form.
- `export func = =>` parsed but always emitted `export var func = …`, ignoring autoConst/autoLet entirely (only the `ExportVarDec` shorthand was affected; `export x := …` already worked).

## Approach

- `TypeAndNamedExports` gets a `!( __ Equals )` lookahead so `export {a} = obj` falls through to `ExportVarDec`. The only other caller (`ExportFromClause`) is always followed by `from`, so the constraint is safe.
- `ExportVarDec` reads `config.autoConst` / `config.autoLet` and inserts `const ` / `let ` / `var ` accordingly, and tags the declaration with `autoExport: true`.
- In `auto-dec.civet`, when an `autoExport` declaration's names are already declared in scope, `splitAutoExport` rewrites the statement to `<assign>; export { names }`. This avoids the TDZ / redeclaration errors that would otherwise result from `let a = 1; export let a = 2`. Unicode-name handling reuses `buildExportSplitClause`.

The two previously-disabled tests in `auto-const.civet` and `auto-let.civet` (which documented the buggy `export var` shortcut) are updated to assert the new correct output, with separate tests added for the split path.

## Test plan

- [x] `export {a} = obj` and `export func = =>` produce `export const …` under autoConst
- [x] Same forms produce `export let …` under autoLet
- [x] No autoConst/autoLet: `export var {a, b} = obj` (previously a parse error) now compiles
- [x] `let a = 1; export a = 2` (autoConst) → `let a = 1; a = 2; export { a }` via split
- [x] Existing `export {a}`, `export {a} from "…"`, `export a, b`, unicode `export 🦀 := 3` all unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)