### PR TITLE
LSP e2e: fix Linux test reliability (Wayland headless + flaky import-completion)

### DIFF
--- a/lsp/vscode/e2e/runTest.civet
+++ b/lsp/vscode/e2e/runTest.civet
@@ -34,8 +34,14 @@ if !process.env.RUNNING_UNDER_XVFB
     if check.error
       console.error 'Error: xvfb-run is not installed. Please install it (e.g. apt install xvfb) to run e2e tests on Linux.'
       process.exit 1
+    // Strip WAYLAND_DISPLAY so Electron uses xvfb's X server, not the host compositor.
+    { WAYLAND_DISPLAY: _ignored, ...envWithoutWayland } := process.env
     child = spawn 'xvfb-run', ['-a', process.execPath, process.argv[1]], {
-      env: { ...process.env, RUNNING_UNDER_XVFB: '1' }
+      env: {
+        ...envWithoutWayland
+        RUNNING_UNDER_XVFB: '1'
+        ELECTRON_OZONE_PLATFORM_HINT: 'x11'
+      }
     }
   else
     child = spawn process.execPath, [process.argv[1]], {
@@ -62,11 +68,19 @@ else
       extensionTestsEnv: Record<string, string> := {}
       if process.env.NODE_V8_COVERAGE
         extensionTestsEnv.NODE_V8_COVERAGE = path.resolve process.env.NODE_V8_COVERAGE
+      launchArgs: string[] := [workspacePath]
+      // Force X11 — Electron auto-discovers Wayland sockets via XDG_RUNTIME_DIR,
+      // so stripping WAYLAND_DISPLAY alone isn't enough.
+      if process.platform is 'linux'
+        launchArgs.push '--ozone-platform=x11'
+      // Built-in in VS Code 1.115+; without auth it floods stderr and can
+      // starve the extension host past tight completion-poll windows.
+      launchArgs.push '--disable-extension', 'github.copilot-chat'
       await runTests({
         version
         extensionDevelopmentPath
         extensionTestsPath
-        launchArgs: [workspacePath]
+        launchArgs
         extensionTestsEnv
       })
     catch err


### PR DESCRIPTION
## Summary

Two related fixes for `pnpm test:e2e` on Linux. Reported locally as:
- a visible VS Code window opening on Wayland sessions (was supposed to be headless)
- the import-completion 'space trigger in import context' test timing out at 2s

## Fix 1: Headless on Wayland

`xvfb-run -a` was correctly starting a virtual X11 display, but Electron auto-discovers Wayland either via `WAYLAND_DISPLAY` or by scanning `$XDG_RUNTIME_DIR/wayland-*` directly. So even after stripping `WAYLAND_DISPLAY`, Electron still found the host's Wayland socket and bypassed xvfb. `ELECTRON_OZONE_PLATFORM_HINT=x11` is only a hint.

Belt and suspenders:
- Strip `WAYLAND_DISPLAY` from the spawn env.
- Pass `--ozone-platform=x11` as a launch arg on Linux. Chromium command-line override; honored unconditionally.

## Fix 2: Flaky import-completion test

VS Code 1.115+ ships `github.copilot-chat` as a built-in extension. Without an auth token it floods stderr with `GitHubLoginFailed` and starves the extension host enough to miss the test's 2s / 500ms poll window. Passed in CI (cold ext-host warms up faster on GH runners); failed on every local run.

Fix: disable it via `--disable-extension github.copilot-chat`.

## Impact

Local Linux Wayland, before/after:

| | before | after |
|---|---|---|
| visible window | yes | no |
| passing | 53 | 54 |
| failing | 1 (Import Path Completion) | 0 |
| wall time | ~15s | ~8s |

CI (already headless, no copilot-chat to disable): no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
