### PR TITLE
Highlight docs examples using Civet TextMate grammar

### DIFF
--- a/civet.dev/.vitepress/config.mjs
+++ b/civet.dev/.vitepress/config.mjs
@@ -99,7 +99,7 @@ export default async function vitePressConfig() {
             const { tsCode } = compileCivet(code, civet, raw ? null : prettier,
               { comptime });
             const inputHtml = highlighter.codeToHtml(code, {
-              lang: 'coffee',
+              lang: 'civet',
               theme: 'one-dark-pro',
             });
             const outputHtml = highlighter.codeToHtml(tsCode, {

--- a/civet.dev/.vitepress/theme/custom.css
+++ b/civet.dev/.vitepress/theme/custom.css
@@ -247,11 +247,11 @@ h1>.info {
   }
 }
 
-.language-coffee .lang {
+.language-civet .lang {
   color: transparent !important;
 }
 
-.language-coffee .lang::after {
+.language-civet .lang::after {
   color: var(--vp-c-text-dark-3);
   content: 'civet';
 }

--- a/civet.dev/.vitepress/utils/getHighlighter.ts
+++ b/civet.dev/.vitepress/utils/getHighlighter.ts
@@ -1,5 +1,6 @@
 import { getSingletonHighlighter } from 'shiki';
 import type { Highlighter } from 'shiki';
+import civetGrammar from '../../../lsp/vscode/syntaxes/civet.json';
 
 let highlighter: Highlighter | null = null;
 
@@ -7,7 +8,7 @@ export async function getHighlighter() {
   if (!highlighter) {
     highlighter = await getSingletonHighlighter({
       themes: ['one-dark-pro'],
-      langs: ['coffee', 'tsx'],
+      langs: [{ ...civetGrammar, name: 'civet' }, 'tsx'],
     });
   }
 


### PR DESCRIPTION
Fixes #174

It's still not perfect, because our TextMate grammar isn't. In particular, this doesn't use semantic tokens. I might try to do that statically... (Full-page Playground already does it dynamically.)

## Before (coffee)

<img width="1082" height="578" alt="image" src="https://github.com/user-attachments/assets/278dae0e-0c04-4946-ac83-d9ca6914ebdc" />

## After (civet)

<img width="1065" height="550" alt="image" src="https://github.com/user-attachments/assets/39daee81-0ac4-47ec-9047-a69eff925453" />
