### PR TITLE
Browser LSP: fix `console` types in non-DOM mode

### DIFF
--- a/lsp/server/source/browser.civet
+++ b/lsp/server/source/browser.civet
@@ -22,7 +22,29 @@ libUrls := (worker as any).CivetLspLibUrls as {
 }? ?? {}
 initialFiles: Record<string, string> :=
   '/workspace/tsconfig.json': JSON.stringify browserDefaultTsConfig
-  '/workspace/globals.d.ts': 'declare const console: { log(...args: any[]): void; error(...args: any[]): void; warn(...args: any[]): void; info(...args: any[]): void }\n'
+  '/workspace/globals.d.ts': ```
+    declare const console: {
+      assert(condition?: boolean, ...args: any[]): void;
+      clear(): void;
+      count(label?: string): void;
+      countReset(label?: string): void;
+      debug(...args: any[]): void;
+      dir(item?: any, options?: any): void;
+      dirxml(...args: any[]): void;
+      error(...args: any[]): void;
+      group(...args: any[]): void;
+      groupCollapsed(...args: any[]): void;
+      groupEnd(): void;
+      info(...args: any[]): void;
+      log(...args: any[]): void;
+      table(tabularData?: any, properties?: string[]): void;
+      time(label?: string): void;
+      timeEnd(label?: string): void;
+      timeLog(label?: string, ...args: any[]): void;
+      trace(...args: any[]): void;
+      warn(...args: any[]): void;
+    }
+    ```
 
 files := new Map<string, string>()
 for [filePath, text] of Object.entries typescriptLibFiles as Record<string, string>

--- a/lsp/server/source/lib/defaults.civet
+++ b/lsp/server/source/lib/defaults.civet
@@ -11,4 +11,5 @@ export browserDefaultTsConfig :=
     lib: ['ES2025']
     allowJs: true
     checkJs: true
+  files: ['globals.d.ts']
   include: ['**/*']

--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -8,7 +8,6 @@ vs, {
   CompletionItemKind
   DiagnosticSeverity
   DocumentSymbol
-  Position
   Range
   type RemoteConsole
   SymbolKind
@@ -18,7 +17,6 @@ vs, {
 { TextDocument } from vscode-languageserver-textdocument
 {
   flattenDiagnosticMessageText
-  forwardMap
   remapRange
   type SourcemapLines
 } from ../../../../source/ts-diagnostic.civet

--- a/lsp/server/test/worker.civet
+++ b/lsp/server/test/worker.civet
@@ -205,15 +205,17 @@ describe "worker helper", ->
           resolve params if params.diagnostics.some (diagnostic) =>
             diagnostic.source is 'typescript' and /not assignable/.test diagnostic.message
 
-      client.change 'x: number := "oops"'
       await client.start 'initial := 1'
 
+      client.change 'console.log "ok"\nx: number := "oops"'
       diagnostics := await diagnosticsPromise
       assert.equal diagnostics.uri, uri
       typeDiagnostic := diagnostics.diagnostics.find (diagnostic) =>
         diagnostic.source is 'typescript' and /not assignable/.test diagnostic.message
       assert typeDiagnostic
       assert.match typeDiagnostic.message, /Type 'string' is not assignable to type 'number'/
+      assert !diagnostics.diagnostics.some (diagnostic) =>
+        /Cannot find name 'console'/.test diagnostic.message
 
       domMissingPromise := new Promise<PublishDiagnosticsParams> (resolve) =>
         client.onDiagnostics (params) =>


### PR DESCRIPTION
There was a tiny bug in the browser default `tsconfig` that stopped our quick-and-dirty type definition of `console` when the DOM lib is turned off. This PR fixes that.

While here, I also fleshed out the `console` definition to more closely match https://console.spec.whatwg.org/, and dropped a couple of unused imports caught while typechecking.