### PR TITLE
Fix: unwrap if/then/else assignment to ternary without ref

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -75,6 +75,7 @@ import {
 } from ./binding.civet
 
 import {
+  canExpressionizeIfAsTernary
   convertNamedImportsToObject
   processCallMemberExpression
 } from ./lib.civet
@@ -196,6 +197,13 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
   return unless exp is like {type: "StatementExpression"}
 
   statementExp := exp.statement
+
+  // Skip ref-hoist when the if/else can be cleanly converted to a ternary
+  // (`processStatementExpressions` will turn the StatementExpression into an
+  //  `IfExpression` later). See #2051.
+  return if statementExp.type is "IfStatement" and
+    canExpressionizeIfAsTernary statementExp
+
   blockStatement: StatementTuple := [ws || "", statementExp, ";"]
   pre: StatementTuple[] := [blockStatement]
   let ref: ASTRef

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -364,9 +364,8 @@ function canExpressionizeIfAsTernary(statement: IfStatement): boolean
 // Mirror of `expressionizeBlock`'s success condition — keep in sync.
 function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
   if { expressions } := blockOrExpression
-    for [, s] of expressions
-      return false unless isExpression(s)
-  true
+    for every [, s] of expressions
+      isExpression(s)
 
 function expressionizeIfStatement(statement: IfStatement): ASTNode
   { condition, then: b, else: e } := statement

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -352,10 +352,9 @@ True iff `expressionizeIfStatement` would produce a clean ternary
 */
 function canExpressionizeIfAsTernary(statement: IfStatement): boolean
   { then: b, else: e } := statement
-  return false unless canExpressionizeBlock b
-  if e
-    return false unless canExpressionizeBlock e.block
-  true
+  (and)
+    canExpressionizeBlock b
+    e ? canExpressionizeBlock e.block : true
 
 function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
   if { expressions } := blockOrExpression

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -346,6 +346,23 @@ function expressionizeBlock(blockOrExpression: ASTNode)
   else
     blockOrExpression
 
+/**
+True iff `expressionizeIfStatement` would produce a clean ternary
+(`IfExpression`) for this statement, rather than wrapping it in an IIFE.
+*/
+function canExpressionizeIfAsTernary(statement: IfStatement): boolean
+  { then: b, else: e } := statement
+  return false unless canExpressionizeBlock b
+  if e
+    return false unless canExpressionizeBlock e.block
+  true
+
+function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
+  if { expressions } := blockOrExpression
+    for [, s] of expressions
+      return false unless isExpression(s)
+  true
+
 function expressionizeIfStatement(statement: IfStatement): ASTNode
   { condition, then: b, else: e } := statement
   [ ...condRest, closeParen ] := condition.children  // separate ')'
@@ -2128,6 +2145,7 @@ export {
   braceBlock
   bracedBlock
   buildExportSplitClause
+  canExpressionizeIfAsTernary
   convertArrowFunctionToMethod
   convertFunctionToMethod
   convertNamedImportsToObject

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -349,6 +349,11 @@ function expressionizeBlock(blockOrExpression: ASTNode)
 /**
 True iff `expressionizeIfStatement` would produce a clean ternary
 (`IfExpression`) for this statement, rather than wrapping it in an IIFE.
+
+Mirrors `expressionizeIfStatement` + `expressionizeBlock` truthiness: must
+return false for the same inputs that would force the IIFE fallback. If
+`expressionizeBlock` gains a new early-return condition, update
+`canExpressionizeBlock` to match.
 */
 function canExpressionizeIfAsTernary(statement: IfStatement): boolean
   { then: b, else: e } := statement
@@ -356,6 +361,7 @@ function canExpressionizeIfAsTernary(statement: IfStatement): boolean
     canExpressionizeBlock b
     e ? canExpressionizeBlock e.block : true
 
+// Mirror of `expressionizeBlock`'s success condition — keep in sync.
 function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
   if { expressions } := blockOrExpression
     for [, s] of expressions

--- a/test/compat/examples.civet
+++ b/test/compat/examples.civet
@@ -44,15 +44,13 @@ describe "example code", ->
         'IDENTIFIER'
     ---
     var tag;var indexOf: <T>(this: T[], searchElement: T) => number = [].indexOf as any;
-    let ref;
-      if (colon || (prev != null) &&
+    tag =
+      (colon || (prev != null) &&
          (indexOf.call(['.', '?.', '::', '?::'], prev[0]) >= 0 ||
-         !prev.spaced && prev[0] === '@')) {
-        ref = 'PROPERTY'
-      }
-      else {
-        ref = 'IDENTIFIER'
-      };tag =ref
+         !prev.spaced && prev[0] === '@')?
+        'PROPERTY'
+      :
+        'IDENTIFIER')
   """
 
   testCase """

--- a/test/examples.civet
+++ b/test/examples.civet
@@ -298,7 +298,7 @@ describe "examples (from real life)", ->
     ---
     date := if x==1 then "a" else "b"
     ---
-    let ref;if (x==1) { ref = "a"} else ref = "b";const date =ref
+    const date = (x==1? "a" : "b")
   """
 
   testCase """

--- a/test/function-block-shorthand.civet
+++ b/test/function-block-shorthand.civet
@@ -570,7 +570,7 @@ describe "&. function block shorthand", ->
     ---
     roundUp := if even then & else &+1
     ---
-    let ref;if (even) { ref = $ => $} else ref = $1 => $1+1;const roundUp =ref
+    const roundUp = (even? ($ => $) : ($1 => $1+1))
   """
 
   testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -815,12 +815,10 @@ describe "if", ->
       else
         "b"
       ---
-      let ref;if (y) {
-        ref = "a"
-      }
-      else {
-        ref = "b"
-      };x = ref
+      x = (y?
+        "a"
+      :
+        "b")
     """
 
     testCase """
@@ -832,13 +830,11 @@ describe "if", ->
       else
         "b"
       ---
-      let ref;
-      if (y) {
-        ref = "a"
-      }
-      else {
-        ref = "b"
-      };x =ref
+      x =
+      (y?
+        "a"
+      :
+        "b")
     """
 
     testCase """
@@ -849,12 +845,10 @@ describe "if", ->
       else
         [2]
       ---
-      let ref;if (cond) {
-        ref = [1]
-      }
-      else {
-        ref = [2]
-      };[a] = ref
+      [a] = (cond?
+        [1]
+      :
+        [2])
     """
 
     testCase """
@@ -864,10 +858,9 @@ describe "if", ->
         "a"
       else "b"
       ---
-      let ref;if (y) {
-        ref = "a"
-      }
-      else ref = "b";x = ref
+      x = (y?
+        "a"
+      : "b")
     """
 
     testCase """
@@ -876,9 +869,8 @@ describe "if", ->
       x = if (y)
         "a"
       ---
-      let ref;if (y) {
-        ref = "a"
-      } else {ref = void 0};x = ref
+      x = (y?
+        "a":void 0)
     """
 
     testCase """
@@ -913,12 +905,10 @@ describe "if", ->
       else
         c; d
       ---
-      let ref;if (y) {
-        a; ref = b
-      }
-      else {
-        c; ref = d
-      };x = ref
+      x = (y?(
+        a,b)
+      :(
+        c,d))
     """
 
     testCase """
@@ -929,12 +919,10 @@ describe "if", ->
       else
         /*c*/ c; /*d*/ d
       ---
-      let ref;if (y) {
-        /*a*/ a; /*b*/ ref = b
-      }
-      else {
-        /*c*/ c; /*d*/ ref = d
-      };x = ref
+      x = (y?(
+        /*a*/ a,b)
+      :(
+        /*c*/ c,d))
     """
 
     testCase """
@@ -977,12 +965,10 @@ describe "if", ->
       else
         "b"
       ---
-      let ref;if (!y) {
-        ref = "a"
-      }
-      else {
-        ref = "b"
-      };x = ref
+      x = (!y?
+        "a"
+      :
+        "b")
     """
 
     testCase """
@@ -990,7 +976,29 @@ describe "if", ->
       ---
       x = if y then {} else {}
       ---
-      let ref;if (y) { ref = ({})} else ref = ({});x = ref
+      x = (y? ({}) : ({}))
+    """
+
+    // #2051
+    testCase """
+      if/then/else expression unwraps to ternary
+      ---
+      k : string := "a"
+      key := if k == " " then "Space" else k
+      ---
+      const k : string = "a"
+      const key = (k == " "? "Space" : k)
+    """
+
+    // #2051
+    testCase """
+      if/then/else expression unwraps to ternary same as parenthesized
+      ---
+      key1 := if k == " " then "Space" else k
+      key2 := (if k == " " then "Space" else k)
+      ---
+      const key1 = (k == " "? "Space" : k)
+      const key2 = ((k == " "? "Space" : k))
     """
 
     testCase """
@@ -1113,9 +1121,8 @@ describe "if", ->
       x = if y
         {}
       ---
-      let ref;if (y) {
-        ref = ({})
-      } else {ref = void 0};x = ref
+      x = (y?
+        ({}):void 0)
     """
 
     testCase """
@@ -1124,9 +1131,8 @@ describe "if", ->
       x = if (y)
         {}
       ---
-      let ref;if (y) {
-        ref = ({})
-      } else {ref = void 0};x = ref
+      x = (y?
+        ({}):void 0)
     """
 
     testCase """

--- a/test/if.civet
+++ b/test/if.civet
@@ -1443,6 +1443,28 @@ describe "if", ->
     """
 
     testCase """
+      declaration condition with if/then/else initializer
+      ---
+      if x := if cond then a else b
+        use x
+      ---
+      let ref;if ((ref = (cond? a : b))) {const x = ref;
+        use(x)
+      }
+    """
+
+    testCase """
+      declaration condition with nonnull check and if/then/else initializer
+      ---
+      if x? := if cond then a else b
+        use x
+      ---
+      let ref;if ((ref= (cond? a : b)) != null) {const x = ref;
+        use(x)
+      }
+    """
+
+    testCase """
       declaration with unless
       ---
       unless x := getBool()


### PR DESCRIPTION
Closes #2051.

When the initializer of a const/let declaration is a bare if/then/else expression with simple-expression branches, skip the `let ref` hoisting in `prependStatementExpressionBlock` and let `processStatementExpressions` convert the StatementExpression to an `IfExpression` (ternary) — matching the behavior of the parenthesized form.

Generated with [Claude Code](https://claude.ai/code)