### PR TITLE
Fix reserved word ref creation

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6905,11 +6905,11 @@ TemplateBlockCharacters
 # before `in`) match the longest match first; boundary check via NonIdContinue.
 # `let` added since Civet assumes strict mode.
 ReservedWord
-  /(?:off|yes|on|no)/ NonIdContinue CoffeeBooleansEnabled -> $1
-  /isnt/ NonIdContinue CoffeeIsntEnabled -> $1
-  /by/ NonIdContinue CoffeeForLoopsEnabled -> $1
-  /of/ NonIdContinue CoffeeOfEnabled -> $1
-  /(?:instanceof|interface|protected|continue|debugger|function|default|extends|finally|private|delete|export|import|public|return|static|switch|typeof|unless|await|break|catch|class|const|false|super|throw|until|while|yield|case|else|enum|loop|null|this|true|void|with|and|for|let|new|not|try|var|do|if|in|is|or)/ NonIdContinue -> $1
+  /(?:off|yes|on|no)/ NonIdContinue CoffeeBooleansEnabled -> $1[0]
+  /isnt/ NonIdContinue CoffeeIsntEnabled -> $1[0]
+  /by/ NonIdContinue CoffeeForLoopsEnabled -> $1[0]
+  /of/ NonIdContinue CoffeeOfEnabled -> $1[0]
+  /(?:instanceof|interface|protected|continue|debugger|function|default|extends|finally|private|delete|export|import|public|return|static|switch|typeof|unless|await|break|catch|class|const|false|super|throw|until|while|yield|case|else|enum|loop|null|this|true|void|with|and|for|let|new|not|try|var|do|if|in|is|or)/ NonIdContinue -> $1[0]
 # https://262.ecma-international.org/#sec-comments
 Comment
   # perf: assertion to exit early

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6905,11 +6905,12 @@ TemplateBlockCharacters
 # before `in`) match the longest match first; boundary check via NonIdContinue.
 # `let` added since Civet assumes strict mode.
 ReservedWord
-  /(?:off|yes|on|no)/ NonIdContinue CoffeeBooleansEnabled -> $1[0]
-  /isnt/ NonIdContinue CoffeeIsntEnabled -> $1[0]
-  /by/ NonIdContinue CoffeeForLoopsEnabled -> $1[0]
-  /of/ NonIdContinue CoffeeOfEnabled -> $1[0]
-  /(?:instanceof|interface|protected|continue|debugger|function|default|extends|finally|private|delete|export|import|public|return|static|switch|typeof|unless|await|break|catch|class|const|false|super|throw|until|while|yield|case|else|enum|loop|null|this|true|void|with|and|for|let|new|not|try|var|do|if|in|is|or)/ NonIdContinue -> $1[0]
+  # `$` returns matched text; bare regex terminals return the full match array.
+  $/(?:off|yes|on|no)/ NonIdContinue CoffeeBooleansEnabled -> $1
+  $/isnt/ NonIdContinue CoffeeIsntEnabled -> $1
+  $/by/ NonIdContinue CoffeeForLoopsEnabled -> $1
+  $/of/ NonIdContinue CoffeeOfEnabled -> $1
+  $/(?:instanceof|interface|protected|continue|debugger|function|default|extends|finally|private|delete|export|import|public|return|static|switch|typeof|unless|await|break|catch|class|const|false|super|throw|until|while|yield|case|else|enum|loop|null|this|true|void|with|and|for|let|new|not|try|var|do|if|in|is|or)/ NonIdContinue -> $1
 # https://262.ecma-international.org/#sec-comments
 Comment
   # perf: assertion to exit early

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -297,6 +297,24 @@ describe "source map", ->
           assert srcCol <= srcLines[srcLine].length,
             `Mapped source col ${srcCol} out of bounds on line ${srcLine} (${srcLines[srcLine].length} chars): ${JSON.stringify srcLines[srcLine]}`
 
+    it "should support reserved word @ bindings with source maps", ->
+      src := """
+        class Arg
+          type: string
+          name: string
+          default: any
+          doc: string
+
+          @(@type, @name, @default, @doc)
+
+      """
+
+      { code } := await compile src,
+        sourceMap: true
+        filename: "test.civet"
+
+      assert.match code, /this\.default = _default/
+
     it "should remap positions through remapPosition to within source line bounds", ->
       src := """
         class Greeter


### PR DESCRIPTION
Fix `ReservedWord` grammar alternatives to return the matched keyword string instead of the regex capture tuple.

This PR fixes a sourcemap crash for reserved-word `@` bindings such as `@default`, exposed by [`unlessgames/mumux`](https://gitlab.com/unlessgames/mumux) when building with latest Civet, with error `outputStr.split is not a function`.

The regression was introduced in #2036, where `ReservedWord` changed from predicate-style matching to returning `$1`. It should have returned `$1[0]` (the string) instead of the entire `match` array (`$1`).

Related, the Hera documentation about the behavior here was incorrect. Now fixed here: https://github.com/DanielXMoore/Hera/pull/90