### PR TITLE
Restore leaf-glom fallback in `prepend`

### DIFF
--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -348,12 +348,14 @@ function prepend(prefix: ASTNode, node: ASTNode): ASTNode
   return node if not prefix or prefix is like []
   if Array.isArray node
     [prefix, ...node]
-  else
-    assert isParent(node), "prepend: can't glom into an AST leaf"
+  else if isParent node
     {
       ...node
       children: [prefix, ...node.children]
     } as typeof node
+  // Mirrors `append`: can't glom into a leaf, so wrap as an array.
+  else
+    [prefix, node]
 
 function append(node: ASTNode, suffix: ASTNode): ASTNode
   return node if not suffix or suffix is like []

--- a/test/util/helpers.civet
+++ b/test/util/helpers.civet
@@ -1,11 +1,14 @@
 assert from assert
 {
   assert: civetAssert
+  append
   inplacePrepend
   makeLeftHandSideExpression
+  prepend
   replaceNodes
   startsWithPredicate
 } from ../../source/parser/util.civet
+type { ASTNode } from ../../source/parser/types.civet
 
 describe "replaceNodes", ->
   it "passes through null root unchanged", ->
@@ -100,3 +103,30 @@ describe "inplacePrepend", ->
     node := { type: "X", children: [1, 2] }
     inplacePrepend("pre", node)
     assert.deepEqual node.children, ["pre", 1, 2]
+
+describe "prepend", ->
+  // Regression: #2058. `prepend` previously fell back to `[prefix, node]`
+  // for leaf nodes, mirroring `append`. The fallback was deleted as
+  // "dead code" but real grammar paths (e.g. token-only AST objects like
+  // `{ $loc, token }`) reach `prepend` with a leaf, and removing the
+  // fallback turned that into a parse-time assertion failure in user code.
+  it "returns node unchanged for empty/missing prefix", ->
+    leaf: ASTNode := { $loc: { pos: 0, length: 1 }, token: "x" }
+    assert.equal prepend(undefined, leaf), leaf
+    assert.equal prepend([], leaf), leaf
+
+  it "prepends to arrays", ->
+    arr: ASTNode := ["a", "b"]
+    assert.deepEqual prepend("pre", arr), ["pre", "a", "b"]
+
+  it "prepends to parent nodes via children", ->
+    // UntypedNode shape (no `type`) so it satisfies ASTNode without a cast.
+    node: ASTNode := { children: ["a", "b"] }
+    result := prepend("pre", node) as { children: unknown[] }
+    assert.deepEqual result.children, ["pre", "a", "b"]
+    assert.deepEqual (node as { children: unknown[] }).children, ["a", "b"], "input not mutated"
+
+  it "wraps leaf nodes in an array (mirrors `append`)", ->
+    leaf: ASTNode := { $loc: { pos: 0, length: 6 }, token: "import" }
+    assert.deepEqual prepend(" ", leaf), [" ", leaf]
+    assert.deepEqual append(leaf, " "), [leaf, " "]


### PR DESCRIPTION
Coverage-cleanup commit `718ec4c8` deleted `prepend`'s leaf-node arm on the grounds that no test reached it. Real user code under `unplugin-civet` does reach it, surfacing as `Assertion failed [prepend: can't glom into an AST leaf]`.

`append` still has the symmetric leaf fallback, so restore the same shape in `prepend` and add unit tests covering all four arms.

Fixes #2058

🤖 Generated with [Claude Code](https://claude.ai/code)