### PR TITLE
LSP: skip semantic tokens in unmapped TS prelude code

### DIFF
--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -25,6 +25,7 @@ export {
   flattenDiagnosticMessageText
   forwardMap
   remapPosition
+  remapPositionStrict
   remapRange
   type SourceMapping
   type SourcemapLines

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -27,7 +27,7 @@
   type Position
 } from vscode-languageserver-textdocument
 * as Previewer from ./lib/previewer.civet
-{ collectCommentTokens, convertNavTree, forwardMap, getCanonicalFileName, convertDiagnostic, getSymbolKind, remapPosition, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
+{ collectCommentTokens, convertNavTree, forwardMap, getCanonicalFileName, convertDiagnostic, getSymbolKind, remapPosition, remapPositionStrict, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
 { asPlainTextWithLinks, tagsToMarkdown } from ./lib/textRendering.civet
 {
   adjustCursorForEmptyQuotes
@@ -1295,9 +1295,17 @@ export function startServer(connection: Connection, dependencies: ServerDependen
         tokenModifiers := (encoded & 0xFF)
         continue if tokenType < 0 or tokenType >= semanticTokenTypes.length
 
-        // Map position from transpiled TS back to Civet source
+        // Map position from transpiled TS back to Civet source.  Use
+        // strict remapping when we have a sourcemap so that tokens in
+        // compiler-inserted prelude code (e.g. `type AutoPromise<T> = ...`)
+        // are skipped rather than collapsed onto unrelated source
+        // identifiers via the identity fallback.
         tsPos := tsDoc.positionAt(tsStart)
-        pos := remapPosition(tsPos, sourcemapLines)
+        pos := if sourcemapLines
+          remapPositionStrict(tsPos, sourcemapLines)
+        else
+          tsPos
+        continue unless pos
         // Skip tokens with invalid remapped positions
         continue if pos.line < 0 or pos.character < 0
 

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -190,6 +190,56 @@ describe "LSP features (shared project server)", ->
         token.line is lineIndex and token.character is expected.character and token.tokenType is commentIndex
       assert token, `expected a comment token for '${expected.text}' at ${lineIndex}:${expected.character}`
 
+  it "semantic tokens don't emit phantom type tokens on Civet bareword imports", ->
+    // Regression test for #2067: TS semantic classifications on a
+    // compiler-inserted prelude line (`type AutoPromise<T> = ...`, emitted
+    // when an async function needs Promise-wrapping) used to be remapped
+    // through `remapPosition`'s identity fallback and land on the trailing
+    // letter of bareword-import identifiers (Civet line 0) as single-char
+    // `type` / `typeParameter` tokens.  The bug only surfaces against a
+    // sufficiently complex file, so we load the real test/cli.civet rather
+    // than a synthetic fixture.
+    testDir := path.dirname new URL(import.meta.url).pathname
+    cliPath := path.resolve testDir, "../../../test/cli.civet"
+    fs2 := await import "node:fs/promises"
+    text := await fs2.readFile cliPath, "utf8"
+
+    uri := docUri path.join(projectRoot, "semtok-bareword-import.civet")
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    legend := init.capabilities.semanticTokensProvider.legend.tokenTypes
+    typeIdx := legend.indexOf "type"
+    typeParamIdx := legend.indexOf "typeParameter"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    // `assert from assert` is a Civet bareword import — pure value, no types.
+    phantom := decoded.find (t) =>
+      t.line is 0 and (t.tokenType is typeIdx or t.tokenType is typeParamIdx)
+    assert.equal phantom, undefined,
+      `expected no type/typeParameter tokens on bareword import line; got ${JSON.stringify phantom}`
+
   it "completion resolve returns details for a symbol", ->
     uri := docUri path.join(projectRoot, "complete-resolve.civet")
     text := """

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -196,13 +196,15 @@ describe "LSP features (shared project server)", ->
     // when an async function needs Promise-wrapping) used to be remapped
     // through `remapPosition`'s identity fallback and land on the trailing
     // letter of bareword-import identifiers (Civet line 0) as single-char
-    // `type` / `typeParameter` tokens.  The bug only surfaces against a
-    // sufficiently complex file, so we load the real test/cli.civet rather
-    // than a synthetic fixture.
-    testDir := path.dirname new URL(import.meta.url).pathname
-    cliPath := path.resolve testDir, "../../../test/cli.civet"
-    fs2 := await import "node:fs/promises"
-    text := await fs2.readFile cliPath, "utf8"
+    // `type` / `typeParameter` tokens.  The fixture below is minimal: a
+    // bareword import on line 0 (target for the phantom token) plus an
+    // async function with an explicit non-Promise return type (forces
+    // the AutoPromise prelude to be emitted).
+    text := """
+      assert from assert
+      async function f(): void
+        await null
+    """
 
     uri := docUri path.join(projectRoot, "semtok-bareword-import.civet")
     client.notify "textDocument/didOpen", {

--- a/source/ts-diagnostic.civet
+++ b/source/ts-diagnostic.civet
@@ -21,19 +21,33 @@ export type SourcemapLines = SourceMap['lines']
  * Take a position in generated code and map it into a position in source code.
  * Reverse mapping.
  *
- * Return position as-is if no sourcemap is available.
+ * Return position as-is if no sourcemap is available or no mapping exists
+ * at `position`.  Callers that need to distinguish "fell back to identity"
+ * from "actually mapped" should use `remapPositionStrict`.
  */
 export function remapPosition(
   position: Position,
   sourcemapLines?: SourcemapLines
 ): Position
   if !sourcemapLines return position
+  return remapPositionStrict(position, sourcemapLines) ?? position
 
+/**
+ * Like `remapPosition`, but returns `undefined` when `position` has no
+ * actual source mapping — i.e. the generated line has no 4-tuple mapping
+ * at or before `position.character`.  This happens when generated code
+ * is purely compiler-synthesized (e.g. Civet's `type AutoPromise<T> = ...`
+ * prelude), in which case mapping back to the original-position fallback
+ * would produce a phantom location in the user's source.
+ */
+export function remapPositionStrict(
+  position: Position,
+  sourcemapLines: SourcemapLines
+): Position | undefined
   { line, character } := position
 
   textLine := sourcemapLines[line]
-  // Return original position if no mapping at this line
-  if !textLine?.length return position
+  return undefined unless textLine?.length
 
   let i = 0,
     p = 0,
@@ -54,19 +68,17 @@ export function remapPosition(
 
     i++
 
-  if lastMapping
-    srcLine := lastMapping[2]
-    srcChar := lastMapping[3]
-    newChar := srcChar + character - lastMappingPosition
+  return undefined unless lastMapping
 
-    // Clamp to non-negative: generated code prepended before source
-    // (e.g. `import` keyword) can produce negative interpolation
-    return
-      line: srcLine
-      character: Math.max(0, newChar)
-  else
-    // console.error("no mapping for ", position)
-    return position
+  srcLine := lastMapping[2]
+  srcChar := lastMapping[3]
+  newChar := srcChar + character - lastMappingPosition
+
+  // Clamp to non-negative: generated code prepended before source
+  // (e.g. `import` keyword) can produce negative interpolation
+  return
+    line: srcLine
+    character: Math.max(0, newChar)
 
 /**
  * Use sourcemap lines to remap the start and end position of a range.


### PR DESCRIPTION
Closes #2067

`remapPosition` falls back to identity when the generated line has no 4-tuple source mapping at or before the requested column. For compiler-inserted prelude lines (e.g. Civet's `type AutoPromise<T> = Promise<Awaited<T>>;` helper, emitted when an async function needs Promise-wrapping), TS still classifies the `AutoPromise` and `T` identifiers as `type` / `typeParameter` tokens, and that identity fallback collapses them onto the corresponding TS-line-0 column in the Civet source — landing on the trailing letter of a bareword-import identifier when one exists.

This PR introduces `remapPositionStrict`, which returns `undefined` when no mapping exists, and has the semantic-tokens path use it: skipping a token that has no source location is correct, whereas the identity fallback emits phantom tokens. Other callers (hover, definition, etc.) keep the existing best-effort fallback.

Includes the regression test from the issue, which fails at `main` and passes here.

Generated with [Claude Code](https://claude.ai/code)