### PR TITLE
Tests: force V8 coverage flush before mocha worker exit

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,7 +4,8 @@
   ],
   "require": [
     "./build/register.js",
-    "./build/test-warmup.js"
+    "./build/test-warmup.js",
+    "./build/coverage-flush.js"
   ],
   "reporter": "./build/dot-batch-reporter.js",
   "recursive": true,

--- a/build/coverage-flush.js
+++ b/build/coverage-flush.js
@@ -1,0 +1,14 @@
+'use strict';
+
+// Mocha root hook plugin: force v8 coverage flush before mocha tears
+// the worker down via IPC disconnect. Without this, the parallel-worker
+// exit can race the profile writer and drop sub-function arm data,
+// producing flaky coverage-gate failures with different files missing
+// each run.
+exports.mochaHooks = {
+  afterAll() {
+    if (process.env.NODE_V8_COVERAGE) {
+      require('v8').takeCoverage();
+    }
+  },
+};

--- a/lsp/monaco/.mocharc.json
+++ b/lsp/monaco/.mocharc.json
@@ -5,7 +5,8 @@
   ],
   "require": [
     "source-map-support",
-    "../../build/register.js"
+    "../../build/register.js",
+    "../../build/coverage-flush.js"
   ],
   "reporter": "dot",
   "recursive": true,

--- a/lsp/server/.mocharc.json
+++ b/lsp/server/.mocharc.json
@@ -5,7 +5,8 @@
   ],
   "require": [
     "source-map-support",
-    "../../build/register.js"
+    "../../build/register.js",
+    "../../build/coverage-flush.js"
   ],
   "reporter": "dot",
   "recursive": true,


### PR DESCRIPTION
## Summary

Fixes flaky `Coverage gate` failures on Ubuntu CI where different files turn up uncovered each run, even on tiny PRs that touch unrelated code (#2054, #2055 reruns).

## Cause

Both root `.mocharc.json` and `lsp/server/.mocharc.json` set `parallel: true`. With `c8 mocha --parallel -j 4`, each mocha worker is a child process that should flush its `NODE_V8_COVERAGE` profile on exit. But mocha tears workers down via IPC disconnect, which races Node's v8 profile writer — the flush can be cut short, dropping sub-function arm data.

Symptom is distinctive: all tests pass, file counts are identical to passing runs (91 / 20 / 3 / 14), but the coverage report shows different files missing arms each run. Three observed instances:

| Run | Branch | Uncovered |
|---|---|---|
| 25828362759 | PR 2054 (commit a) | LSP server files (config, doc, host, service, snapshot, typecheck) |
| 25828849944 | PR 2054 (commit b) | `unplugin.civet` 91.1% + `service.civet` missing 1 function |
| 25828620180 | PR 2055 | `parser.hera` missing 1 branch |

Same base as main; main's run on the same merge base shows 100%.

## Fix

`build/coverage-flush.js` — mocha root hook plugin whose `afterAll` calls `v8.takeCoverage()`. Forces a synchronous flush while the worker is firmly alive, before any IPC tear-down can race. Wired into `.mocharc.json`, `lsp/server/.mocharc.json`, and `lsp/monaco/.mocharc.json`.

`takeCoverage()` is a no-op when `NODE_V8_COVERAGE` isn't set, so regular test runs are unaffected.

## Test plan

- [x] `pnpm test` still passes (3964 passing locally)
- [x] `pnpm -C lsp/server test:coverage` still passes (260 passing, coverage tmp populated)
- [x] Coverage tmp dirs receive 2–3× more profile files than before (intermediate `takeCoverage` snapshots + natural exit write); c8 merges them all
- [ ] CI coverage gate stops drifting across reruns

🤖 Generated with [Claude Code](https://claude.com/claude-code)