### PR TITLE
Fix `x.literal` shorthand

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1923,11 +1923,27 @@ PropertyAccess
   # NOTE: Added shorthand x.3 -> x[3]
   # NOTE: Added shorthand x.:symbol -> x[Symbol.for("symbol")]
   AccessStart:dot ( TemplateLiteral / StringLiteral / IntegerLiteral / SymbolLiteral ):literal ->
+    // Wrap simple literals so consumers (e.g. PropertyDefinition shorthand, postfix
+    // update extraction) that read `expression` and feed it through `needsRef` see
+    // a Literal — matching the bracket-form `{a[1]}`/`{a["b"]}` no-ref behavior.
+    // TemplateLiteral/SymbolLiteral keep their own types so refs are introduced.
+    expression .= literal as ASTNode
+    if literal.type is "StringLiteral" or not literal.type
+      expression = {
+        type: "Literal",
+        subtype: literal.type ?? "NumericLiteral",
+        children: [literal],
+        raw: literal.token,
+      }
     return {
       type: "Index",
+      expression,
+      // children layout mirrors the bracket-form Index `[open, expression, ws, close]`
+      // so `last.children.slice(-2)` still yields `[ws, close]`.
       children: [
         adjustIndexAccess(dot),
-        literal,
+        expression,
+        "",
         "]",
       ]
     }
@@ -1954,12 +1970,21 @@ PropertyAccess
   AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
     // `data.😊` → `data["😊"]` since `u$1F60A$` isn't the real property.
     if id.unicode
+      key := propertyKey(id)
+      expression := {
+        type: "Literal",
+        subtype: "StringLiteral",
+        children: [key],
+        raw: key.token,
+      }
       return {
         type: "Index",
+        expression,
         children: [
           adjustIndexAccess(dot),
           ...comments,
-          propertyKey(id),
+          expression,
+          "",
           "]",
         ],
       }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -87,6 +87,7 @@ import type {
   ArrayBindingPattern,
   ASTNode,
   BlockStatement,
+  Index,
   ObjectBindingPattern,
 } from "./parser/types.civet"
 
@@ -1922,24 +1923,12 @@ PropertyAccess
   # NOTE: Added shorthand x."string" -> x["string"]
   # NOTE: Added shorthand x.3 -> x[3]
   # NOTE: Added shorthand x.:symbol -> x[Symbol.for("symbol")]
-  AccessStart:dot ( TemplateLiteral / StringLiteral / IntegerLiteral / SymbolLiteral ):literal ->
-    // Wrap simple literals so consumers (e.g. PropertyDefinition shorthand, postfix
-    // update extraction) that read `expression` and feed it through `needsRef` see
-    // a Literal — matching the bracket-form `{a[1]}`/`{a["b"]}` no-ref behavior.
-    // TemplateLiteral/SymbolLiteral keep their own types so refs are introduced.
-    expression .= literal as ASTNode
-    if literal.type is "StringLiteral" or not literal.type
-      expression = {
-        type: "Literal",
-        subtype: literal.type ?? "NumericLiteral",
-        children: [literal],
-        raw: literal.token,
-      }
+  AccessStart:dot ( TemplateLiteral / AccessLiteral / SymbolLiteral ):expression ::Index ->
+    // children layout mirrors the bracket-form Index `[open, expression, ws, close]`
+    // so `last.children.slice(-2)` still yields `[ws, close]`.
     return {
       type: "Index",
       expression,
-      // children layout mirrors the bracket-form Index `[open, expression, ws, close]`
-      // so `last.children.slice(-2)` still yields `[ws, close]`.
       children: [
         adjustIndexAccess(dot),
         expression,
@@ -2045,6 +2034,23 @@ PropertyAccess
         dot: start,
         children: [ start, "prototype" ],
       }
+
+# Wrap simple literals in a `Literal` node so consumers reading `expression`
+# (e.g. PropertyDefinition shorthand, postfix update extraction) feed it
+# through `needsRef` and treat it as a no-ref value, matching the bracket-form
+# `{a[1]}`/`{a["b"]}` behavior. TemplateLiteral and SymbolLiteral are
+# deliberately not wrapped so refs are still introduced for their
+# side-effecting evaluation.
+# NOTE: We can't reuse the `Literal` rule here — it would match
+# `NumericLiteral` (e.g. `0.0`) and break `x.0.0 → x[0][0]`.
+AccessLiteral
+  ( StringLiteral / IntegerLiteral ):literal ->
+    return {
+      type: "Literal",
+      subtype: literal.type,
+      children: [literal],
+      raw: literal.token,
+    }
 
 # Property glob that starts with "." or "?.", not a brace
 ExplicitPropertyGlob
@@ -6674,7 +6680,7 @@ HexIntegerLiteral
 IntegerLiteral
   # perf: short circuit if no possibility of being an integer
   /(?=[0-9])/ IntegerLiteralKind:token ->
-    return { $loc, token }
+    return { type: "NumericLiteral", $loc, token }
 
 IntegerLiteralKind
   DecimalBigIntegerLiteral

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -506,6 +506,7 @@ export type Call = ASTParent &
 
 export type Index = ASTParent &
   type: "Index"
+  expression: ASTNode
   optional?: Optional?
 
 export type SliceExpression = ASTParent &

--- a/test/object.civet
+++ b/test/object.civet
@@ -1346,6 +1346,54 @@ describe "object", ->
     """
 
     testCase """
+      integer literal shorthand
+      ---
+      {x.1}
+      ---
+      ({[1]: x[1]})
+    """
+
+    testCase """
+      string literal shorthand
+      ---
+      {x."b"}
+      ---
+      ({["b"]: x["b"]})
+    """
+
+    testCase """
+      template literal shorthand
+      ---
+      {x.`b`}
+      ---
+      let ref;({[(ref = `b`,ref)]: x[ref]})
+    """
+
+    testCase """
+      unicode property shorthand
+      ---
+      {x.😊}
+      ---
+      ({["😊"]: x["😊"]})
+    """
+
+    testCase """
+      symbol literal shorthand
+      ---
+      {x.:sym}
+      ---
+      let ref;({[(ref = Symbol.for("sym"),ref)]: x[ref]})
+    """
+
+    throws """
+      unclosed integer literal shorthand
+      ---
+      {x.1
+      ---
+      ParseError
+    """
+
+    testCase """
       not
       ---
       boolified := {not not exists}


### PR DESCRIPTION
`x.<literal>` and `x.<unicode>` PropertyAccess shorthands produced an Index AST node with no `expression` field. The PropertyDefinition object-shorthand path (`{x.1}`, `{x."b"}`, `{x.😊}`, etc.) feeds `expression` through `maybeRefAssignment` → `needsRef`, which crashed on the missing property.

Wrap simple literals (StringLiteral, IntegerLiteral) in a `Literal` node so `needsRef` recognises them as no-ref values, matching the bracket-form `{x[1]}`/`{x["b"]}` behavior. TemplateLiteral and SymbolLiteral keep their own types so refs are still introduced for their side-effecting evaluation. Index children layout is shifted to `[open, expression, ws, close]` so `last.children.slice(-2)` continues to yield `[ws, close]` when refs are needed.

Fixes #2065.