### PR TITLE
CI: rolling cache keys + prune stale entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,16 +39,14 @@ jobs:
           cache: pnpm
           node-version: 24
 
-      - name: Cache month bucket
-        id: month
-        run: echo "ym=$(date -u +%Y-%m)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache/restore@v4
         id: cache
         with:
           path: .cache
-          key: ${{ github.ref_name }}-${{ steps.month.outputs.ym }}
+          key: ${{ github.ref_name }}-${{ github.run_id }}
           restore-keys: |
-            main-${{ steps.month.outputs.ym }}
+            ${{ github.ref_name }}-
+            main-
 
       - name: Read VS Code version
         id: vscode
@@ -86,10 +84,13 @@ jobs:
         run: |
           pnpm typecheck --max-errors 888
 
+      - name: Prune stale cache entries
+        run: pnpm clean:cache:prune
+
       - uses: actions/cache/save@v4
         with:
           path: .cache
-          key: ${{ github.ref_name }}-${{ steps.month.outputs.ym }}
+          key: ${{ github.ref_name }}-${{ github.run_id }}
 
       - uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "bash ./build/build.sh",
     "build:self": "pnpm build && bash ./build/build-self.sh",
     "clean:cache": "rm -rf .cache",
-    "clean:cache:prune": "bash -c 'find .cache/build -type f -mtime +${1:-14} -delete 2>/dev/null || true' --",
+    "clean:cache:prune": "bash -c 'find .cache/build -type f -mtime +\"${1:-14}\" -delete 2>/dev/null || true' --",
     "docs:dev": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && vitepress dev civet.dev",
     "docs:build": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && vitepress build civet.dev",
     "docs:preview": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && vitepress preview civet.dev",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "bash ./build/build.sh",
     "build:self": "pnpm build && bash ./build/build-self.sh",
     "clean:cache": "rm -rf .cache",
+    "clean:cache:prune": "bash -c 'find .cache/build -type f -mtime +${1:-14} -delete 2>/dev/null || true' --",
     "docs:dev": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && vitepress dev civet.dev",
     "docs:build": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && vitepress build civet.dev",
     "docs:preview": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && vitepress preview civet.dev",


### PR DESCRIPTION
## Summary

GH Actions cache keys are immutable. The current workflow uses a monthly key (`${ref_name}-${YYYY-MM}`), so the first run of the month creates the cache and **every subsequent save no-ops** with `Failed to reserve cache: another job may be creating this cache.` That freezes the cache snapshot for the rest of the month.

Observed impact on this repo: main-branch typecheck consistently takes **~95 s** even though PRs whose own first run populates the cache see **~1–4 s** for the same step. Same `restore-keys: main-2026-05`, very different content.

## Changes

- **Rolling save keys.** `key: ${ref_name}-${run_id}` is unique per run, so save always succeeds. `restore-keys` falls back via prefix (`${ref_name}-`, then `main-`) — GH returns the most recently created cache for each prefix. Each run inherits the freshest snapshot and adds its own new entries to the next save. Combined with GH's 10 GB LRU + 7-day TTL, old snapshots get evicted automatically; no need for an explicit time bucket.
- **`pnpm clean:cache:prune [days=14]`.** Drops `.cache/build/` entries with mtime older than the given threshold (defaults to 14). The disk cache already calls `fs.utimesSync` on every successful `get` (`source/cache.civet:117`), so unread entries naturally age out. The workflow runs this before save so the tarball doesn't accumulate dead weight forever (e.g., post-compiler-version-bump, where `civetMtime` invalidates the old keys but the files would otherwise persist).

## Notes on cross-branch behavior

`restore-keys` is order-significant and per-entry "newest match wins":
- Branch with prior runs → its own freshest snapshot via `${ref_name}-`
- First-run branch / month rollover → freshest main via `main-`

The CAS layout of `.cache/build/` (SHA1 of `(source, compiler-version, options)`) means parallel restores never conflict at the file level — two different runs computing the same input produce identical filenames with identical content.

## Test plan

- [x] `pnpm clean:cache:prune` is silent and exit-0 on a fresh checkout (no `.cache`)
- [x] `pnpm clean:cache:prune 1` against local cache pruned 2062/3606 entries (977M → 123M), leaving the 0d/1d mtime buckets intact
- [x] Default 14d threshold doesn't touch a 5-day-old cache
- [x] CI: first run on this branch will be a cold restore from `main-…` prefix, save under `ci-cache-rolling-keys-${run_id}`. Subsequent merges to main should show typecheck dropping back to seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)