### PR TITLE
Fix Unicode property names in `@`-bind, `::` prototype access, `:` symbol shorthand

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2003,11 +2003,15 @@ PropertyAccess
       optional: modifier?.token === "?",
     }
     if id
+      // `x::😊` → `x.prototype["😊"]`: unicode names need bracket access.
+      access := id.unicode
+        ? [ "prototype[", propertyKey(id), "]" ]
+        : [ "prototype.", id ]
       return {
         type: "PropertyAccess",
         name: id.name,
         dot: start,
-        children: [ start, "prototype.", id ],
+        children: [ start, ...access ],
       }
     else
       return {
@@ -2035,20 +2039,30 @@ PropertyBind
   # NOTE: foo@.bar and foo@bar shorthand for foo.bar.bind(foo)
   # foo@bar(baz) shorthand for foo.bar.bind(foo, baz)
   PropertyAccessModifier?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id Arguments?:args ->
+    // `x@😊` → `x["😊"].bind(x)`: dot-access requires a JS identifier, so
+    // unicode names use bracket access with the user-visible name. Only the
+    // optional-chain `?` modifier keeps its dot (`x?.["😊"]`); plain `x@😊`
+    // and non-null `x!@😊` drop it since `.[` only pairs with `?.`.
+    children := id.unicode
+      ? [modifier, modifier?.token is "?" ? dot : null, "[", propertyKey(id), "]"]
+      : [modifier, dot, id]
     return {
       type: "PropertyBind",
       name: id.name,
-      children: [modifier, dot, id],  // omit `@` from children
+      children,  // omit `@` from children
       args: args?.children.slice(1, -1) ?? [], // remove the parens from the arg list, or give an empty list
     }
 
 # Variation on PropertyBind that forbids implicit arguments (for JSX)
 PropertyBindExplicitArguments
   PropertyAccessModifier?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id ExplicitArguments?:args ->
+    children := id.unicode
+      ? [modifier, modifier?.token is "?" ? dot : null, "[", propertyKey(id), "]"]
+      : [modifier, dot, id]
     return {
       type: "PropertyBind",
       name: id.name,
-      children: [modifier, dot, id],  // omit `@` from children
+      children,  // omit `@` from children
       args: args?.children.slice(1, -1) ?? [], // remove the parens from the arg list, or give an empty list
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3291,9 +3291,18 @@ CoffeeScriptBooleanLiteral
 # NOTE: Added :symbol shorthand for Symbol.symbol or Symbol.for("symbol")
 SymbolLiteral
   Colon:colon ( IdentifierName / StringLiteral ):id ->
-    let name, token
+    let name, token, quoted
     if id.type is "Identifier"
-      { name, children: [ token ] } = id
+      if id.unicode
+        // `:🍊` → `Symbol.for("🍊")`: route unicode through the quoted
+        // path so the registry key matches the user-visible name, not
+        // the mangled `u$1F34A$` binding form.
+        name = id.unicode
+        token = { $loc: id.children?.[0]?.$loc, token: `"${id.unicode}"` }
+        quoted = true
+      else
+        { name, children: [ token ] } = id
+        quoted = false
     else
       name = literalValue({
         type: "Literal",
@@ -3302,17 +3311,18 @@ SymbolLiteral
         children: [id],
       })
       token = id
+      quoted = true
     if config.symbols.includes(name) // well-known symbol
       return {
         type: "SymbolLiteral",
         children:
-          id.type is "Identifier" ? [
-            { ...colon, token: "Symbol." },
-            token,
-          ] : [
+          quoted ? [
             { ...colon, token: "Symbol[" },
             token,
             "]",
+          ] : [
+            { ...colon, token: "Symbol." },
+            token,
           ],
         name,
       }
@@ -3321,7 +3331,7 @@ SymbolLiteral
         type: "SymbolLiteral",
         children: [
           { ...colon, token: 'Symbol.for(' },
-          id.type is "Identifier" ? [ '"', token, '"' ] : token,
+          quoted ? token : [ '"', token, '"' ],
           ')'
         ],
         name,

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -206,6 +206,36 @@ describe "identifier", ->
       x?.prototype["😊"]
     """
 
+    // -- `:symbol` shorthand: unicode names go through the global registry
+    //    with the source key so `:😊` matches the runtime symbol.
+
+    testCase """
+      symbol shorthand with unicode name
+      ---
+      :😊
+      ---
+      Symbol.for("😊")
+    """
+
+    testCase """
+      symbol shorthand with unicode in class member
+      ---
+      class Foo
+        @:😊 = 1
+      ---
+      class Foo {
+        static [Symbol.for("😊")] = 1
+      }
+    """
+
+    testCase """
+      dot-symbol shorthand with unicode name
+      ---
+      obj.:😊
+      ---
+      obj[Symbol.for("😊")]
+    """
+
     // -- Methods and class fields use the user-visible name as a quoted key.
 
     testCase """

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -161,6 +161,51 @@ describe "identifier", ->
       data?.["😊"]
     """
 
+    // -- `@`-bind and CoffeeScript `::` prototype access also use the
+    //    user-visible name as a quoted bracket key for unicode properties.
+
+    testCase """
+      property bind with unicode property
+      ---
+      x@😊
+      ---
+      x["😊"].bind(x)
+    """
+
+    testCase """
+      optional property bind with unicode property
+      ---
+      x?@😊
+      ---
+      x?.["😊"].bind(x)
+    """
+
+    testCase """
+      non-null property bind with unicode property
+      ---
+      x!@😊
+      ---
+      x!["😊"].bind(x)
+    """
+
+    testCase """
+      prototype shorthand with unicode property
+      ---
+      'civet coffeePrototype'
+      x::😊
+      ---
+      x.prototype["😊"]
+    """
+
+    testCase """
+      optional prototype shorthand with unicode property
+      ---
+      'civet coffeePrototype'
+      x?::😊
+      ---
+      x?.prototype["😊"]
+    """
+
     // -- Methods and class fields use the user-visible name as a quoted key.
 
     testCase """

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -189,6 +189,14 @@ describe "identifier", ->
     """
 
     testCase """
+      explicit-dot property bind with unicode property
+      ---
+      x@.😊
+      ---
+      x["😊"].bind(x)
+    """
+
+    testCase """
       prototype shorthand with unicode property
       ---
       'civet coffeePrototype'
@@ -204,6 +212,15 @@ describe "identifier", ->
       x?::😊
       ---
       x?.prototype["😊"]
+    """
+
+    testCase """
+      non-null prototype shorthand with unicode property
+      ---
+      'civet coffeePrototype'
+      x!::😊
+      ---
+      x!.prototype["😊"]
     """
 
     // -- `:symbol` shorthand: unicode names go through the global registry

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -156,6 +156,38 @@ describe "braced JSX attributes", ->
   """
 
   testCase """
+    bind shorthand with unicode property
+    ---
+    <Component x=a@🍊 />
+    ---
+    <Component x={a["🍊"].bind(a)} />
+  """
+
+  testCase """
+    bind shorthand with unicode property and explicit argument
+    ---
+    <Component x=a@🍊(c) />
+    ---
+    <Component x={a["🍊"].bind(a, c)} />
+  """
+
+  testCase """
+    optional bind shorthand with unicode property
+    ---
+    <Component x=a?@🍊 />
+    ---
+    <Component x={a?.["🍊"].bind(a)} />
+  """
+
+  testCase """
+    non-null bind shorthand with unicode property
+    ---
+    <Component x=a!@🍊 />
+    ---
+    <Component x={a!["🍊"].bind(a)} />
+  """
+
+  testCase """
     ++ and --
     ---
     <Component post=foo++ pre=++foo />


### PR DESCRIPTION
Fixes #2052

`x@🍊` and `x::🍊` used the mangled binding name (`u$1F34A$`) as a JS property, which doesn't match the user-visible key the property was stored under. They now emit bracket access with the source name so that `{ 🍊() ... }@🍊` and `class { 🍊() ... }::🍊` resolve at runtime, matching how `data.🍊` already compiled to `data["🍊"]`.

Non-null `x!@🍊` drops the dot (`x!["🍊"]`) since TS only pairs `.[` with optional `?.`; optional `x?@🍊` keeps it as `x?.["🍊"]`.

Generated with [Claude Code](https://claude.ai/code)