### PR TITLE
LSP: emit semantic tokens for import binding names

### DIFF
--- a/lsp/server/integration/project-test/import-fixture.ts
+++ b/lsp/server/integration/project-test/import-fixture.ts
@@ -1,0 +1,18 @@
+// Fixture exporting one symbol of each TS SymbolFlags kind that
+// pickImportBindingTokenType (in lsp/server/source/lib/util.civet) branches
+// on. Used by semantic-token tests to exercise the class/enum/interface/
+// type-alias/namespace/variable-fallback paths.
+
+export class FixtureClass {}
+
+export enum FixtureEnum { A, B }
+
+export interface FixtureInterface { x: number }
+
+export type FixtureType = string
+
+export function fixtureFn(): void {}
+
+export const fixtureConst = 0
+
+export namespace FixtureNs { export const v = 1 }

--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -18,6 +18,7 @@ vs, {
 {
   flattenDiagnosticMessageText
   remapPosition
+  remapPositionStrict
   remapRange
   type SourcemapLines
 } from ../../../../source/ts-diagnostic.civet
@@ -456,7 +457,14 @@ export function addImportBindingTokens(
     tsLen := identifier.getEnd() - tsStart
     return unless tsLen > 0
     tsPos := tsDoc.positionAt(tsStart)
-    pos := remapPosition(tsPos, sourcemapLines)
+    // Strict remap so a synthesized import (no source mapping) drops its
+    // binding tokens instead of identity-collapsing them onto source
+    // line 0, matching the main classifier path in server.civet.
+    pos := if sourcemapLines
+      remapPositionStrict(tsPos, sourcemapLines)
+    else
+      tsPos
+    return unless pos
     return if pos.line < 0 or pos.character < 0
 
     // Measure how many word characters live at the remapped Civet offset so

--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -369,10 +369,10 @@ export function collectCommentTokens(
 
 // Pick a semantic token type for an imported binding identifier. TS's
 // `getEncodedSemanticClassifications` does not classify the binding side of
-// imports, but for Civet's bareword-import forms there is no `import`
-// keyword in source for textmate to anchor on, so we emit tokens here.
-// `tokenTypes` is the server's ordered token-type list and lookups are by
-// name; unknown shapes fall back to "variable".
+// imports, and the Civet TextMate grammar scopes the module specifier of
+// these forms but not the imported binding names, so we emit those tokens
+// here. `tokenTypes` is the server's ordered token-type list and lookups
+// are by name; unknown shapes fall back to "variable".
 pickImportBindingTokenType := (
   identifier: ts.Identifier
   isTypeOnly: boolean
@@ -382,16 +382,14 @@ pickImportBindingTokenType := (
   // Clamp to 0 so an unconfigured tokenTypes list cannot leak a -1 token
   // type into the delta-encoded response (the main classifier path guards
   // with `continue if tokenType < 0`; tokens we push here go straight to
-  // the encoder which only checks length).
+  // the encoder which only checks length).  Every name we ever pass lives
+  // in semanticTokenTypes, so the negative-idx fallback is unreachable
+  // under the server's own legend.
   resolveTokenIndex := (name: string): number =>
     idx := tokenTypes.indexOf(name)
-    return idx if idx >= 0
-    /* c8 ignore start — defensive: every name we ever pass lives in
-       semanticTokenTypes, so these fallbacks are unreachable under the
-       server's own legend. */
-    fallback := tokenTypes.indexOf("variable")
-    if fallback >= 0 then fallback else 0
-    /* c8 ignore stop */
+    /* c8 ignore next 2 — defensive fallback for an unconfigured legend */
+    return idx unless idx < 0
+    Math.max 0, tokenTypes.indexOf "variable"
 
   if isTypeOnly
     return resolveTokenIndex("type")
@@ -470,6 +468,10 @@ export function addImportBindingTokens(
       lineEnd := civetText.indexOf('\n', offset)
       remaining := (if lineEnd < 0 then civetText.length else lineEnd) - offset
       match := civetText.slice(offset, offset + remaining).match(/^\w+/)
+      // Defensive fallback to tsLen if the sourcemap anchors the binding on
+      // a non-word char (whitespace/punctuation); in normal operation the
+      // remap always lands on the identifier.
+      /* c8 ignore next */
       length = if match then match[0].length else tsLen
       return if length <= 0 or length > remaining
 

--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -379,15 +379,28 @@ pickImportBindingTokenType := (
   checker: ts.TypeChecker
   tokenTypes: readonly string[]
 ): number ->
+  // Clamp to 0 so an unconfigured tokenTypes list cannot leak a -1 token
+  // type into the delta-encoded response (the main classifier path guards
+  // with `continue if tokenType < 0`; tokens we push here go straight to
+  // the encoder which only checks length).
   resolveTokenIndex := (name: string): number =>
     idx := tokenTypes.indexOf(name)
-    if idx >= 0 then idx else tokenTypes.indexOf("variable")
+    return idx if idx >= 0
+    /* c8 ignore start — defensive: every name we ever pass lives in
+       semanticTokenTypes, so these fallbacks are unreachable under the
+       server's own legend. */
+    fallback := tokenTypes.indexOf("variable")
+    if fallback >= 0 then fallback else 0
+    /* c8 ignore stop */
 
   if isTypeOnly
     return resolveTokenIndex("type")
 
   symbol .= checker.getSymbolAtLocation(identifier)
+  /* c8 ignore start — defensive: TS hands back undefined only for broken
+     imports; treat as a plain variable in that case. */
   return resolveTokenIndex("variable") unless symbol
+  /* c8 ignore stop */
 
   // Import binding identifiers are alias symbols; resolve to the actual
   // declaration to decide whether it's a function/class/etc.
@@ -431,9 +444,12 @@ export function addImportBindingTokens(
   civetText: string?
   sourcemapLines: SourcemapLines?
   tokenTypes: readonly string[]
+  tokenModifiers: readonly string[]
   out: { line: number, character: number, length: number, tokenType: number, tokenModifiers: number }[]
 ): void
-  declarationModifier := 1 << 0  // matches semanticTokenModifiers "declaration" position
+  // Look up "declaration" by name so reordering semanticTokenModifiers in
+  // server.civet stays in sync.
+  declarationModifier := 1 << tokenModifiers.indexOf("declaration")
 
   emit := (identifier: ts.Identifier, isTypeOnly: boolean): void =>
     tokenType := pickImportBindingTokenType identifier, isTypeOnly, checker, tokenTypes

--- a/lsp/server/source/lib/util.civet
+++ b/lsp/server/source/lib/util.civet
@@ -17,6 +17,7 @@ vs, {
 { TextDocument } from vscode-languageserver-textdocument
 {
   flattenDiagnosticMessageText
+  remapPosition
   remapRange
   type SourcemapLines
 } from ../../../../source/ts-diagnostic.civet
@@ -365,6 +366,123 @@ export function collectCommentTokens(
         start = tokenEnd + 1
 
   tokens
+
+// Pick a semantic token type for an imported binding identifier. TS's
+// `getEncodedSemanticClassifications` does not classify the binding side of
+// imports, but for Civet's bareword-import forms there is no `import`
+// keyword in source for textmate to anchor on, so we emit tokens here.
+// `tokenTypes` is the server's ordered token-type list and lookups are by
+// name; unknown shapes fall back to "variable".
+pickImportBindingTokenType := (
+  identifier: ts.Identifier
+  isTypeOnly: boolean
+  checker: ts.TypeChecker
+  tokenTypes: readonly string[]
+): number ->
+  resolveTokenIndex := (name: string): number =>
+    idx := tokenTypes.indexOf(name)
+    if idx >= 0 then idx else tokenTypes.indexOf("variable")
+
+  if isTypeOnly
+    return resolveTokenIndex("type")
+
+  symbol .= checker.getSymbolAtLocation(identifier)
+  return resolveTokenIndex("variable") unless symbol
+
+  // Import binding identifiers are alias symbols; resolve to the actual
+  // declaration to decide whether it's a function/class/etc.
+  if symbol.flags & ts.SymbolFlags.Alias
+    try
+      symbol = checker.getAliasedSymbol(symbol)
+    /* c8 ignore start — defensive: resolving an unresolvable alias can
+       throw; treat as a plain variable in that case. */
+    catch
+      return resolveTokenIndex("variable")
+    /* c8 ignore stop */
+
+  flags := symbol.flags
+  if flags & ts.SymbolFlags.Class
+    return resolveTokenIndex("class")
+  if flags & ts.SymbolFlags.Enum
+    return resolveTokenIndex("enum")
+  if flags & ts.SymbolFlags.Interface
+    return resolveTokenIndex("interface")
+  if flags & ts.SymbolFlags.TypeAlias
+    return resolveTokenIndex("type")
+  if flags & ts.SymbolFlags.Function
+    return resolveTokenIndex("function")
+  if flags & (ts.SymbolFlags.Namespace | ts.SymbolFlags.Module)
+    return resolveTokenIndex("namespace")
+  return resolveTokenIndex("variable")
+
+/**
+ * Walk the transpiled TS source for `ImportDeclaration` nodes and append
+ * semantic tokens for each imported binding identifier to `out`. Positions
+ * are remapped through `sourcemapLines` (when present) so they land in the
+ * Civet source; tokens whose remapped position lies outside the source
+ * (start of line) are dropped. Token lengths are measured against the
+ * Civet text when available, mirroring the main classifier path.
+ */
+export function addImportBindingTokens(
+  tsSourceFile: ts.SourceFile
+  checker: ts.TypeChecker
+  tsDoc: TextDocument
+  doc: TextDocument
+  civetText: string?
+  sourcemapLines: SourcemapLines?
+  tokenTypes: readonly string[]
+  out: { line: number, character: number, length: number, tokenType: number, tokenModifiers: number }[]
+): void
+  declarationModifier := 1 << 0  // matches semanticTokenModifiers "declaration" position
+
+  emit := (identifier: ts.Identifier, isTypeOnly: boolean): void =>
+    tokenType := pickImportBindingTokenType identifier, isTypeOnly, checker, tokenTypes
+    tsStart := identifier.getStart(tsSourceFile)
+    tsLen := identifier.getEnd() - tsStart
+    return unless tsLen > 0
+    tsPos := tsDoc.positionAt(tsStart)
+    pos := remapPosition(tsPos, sourcemapLines)
+    return if pos.line < 0 or pos.character < 0
+
+    // Measure how many word characters live at the remapped Civet offset so
+    // that a rename-on-import (e.g. `{ a as b }`) lights up the source-side
+    // name rather than emitting the TS-side length blindly.
+    length .= tsLen
+    if civetText
+      offset := doc.offsetAt(pos)
+      return if offset >= civetText.length
+      lineEnd := civetText.indexOf('\n', offset)
+      remaining := (if lineEnd < 0 then civetText.length else lineEnd) - offset
+      match := civetText.slice(offset, offset + remaining).match(/^\w+/)
+      length = if match then match[0].length else tsLen
+      return if length <= 0 or length > remaining
+
+    out.push {
+      line: pos.line
+      character: pos.character
+      length
+      tokenType
+      tokenModifiers: declarationModifier
+    }
+
+  visit := (node: ts.Node): void =>
+    if ts.isImportDeclaration(node) and node.importClause
+      { importClause } := node
+      clauseTypeOnly := !!importClause.isTypeOnly
+      // Default import: `import name from "mod"`
+      if importClause.name
+        emit importClause.name, clauseTypeOnly
+      // Named or namespace bindings
+      if importClause.namedBindings
+        nb := importClause.namedBindings
+        if ts.isNamespaceImport(nb)
+          emit nb.name, clauseTypeOnly
+        else
+          for element of nb.elements
+            emit element.name, clauseTypeOnly or !!element.isTypeOnly
+    ts.forEachChild(node, visit)
+
+  visit(tsSourceFile)
 
 export function withResolvers<T>() {
   let resolve: (value: T) => void

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -1316,24 +1316,23 @@ export function startServer(connection: Connection, dependencies: ServerDependen
       remapped.push ...collectCommentTokens doc, commentRanges, commentSemanticTokenType
 
       // TS's classifier emits no tokens for the binding identifiers in an
-      // import declaration; in plain TS that's fine because textmate handles
-      // them, but Civet's bareword-import syntax (`name from "module"`,
-      // `{ a, b } from "module"`) has no `import` keyword in source so
-      // textmate can't anchor highlighting on it. Walk the TS AST and emit
-      // tokens for those bindings ourselves.
+      // import declaration, and the Civet TextMate grammar scopes the
+      // module specifier of bareword imports (`name from "module"`,
+      // `{ a, b } from "module"`) but not the binding names. Walk the TS
+      // AST and emit tokens for those bindings ourselves.
       program := service.getProgram()
       tsSourceFile := program?.getSourceFile(transpiledPath)
       if program and tsSourceFile
         checker := program.getTypeChecker()
         addImportBindingTokens
-          tsSourceFile,
-          checker,
-          tsDoc,
-          doc,
-          civetText,
-          sourcemapLines,
-          semanticTokenTypes,
-          semanticTokenModifiers,
+          tsSourceFile
+          checker
+          tsDoc
+          doc
+          civetText
+          sourcemapLines
+          semanticTokenTypes
+          semanticTokenModifiers
           remapped
 
       // Sort by position (required for valid delta encoding)

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -1333,6 +1333,7 @@ export function startServer(connection: Connection, dependencies: ServerDependen
           civetText,
           sourcemapLines,
           semanticTokenTypes,
+          semanticTokenModifiers,
           remapped
 
       // Sort by position (required for valid delta encoding)

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -27,7 +27,7 @@
   type Position
 } from vscode-languageserver-textdocument
 * as Previewer from ./lib/previewer.civet
-{ collectCommentTokens, convertNavTree, forwardMap, getCanonicalFileName, convertDiagnostic, getSymbolKind, remapPosition, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
+{ addImportBindingTokens, collectCommentTokens, convertNavTree, forwardMap, getCanonicalFileName, convertDiagnostic, getSymbolKind, remapPosition, logTiming, type WithResolvers, withResolvers, type SourcemapLines } from ./lib/util.civet
 { asPlainTextWithLinks, tagsToMarkdown } from ./lib/textRendering.civet
 {
   adjustCursorForEmptyQuotes
@@ -1314,6 +1314,26 @@ export function startServer(connection: Connection, dependencies: ServerDependen
         remapped.push { line: pos.line, character: pos.character, length, tokenType, tokenModifiers }
 
       remapped.push ...collectCommentTokens doc, commentRanges, commentSemanticTokenType
+
+      // TS's classifier emits no tokens for the binding identifiers in an
+      // import declaration; in plain TS that's fine because textmate handles
+      // them, but Civet's bareword-import syntax (`name from "module"`,
+      // `{ a, b } from "module"`) has no `import` keyword in source so
+      // textmate can't anchor highlighting on it. Walk the TS AST and emit
+      // tokens for those bindings ourselves.
+      program := service.getProgram()
+      tsSourceFile := program?.getSourceFile(transpiledPath)
+      if program and tsSourceFile
+        checker := program.getTypeChecker()
+        addImportBindingTokens
+          tsSourceFile,
+          checker,
+          tsDoc,
+          doc,
+          civetText,
+          sourcemapLines,
+          semanticTokenTypes,
+          remapped
 
       // Sort by position (required for valid delta encoding)
       remapped.sort (a, b) => a.line - b.line or a.character - b.character

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -135,6 +135,115 @@ describe "LSP features (shared project server)", ->
     assert Array.isArray(tokens.data), "expected tokens.data to be an array"
     assert tokens.data.length > 0, "expected at least one token"
 
+  it "semantic tokens cover names in destructured imports", ->
+    uri := docUri path.join(projectRoot, "semtok-destruct-import.civet")
+    text := """
+      { writeFile } from fs/promises
+      writeFile "x", "y"
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    importBindingToken := decoded.find (t) =>
+      t.line is 0 and t.character <= 2 and (t.character + t.length) >= 11
+    assert importBindingToken,
+      `expected a semantic token covering \`writeFile\` (line 0, chars 2..11); decoded=${JSON.stringify decoded}`
+
+  it "semantic tokens cover names in bareword imports", ->
+    uri := docUri path.join(projectRoot, "semtok-bareword-import.civet")
+    text := """
+      assert from assert
+      assert true
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    importBindingToken := decoded.find (t) =>
+      t.line is 0 and t.character is 0 and t.length is 6
+    assert importBindingToken,
+      `expected a semantic token covering \`assert\` (line 0, chars 0..6); decoded=${JSON.stringify decoded}`
+
+  it "semantic tokens cover names in type-only imports", ->
+    uri := docUri path.join(projectRoot, "semtok-typeonly-import.civet")
+    text := """
+      { type ParsedPath } from path
+      x: ParsedPath = {} as ParsedPath
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    parsedPathStart := text.indexOf("ParsedPath")
+    importBindingToken := decoded.find (t) =>
+      t.line is 0 and t.character is parsedPathStart and t.length is "ParsedPath".length
+    assert importBindingToken,
+      `expected a semantic token covering \`ParsedPath\` in the import; decoded=${JSON.stringify decoded}`
+
   it "semantic tokens marks civet comments as comments", ->
     uri := docUri path.join(projectRoot, "semtok-coffee-comment.civet")
     text := '''

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -244,6 +244,67 @@ describe "LSP features (shared project server)", ->
     assert importBindingToken,
       `expected a semantic token covering \`ParsedPath\` in the import; decoded=${JSON.stringify decoded}`
 
+  it "semantic tokens classify imported bindings by symbol kind", ->
+    // Exercises every branch of `pickImportBindingTokenType`: a class,
+    // enum, interface, type alias, function, namespace, and a plain
+    // const (variable fallback), plus the namespace-import (`* as`)
+    // path of `addImportBindingTokens`.
+    uri := docUri path.join(projectRoot, "semtok-import-kinds.civet")
+    text := """
+      { FixtureClass, FixtureEnum, FixtureInterface, FixtureType, fixtureFn, fixtureConst, FixtureNs } from ./import-fixture
+      * as fixtureMod from ./import-fixture
+      FixtureClass; FixtureEnum; FixtureInterface; FixtureType; fixtureFn; fixtureConst; FixtureNs; fixtureMod
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    legend := init.capabilities.semanticTokensProvider.legend
+    typeIdx := (name: string) => legend.tokenTypes.indexOf(name)
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    // Helper finds the token covering an identifier on a given line by name.
+    findToken := (lineNo: number, name: string) =>
+      col := text.split("\n")[lineNo].indexOf(name)
+      assert col >= 0, `\`${name}\` not found on line ${lineNo} of test source`
+      decoded.find (t) =>
+        t.line is lineNo and t.character is col and t.length is name.length
+
+    expectKind := (lineNo: number, name: string, kind: string) =>
+      tok := findToken(lineNo, name)
+      assert tok, `expected import-binding token for \`${name}\`; decoded=${JSON.stringify decoded}`
+      assert.equal tok.tokenType, typeIdx(kind),
+        `\`${name}\` classified as ${legend.tokenTypes[tok.tokenType]}, expected ${kind}`
+
+    expectKind 0, "FixtureClass",     "class"
+    expectKind 0, "FixtureEnum",      "enum"
+    expectKind 0, "FixtureInterface", "interface"
+    expectKind 0, "FixtureType",      "type"
+    expectKind 0, "fixtureFn",        "function"
+    expectKind 0, "fixtureConst",     "variable"
+    expectKind 0, "FixtureNs",        "namespace"
+    expectKind 1, "fixtureMod",       "namespace"
+
   it "semantic tokens marks civet comments as comments", ->
     uri := docUri path.join(projectRoot, "semtok-coffee-comment.civet")
     text := '''

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -382,6 +382,24 @@ describe "LSP features (shared project server)", ->
     expectKind 0, "FixtureNs",        "namespace"
     expectKind 1, "fixtureMod",       "namespace"
 
+  // A raw .ts file has no sourcemap, so addImportBindingTokens hits the
+  // identity branch (`pos := tsPos` instead of `remapPositionStrict`).
+  // t.ts contains two imports, so the emit path runs.
+  it "semantic tokens cover import bindings in raw .ts files", ->
+    tsPath := path.resolve "./integration/project-test/t.ts"
+    uri := docUri tsPath
+    text := await fs.promises.readFile tsPath, 'utf8'
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "typescript", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+    assert Array.isArray(tokens.data), "expected tokens.data to be an array"
+
   it "semantic tokens marks civet comments as comments", ->
     uri := docUri path.join(projectRoot, "semtok-coffee-comment.civet")
     text := '''

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -173,10 +173,9 @@ describe "LSP features (shared project server)", ->
 
   it "semantic tokens cover names in bareword imports", ->
     uri := docUri path.join(projectRoot, "semtok-bareword-import.civet")
-    text := """
-      assert from assert
-      assert true
-    """
+    // Single-line source with no trailing newline exercises the
+    // `lineEnd < 0` arm of length-measurement in addImportBindingTokens.
+    text := "assert from assert"
     client.notify "textDocument/didOpen", {
       textDocument: { uri, languageId: "civet", version: 1, text }
     }
@@ -206,6 +205,84 @@ describe "LSP features (shared project server)", ->
       t.line is 0 and t.character is 0 and t.length is 6
     assert importBindingToken,
       `expected a semantic token covering \`assert\` (line 0, chars 0..6); decoded=${JSON.stringify decoded}`
+
+  // Civet rename forms: `{x: y}` (shorthand) and `{x as y}` both compile
+  // to TS `import { x as y } from ...`, but the source-side binding name
+  // differs from the TS-side identifier. The token must land on the
+  // Civet-side name and use its length, not the TS-side length.
+  it "semantic tokens cover renamed names in {x: y} shorthand imports", ->
+    uri := docUri path.join(projectRoot, "semtok-rename-shorthand-import.civet")
+    text := """
+      { writeFile: writeFileRenamed } from fs/promises
+      writeFileRenamed "x", "y"
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    renamedStart := text.indexOf("writeFileRenamed")
+    importBindingToken := decoded.find (t) =>
+      t.line is 0 and t.character is renamedStart and t.length is "writeFileRenamed".length
+    assert importBindingToken,
+      `expected a semantic token covering renamed \`writeFileRenamed\` (line 0, char ${renamedStart}); decoded=${JSON.stringify decoded}`
+
+  it "semantic tokens cover renamed names in {x as y} imports", ->
+    uri := docUri path.join(projectRoot, "semtok-rename-as-import.civet")
+    text := """
+      { writeFile as writeFileAliased } from fs/promises
+      writeFileAliased "x", "y"
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    aliasedStart := text.indexOf("writeFileAliased")
+    importBindingToken := decoded.find (t) =>
+      t.line is 0 and t.character is aliasedStart and t.length is "writeFileAliased".length
+    assert importBindingToken,
+      `expected a semantic token covering aliased \`writeFileAliased\` (line 0, char ${aliasedStart}); decoded=${JSON.stringify decoded}`
 
   it "semantic tokens cover names in type-only imports", ->
     uri := docUri path.join(projectRoot, "semtok-typeonly-import.civet")


### PR DESCRIPTION
Fixes #2068

TypeScript's `getEncodedSemanticClassifications` does not classify the binding side of an `ImportDeclaration` — in plain TS that's harmless because textmate handles those identifiers, but Civet's bareword-import forms (`name from "mod"`, `{ a, b } from "mod"`, `{ type X } from "mod"`) have no `import` keyword in source for a grammar to anchor on, so the binding names ended up with no highlighting at all.

After remapping TS's tokens, walk the transpiled AST for ImportDeclarations and emit additional tokens for each imported binding identifier, picking the token type from the resolved alias symbol's flags.

Generated with [Claude Code](https://claude.ai/code)