### PR TITLE
Sourcemap: walk back in `remapPosition` when line has no mapping

### DIFF
--- a/source/ts-diagnostic.civet
+++ b/source/ts-diagnostic.civet
@@ -21,7 +21,16 @@ export type SourcemapLines = SourceMap['lines']
  * Take a position in generated code and map it into a position in source code.
  * Reverse mapping.
  *
- * Return position as-is if no sourcemap is available.
+ * When the queried line has no usable 4-tuple mapping, walks back through
+ * preceding lines until one is found — matching the standard sourcemap
+ * "nearest preceding mapping wins" behavior (e.g. source-map's
+ * `originalPositionFor`).  Required for chained / sparse maps like the
+ * Hera→Civet→TS pipeline, where only ~18% of generated TS lines have a
+ * direct source mapping; without walk-back, the other 82% return raw TS
+ * line numbers and land far past EOF in the .hera source.
+ *
+ * Return position as-is if no sourcemap is available or no mapping exists
+ * anywhere at or before the queried position.
  */
 export function remapPosition(
   position: Position,
@@ -32,41 +41,55 @@ export function remapPosition(
   { line, character } := position
 
   textLine := sourcemapLines[line]
-  // Return original position if no mapping at this line
-  if !textLine?.length return position
+  if textLine?.length
+    let i = 0,
+      p = 0,
+      l = textLine.length,
+      lastMapping,
+      lastMappingPosition = 0
 
-  let i = 0,
-    p = 0,
-    l = textLine.length,
-    lastMapping,
-    lastMappingPosition = 0
+    while i < l
+      mapping := textLine[i]!
+      p += mapping[0]!
 
-  while i < l
-    mapping := textLine[i]!
-    p += mapping[0]!
+      if mapping.length === 4
+        lastMapping = mapping
+        lastMappingPosition = p
 
-    if mapping.length === 4
-      lastMapping = mapping
-      lastMappingPosition = p
+      if p >= character
+        break
 
-    if p >= character
-      break
+      i++
 
-    i++
+    if lastMapping
+      srcLine := lastMapping[2]
+      srcChar := lastMapping[3]
+      newChar := srcChar + character - lastMappingPosition
 
-  if lastMapping
-    srcLine := lastMapping[2]
-    srcChar := lastMapping[3]
-    newChar := srcChar + character - lastMappingPosition
+      // Clamp to non-negative: generated code prepended before source
+      // (e.g. `import` keyword) can produce negative interpolation
+      return
+        line: srcLine
+        character: Math.max(0, newChar)
 
-    // Clamp to non-negative: generated code prepended before source
-    // (e.g. `import` keyword) can produce negative interpolation
-    return
-      line: srcLine
-      character: Math.max(0, newChar)
-  else
-    // console.error("no mapping for ", position)
-    return position
+  // No usable mapping on the queried line — walk back through preceding
+  // lines for the nearest 4-tuple.  Character offset does not interpolate
+  // across line boundaries; the source column is the mapping's anchor.
+  let l = line - 1
+  while l >= 0
+    prevLine := sourcemapLines[l]
+    if prevLine?.length
+      lastMapping .= undefined
+      for mapping of prevLine
+        if mapping.length === 4
+          lastMapping = mapping
+      if lastMapping
+        return
+          line: lastMapping[2]!
+          character: Math.max(0, lastMapping[3]!)
+    l--
+
+  return position
 
 /**
  * Use sourcemap lines to remap the start and end position of a range.

--- a/source/ts-diagnostic.civet
+++ b/source/ts-diagnostic.civet
@@ -75,7 +75,7 @@ export function remapPosition(
   // No usable mapping on the queried line — walk back through preceding
   // lines for the nearest 4-tuple.  Character offset does not interpolate
   // across line boundaries; the source column is the mapping's anchor.
-  let l = line - 1
+  let l = Math.min(line - 1, sourcemapLines.length - 1)
   while l >= 0
     prevLine := sourcemapLines[l]
     if prevLine?.length

--- a/test/infra/ts-diagnostic.civet
+++ b/test/infra/ts-diagnostic.civet
@@ -1,6 +1,6 @@
 assert from assert
 
-{ remapPosition, remapRange, flattenDiagnosticMessageText } from ../../source/ts-diagnostic.civet
+{ remapPosition, remapRange, flattenDiagnosticMessageText, type SourcemapLines } from ../../source/ts-diagnostic.civet
 
 describe "ts-diagnostic", ->
   describe "remapPosition", ->
@@ -35,20 +35,60 @@ describe "ts-diagnostic", ->
     it "picks the last 4-element mapping before the queried position", ->
       // [2] has no source info; [2, 0, 0, 10] anchors at cumulative col 4; querying col 5 -> src col 11
       pos := { line: 0, character: 5 }
-      sourcemapLines := [[[2], [2, 0, 0, 10]]]
+      sourcemapLines: SourcemapLines := [[[2], [2, 0, 0, 10]]]
       assert.deepEqual remapPosition(pos, sourcemapLines), { line: 0, character: 11 }
 
     it "handles multiple lines independently", ->
-      sourcemapLines := [
+      sourcemapLines: SourcemapLines := [
         [[0, 0, 0, 0]]
         [[0, 0, 2, 0]]
       ]
       assert.deepEqual remapPosition({ line: 0, character: 1 }, sourcemapLines), { line: 0, character: 1 }
       assert.deepEqual remapPosition({ line: 1, character: 3 }, sourcemapLines), { line: 2, character: 3 }
 
+    // Walk-back: when the queried line has no usable mapping, scan preceding
+    // lines for the nearest 4-tuple.  Without this, sparse stage-1 maps
+    // (Hera→Civet) yield raw TS line numbers for ~82% of generated lines,
+    // which then land past EOF in the .hera source.
+    it "walks back to previous line when current line is empty", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 5, 0]], []]
+      assert.deepEqual remapPosition({ line: 1, character: 3 }, sourcemapLines),
+        { line: 5, character: 0 }
+
+    it "walks back across multiple unmapped lines", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 5, 2]], [], [], []]
+      assert.deepEqual remapPosition({ line: 3, character: 7 }, sourcemapLines),
+        { line: 5, character: 2 }
+
+    it "uses last 4-tuple on the preceding mapped line", ->
+      // line 0 has two 4-tuples; the second (col 10 in generated) is closer
+      sourcemapLines: SourcemapLines := [[[0, 0, 1, 0], [10, 0, 0, 7]], []]
+      assert.deepEqual remapPosition({ line: 1, character: 0 }, sourcemapLines),
+        { line: 0, character: 7 }
+
+    it "skips column-delta-only lines while walking back", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 5, 0]], [[4]], []]
+      assert.deepEqual remapPosition({ line: 2, character: 0 }, sourcemapLines),
+        { line: 5, character: 0 }
+
+    it "walks back when current line has only column-delta entries", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 5, 0]], [[4]]]
+      assert.deepEqual remapPosition({ line: 1, character: 4 }, sourcemapLines),
+        { line: 5, character: 0 }
+
+    it "returns position as-is when no preceding line has a 4-tuple", ->
+      pos := { line: 5, character: 3 }
+      sourcemapLines: SourcemapLines := [[], [], [[4]]]
+      assert.deepEqual remapPosition(pos, sourcemapLines), pos
+
+    it "walks back from out-of-bounds line to nearest mapped line", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 9, 1]]]
+      assert.deepEqual remapPosition({ line: 50, character: 3 }, sourcemapLines),
+        { line: 9, character: 1 }
+
   describe "remapRange", ->
     it "remaps both start and end positions", ->
-      sourcemapLines := [[[0, 0, 5, 2]]]
+      sourcemapLines: SourcemapLines := [[[0, 0, 5, 2]]]
       range :=
         start: { line: 0, character: 0 }
         end: { line: 0, character: 3 }


### PR DESCRIPTION
## Summary

- `remapPosition` now walks back through preceding lines when the queried TS line has no usable 4-tuple mapping (standard sourcemap "nearest preceding mapping wins" semantics, like `source-map`'s `originalPositionFor`).
- Existing "no preceding mapping anywhere → return position as-is" behavior is preserved.

## Why

The Hera → Civet → TS pipeline composes two sourcemaps.  Stage 1 (Hera → Civet) is sparse — only ~17% of generated Civet lines carry a 4-tuple back to `.hera` source.  After composition with the dense stage-2 (Civet → TS) map, the final TS → `.hera` map inherits stage 1's sparsity: ~82% of generated TS lines have no source position.

When TS reported a diagnostic on one of those 82% of lines, the old `remapPosition` walked the entries on that line, found no 4-tuple, and fell through to `return position` — handing back a raw TS line number.  On `source/parser.hera` (9,696 lines, compiles to a ~32,000-line .tsx), most diagnostics ended up thousands of lines past EOF.  LSP clients either crashed (e.g. `mcp-language-server` panicked on `lines[10035]` when reading `.hera` of length 9696) or pointed at garbage lines.

After the fix, every diagnostic lands on a valid `.hera` line — the nearest enclosing rule.  Character offset doesn't interpolate across line boundaries; the source column is the mapping's anchor.

## Test plan

- [ ] `pnpm build`
- [ ] `pnpm test` — 3,992 passing locally (6 new tests for walk-back paths)
- [ ] LSP `.hera` diagnostics return valid positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)