### PR TITLE
LSP: auto-indent on Enter for Civet block-openers

### DIFF
--- a/lsp/vscode/e2e/indentation.test.civet
+++ b/lsp/vscode/e2e/indentation.test.civet
@@ -53,6 +53,14 @@ suite 'Auto-indent on Enter (issue #170)', =>
     indent := await indentAfterEnter 'class Foo'
     assert indent >= 1, `expected indent after 'class Foo', got ${indent}`
 
+  test 'indents body after catch with bound variable', async =>
+    indent := await indentAfterEnter 'catch err'
+    assert indent >= 1, `expected indent after 'catch err', got ${indent}`
+
+  test 'indents body after catch with parenthesized binding', async =>
+    indent := await indentAfterEnter 'catch (e)'
+    assert indent >= 1, `expected indent after 'catch (e)', got ${indent}`
+
   test 'does NOT indent after a plain function call', async =>
     indent := await indentAfterEnter 'foo()'
     assert indent is 0, `expected no indent after 'foo()', got ${indent}`

--- a/lsp/vscode/e2e/indentation.test.civet
+++ b/lsp/vscode/e2e/indentation.test.civet
@@ -1,0 +1,62 @@
+// Issue #170: pressing Enter at the end of a block-opening line should
+// auto-indent the next line.  VSCode applies this via the language
+// configuration's `indentationRules.increaseIndentPattern`; this suite
+// exercises the common block-openers in Civet.
+
+* as vscode from vscode
+assert from assert
+
+// Open an untitled Civet doc with the given content and place cursor at end.
+async function openCivetAtEnd(content: string)
+  doc := await vscode.workspace.openTextDocument({ language: 'civet', content })
+  editor := await vscode.window.showTextDocument doc
+  lastLine := doc.lineAt doc.lineCount - 1
+  pos := lastLine.range.end
+  editor.selection = new vscode.Selection pos, pos
+  { doc, editor }
+
+// Length of leading whitespace on a line of text.
+indentOf := (text: string): number =>
+  text.match(/^\s*/)![0].length
+
+// Open a doc, press Enter at end, return the resulting next-line indent.
+indentAfterEnter := async (content: string): Promise<number> =>
+  { doc } := await openCivetAtEnd content
+  await vscode.commands.executeCommand 'type', { text: '\n' }
+  // The line we care about is right after the last line of the original
+  // content.  Count lines in the input so callers can pass multi-line setups.
+  newLineIndex := content.split('\n').length
+  indentOf doc.lineAt(newLineIndex).text
+
+suite 'Auto-indent on Enter (issue #170)', =>
+  test 'indents body after function declaration', async =>
+    indent := await indentAfterEnter 'function foo()'
+    assert indent >= 1, `expected indent after 'function foo()', got ${indent}`
+
+  test 'indents body after arrow function', async =>
+    indent := await indentAfterEnter 'f := =>'
+    assert indent >= 1, `expected indent after 'f := =>', got ${indent}`
+
+  test "indents body after thin arrow function", async =>
+    indent := await indentAfterEnter 'f := () ->'
+    assert indent >= 1, `expected indent after 'f := () ->', got ${indent}`
+
+  test 'indents body after if statement', async =>
+    indent := await indentAfterEnter 'if cond'
+    assert indent >= 1, `expected indent after 'if cond', got ${indent}`
+
+  test 'indents body after for loop', async =>
+    indent := await indentAfterEnter 'for x of arr'
+    assert indent >= 1, `expected indent after 'for x of arr', got ${indent}`
+
+  test 'indents body after class declaration', async =>
+    indent := await indentAfterEnter 'class Foo'
+    assert indent >= 1, `expected indent after 'class Foo', got ${indent}`
+
+  test 'does NOT indent after a plain function call', async =>
+    indent := await indentAfterEnter 'foo()'
+    assert indent is 0, `expected no indent after 'foo()', got ${indent}`
+
+  test 'does NOT indent after an inline-then conditional', async =>
+    indent := await indentAfterEnter 'if cond then x else y'
+    assert indent is 0, `expected no indent after inline-then, got ${indent}`

--- a/lsp/vscode/syntaxes/civet-configuration.json
+++ b/lsp/vscode/syntaxes/civet-configuration.json
@@ -26,5 +26,9 @@
     ["'", "'"],
     ["\"", "\""],
     ["`", "`"]
-  ]
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else)\\b(?!.*\\bthen\\b).*$)",
+    "decreaseIndentPattern": "^\\s*(?:else\\b|catch\\b|finally\\b|when\\b|case\\b|[)\\]}])"
+  }
 }

--- a/lsp/vscode/syntaxes/civet-configuration.json
+++ b/lsp/vscode/syntaxes/civet-configuration.json
@@ -28,7 +28,7 @@
     ["`", "`"]
   ],
   "indentationRules": {
-    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else)\\b(?!.*\\bthen\\b).*$)",
+    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\\b(?!.*\\bthen\\b).*$)",
     "decreaseIndentPattern": "^\\s*(?:else\\b|catch\\b|finally\\b|when\\b|case\\b|[)\\]}])"
   }
 }

--- a/lsp/zed/languages/civet/config.toml
+++ b/lsp/zed/languages/civet/config.toml
@@ -7,5 +7,5 @@ line_comments = ["// "]
 # no lookaround, so the inline-`then` exclusion from the VSCode pattern is
 # omitted; lines like `if cond then x else y` will spuriously indent — outdent
 # manually.
-increase_indent_pattern = '^(?:.*(?:[({\[]|=>>|->>|=>|->|\bdo\b|\btry\b|\belse\b|\bcatch\b|\bfinally\b|\bloop\b|\bthen\b)\s*$|\s*(?:export\s+|async\s+|default\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else)\b.*$)'
+increase_indent_pattern = '^(?:.*(?:[({\[]|=>>|->>|=>|->|\bdo\b|\btry\b|\belse\b|\bcatch\b|\bfinally\b|\bloop\b|\bthen\b)\s*$|\s*(?:export\s+|async\s+|default\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\b.*$)'
 decrease_indent_pattern = '^\s*(?:else\b|catch\b|finally\b|when\b|case\b|[)\]}])'

--- a/lsp/zed/languages/civet/config.toml
+++ b/lsp/zed/languages/civet/config.toml
@@ -2,3 +2,10 @@ name = "Civet"
 grammar = "civet"
 path_suffixes = ["civet"]
 line_comments = ["// "]
+
+# Auto-indent rules (issue #170).  Zed uses the Rust `regex` crate, which has
+# no lookaround, so the inline-`then` exclusion from the VSCode pattern is
+# omitted; lines like `if cond then x else y` will spuriously indent — outdent
+# manually.
+increase_indent_pattern = '^(?:.*(?:[({\[]|=>>|->>|=>|->|\bdo\b|\btry\b|\belse\b|\bcatch\b|\bfinally\b|\bloop\b|\bthen\b)\s*$|\s*(?:export\s+|async\s+|default\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else)\b.*$)'
+decrease_indent_pattern = '^\s*(?:else\b|catch\b|finally\b|when\b|case\b|[)\]}])'


### PR DESCRIPTION
## Summary
- Closes #170 — VSCode and Zed now auto-indent the next line after a Civet block-opener (`function foo()`, `if x`, `=>`, `->`, etc.).
- Rules live in `lsp/vscode/syntaxes/civet-configuration.json` (`indentationRules`) and `lsp/zed/languages/civet/config.toml` (`increase_indent_pattern` / `decrease_indent_pattern`).
- VSCode pattern excludes inline-`then` conditionals via lookahead; Zed's Rust regex engine has no lookaround, so `if cond then x else y` falsely indents in Zed — documented in the config.

## Test plan
- [x] `lsp/vscode/e2e/indentation.test.civet` — 8 cases (6 positive block-openers, 2 negative). Full e2e suite: 52 passing.
- [ ] Manual: install Zed extension, type `if cond` + Enter, confirm the next line is indented.