### PR TITLE
Pin VS Code version for tests and cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,17 @@ jobs:
           restore-keys: |
             main-${{ steps.month.outputs.ym }}
 
+      - name: Read VS Code version
+        id: vscode
+        run: |
+          version=$(jq -r '.engines.vscode | sub("^[\\^~]"; "")' lsp/vscode/package.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache VS Code download
         uses: actions/cache@v4
         with:
           path: lsp/vscode/.vscode-test
-          key: vscode-test-${{ runner.os }}-${{ hashFiles('lsp/vscode/package.json') }}
-          restore-keys: |
-            vscode-test-${{ runner.os }}-
+          key: vscode-test-${{ runner.os }}-${{ steps.vscode.outputs.version }}
 
       - name: Install and Build
         run: |

--- a/lsp/vscode/e2e/runTest.civet
+++ b/lsp/vscode/e2e/runTest.civet
@@ -1,6 +1,7 @@
 * as path from path
 { runTests } from @vscode/test-electron
 { spawn, spawnSync } from child_process
+{ readFileSync } from fs
 * as readline from readline
 
 // Strip ANSI escape codes for pattern matching (keep original for output)
@@ -56,10 +57,13 @@ else
       extensionDevelopmentPath := path.resolve(__dirname, '../../')
       extensionTestsPath := path.resolve(__dirname, './index')
       workspacePath := path.resolve(__dirname, '../fixture')
+      packageJson := JSON.parse readFileSync(path.resolve(extensionDevelopmentPath, 'package.json'), 'utf-8')
+      version := packageJson.engines.vscode.replace /^[\^~]/, ''
       extensionTestsEnv: Record<string, string> := {}
       if process.env.NODE_V8_COVERAGE
         extensionTestsEnv.NODE_V8_COVERAGE = path.resolve process.env.NODE_V8_COVERAGE
       await runTests({
+        version
         extensionDevelopmentPath
         extensionTestsPath
         launchArgs: [workspacePath]


### PR DESCRIPTION
## Summary

- Replace `hashFiles('lsp/vscode/package.json')` in the `vscode-test` cache key with the version parsed from `engines.vscode`, so the key only changes when the targeted VS Code version changes.
- Pass that same version to `runTests` so the e2e runner stops requesting `'stable'` as a moving target.
- Drop `restore-keys` for this cache — with a version-pinned key, prefix fallbacks only kept old entries warm and blocked GitHub's 7-day idle eviction.

## Why

Today's `vscode-test-${{ runner.os }}-${{ hashFiles('lsp/vscode/package.json') }}` invalidates on every edit to `lsp/vscode/package.json` — version bumps, syntax additions, etc. — even though `engines.vscode` and `@vscode/test-electron` haven't moved in over a month. The result is multiple ~1 GiB `vscode-test-*` entries per OS at any moment (currently ~9.4 GiB across 9 entries), each holding what's effectively the same VS Code download.

Tying the key to `engines.vscode` means one entry per OS until you actually bump the engine. Tying the test runner to the same value (instead of `'stable'`) keeps the cached binary aligned with the key and removes the bandwidth re-download path the cache-as-frozen-snapshot would otherwise introduce.

Expected steady-state cache footprint for this key: ~2.1 GiB total (1 entry per OS) vs ~9.4 GiB today.

## Test plan

- [ ] First run on this branch: cache miss, downloads VS Code 1.115.0, saves under vscode-test-Linux-1.115.0 / vscode-test-Windows-1.115.0.
- [ ] Second run (no package.json edits to engines): cache hit on the same key, no redownload.
- [ ] Edit an unrelated field in lsp/vscode/package.json (e.g. bump extension version) and push: cache still hits — proves the key no longer churns on irrelevant edits.
- [ ] Confirm e2e tests pass against the pinned 1.115.0 (this is the declared minimum supported version, so this is what we want CI to exercise).