### PR TITLE
diag(coverage): re-enable parallel + log SIGTERM'd workers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,25 +65,38 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: Test (with coverage)
+      - name: Test (with coverage, forced-low worker timeout to PROVE the bug)
         if: runner.os == 'Linux'
-        # Allow coverage gate failure here — the SIGTERM-trace check runs
-        # next regardless, and is the diagnostic signal we're after.
+        # Allow coverage gate failure here — the trace check runs next.
+        # CIVET_WORKER_TERMINATE_TIMEOUT=1 means workers have 1 ms to
+        # respond to the IPC terminate before the parent SIGTERMs them.
+        # If the hypothesis is right, this run should leave SIGTERM entries
+        # in the trace log AND tank coverage.
+        env:
+          CIVET_WORKER_TERMINATE_TIMEOUT: "1"
         continue-on-error: true
         run: |
           rm -f /tmp/civet-sigterm-trace.log
           pnpm coverage
 
-      - name: SIGTERM trace (diagnostic — fails if any worker was force-killed)
+      - name: Worker exit-path trace (diagnostic — fails if any SIGTERM entries)
         if: always() && runner.os == 'Linux'
         run: |
           if [ -s /tmp/civet-sigterm-trace.log ]; then
-            count=$(wc -l < /tmp/civet-sigterm-trace.log)
-            echo "::error::Mocha parallel workers were SIGTERM'd ($count PID(s)):"
+            echo "Full trace log:"
             cat /tmp/civet-sigterm-trace.log
-            exit 1
+            echo ""
+            echo "Event counts:"
+            awk '{print $1}' /tmp/civet-sigterm-trace.log | sort | uniq -c
+            sigterm_count=$(grep -c '^SIGTERM ' /tmp/civet-sigterm-trace.log || true)
+            if [ "$sigterm_count" -gt 0 ]; then
+              echo "::error::$sigterm_count worker(s) were SIGTERM'd by the parent."
+              exit 1
+            fi
+            echo "No SIGTERM entries (other events seen but those aren't the bug)."
+          else
+            echo "No worker exit-path events detected."
           fi
-          echo "No SIGTERM'd workers detected."
 
       - name: Test (Windows, no coverage)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,23 @@ jobs:
 
       - name: Test (with coverage)
         if: runner.os == 'Linux'
-        run: pnpm coverage
+        # Allow coverage gate failure here — the SIGTERM-trace check runs
+        # next regardless, and is the diagnostic signal we're after.
+        continue-on-error: true
+        run: |
+          rm -f /tmp/civet-sigterm-trace.log
+          pnpm coverage
+
+      - name: SIGTERM trace (diagnostic — fails if any worker was force-killed)
+        if: always() && runner.os == 'Linux'
+        run: |
+          if [ -s /tmp/civet-sigterm-trace.log ]; then
+            count=$(wc -l < /tmp/civet-sigterm-trace.log)
+            echo "::error::Mocha parallel workers were SIGTERM'd ($count PID(s)):"
+            cat /tmp/civet-sigterm-trace.log
+            exit 1
+          fi
+          echo "No SIGTERM'd workers detected."
 
       - name: Test (Windows, no coverage)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,15 +65,13 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm build
 
-      - name: Test (with coverage, forced-low worker timeout to PROVE the bug)
+      - name: Test (with coverage, parallel control)
         if: runner.os == 'Linux'
-        # Allow coverage gate failure here — the trace check runs next.
-        # CIVET_WORKER_TERMINATE_TIMEOUT=1 means workers have 1 ms to
-        # respond to the IPC terminate before the parent SIGTERMs them.
-        # If the hypothesis is right, this run should leave SIGTERM entries
-        # in the trace log AND tank coverage.
-        env:
-          CIVET_WORKER_TERMINATE_TIMEOUT: "1"
+        # 1 ms-timeout proof run (commit 616b85ff) disproved the SIGTERM
+        # hypothesis.  Now run the parallel-control configuration: default
+        # workerpool timeout, parallel coverage re-enabled, trace shim wired.
+        # If 5+ reruns of this all pass at 100 %, the dual-compile fix from
+        # PR #2060 was sufficient and --no-parallel can be reverted.
         continue-on-error: true
         run: |
           rm -f /tmp/civet-sigterm-trace.log
@@ -83,19 +81,21 @@ jobs:
         if: always() && runner.os == 'Linux'
         run: |
           if [ -s /tmp/civet-sigterm-trace.log ]; then
-            echo "Full trace log:"
-            cat /tmp/civet-sigterm-trace.log
-            echo ""
-            echo "Event counts:"
+            echo "Event counts (column 1 is event, count is occurrences):"
             awk '{print $1}' /tmp/civet-sigterm-trace.log | sort | uniq -c
+            echo ""
+            installs=$(grep -c '^install' /tmp/civet-sigterm-trace.log || true)
+            echo "Distinct worker processes that loaded the shim: $installs"
             sigterm_count=$(grep -c '^SIGTERM ' /tmp/civet-sigterm-trace.log || true)
             if [ "$sigterm_count" -gt 0 ]; then
               echo "::error::$sigterm_count worker(s) were SIGTERM'd by the parent."
+              grep '^SIGTERM ' /tmp/civet-sigterm-trace.log
               exit 1
             fi
-            echo "No SIGTERM entries (other events seen but those aren't the bug)."
+            echo "No SIGTERM entries."
           else
-            echo "No worker exit-path events detected."
+            echo "::error::No worker exit-path events detected — workers may not have run."
+            exit 1
           fi
 
       - name: Test (Windows, no coverage)

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,7 +4,8 @@
   ],
   "require": [
     "./build/register.js",
-    "./build/test-warmup.js"
+    "./build/test-warmup.js",
+    "./build/sigterm-trace.js"
   ],
   "reporter": "./build/dot-batch-reporter.js",
   "recursive": true,

--- a/build/sigterm-trace.js
+++ b/build/sigterm-trace.js
@@ -1,0 +1,25 @@
+// Diagnostic shim: log PIDs of mocha parallel workers that get SIGTERM'd
+// by the workerpool's force-kill fallback. See MOCHA-PARALLEL-COVERAGE-RACE.md
+// for context — when the parent's `workerTerminateTimeout` (default 1 s) elapses
+// before a worker exits, the parent kills it and any V8 coverage data the
+// worker had accumulated is silently dropped, producing flaky 99.x% gates.
+//
+// We only install the handler in worker processes (identified by mocha's
+// MOCHA_WORKER_ID env), so the parent's own SIGTERM behavior is unchanged.
+// The path is overridable via CIVET_SIGTERM_TRACE for ad-hoc local runs;
+// CI inspects this file after the suite and fails the job if it has PIDs.
+//
+// We deliberately SIGKILL ourselves after logging instead of running normal
+// exit cleanup — we want to preserve the coverage-loss symptom so we can
+// correlate "SIGTERM log has PIDs" with "coverage gate failed".
+
+if (process.env.MOCHA_WORKER_ID !== undefined) {
+  const fs = require("fs");
+  const path = process.env.CIVET_SIGTERM_TRACE || "/tmp/civet-sigterm-trace.log";
+  process.on("SIGTERM", () => {
+    try {
+      fs.appendFileSync(path, `${process.pid}\n`);
+    } catch {}
+    process.kill(process.pid, "SIGKILL");
+  });
+}

--- a/build/sigterm-trace.js
+++ b/build/sigterm-trace.js
@@ -24,6 +24,9 @@ if (process.env.MOCHA_WORKER_ID !== undefined) {
       fs.appendFileSync(path, `${event} ${process.pid}\n`);
     } catch {}
   };
+  // Direct evidence that this worker process exists.  Counting `install`
+  // entries in CI gives us actual worker count per coverage run.
+  log(`install/worker${process.env.MOCHA_WORKER_ID}`);
   process.on("SIGTERM", () => {
     log("SIGTERM");
     process.kill(process.pid, "SIGKILL");

--- a/build/sigterm-trace.js
+++ b/build/sigterm-trace.js
@@ -1,25 +1,38 @@
-// Diagnostic shim: log PIDs of mocha parallel workers that get SIGTERM'd
-// by the workerpool's force-kill fallback. See MOCHA-PARALLEL-COVERAGE-RACE.md
-// for context — when the parent's `workerTerminateTimeout` (default 1 s) elapses
-// before a worker exits, the parent kills it and any V8 coverage data the
-// worker had accumulated is silently dropped, producing flaky 99.x% gates.
+// Diagnostic shim: log mocha parallel worker exit paths to a trace file so
+// we can tell whether the workerpool's force-kill fallback is firing in CI
+// (see MOCHA-PARALLEL-COVERAGE-DIAGNOSIS.md).
 //
-// We only install the handler in worker processes (identified by mocha's
-// MOCHA_WORKER_ID env), so the parent's own SIGTERM behavior is unchanged.
-// The path is overridable via CIVET_SIGTERM_TRACE for ad-hoc local runs;
-// CI inspects this file after the suite and fails the job if it has PIDs.
+// Each log line is `<event> <pid>` so the post-run check can distinguish:
+//   SIGTERM <pid>   — parent's workerTerminateTimeout elapsed; force-killed
+//   SIGINT  <pid>   — Ctrl-C path
+//   disconnect <pid> — IPC channel closed before clean exit (workerpool's
+//                       internal handler calls process.exit(1) on this)
+// Only installed in worker processes (MOCHA_WORKER_ID env set by mocha's
+// BufferedWorkerPool); parent's own behavior is unchanged.  Overridable
+// via CIVET_SIGTERM_TRACE.
 //
-// We deliberately SIGKILL ourselves after logging instead of running normal
-// exit cleanup — we want to preserve the coverage-loss symptom so we can
-// correlate "SIGTERM log has PIDs" with "coverage gate failed".
+// For SIGTERM we deliberately SIGKILL ourselves after logging — we want
+// to preserve the coverage-loss symptom so we can correlate "trace log
+// has SIGTERM entries" with "coverage gate failed".  The other events
+// just log and let normal handling proceed.
 
 if (process.env.MOCHA_WORKER_ID !== undefined) {
   const fs = require("fs");
   const path = process.env.CIVET_SIGTERM_TRACE || "/tmp/civet-sigterm-trace.log";
-  process.on("SIGTERM", () => {
+  const log = (event) => {
     try {
-      fs.appendFileSync(path, `${process.pid}\n`);
+      fs.appendFileSync(path, `${event} ${process.pid}\n`);
     } catch {}
+  };
+  process.on("SIGTERM", () => {
+    log("SIGTERM");
     process.kill(process.pid, "SIGKILL");
   });
+  process.on("SIGINT", () => {
+    log("SIGINT");
+    process.kill(process.pid, "SIGKILL");
+  });
+  // workerpool registers its own 'disconnect' listener that calls
+  // process.exit(1); use prependListener so ours logs first.
+  process.prependListener("disconnect", () => log("disconnect"));
 }

--- a/build/test.sh
+++ b/build/test.sh
@@ -54,8 +54,11 @@ if [ "${CIVET_COVERAGE:-0}" = "1" ] && [ "$threads" != "0" ]; then
   args="$args --worker-termination-timeout ${CIVET_WORKER_TERMINATE_TIMEOUT:-30000}"
 fi
 
+echo "[test.sh] CIVET_WORKER_TERMINATE_TIMEOUT=${CIVET_WORKER_TERMINATE_TIMEOUT:-<unset>}, args=$args"
 if [ "${CIVET_COVERAGE:-0}" = "1" ]; then
+  set -x
   c8 mocha $args "$@"
+  set +x
 else
   node_modules/.bin/mocha $args "$@"
 fi

--- a/build/test.sh
+++ b/build/test.sh
@@ -46,6 +46,14 @@ if [ "${CIVET_COVERAGE:-0}" = "1" ]; then
   args="$args --timeout 10000"
 fi
 
+# Bump workerpool's worker-terminate timeout for coverage runs (requires the
+# STRd6/mocha#worker-termination-timeout fork — pinned via pnpm.overrides).
+# Default is 1 s, which lets workers serializing the final V8 coverage data
+# get SIGTERM'd and silently lose hits.  30 s gives them ample headroom.
+if [ "${CIVET_COVERAGE:-0}" = "1" ] && [ "$threads" != "0" ]; then
+  args="$args --worker-termination-timeout 30000"
+fi
+
 if [ "${CIVET_COVERAGE:-0}" = "1" ]; then
   c8 mocha $args "$@"
 else

--- a/build/test.sh
+++ b/build/test.sh
@@ -46,12 +46,12 @@ if [ "${CIVET_COVERAGE:-0}" = "1" ]; then
   args="$args --timeout 10000"
 fi
 
-# Bump workerpool's worker-terminate timeout for coverage runs (requires the
-# STRd6/mocha#worker-termination-timeout fork — pinned via pnpm.overrides).
-# Default is 1 s, which lets workers serializing the final V8 coverage data
-# get SIGTERM'd and silently lose hits.  30 s gives them ample headroom.
+# Worker-terminate timeout (requires the STRd6/mocha#worker-termination-timeout
+# fork — pinned via pnpm.overrides).  Configurable via env so we can flip
+# between "extreme low → force the bug" and "high → bypass the bug" without
+# touching this file.  Default 30000 (30 s) is the proposed fix value.
 if [ "${CIVET_COVERAGE:-0}" = "1" ] && [ "$threads" != "0" ]; then
-  args="$args --worker-termination-timeout 30000"
+  args="$args --worker-termination-timeout ${CIVET_WORKER_TERMINATE_TIMEOUT:-30000}"
 fi
 
 if [ "${CIVET_COVERAGE:-0}" = "1" ]; then

--- a/build/test.sh
+++ b/build/test.sh
@@ -15,15 +15,11 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" && ( "$OSTYPE" == msys* || "$OSTYPE" == cy
   cap=2
 fi
 threads="${CIVET_THREADS:-$(node -e "const cpus = require('os').cpus().length; process.stdout.write(String(Math.min(cpus, $cap)))")}"
-# Parallel mocha workers race v8's NODE_V8_COVERAGE profile writer: hits
-# generated during mocha's IPC-disconnect teardown are lost, producing
-# flaky 99.x% gate failures with different files missing each run.
-# `afterAll` + `v8.takeCoverage()` only flushes what's accumulated up to
-# that point.  Serializing under coverage is the only known reliable fix
-# (see vitest #2591, mochista's design rationale).
-if [ "${CIVET_COVERAGE:-0}" = "1" ]; then
-  threads=0
-fi
+# Temporarily re-enabled parallel under coverage to gather diagnostic data
+# on the workerpool SIGTERM hypothesis (see MOCHA-PARALLEL-COVERAGE-RACE.md).
+# build/sigterm-trace.js logs worker PIDs that hit SIGTERM; CI inspects the
+# log after the run.  Revert this block (and the lsp/server --no-parallel
+# removal) once we have empirical confirmation.
 args=""
 if [ "$threads" != "0" ]; then
   args="--parallel -j $threads"

--- a/lsp/server/.mocharc.json
+++ b/lsp/server/.mocharc.json
@@ -5,7 +5,8 @@
   ],
   "require": [
     "source-map-support",
-    "../../build/register.js"
+    "../../build/register.js",
+    "../../build/sigterm-trace.js"
   ],
   "reporter": "dot",
   "recursive": true,

--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -39,7 +39,7 @@
     "build": "bash ./build/build.sh",
     "build-dev": "bash ./build/build.sh development",
     "test": "pnpm build && mocha --config .mocharc.json",
-    "test:coverage": "pnpm build && c8 mocha --config .mocharc.json --no-parallel"
+    "test:coverage": "pnpm build && c8 mocha --config .mocharc.json"
   },
   "c8": {
     "all": true,

--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -39,7 +39,7 @@
     "build": "bash ./build/build.sh",
     "build-dev": "bash ./build/build.sh development",
     "test": "pnpm build && mocha --config .mocharc.json",
-    "test:coverage": "pnpm build && c8 mocha --config .mocharc.json"
+    "test:coverage": "pnpm build && c8 mocha --config .mocharc.json --worker-termination-timeout 30000"
   },
   "c8": {
     "all": true,

--- a/package.json
+++ b/package.json
@@ -206,7 +206,8 @@
       "tmp": "^0.2.5",
       "lodash": "^4.18.0",
       "esbuild": "0.27.5",
-      "diff": "^8.0.3"
+      "diff": "^8.0.3",
+      "mocha": "github:STRd6/mocha#worker-termination-timeout"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   lodash: ^4.18.0
   esbuild: 0.27.5
   diff: ^8.0.3
+  mocha: github:STRd6/mocha#worker-termination-timeout
 
 importers:
 
@@ -71,8 +72,8 @@ importers:
         specifier: ^4.2.4
         version: 4.3.0
       mocha:
-        specifier: ^10.7.3
-        version: 10.8.2
+        specifier: github:STRd6/mocha#worker-termination-timeout
+        version: https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -122,8 +123,8 @@ importers:
         specifier: ^9.17.0
         version: 9.39.4
       mocha:
-        specifier: ^10.7.3
-        version: 10.8.2
+        specifier: github:STRd6/mocha#worker-termination-timeout
+        version: https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7
       typescript-eslint:
         specifier: ^8.19.0
         version: 8.58.0(eslint@9.39.4)(typescript@6.0.2)
@@ -162,8 +163,8 @@ importers:
         specifier: workspace:*
         version: link:../..
       mocha:
-        specifier: ^11.7.5
-        version: 11.7.5
+        specifier: github:STRd6/mocha#worker-termination-timeout
+        version: https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7
       vinyl:
         specifier: ^3.0.1
         version: 3.0.1
@@ -319,8 +320,8 @@ importers:
         specifier: 0.27.5
         version: 0.27.5
       mocha:
-        specifier: ^11.7.5
-        version: 11.7.5
+        specifier: github:STRd6/mocha#worker-termination-timeout
+        version: https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -365,8 +366,8 @@ importers:
         specifier: 0.27.5
         version: 0.27.5
       mocha:
-        specifier: ^11.7.5
-        version: 11.7.5
+        specifier: github:STRd6/mocha#worker-termination-timeout
+        version: https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -1345,10 +1346,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
@@ -1651,10 +1648,6 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@prettier/sync@0.5.5':
     resolution: {integrity: sha512-6BMtNr7aQhyNcGzmumkL0tgr1YQGfm9d7ZdmRpWqWuqpc9vZBind4xMe5NMiRECOhjuSiWHfBWLBnXkpeE90bw==}
@@ -2678,10 +2671,6 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   ansi-wrap@0.1.0:
     resolution: {integrity: sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==}
     engines: {node: '>=0.10.0'}
@@ -2971,10 +2960,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -3354,9 +3339,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -3382,9 +3364,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -3836,11 +3815,6 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
@@ -4145,10 +4119,6 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-path-inside@3.0.3:
-    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
-    engines: {node: '>=8'}
-
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
@@ -4254,9 +4224,6 @@ packages:
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
-
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -4906,10 +4873,6 @@ packages:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -4926,14 +4889,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-  mocha@10.8.2:
-    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
+  mocha@https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7:
+    resolution: {tarball: https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7}
+    version: 10.8.2
     engines: {node: '>= 14.0.0'}
-    hasBin: true
-
-  mocha@11.7.5:
-    resolution: {integrity: sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
   monaco-editor@0.55.1:
@@ -5239,10 +5198,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -5415,10 +5370,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -5796,10 +5747,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -6573,9 +6520,6 @@ packages:
   workerpool@6.5.1:
     resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
 
-  workerpool@9.3.4:
-    resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
-
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -6583,10 +6527,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -7732,15 +7672,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.2
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/cliui@9.0.0': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
@@ -8099,9 +8030,6 @@ snapshots:
   '@oxc-project/types@0.122.0': {}
 
   '@oxc-project/types@0.124.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@prettier/sync@0.5.5(prettier@3.8.1)':
     dependencies:
@@ -9160,8 +9088,6 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansi-styles@6.2.3: {}
-
   ansi-wrap@0.1.0: {}
 
   anymatch@3.1.3:
@@ -9558,10 +9484,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -9883,8 +9805,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0: {}
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -9904,8 +9824,6 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   encodeurl@1.0.2: {}
 
@@ -10385,15 +10303,6 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
@@ -10784,8 +10693,6 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-path-inside@3.0.3: {}
-
   is-plain-obj@2.1.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -10885,12 +10792,6 @@ snapshots:
       binaryextensions: 6.11.0
       editions: 6.22.0
       textextensions: 6.11.0
-
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
 
   jackspeak@4.2.3:
     dependencies:
@@ -11890,10 +11791,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.3
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.0.3
-
   minimist@1.2.8:
     optional: true
 
@@ -11906,7 +11803,7 @@ snapshots:
   mkdirp-classic@0.5.3:
     optional: true
 
-  mocha@10.8.2:
+  mocha@https://codeload.github.com/STRd6/mocha/tar.gz/ce26a81ad5bcd6f2e866ce4ddb23c45ca6f3dae7:
     dependencies:
       ansi-colors: 4.1.3
       browser-stdout: 1.3.1
@@ -11927,30 +11824,6 @@ snapshots:
       workerpool: 6.5.1
       yargs: 16.2.0
       yargs-parser: 20.2.9
-      yargs-unparser: 2.0.0
-
-  mocha@11.7.5:
-    dependencies:
-      browser-stdout: 1.3.1
-      chokidar: 4.0.3
-      debug: 4.4.3(supports-color@8.1.1)
-      diff: 8.0.4
-      escape-string-regexp: 4.0.0
-      find-up: 5.0.0
-      glob: 10.5.0
-      he: 1.2.0
-      is-path-inside: 3.0.3
-      js-yaml: 4.1.1
-      log-symbols: 4.1.0
-      minimatch: 9.0.9
-      ms: 2.1.3
-      picocolors: 1.1.1
-      serialize-javascript: 7.0.5
-      strip-json-comments: 3.1.1
-      supports-color: 8.1.1
-      workerpool: 9.3.4
-      yargs: 17.7.2
-      yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
   monaco-editor@0.55.1:
@@ -12275,11 +12148,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.3.3
@@ -12456,8 +12324,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
-
-  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 
@@ -12991,12 +12857,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
@@ -13725,8 +13585,6 @@ snapshots:
 
   workerpool@6.5.1: {}
 
-  workerpool@9.3.4: {}
-
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -13738,12 +13596,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
## Purpose

**Diagnostic-only.** Empirically validate the workerpool-SIGTERM hypothesis from `MOCHA-PARALLEL-COVERAGE-RACE.md` — that the flaky 99.x% coverage gate is caused by parallel mocha workers occasionally taking longer than workerpool's 1 s default `workerTerminateTimeout` to drain, getting SIGTERM'd by the parent, and silently losing their V8 coverage data.

Not for merge. Revert once we have data.

## What the branch does

- Reverts the `--no-parallel`/`threads=0` workarounds from #2060 so coverage runs in parallel again.
- Adds `build/sigterm-trace.js`, a `--require` shim gated on `MOCHA_WORKER_ID`. On `SIGTERM` it appends the worker PID to `/tmp/civet-sigterm-trace.log`, then `SIGKILL`s itself — preserving the coverage-loss symptom so we can correlate "log has PIDs" with "coverage gate failed".
- Wires the shim into root `.mocharc.json` and `lsp/server/.mocharc.json`.
- CI workflow: clears the log before `pnpm coverage`, marks the coverage step `continue-on-error: true`, and adds a dedicated **SIGTERM trace** step that `exit 1`s when the log has any PIDs.

## What outcomes mean

| `pnpm coverage` | SIGTERM trace step | Interpretation |
|---|---|---|
| pass | pass (no PIDs) | This run didn't trigger the bug; rerun. |
| fail | **fail (PIDs logged)** | **Hypothesis confirmed.** |
| pass | fail (PIDs logged) | SIGTERMs happen but didn't cause measurable coverage loss this run. Still confirms the mechanism. |
| fail | pass (no PIDs) | Hypothesis wrong; bug is somewhere else. |

Plan: rerun a few times to collect data, then decide on the upstream fix shape (e.g. bumping `workerTerminateTimeout` via the new mocha option we drafted).