### PR TITLE
Add -w/--watch flag for continuous compilation

### DIFF
--- a/source/cli.civet
+++ b/source/cli.civet
@@ -172,6 +172,13 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
 
   options.typescript = true if options.typecheck or options.emitDeclaration
 
+  // --watch routes through the lightweight per-file compile path; the unplugin
+  // pipeline (used for --typecheck / --emit-declaration) has its own watch
+  // semantics and would silently ignore -w otherwise.
+  if options.watch and options.typescript
+    console.error `--watch is not compatible with --typecheck or --emit-declaration`
+    errors++
+
   // CLI flag wins over env var so CI scripts can override per-invocation.
   if not options.maxErrors? and process.env.CIVET_TYPECHECK_MAX_ERRORS
     parsed := parseInt process.env.CIVET_TYPECHECK_MAX_ERRORS, 10
@@ -751,13 +758,15 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     console.error error for error of errors
     errorCount++ if errors#
 
-  if options.watch and not unplugin?
+  if options.watch
     unless filenames.length and not (filenames.length is 1 and filenames[0] is '-')
       console.error `--watch requires one or more input filenames`
       process.exit 1
     fsSync from node:fs
+    type FSWatcher = ReturnType<typeof fsSync.watch>
     console.error `Civet watching for changes... (Ctrl+C to stop)`
     debounceTimers := new Map<string, ReturnType<typeof setTimeout>>
+    watchers := new Map<string, FSWatcher>
     recompile := (filename: string): Promise<void> =>
       outputFilename := makeOutputFilename filename, options
       try
@@ -780,16 +789,37 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
         debounceTimers.delete filename
         void recompile filename
       debounceTimers.set filename, setTimeout cb, 100
-    for filename of filenames
-      continue if filename is '-'  // can't watch stdin
+    startWatching := (filename: string): void =>
       try
-        fsSync.watch filename, (eventType: string) =>
+        watcher := fsSync.watch filename, (eventType: string) =>
           return unless eventType is 'change' or eventType is 'rename'
           scheduleRebuild filename
+          // On Linux, inotify watches an inode and is invalidated by a
+          // `rename` event (the default for atomic-saving editors like
+          // vim and emacs).  Tear the watcher down and re-arm on the
+          // path so subsequent edits keep firing.
+          if eventType is 'rename'
+            watchers.get(filename)?.close()
+            watchers.delete filename
+            setTimeout (=> startWatching filename), 100
+        watchers.set filename, watcher
       catch error
         console.error `Could not watch ${filename}:`
         console.error error
-    return  // Skip unplugin.buildEnd; watchers keep the process alive
+    for filename of filenames
+      continue if filename is '-'  // can't watch stdin
+      startWatching filename
+    // Returned so tests can shut watchers down deterministically; in normal
+    // usage Ctrl+C / SIGTERM terminates the process and the OS reaps them.
+    return {
+      close: =>
+        for watcher of watchers.values()
+          watcher.close()
+        watchers.clear()
+        for timer of debounceTimers.values()
+          clearTimeout timer
+        debounceTimers.clear()
+    }
 
   process.exitCode = Math.min 255, errorCount
   if unplugin?

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -772,7 +772,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
       outputFilename := makeOutputFilename filename, options
       try
         content := await fs.readFile filename, encoding
-        output := await compile content, {...options, filename, outputFilename}
+        output := await compile content, {...options as CompilerOptions, filename, outputFilename}
         if options.output is '-'
           process.stdout.write output
         else
@@ -793,6 +793,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     startWatching := (filename: string): void =>
       try
         watcher := fsSync.watch filename, (eventType: string) =>
+          /* c8 ignore next -- fs.watch in practice only emits 'change' and 'rename'; this guards against unexpected Node-internal event types */
           return unless eventType is 'change' or eventType is 'rename'
           scheduleRebuild filename
           // On Linux, inotify watches an inode and is invalidated by a
@@ -804,13 +805,13 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
             watchers.delete filename
             setTimeout (=> startWatching filename), 100
         watchers.set filename, watcher
+      /* c8 ignore next 3 -- fsSync.watch already passed an existsSync check above; only fires on a TOCTOU race (file deleted between check and watch) or rare permission failures */
       catch error
         console.error `Could not watch ${filename}:`
         console.error error
     for filename of filenames
-      continue if filename is '-'  // can't watch stdin
-      // Pipeline already reported a load failure; avoid surfacing a
-      // duplicate "Could not watch" for the same root cause.
+      // existsSync(`-`) is false too, so this also filters stdin without a
+      // separate branch.  Pipeline already reported any load failure.
       continue unless fsSync.existsSync filename
       startWatching filename
     // Returned so tests can shut watchers down deterministically; in normal

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -768,6 +768,10 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     console.error `Civet watching for changes... (Ctrl+C to stop)`
     debounceTimers := new Map<string, ReturnType<typeof setTimeout>>
     watchers := new Map<string, FSWatcher>
+    // Re-watch timers tracked so close() can cancel them; otherwise a
+    // rename followed immediately by close() leaks a new watcher created
+    // 100 ms later into the already-cleared `watchers` map.
+    rewatchTimers := new Map<string, ReturnType<typeof setTimeout>>
     recompile := (filename: string): Promise<void> =>
       outputFilename := makeOutputFilename filename, options
       try
@@ -803,7 +807,17 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
           if eventType is 'rename'
             watchers.get(filename)?.close()
             watchers.delete filename
-            setTimeout (=> startWatching filename), 100
+            // Defensive: the original watcher is closed above, so no
+            // second rename can race the pending timer.  Kept in case
+            // a future event source breaks that invariant.
+            existing := rewatchTimers.get filename
+            /* c8 ignore next -- unreachable under the closed-watcher invariant above */
+            clearTimeout existing if existing?
+            timer := setTimeout =>
+              rewatchTimers.delete filename
+              startWatching filename
+            , 100
+            rewatchTimers.set filename, timer
         watchers.set filename, watcher
       /* c8 ignore next 3 -- fsSync.watch already passed an existsSync check above; only fires on a TOCTOU race (file deleted between check and watch) or rare permission failures */
       catch error
@@ -824,6 +838,9 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
         for timer of debounceTimers.values()
           clearTimeout timer
         debounceTimers.clear()
+        for timer of rewatchTimers.values()
+          clearTimeout timer
+        rewatchTimers.clear()
     }
 
   process.exitCode = Math.min 255, errorCount

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -179,6 +179,10 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
     console.error `--watch is not compatible with --typecheck or --emit-declaration`
     errors++
 
+  if options.watch and not filenames.some (f: string) => f is not '-'
+    console.error `--watch requires one or more input filenames`
+    errors++
+
   // CLI flag wins over env var so CI scripts can override per-invocation.
   if not options.maxErrors? and process.env.CIVET_TYPECHECK_MAX_ERRORS
     parsed := parseInt process.env.CIVET_TYPECHECK_MAX_ERRORS, 10
@@ -759,9 +763,6 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     errorCount++ if errors#
 
   if options.watch
-    unless filenames.length and not (filenames.length is 1 and filenames[0] is '-')
-      console.error `--watch requires one or more input filenames`
-      process.exit 1
     fsSync from node:fs
     type FSWatcher = ReturnType<typeof fsSync.watch>
     console.error `Civet watching for changes... (Ctrl+C to stop)`
@@ -808,6 +809,9 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
         console.error error
     for filename of filenames
       continue if filename is '-'  // can't watch stdin
+      // Pipeline already reported a load failure; avoid surfacing a
+      // duplicate "Could not watch" for the same root cause.
+      continue unless fsSync.existsSync filename
       startWatching filename
     // Returned so tests can shut watchers down deterministically; in normal
     // usage Ctrl+C / SIGTERM terminates the process and the OS reaps them.

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -43,6 +43,7 @@ export interface Options extends CompileOptions
   config?: string | false | undefined
   ast?: boolean | "raw"
   repl?: boolean
+  watch?: boolean
   typecheck?: boolean
   /**
    * Allow up to N TypeScript diagnostics before exiting non-zero.
@@ -105,6 +106,9 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
       when '-h', '--help'
         options.help = true
       when '-c', '--compile'
+        options.compile = true
+      when '-w', '--watch'
+        options.watch = true
         options.compile = true
       when '-o', '--output'
         options.output = args[++i]
@@ -173,7 +177,7 @@ export function parseArgs(args: string[], isTTY = process.stdin.isTTY): Promise<
     parsed := parseInt process.env.CIVET_TYPECHECK_MAX_ERRORS, 10
     options.maxErrors = parsed unless isNaN parsed
 
-  unless filenames.length or options.typescript or options.eval
+  unless filenames.length or options.typescript or options.eval or options.watch
     if isTTY
       options.repl = true
     else
@@ -504,6 +508,7 @@ Options:
   --version        Show the version number
   -o / --output XX Specify output directory and/or extension, or filename
   -c / --compile   Compile input files to TypeScript (or JavaScript)
+  -w / --watch     Watch input files and recompile on change (implies -c)
   -e / --eval XX   Evaluate specified code (or compile it with -c)
   --config XX      Specify a config file (default scans for a config.civet, civet.json, civetconfig.civet or civetconfig.json file, optionally in a .config directory, or starting with a .)
   --civet XX       Specify civet compiler flag, as in "civet XX" prologue
@@ -745,6 +750,46 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     process.stdout.write stdout if stdout?
     console.error error for error of errors
     errorCount++ if errors#
+
+  if options.watch and not unplugin?
+    unless filenames.length and not (filenames.length is 1 and filenames[0] is '-')
+      console.error `--watch requires one or more input filenames`
+      process.exit 1
+    fsSync from node:fs
+    console.error `Civet watching for changes... (Ctrl+C to stop)`
+    debounceTimers := new Map<string, ReturnType<typeof setTimeout>>
+    recompile := (filename: string): Promise<void> =>
+      outputFilename := makeOutputFilename filename, options
+      try
+        content := await fs.readFile filename, encoding
+        output := await compile content, {...options, filename, outputFilename}
+        if options.output is '-'
+          process.stdout.write output
+        else
+          outputDir := path.dirname outputFilename
+          await fs.mkdir outputDir, recursive: true unless outputDir is '.'
+          await fs.writeFile outputFilename, output
+          console.error `[${new Date().toLocaleTimeString()}] Compiled ${filename} -> ${outputFilename}`
+      catch error
+        console.error `[${new Date().toLocaleTimeString()}] Failed to compile ${filename}:`
+        console.error error
+    scheduleRebuild := (filename: string): void =>
+      existing := debounceTimers.get filename
+      clearTimeout existing if existing?
+      cb := =>
+        debounceTimers.delete filename
+        void recompile filename
+      debounceTimers.set filename, setTimeout cb, 100
+    for filename of filenames
+      continue if filename is '-'  // can't watch stdin
+      try
+        fsSync.watch filename, (eventType: string) =>
+          return unless eventType is 'change' or eventType is 'rename'
+          scheduleRebuild filename
+      catch error
+        console.error `Could not watch ${filename}:`
+        console.error error
+    return  // Skip unplugin.buildEnd; watchers keep the process alive
 
   process.exitCode = Math.min 255, errorCount
   if unplugin?

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1149,6 +1149,10 @@ describe "CLI --typecheck", ->
       process.chdir origCwd
 
 describe "CLI --watch", ->
+  // Coverage-instrumented CI runs are slow enough that the default
+  // 2s mocha timeout is unreliable for fs.watch-based tests; bump the
+  // whole block to 10s instead of relying on per-test @timeout calls.
+  @timeout 10000
   let tmpDir: string
   fileNum .= 0
   before ->
@@ -1192,7 +1196,6 @@ describe "CLI --watch", ->
     assert stdErr.includes('not compatible'), stdErr
 
   it "performs initial compile and recompiles on subsequent change", ->
-    @timeout 10000
     inputFile := await makeCivetTempFile "aInit := 1\n"
     let handle: any
     await captureProcess =>
@@ -1214,7 +1217,6 @@ describe "CLI --watch", ->
       handle?.close()
 
   it "logs compilation failures and keeps watching", ->
-    @timeout 10000
     inputFile := await makeCivetTempFile "xKeep := 1\n"
     let handle: any
     await captureProcess =>
@@ -1245,7 +1247,6 @@ describe "CLI --watch", ->
       handle?.close()
 
   it "writes recompiled output to stdout when -o - is set (debounced)", ->
-    @timeout 10000
     inputFile := await makeCivetTempFile "cStart := 3\n"
     let handle: any
     await captureProcess =>
@@ -1272,7 +1273,6 @@ describe "CLI --watch", ->
       handle?.close()
 
   it "re-establishes watcher after rename event (atomic-save editors)", ->
-    @timeout 10000
     inputFile := await makeCivetTempFile "fStart := 6\n"
     let handle: any
     await captureProcess =>

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -500,7 +500,14 @@ describe 'CLI makeOutputFilename', ->
     assert.equal path.dirname(result), 'build'
     assert.doesNotMatch result, /\.civet/
 
-function captureProcess(fn: => unknown | Promise<unknown>): Promise<{exitCode: number?, stdOut: string, stdErr: string}>
+// Captures stdout/stderr/exit for the duration of fn().  The live chunks
+// arrays are also passed in so tests for long-running flows (e.g. --watch)
+// can poll the captured output mid-flight without restoring streams.
+interface CaptureLive
+  stdOutChunks: string[]
+  stdErrChunks: string[]
+
+function captureProcess(fn: (live: CaptureLive) => unknown | Promise<unknown>): Promise<{exitCode: number?, stdOut: string, stdErr: string}>
   orig := {
     stdout: process.stdout.write
     stderr: process.stderr.write
@@ -524,7 +531,7 @@ function captureProcess(fn: => unknown | Promise<unknown>): Promise<{exitCode: n
     throw exit
 
   try
-    await fn()
+    await fn {stdOutChunks, stdErrChunks}
   catch err: any
     throw err unless err is exit
   finally
@@ -1200,41 +1207,34 @@ describe "CLI --watch", ->
     let handle: any
     await captureProcess =>
       handle = await cli ['-w', '--no-config', inputFile]
-    try
-      outputFile := inputFile + '.tsx'
-      content1 := await readFile outputFile, 'utf8'
-      assert content1.includes('aInit'), "initial output: " + content1
-      // fs.watch can take a few ms to arm on Linux; brief pause avoids
-      // racing the modification against the watcher's setup.
-      await new Promise (r) => setTimeout r, 50
-      await writeFile inputFile, "bAfter := 2\n"
-      await waitFor =>
-        try
-          (await readFile outputFile, 'utf8').includes 'bAfter'
-        catch
-          false
-    finally
-      handle?.close()
+      try
+        outputFile := inputFile + '.tsx'
+        content1 := await readFile outputFile, 'utf8'
+        assert content1.includes('aInit'), "initial output: " + content1
+        // fs.watch can take a few ms to arm on Linux; brief pause avoids
+        // racing the modification against the watcher's setup.
+        await new Promise (r) => setTimeout r, 50
+        await writeFile inputFile, "bAfter := 2\n"
+        await waitFor =>
+          try
+            (await readFile outputFile, 'utf8').includes 'bAfter'
+          catch
+            false
+      finally
+        handle?.close()
 
   it "logs compilation failures and keeps watching", ->
     inputFile := await makeCivetTempFile "xKeep := 1\n"
     let handle: any
-    await captureProcess =>
+    await captureProcess ({stdErrChunks}) =>
       handle = await cli ['-w', '--no-config', inputFile]
-    try
-      stderrChunks: string[] := []
-      origWrite := process.stderr.write.bind(process.stderr)
-      process.stderr.write = ((chunk: any) =>
-        stderrChunks.push String(chunk)
-        true
-      ) as any
       try
         await new Promise (r) => setTimeout r, 50
+        setupErrLen := stdErrChunks.join('').length
         await writeFile inputFile, "}\n"  // invalid Civet
         await waitFor =>
-          stderrChunks.join('').includes 'Failed to compile'
+          stdErrChunks.join('').slice(setupErrLen).includes 'Failed to compile'
         // Now write valid code and confirm the watcher kept running
-        stderrChunks.length = 0
         await writeFile inputFile, "yRevived := 9\n"
         await waitFor =>
           try
@@ -1242,22 +1242,13 @@ describe "CLI --watch", ->
           catch
             false
       finally
-        process.stderr.write = origWrite as any
-    finally
-      handle?.close()
+        handle?.close()
 
   it "writes recompiled output to stdout when -o - is set (debounced)", ->
     inputFile := await makeCivetTempFile "cStart := 3\n"
     let handle: any
-    await captureProcess =>
+    await captureProcess ({stdOutChunks}) =>
       handle = await cli ['-w', '-o', '-', '--no-config', inputFile]
-    try
-      stdoutChunks: string[] := []
-      origStdout := process.stdout.write.bind(process.stdout)
-      process.stdout.write = ((chunk: any) =>
-        stdoutChunks.push String(chunk)
-        true
-      ) as any
       try
         await new Promise (r) => setTimeout r, 50
         // Two quick changes — debounce coalesces to one recompile, so only
@@ -1266,42 +1257,40 @@ describe "CLI --watch", ->
         await new Promise (r) => setTimeout r, 30
         await writeFile inputFile, "eFinal := 5\n"
         await waitFor =>
-          stdoutChunks.join('').includes 'eFinal'
+          stdOutChunks.join('').includes 'eFinal'
       finally
-        process.stdout.write = origStdout as any
-    finally
-      handle?.close()
+        handle?.close()
 
   it "re-establishes watcher after rename event (atomic-save editors)", ->
     inputFile := await makeCivetTempFile "fStart := 6\n"
     let handle: any
     await captureProcess =>
       handle = await cli ['-w', '--no-config', inputFile]
-    try
-      outputFile := inputFile + '.tsx'
-      // Simulate vim/emacs atomic save: write to a temp path, then rename
-      // over the watched file.  On Linux this fires `rename`, invalidating
-      // the inotify watch; the re-watch logic must recover so a later
-      // in-place edit still triggers a recompile.
-      tempPath := inputFile + '.tmp'
-      await writeFile tempPath, "gAtomic := 7\n"
-      { rename } := await import 'fs/promises'
-      await rename tempPath, inputFile
-      await waitFor =>
-        try
-          (await readFile outputFile, 'utf8').includes 'gAtomic'
-        catch
-          false
-      // Wait past the 100ms re-watch delay before mutating again.
-      await new Promise (r) => setTimeout r, 300
-      await writeFile inputFile, "hAfterRewatch := 8\n"
-      await waitFor =>
-        try
-          (await readFile outputFile, 'utf8').includes 'hAfterRewatch'
-        catch
-          false
-    finally
-      handle?.close()
+      try
+        outputFile := inputFile + '.tsx'
+        // Simulate vim/emacs atomic save: write to a temp path, then rename
+        // over the watched file.  On Linux this fires `rename`, invalidating
+        // the inotify watch; the re-watch logic must recover so a later
+        // in-place edit still triggers a recompile.
+        tempPath := inputFile + '.tmp'
+        await writeFile tempPath, "gAtomic := 7\n"
+        { rename } := await import 'fs/promises'
+        await rename tempPath, inputFile
+        await waitFor =>
+          try
+            (await readFile outputFile, 'utf8').includes 'gAtomic'
+          catch
+            false
+        // Wait past the 100ms re-watch delay before mutating again.
+        await new Promise (r) => setTimeout r, 300
+        await writeFile inputFile, "hAfterRewatch := 8\n"
+        await waitFor =>
+          try
+            (await readFile outputFile, 'utf8').includes 'hAfterRewatch'
+          catch
+            false
+      finally
+        handle?.close()
 
   it "logs and continues when fsSync.watch fails (missing file)", ->
     missing := path.join tmpDir, "definitely-does-not-exist.civet"

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -158,6 +158,27 @@ describe 'CLI parseArgs', ->
           run: false
           parseOptions: rewriteCivetImports: '.civet.jsx'
 
+  for watch of [ '-w', '--watch' ]
+    it `parses ${watch} with filename`, =>
+      argsParse `${watch} input.civet`,
+        filenames: [ 'input.civet' ]
+        scriptArgs: []
+        options:
+          watch: true
+          compile: true
+          run: false
+          parseOptions: rewriteCivetImports: '.civet.jsx'
+
+    it `parses ${watch} without filename (no REPL)`, =>
+      assert.deepStrictEqual await parseArgs([watch], true),
+        filenames: []
+        scriptArgs: []
+        options:
+          watch: true
+          compile: true
+          run: false
+          parseOptions: rewriteCivetImports: '.civet.jsx'
+
   for output of [ '-o', '--output' ]
     it `parses ${output} with -`, =>
       argsOptions `${output} -`,

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -179,6 +179,34 @@ describe 'CLI parseArgs', ->
           run: false
           parseOptions: rewriteCivetImports: '.civet.jsx'
 
+  for typeFlag of [ '--typecheck', '--emit-declaration' ]
+    it `errors when -w combined with ${typeFlag}`, =>
+      origExit := process.exit
+      origStderr := process.stderr.write
+      stderr: string[] := []
+      process.stderr.write = ((chunk: any) =>
+        stderr.push String(chunk)
+        true
+      ) as any
+      exitCode: number? .= undefined
+      sentinel := {}
+      process.exit = ((code?: number) =>
+        exitCode = code
+        throw sentinel
+      ) as any
+      try
+        try
+          await parseArgs ['-w', typeFlag, 'placeholder.civet'], true
+        catch e
+          throw e unless e is sentinel
+      finally
+        process.exit = origExit
+        process.stderr.write = origStderr
+      assert exitCode? and exitCode > 0,
+        `parseArgs should exit non-zero for -w ${typeFlag}, got: ${exitCode}`
+      assert stderr.join('').includes('not compatible'),
+        `stderr should mention incompatibility, got: ${stderr.join('')}`
+
   for output of [ '-o', '--output' ]
     it `parses ${output} with -`, =>
       argsOptions `${output} -`,
@@ -1119,3 +1147,171 @@ describe "CLI --typecheck", ->
       assert declFiles.length > 0, `.d.ts emitted; got: ${JSON.stringify files}; exitCode=${exitCode}; stdErr=${stdErr}; stdOut=${stdOut}`
     finally
       process.chdir origCwd
+
+describe "CLI --watch", ->
+  let tmpDir: string
+  fileNum .= 0
+  before ->
+    tmpDir = path.join tmpdir(), "civet-cli-watch-test-" + Math.random().toString(36).substring(2, 15)
+    await mkdir tmpDir, { recursive: true }
+  after ->
+    await rm tmpDir, { recursive: true, force: true }
+
+  function makeCivetTempFile(content: string): string
+    filePath := path.join tmpDir, `watch-${fileNum++}.civet`
+    await writeFile filePath, content
+    filePath
+
+  // Poll a predicate until it returns truthy, with a timeout.  Used in place
+  // of fixed sleeps to keep tests responsive on fast machines without
+  // flaking on slow CI.
+  async function waitFor(check: => Promise<unknown>, timeout = 3000): Promise<void>
+    start := Date.now()
+    while Date.now() - start < timeout
+      return if await check()
+      await new Promise (r) => setTimeout r, 30
+    throw new Error `waitFor: condition not met within ${timeout}ms`
+
+  it "errors when --watch is given no filename", ->
+    { exitCode, stdErr } := await captureProcess =>
+      await cli ['-w', '--no-config']
+    assert exitCode? and exitCode > 0, "exitCode: " + exitCode
+    assert stdErr.includes('--watch'), stdErr
+
+  it "errors when --watch is given only stdin '-'", ->
+    { exitCode, stdErr } := await captureProcess =>
+      await cli ['-w', '--no-config', '-']
+    assert exitCode? and exitCode > 0, "exitCode: " + exitCode
+    assert stdErr.includes('--watch'), stdErr
+
+  it "errors when --watch combined with --typecheck via cli()", ->
+    inputFile := await makeCivetTempFile "x := 1\n"
+    { exitCode, stdErr } := await captureProcess =>
+      await cli ['-w', '--typecheck', '--no-config', inputFile]
+    assert exitCode? and exitCode > 0
+    assert stdErr.includes('not compatible'), stdErr
+
+  it "performs initial compile and recompiles on subsequent change", ->
+    @timeout 10000
+    inputFile := await makeCivetTempFile "aInit := 1\n"
+    let handle: any
+    await captureProcess =>
+      handle = await cli ['-w', '--no-config', inputFile]
+    try
+      outputFile := inputFile + '.tsx'
+      content1 := await readFile outputFile, 'utf8'
+      assert content1.includes('aInit'), "initial output: " + content1
+      // fs.watch can take a few ms to arm on Linux; brief pause avoids
+      // racing the modification against the watcher's setup.
+      await new Promise (r) => setTimeout r, 50
+      await writeFile inputFile, "bAfter := 2\n"
+      await waitFor =>
+        try
+          (await readFile outputFile, 'utf8').includes 'bAfter'
+        catch
+          false
+    finally
+      handle?.close()
+
+  it "logs compilation failures and keeps watching", ->
+    @timeout 10000
+    inputFile := await makeCivetTempFile "xKeep := 1\n"
+    let handle: any
+    await captureProcess =>
+      handle = await cli ['-w', '--no-config', inputFile]
+    try
+      stderrChunks: string[] := []
+      origWrite := process.stderr.write.bind(process.stderr)
+      process.stderr.write = ((chunk: any) =>
+        stderrChunks.push String(chunk)
+        true
+      ) as any
+      try
+        await new Promise (r) => setTimeout r, 50
+        await writeFile inputFile, "}\n"  // invalid Civet
+        await waitFor =>
+          stderrChunks.join('').includes 'Failed to compile'
+        // Now write valid code and confirm the watcher kept running
+        stderrChunks.length = 0
+        await writeFile inputFile, "yRevived := 9\n"
+        await waitFor =>
+          try
+            (await readFile inputFile + '.tsx', 'utf8').includes 'yRevived'
+          catch
+            false
+      finally
+        process.stderr.write = origWrite as any
+    finally
+      handle?.close()
+
+  it "writes recompiled output to stdout when -o - is set (debounced)", ->
+    @timeout 10000
+    inputFile := await makeCivetTempFile "cStart := 3\n"
+    let handle: any
+    await captureProcess =>
+      handle = await cli ['-w', '-o', '-', '--no-config', inputFile]
+    try
+      stdoutChunks: string[] := []
+      origStdout := process.stdout.write.bind(process.stdout)
+      process.stdout.write = ((chunk: any) =>
+        stdoutChunks.push String(chunk)
+        true
+      ) as any
+      try
+        await new Promise (r) => setTimeout r, 50
+        // Two quick changes — debounce coalesces to one recompile, so only
+        // the final value need be observed in stdout.
+        await writeFile inputFile, "dMid := 4\n"
+        await new Promise (r) => setTimeout r, 30
+        await writeFile inputFile, "eFinal := 5\n"
+        await waitFor =>
+          stdoutChunks.join('').includes 'eFinal'
+      finally
+        process.stdout.write = origStdout as any
+    finally
+      handle?.close()
+
+  it "re-establishes watcher after rename event (atomic-save editors)", ->
+    @timeout 10000
+    inputFile := await makeCivetTempFile "fStart := 6\n"
+    let handle: any
+    await captureProcess =>
+      handle = await cli ['-w', '--no-config', inputFile]
+    try
+      outputFile := inputFile + '.tsx'
+      // Simulate vim/emacs atomic save: write to a temp path, then rename
+      // over the watched file.  On Linux this fires `rename`, invalidating
+      // the inotify watch; the re-watch logic must recover so a later
+      // in-place edit still triggers a recompile.
+      tempPath := inputFile + '.tmp'
+      await writeFile tempPath, "gAtomic := 7\n"
+      { rename } := await import 'fs/promises'
+      await rename tempPath, inputFile
+      await waitFor =>
+        try
+          (await readFile outputFile, 'utf8').includes 'gAtomic'
+        catch
+          false
+      // Wait past the 100ms re-watch delay before mutating again.
+      await new Promise (r) => setTimeout r, 300
+      await writeFile inputFile, "hAfterRewatch := 8\n"
+      await waitFor =>
+        try
+          (await readFile outputFile, 'utf8').includes 'hAfterRewatch'
+        catch
+          false
+    finally
+      handle?.close()
+
+  it "logs and continues when fsSync.watch fails (missing file)", ->
+    missing := path.join tmpDir, "definitely-does-not-exist.civet"
+    let handle: any
+    { stdErr } := await captureProcess =>
+      handle = await cli ['-w', '--no-config', missing]
+    try
+      // readFiles reports a load error first ("failed to load") and the
+      // watch setup additionally fails with ENOENT ("Could not watch").
+      assert stdErr.includes('Could not watch') or stdErr.includes('failed to load'),
+        "stderr surfaces missing file: " + stdErr
+    finally
+      handle?.close()

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1324,3 +1324,35 @@ describe "CLI --watch", ->
           "output unchanged after close cancelled the pending recompile"
       finally
         handle?.close()
+
+  it "cancels pending re-watch when closed mid rename-recovery window", ->
+    inputFile := await makeCivetTempFile "rwStart := 1\n"
+    outputFile := inputFile + '.tsx'
+    let handle: any
+    await captureProcess =>
+      handle = await cli ['-w', '--no-config', inputFile]
+      try
+        initial := await readFile outputFile, 'utf8'
+        await new Promise (r) => setTimeout r, 50
+        // Trigger a rename: this closes the watcher and queues a 100ms
+        // setTimeout that would re-arm startWatching on the same path.
+        { rename } := await import 'fs/promises'
+        tempPath := inputFile + '.tmp'
+        await writeFile tempPath, "rwAtomic := 7\n"
+        await rename tempPath, inputFile
+        // Close inside the 100ms re-arm window.  Without timer tracking
+        // a brand-new FSWatcher would be created post-close and leak
+        // into the cleared `watchers` map.
+        await new Promise (r) => setTimeout r, 30
+        handle?.close()
+        handle = null
+        // Past the 100ms re-arm window plus the 100ms debounce window:
+        // if a leaked watcher exists, the edit below would still recompile.
+        await new Promise (r) => setTimeout r, 250
+        await writeFile inputFile, "rwAfterClose := 9\n"
+        await new Promise (r) => setTimeout r, 250
+        after := await readFile outputFile, 'utf8'
+        assert.equal after, initial,
+          "output unchanged after close cancelled the rename re-watch"
+      finally
+        handle?.close()

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -169,43 +169,43 @@ describe 'CLI parseArgs', ->
           run: false
           parseOptions: rewriteCivetImports: '.civet.jsx'
 
-    it `parses ${watch} without filename (no REPL)`, =>
-      assert.deepStrictEqual await parseArgs([watch], true),
-        filenames: []
-        scriptArgs: []
-        options:
-          watch: true
-          compile: true
-          run: false
-          parseOptions: rewriteCivetImports: '.civet.jsx'
+  // parseArgs is expected to call process.exit on rejection; capture that
+  // and the stderr it wrote so each test can assert on both.
+  async function parseArgsExpectExit(args: string[]): Promise<{exitCode: number?, stderr: string}>
+    origExit := process.exit
+    origStderr := process.stderr.write
+    stderr: string[] := []
+    process.stderr.write = ((chunk: any) =>
+      stderr.push String(chunk)
+      true
+    ) as any
+    exitCode: number? .= undefined
+    sentinel := {}
+    process.exit = ((code?: number) =>
+      exitCode = code
+      throw sentinel
+    ) as any
+    try
+      try
+        await parseArgs args, true
+      catch e
+        throw e unless e is sentinel
+    finally
+      process.exit = origExit
+      process.stderr.write = origStderr
+    {exitCode, stderr: stderr.join('')}
+
+  for watchNoInput of [ ['-w'], ['--watch'], ['-w', '-'], ['--watch', '-'] ]
+    it `errors when ${watchNoInput.join(' ')} has no real filename`, =>
+      {exitCode, stderr} := await parseArgsExpectExit watchNoInput
+      assert exitCode? and exitCode > 0, `expected non-zero exit, got: ${exitCode}`
+      assert stderr.includes('--watch'), `stderr mentions --watch: ${stderr}`
 
   for typeFlag of [ '--typecheck', '--emit-declaration' ]
     it `errors when -w combined with ${typeFlag}`, =>
-      origExit := process.exit
-      origStderr := process.stderr.write
-      stderr: string[] := []
-      process.stderr.write = ((chunk: any) =>
-        stderr.push String(chunk)
-        true
-      ) as any
-      exitCode: number? .= undefined
-      sentinel := {}
-      process.exit = ((code?: number) =>
-        exitCode = code
-        throw sentinel
-      ) as any
-      try
-        try
-          await parseArgs ['-w', typeFlag, 'placeholder.civet'], true
-        catch e
-          throw e unless e is sentinel
-      finally
-        process.exit = origExit
-        process.stderr.write = origStderr
-      assert exitCode? and exitCode > 0,
-        `parseArgs should exit non-zero for -w ${typeFlag}, got: ${exitCode}`
-      assert stderr.join('').includes('not compatible'),
-        `stderr should mention incompatibility, got: ${stderr.join('')}`
+      {exitCode, stderr} := await parseArgsExpectExit ['-w', typeFlag, 'placeholder.civet']
+      assert exitCode? and exitCode > 0, `expected non-zero exit, got: ${exitCode}`
+      assert stderr.includes('not compatible'), `stderr mentions incompatibility: ${stderr}`
 
   for output of [ '-o', '--output' ]
     it `parses ${output} with -`, =>

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1176,7 +1176,7 @@ describe "CLI --watch", ->
   // Poll a predicate until it returns truthy, with a timeout.  Used in place
   // of fixed sleeps to keep tests responsive on fast machines without
   // flaking on slow CI.
-  async function waitFor(check: => Promise<unknown>, timeout = 3000): Promise<void>
+  async function waitFor(check: => unknown | Promise<unknown>, timeout = 3000): Promise<void>
     start := Date.now()
     while Date.now() - start < timeout
       return if await check()
@@ -1292,15 +1292,35 @@ describe "CLI --watch", ->
       finally
         handle?.close()
 
-  it "logs and continues when fsSync.watch fails (missing file)", ->
+  it "logs missing-file load error and doesn't attempt to watch", ->
     missing := path.join tmpDir, "definitely-does-not-exist.civet"
     let handle: any
     { stdErr } := await captureProcess =>
       handle = await cli ['-w', '--no-config', missing]
-    try
-      // readFiles reports a load error first ("failed to load") and the
-      // watch setup additionally fails with ENOENT ("Could not watch").
-      assert stdErr.includes('Could not watch') or stdErr.includes('failed to load'),
-        "stderr surfaces missing file: " + stdErr
-    finally
       handle?.close()
+    assert stdErr.includes('failed to load'),
+      "stderr surfaces missing file: " + stdErr
+
+  it "clears pending debounce timers when closed mid-debounce", ->
+    inputFile := await makeCivetTempFile "cancel := 1\n"
+    outputFile := inputFile + '.tsx'
+    let handle: any
+    await captureProcess =>
+      handle = await cli ['-w', '--no-config', inputFile]
+      try
+        initial := await readFile outputFile, 'utf8'
+        // fs.watch can take a few ms to arm on Linux
+        await new Promise (r) => setTimeout r, 50
+        await writeFile inputFile, "cancelAfter := 2\n"
+        // Let the inotify callback fire scheduleRebuild (queueing a 100ms
+        // debounce timer) but close before the debounce expires.
+        await new Promise (r) => setTimeout r, 50
+        handle?.close()
+        handle = null
+        // Past the debounce window: the cleared timer must not recompile.
+        await new Promise (r) => setTimeout r, 200
+        after := await readFile outputFile, 'utf8'
+        assert.equal after, initial,
+          "output unchanged after close cancelled the pending recompile"
+      finally
+        handle?.close()


### PR DESCRIPTION
Implements `civet -w <files>` watch mode: after the initial compile, `fs.watch` each input file and recompile (debounced 100ms) on change. The flag implies `--compile` and keeps the process alive via active watcher handles.

Closes #163

Generated with [Claude Code](https://claude.ai/code)