### PR TITLE
Coffee classes: backtrack on `:symbol` LHS so `[Symbol.x]` wraps

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -85,6 +85,7 @@ import {
 } from "./parser/lib.civet"
 import type {
   ArrayBindingPattern,
+  AssignmentExpression,
   ASTNode,
   BlockStatement,
   ObjectBindingPattern,
@@ -890,7 +891,7 @@ ActualAssignment
   # NOTE: Consolidated assignment ops
   # NOTE: UpdateExpression instead of LeftHandSideExpression to allow
   # e.g. ++x *= 2 which we later convert to ++x, x *= 2
-  ( NotDedented UpdateExpressionPattern WAssignmentOp )+ MaybeNestedExpression ::ASTNode ->
+  ( NotDedented UpdateExpressionPattern WAssignmentOp )+ MaybeNestedExpression ::AssignmentExpression ->
     $1 = $1.map((x) => [x[0], x[1], ...x[2]])
     $0 = [$1, $2]
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1394,6 +1394,10 @@ ClassElement
   # CoffeeScript public static class variable: @identifier = Expression
   # CoffeeScript private static class variable: identifier = Expression
   CoffeeClassesEnabled Decorators?:decorators DeclareModifier?:declare AccessModifier?:access StaticModifier?:static_ OverrideModifier?:override ActualAssignment:assignment ->
+    // Fall through to the standard class field rule when the LHS is a
+    // :symbol literal; that rule wraps it as a computed `[Symbol.x]`
+    // name, whereas this one would emit invalid `static Symbol.x = ...`.
+    if(assignment.assigned?.type === "SymbolLiteral") return $skip
     return {
       type: static_ ? "CoffeeClassPublic" : "CoffeeClassPrivate",
       children: [decorators, declare, access, static_, override, assignment],

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -131,6 +131,7 @@ export type OtherNode =
   | SliceExpression
   | SpreadElement
   | Star
+  | SymbolLiteral
   | ThisType
   | TypeArgument
   | TypeArguments
@@ -878,6 +879,9 @@ export type SpreadElement = ASTParent &
   type: "SpreadElement"
   expression: ASTNode
   names: string[]
+
+export type SymbolLiteral = ASTParent &
+  type: "SymbolLiteral"
 
 export type Argument = ASTParent &
   type: "Argument"

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -218,16 +218,42 @@ describe "coffeeClasses", ->
   testCase """
     public static class field assignment
     ---
-    "civet coffeeClasses"    
+    "civet coffeeClasses"
     class MathOps
-      @PI = 3.14      
+      @PI = 3.14
       circleArea: (radius) ->
         MathOps.PI * radius * radius
     ---
     class MathOps {
-      static PI = 3.14      
+      static PI = 3.14
       circleArea(radius) {
         return MathOps.PI * radius * radius
       }
+    }
+  """
+
+  testCase """
+    symbol-keyed static field assignment
+    ---
+    "civet coffeeClasses"
+    class X
+      @:iterator = 5
+      @:isConcatSpreadable = true
+    ---
+    class X {
+      static [Symbol.iterator] = 5
+      static [Symbol.isConcatSpreadable] = true
+    }
+  """
+
+  testCase """
+    symbol-keyed instance field assignment
+    ---
+    "civet coffeeClasses"
+    class X
+      :iterator = 5
+    ---
+    class X {
+      [Symbol.iterator] = 5
     }
   """


### PR DESCRIPTION
## Summary
- Fixes #2053 — `@:iterator = 5` under `coffeeClasses` now compiles to `static [Symbol.iterator] = 5` instead of invalid `static Symbol.iterator = 5`.
- Root cause: `CoffeeClassesEnabled` ClassElement rule captured the LHS as a generic `ActualAssignment`, in which `:iterator` lowers to bare `Symbol.iterator`. The standard ClassElement rule (which wraps `:symbol` via `SymbolElement`) was never tried because the coffeeClasses rule matched first.
- Fix: `$skip` (backtrack) when `assignment.assigned.type === "SymbolLiteral"`, letting the standard rule wrap it as a computed `[Symbol.x]` field name.
- Bonus: also repairs the non-static case `:iterator = 5` under `coffeeClasses`, which previously emitted `Symbol.iterator = 5` inside an IIFE.

## Test plan
- [x] Added two `testCase` entries to `test/compat/coffee-classes.civet` (`@:iterator = 5` and `:iterator = 5`)
- [x] `pnpm test` (3987 passing)
- [x] `pnpm test:self` (3987 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)