### PR TITLE
LSP: fix missing line/column info by unwrapping ParseErrors

### DIFF
--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -316,23 +316,19 @@ export function parseErrorsToDiagnostics(
       diagnostics.push ...parseErrorsToDiagnostics(inner.errors)
       continue
     pe := e as ParseError
-    if 'line' in pe and 'column' in pe and pe.line? and pe.column?
-      { start, end, message } := parseErrorRange(pe)
-      diagnostics.push {
-        severity: DiagnosticSeverity.Error
-        range: { start, end }
-        message
-        source: 'civet'
-      }
-    else
-      diagnostics.push {
-        severity: DiagnosticSeverity.Error
-        range:
-          start: { line: 0, character: 0 }
-          end:   { line: 0, character: 10 }
-        message: (e as Error).message
-        source: 'civet'
-      }
+    { start, end, message } :=
+      if pe.line? and pe.column?
+        parseErrorRange(pe)
+      else
+        start: { line: 0, character: 0 }
+        end:   { line: 0, character: 10 }
+        message: pe.message
+    diagnostics.push {
+      severity: DiagnosticSeverity.Error
+      range: { start, end }
+      message
+      source: 'civet'
+    }
   diagnostics
 
 // -- semantic token length measurement --------------------------------------

--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -12,8 +12,10 @@
 
 {
   type CompletionItem
+  type Diagnostic
   CompletionItemKind
   CompletionItemTag
+  DiagnosticSeverity
 } from vscode-languageserver
 
 ts from typescript
@@ -299,6 +301,39 @@ export function parseErrorRange(e: ParseError): {
   start.character = column - 1
   end.character = column + 3
   { start, end, message }
+
+// Convert a list of parse errors collected on FileMeta.parseErrors into LSP
+// diagnostics, unwrapping ParseErrors (plural) wrappers along the way.  The
+// wrapper has no line/column of its own; without unwrapping every diagnostic
+// degenerates to the (0,0)–(0,10) fallback (issue #2072).
+export function parseErrorsToDiagnostics(
+  parseErrors: readonly (Error | ParseError | { errors: (Error | ParseError)[] })[]
+): Diagnostic[]
+  diagnostics: Diagnostic[] := []
+  for e of parseErrors
+    inner := e as { errors?: (Error | ParseError)[] }
+    if Array.isArray(inner.errors)
+      diagnostics.push ...parseErrorsToDiagnostics(inner.errors)
+      continue
+    pe := e as ParseError
+    if 'line' in pe and 'column' in pe and pe.line? and pe.column?
+      { start, end, message } := parseErrorRange(pe)
+      diagnostics.push {
+        severity: DiagnosticSeverity.Error
+        range: { start, end }
+        message
+        source: 'civet'
+      }
+    else
+      diagnostics.push {
+        severity: DiagnosticSeverity.Error
+        range:
+          start: { line: 0, character: 0 }
+          end:   { line: 0, character: 10 }
+        message: (e as Error).message
+        source: 'civet'
+      }
+  diagnostics
 
 // -- semantic token length measurement --------------------------------------
 

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -39,7 +39,7 @@
   getCurrentLineText
   likelyImportContext
   measureTokenLength
-  parseErrorRange
+  parseErrorsToDiagnostics
   resolvePathAliasDir
 } from ./lib/completions.civet
 assert from node:assert
@@ -1016,25 +1016,10 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     diagnostics: Diagnostic[] := []
 
     if parseErrors?#
-      diagnostics.push ...parseErrors.map (e) =>
-        if 'line' in e and 'column' in e and e.line? and e.column?
-          { start, end, message } := parseErrorRange(e as Parameters<typeof parseErrorRange>[0])
-          return {
-            severity: DiagnosticSeverity.Error
-            // Range is already in source file coordinates
-            range: { start, end }
-            message
-            source: 'civet'
-          }
-        /* c8 ignore next 8 -- defensive fallback for non-standard ParseError shapes without line/column. */
-        return {
-          severity: DiagnosticSeverity.Error
-          range:
-            start: { line: 0, character: 0 }
-            end:   { line: 0, character: 10 }
-          message: e.message
-          source: 'civet'
-        }
+      // Diagnostics already in source-file coordinates; unwraps any
+      // ParseErrors wrapper so its inner errors get their own ranges
+      // rather than collapsing onto the (0,0) fallback (#2072).
+      diagnostics.push ...parseErrorsToDiagnostics(parseErrors)
 
     unless fatal
       diagnostics.push(...getTypeScriptDiagnostics(transpiledPath, transpiledDoc, sourcemapLines))

--- a/lsp/server/test/completions.civet
+++ b/lsp/server/test/completions.civet
@@ -21,6 +21,7 @@ path from node:path
   likelyImportContext
   measureTokenLength
   parseErrorRange
+  parseErrorsToDiagnostics
   resolvePathAliasDir
 } from ../source/lib/completions.civet
 
@@ -328,6 +329,67 @@ describe "completions helpers", ->
       { start, end } := parseErrorRange(err)
       assert.deepEqual start, { line: 0, character: 0 }
       assert.deepEqual end, { line: 0, character: 4 }
+
+  describe "parseErrorsToDiagnostics", ->
+    it "produces a diagnostic at the ParseError's line/column", ->
+      // Regression for #2072: bare ParseError must map to its line/column,
+      // not the (0,0)–(0,10) fallback.
+      err := {
+        name: "ParseError"
+        message: "file.civet:4:1 Failed to parse"
+        line: 4
+        column: 1
+      } as any
+      diags := parseErrorsToDiagnostics [err]
+      assert.equal diags.length, 1
+      assert.equal diags[0].range.start.line, 3
+      assert.equal diags[0].range.start.character, 0
+      assert.equal diags[0].source, 'civet'
+      assert.equal diags[0].message, "Failed to parse"
+
+    it "unwraps ParseErrors (plural) wrappers to their inner errors", ->
+      // Regression for #2072: when civet's compile throws a ParseErrors
+      // wrapper (instead of populating an `errors` array), the LSP host
+      // stores the wrapper in parseErrors.  The wrapper has no line/column
+      // of its own; the inner errors do.  Without unwrapping, every
+      // diagnostic snapped to line 0 char 0.
+      inner1 := {
+        name: "ParseError"
+        message: "file.civet:4:1 Failed to parse"
+        line: 4
+        column: 1
+      } as any
+      inner2 := {
+        name: "ParseError"
+        message: "file.civet:7:3 Unexpected token"
+        line: 7
+        column: 3
+      } as any
+      wrapper := {
+        name: "ParseErrors"
+        message: "wrapper message"
+        errors: [inner1, inner2]
+      } as any
+      diags := parseErrorsToDiagnostics [wrapper]
+      assert.equal diags.length, 2
+      assert.equal diags[0].range.start.line, 3
+      assert.equal diags[0].range.start.character, 0
+      assert.equal diags[0].message, "Failed to parse"
+      assert.equal diags[1].range.start.line, 6
+      assert.equal diags[1].range.start.character, 2
+      assert.equal diags[1].message, "Unexpected token"
+
+    it "falls back to (0,0)–(0,10) for shapes without line/column", ->
+      err := {
+        name: "Error"
+        message: "something else"
+      } as any
+      diags := parseErrorsToDiagnostics [err]
+      assert.equal diags.length, 1
+      assert.deepEqual diags[0].range,
+        start: { line: 0, character: 0 }
+        end:   { line: 0, character: 10 }
+      assert.equal diags[0].message, "something else"
 
   describe "convertCompletions", ->
     doc := TextDocument.create("file:///a.ts", "typescript", 0, "const x = 1")

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -313,6 +313,24 @@ describe "LSP features (shared project server)", ->
     diagnostics := await waitForDiag(client, (p) => p.uri is uri and p.diagnostics.length > 0)
     assert diagnostics.diagnostics.length > 0, "expected at least one parse diagnostic"
 
+  it "parse diagnostic range points at the failing line, not line 0 (#2072)", ->
+    // The error in this source is on line 3 (1-based); helix users in
+    // #2072 saw every parse diagnostic snap to line 0 because the LSP
+    // failed to unwrap civet's ParseErrors wrapper.
+    uri := docUri path.join(projectRoot, "parse-error-line.civet")
+    client.notify "textDocument/didOpen", {
+      textDocument: {
+        uri, languageId: "civet", version: 1
+        text: "some := 0\nother := 10\nlater := \n"
+      }
+    }
+    diagnostics := await waitForDiag(client, (p) => p.uri is uri and p.diagnostics.length > 0)
+    parseDiag := diagnostics.diagnostics.find (d: any) =>
+      d.source is 'civet' and d.severity is 1
+    assert parseDiag, "expected a civet parse diagnostic"
+    assert parseDiag!.range.start.line > 0,
+      `expected parse diagnostic past line 0, got ${JSON.stringify parseDiag!.range}`
+
   it "handles workspace folder change notifications", ->
     // Before hook opted into workspace.workspaceFolders capability, so the
     // server registered the change listener — fire an event and verify the


### PR DESCRIPTION
Fixes #2072.

### Root cause

`lsp/server/source/server.civet` iterated `parseErrors` and expected each entry to be a single `ParseError` with own `line`/`column`. When civet's `compile` threw a `ParseErrors` (plural) wrapper — which has only an `errors[]` array — the inline check `'line' in e and 'column' in e` returned false, and every diagnostic collapsed onto the defensive `(0,0)–(0,10)` fallback. The inner `ParseError.message` already carried the `filename:line:column` prefix so the text was correct even though the range wasn't.

### Fix

Extracted a `parseErrorsToDiagnostics` helper into `lib/completions.civet` that recurses into any entry carrying an `errors[]` array, so inner `ParseError`s contribute their own ranges.

### Tests

- Unit: 3 new cases in `test/completions.civet` (single ParseError, unwrapped wrapper, fallback)
- Protocol: new case in `test/lsp-features.test.civet` using the issue's exact source, asserts the diagnostic range falls past line 0
- Full LSP suite: 264 passing, 0 failing

Generated with [Claude Code](https://claude.ai/code)