### PR TITLE
LSP: implement workspace/symbol

### DIFF
--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -37,7 +37,7 @@ export { getCanonicalFileName } from ../../../../source/ts-service/path.civet
 
 // https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/src/languageFeatures/documentSymbol.ts#L63
 
-getSymbolKind := (kind: ts.ScriptElementKind): SymbolKind => {
+export getSymbolKind := (kind: ts.ScriptElementKind): SymbolKind => {
   switch (kind) {
     case ScriptElementKind.moduleElement: return SymbolKind.Module
     case ScriptElementKind.classElement: return SymbolKind.Class

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -747,9 +747,11 @@ export function startServer(connection: Connection, dependencies: ServerDependen
   connection.onWorkspaceSymbol ({ query }) =>
     items: SymbolInformation[] := []
     for service of projectPathToServiceMap.values()
-      navItems := service.getNavigateToItems(query, WORKSPACE_SYMBOL_LIMIT)
       program := service.getProgram()
       continue unless program
+      // excludeDtsFiles=true keeps node_modules/@types/... declarations out
+      // of results so clients see user code, not library noise.
+      navItems := service.getNavigateToItems(query, WORKSPACE_SYMBOL_LIMIT, undefined, true)
 
       for navItem of navItems
         sourceFile := program.getSourceFile(navItem.fileName)

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -15,6 +15,7 @@
   CompletionList
   type Location
   DiagnosticSeverity
+  type SymbolInformation
   TextEdit
   SemanticTokensRequest
   FileChangeType
@@ -26,7 +27,7 @@
   type Position
 } from vscode-languageserver-textdocument
 * as Previewer from ./lib/previewer.civet
-{ collectCommentTokens, convertNavTree, forwardMap, getCanonicalFileName, convertDiagnostic, remapPosition, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
+{ collectCommentTokens, convertNavTree, forwardMap, getCanonicalFileName, convertDiagnostic, getSymbolKind, remapPosition, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
 { asPlainTextWithLinks, tagsToMarkdown } from ./lib/textRendering.civet
 {
   adjustCursorForEmptyQuotes
@@ -203,6 +204,7 @@ export function startServer(connection: Connection, dependencies: ServerDependen
         //   resolveProvider: true
         // }
         documentSymbolProvider: true
+        workspaceSymbolProvider: true
         definitionProvider: true
         hoverProvider: true
         referencesProvider: true
@@ -736,6 +738,41 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     if navTree.childItems
       for child of navTree.childItems
         convertNavTree(child, items, document, sourcemapLines)
+
+    return items
+
+  // workspace/symbol — fuzzy match via TS's getNavigateToItems across every
+  // loaded project; remap to .civet source space for transpiled files.
+  WORKSPACE_SYMBOL_LIMIT := 256
+  connection.onWorkspaceSymbol ({ query }) =>
+    items: SymbolInformation[] := []
+    for service of projectPathToServiceMap.values()
+      navItems := service.getNavigateToItems(query, WORKSPACE_SYMBOL_LIMIT)
+      program := service.getProgram()
+      continue unless program
+
+      for navItem of navItems
+        sourceFile := program.getSourceFile(navItem.fileName)
+        continue unless sourceFile
+
+        start .= sourceFile.getLineAndCharacterOfPosition(navItem.textSpan.start)
+        end .= sourceFile.getLineAndCharacterOfPosition(navItem.textSpan.start + navItem.textSpan.length)
+        rawSourceName := service.getSourceFileName(navItem.fileName)
+
+        // Reverse map to .civet source space for transpiled files.
+        meta := service.host.getMeta(rawSourceName)
+        if meta?.sourcemapLines
+          start = remapPosition(start, meta.sourcemapLines)
+          end = remapPosition(end, meta.sourcemapLines)
+
+        items.push {
+          name: navItem.name
+          kind: getSymbolKind(navItem.kind)
+          location:
+            uri: URI.file(rawSourceName).toString()
+            range: { start, end }
+          containerName: navItem.containerName
+        }
 
     return items
 

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -9,6 +9,8 @@
 // which under coverage dominated the wallclock.
 
 { spawnLspServer, docUri, type LspClient } from ./lsp-harness.civet
+{ getCanonicalFileName } from ../source/lib/util.civet
+{ URI } from vscode-uri
 path from node:path
 fs from node:fs
 os from node:os
@@ -40,6 +42,13 @@ initializeClient := (client: LspClient, opts: { workspaceFolders?: any, capabili
 // as a plain function (three-arg call without ambiguity).
 waitForDiag := (client: LspClient, match: (p: any) => boolean, timeout = WAIT): Promise<any> =>
   client.waitFor("textDocument/publishDiagnostics", match, timeout)
+
+// Compare two file URIs in a way that survives Windows' case-insensitive
+// filesystem: TS canonicalises sourceFile.fileName to lowercase, so URIs
+// the server constructs from those paths can differ in case from the
+// original-case URIs the harness builds via docUri.
+sameUri := (a: string, b: string): boolean =>
+  getCanonicalFileName(URI.parse(a).fsPath) is getCanonicalFileName(URI.parse(b).fsPath)
 
 // Spawn a single server for the whole describe and reuse it.  Tests must use
 // unique URIs so one test's open documents don't leak into another's view.
@@ -421,7 +430,8 @@ describe "LSP features (shared project server)", ->
     match := syms.find (s: any) => s.name is "uniqueGreet"
     assert match, "expected uniqueGreet in results; got " + JSON.stringify(syms.map (s: any) => s.name)
     assert match.location, "expected location on symbol"
-    assert match.location.uri is uri, "expected location.uri to point at source file, got " + match.location.uri
+    assert sameUri(match.location.uri, uri),
+      "expected location.uri to point at source file, got " + match.location.uri
     // Civet source position: line 0, char 7 ('uniqueGreet' starts after 'export ').
     assert match.location.range.start.line is 0,
       `expected line 0, got ${match.location.range.start.line}`
@@ -445,7 +455,8 @@ describe "LSP features (shared project server)", ->
     assert Array.isArray(syms), "expected workspace/symbol array"
     cls := syms.find (s: any) => s.name is "WssymBetaGadget"
     assert cls, "expected WssymBetaGadget in results"
-    assert cls.location.uri is uri, "expected civet source uri, got " + cls.location.uri
+    assert sameUri(cls.location.uri, uri),
+      "expected civet source uri, got " + cls.location.uri
     // 'class WssymBetaGadget' starts at line 0 (after 'export class ').
     assert cls.location.range.start.line is 0,
       `expected line 0, got ${cls.location.range.start.line}`

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -402,6 +402,58 @@ describe "LSP features (shared project server)", ->
       edits := Object.values(result.changes)[0] as any[]
       assert Array.isArray(edits) and edits.length >= 1, "expected rename edits"
 
+  it "workspace/symbol finds top-level symbols across the project", ->
+    uri := docUri path.join(projectRoot, "wssym-a.civet")
+    text := """
+      export uniqueGreet := (name: string) => `hi ${name}`
+      export class UniqueWidget
+        render(): string
+          "<div/>"
+
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    syms := await client.request "workspace/symbol", { query: "uniqueGreet" }
+    assert Array.isArray(syms), "expected workspace/symbol array, got " + JSON.stringify(syms)
+    match := syms.find (s: any) => s.name is "uniqueGreet"
+    assert match, "expected uniqueGreet in results; got " + JSON.stringify(syms.map (s: any) => s.name)
+    assert match.location, "expected location on symbol"
+    assert match.location.uri is uri, "expected location.uri to point at source file, got " + match.location.uri
+    // Civet source position: line 0, char 7 ('uniqueGreet' starts after 'export ').
+    assert match.location.range.start.line is 0,
+      `expected line 0, got ${match.location.range.start.line}`
+
+  it "workspace/symbol returns class symbols and remaps civet positions", ->
+    // Class name distinct from wssym-a.civet's UniqueWidget so a fuzzy match
+    // in the shared workspace points unambiguously at this file.
+    uri := docUri path.join(projectRoot, "wssym-b.civet")
+    text := """
+      export class WssymBetaGadget
+        render(): string
+          "<div/>"
+
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    syms := await client.request "workspace/symbol", { query: "WssymBetaGadget" }
+    assert Array.isArray(syms), "expected workspace/symbol array"
+    cls := syms.find (s: any) => s.name is "WssymBetaGadget"
+    assert cls, "expected WssymBetaGadget in results"
+    assert cls.location.uri is uri, "expected civet source uri, got " + cls.location.uri
+    // 'class WssymBetaGadget' starts at line 0 (after 'export class ').
+    assert cls.location.range.start.line is 0,
+      `expected line 0, got ${cls.location.range.start.line}`
+
+  it "workspace/symbol with empty query returns an array (not an error)", ->
+    syms := await client.request "workspace/symbol", { query: "" }
+    assert Array.isArray(syms), "expected an array even for empty query"
+
   it "completion with unresolvable path alias", ->
     // Exercises resolvePathAliasDir returning undefined → aliasDir falsy branch.
     uri := docUri path.join(projectRoot, "imp-alias.civet")


### PR DESCRIPTION
## Summary

Adds `workspace/symbol` to the Civet language server so clients can fuzzy-look up symbols by name across the workspace.

The handler mirrors `onDefinition` / `onReferences`: iterates every loaded project's `TSService`, calls `service.getNavigateToItems(query, 256)`, and maps each `NavigateToItem` → `SymbolInformation` with sourcemap remapping for `.civet` files. Capability `workspaceSymbolProvider: true` is declared in the initialize result. `getSymbolKind` (already used internally by `convertNavTree`) is promoted to an export so the new handler can reuse it.

## Why

LSP clients that look symbols up by name first failed against civet-lsp with `-32601 Unhandled method workspace/symbol`. The most visible case is `mcp-language-server`'s `definition` / `references` / `rename_symbol` tools (used in agentic typecheck-iteration workflows), but the gap also affected any future client surface that depends on workspace-wide symbol search.

Verified end-to-end against `civet-lsp + mcp-language-server`: `definition` for `square` previously returned `failed to fetch symbol`, now returns `L3:C1-C31` with the correct Civet source range.

## Test plan

- [x] 3 new tests under `LSP features (shared project server)` in `lsp-features.test.civet` (function lookup, class lookup with civet position remap, empty query)
- [x] Full LSP test suite: 254 passing (the one pre-existing `web-worker` ERR_MODULE_NOT_FOUND on `worker.civet` reproduces on `main` and is unrelated)
- [x] End-to-end smoke test through `mcp-language-server` confirms `definition` now resolves Civet symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)