### PR TITLE
LSP: warn + narrow scope when project has no tsconfig.json

### DIFF
--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -132,7 +132,11 @@ export function startServer(connection: Connection, dependencies: ServerDependen
   warnIfConfigMissing := (projPath: string, service: ResolvedService): void =>
     return if service.configFound or missingConfigWarned.has projPath
     missingConfigWarned.add projPath
-    message := `No tsconfig.json found at ${projPath} — Civet LSP fell back to a Civet/Hera-only project scope.  Add a tsconfig.json to enable cross-file types and analysis of .ts/.js files.`
+    // projPath is a file:// URI; show the user the native filesystem path so
+    // the message reads naturally and the platform-native separator matches
+    // what they'd see in their editor (esp. Windows: backslashes, decoded `~`).
+    displayPath := URI.parse(projPath).fsPath
+    message := `No tsconfig.json found at ${displayPath} — Civet LSP fell back to a Civet/Hera-only project scope.  Add a tsconfig.json to enable cross-file types and analysis of .ts/.js files.`
     // window/logMessage (output channel) + window/showMessage (toast).  The
     // vscode-languageserver `showWarningMessage` helper uses showMessageRequest
     // even with no actions, which not every client renders as a passive toast,

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -124,6 +124,30 @@ export function startServer(connection: Connection, dependencies: ServerDependen
   // Set of project paths that need another rebuild after the current one completes
   rebuildQueued := new Set<string>()
 
+  // Project paths we've already warned the user about (missing tsconfig.json).
+  // Dedupes the warning so the popup fires once per project per session, not on
+  // every TSService reload (#240).
+  missingConfigWarned := new Set<string>()
+
+  warnIfConfigMissing := (projPath: string, service: ResolvedService): void =>
+    return if service.configFound or missingConfigWarned.has projPath
+    missingConfigWarned.add projPath
+    message := `No tsconfig.json found at ${projPath} — Civet LSP fell back to a Civet/Hera-only project scope.  Add a tsconfig.json to enable cross-file types and analysis of .ts/.js files.`
+    // window/logMessage (output channel) + window/showMessage (toast).  The
+    // vscode-languageserver `showWarningMessage` helper uses showMessageRequest
+    // even with no actions, which not every client renders as a passive toast,
+    // so send the plain ShowMessageNotification directly.
+    logger.warn? message
+    /* c8 ignore start -- defensive: connection.sendNotification is always
+       present on createConnection's return, but a custom Connection stub in
+       a test harness might not have it; better to swallow than crash the
+       reload path. */
+    try
+      connection.sendNotification 'window/showMessage', { type: 2, message }
+    catch e
+      logger.error `Failed to surface missing-tsconfig warning: ${e}`
+    /* c8 ignore stop */
+
   let rootUri: string | undefined, rootDir: string | undefined
 
   getProjectPathFromSourcePath := (sourcePath: string): string =>
@@ -172,6 +196,7 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     await service.loadPlugins()
     projectPathToServiceMap.set(projPath, service)
     projectPathToPendingPromiseMap.delete(projPath)
+    warnIfConfigMissing(projPath, service)
     resolveInit!()
 
     return service
@@ -1162,6 +1187,7 @@ export function startServer(connection: Connection, dependencies: ServerDependen
       // Atomically swap: incoming requests continue using the old service until this point
       oldService := projectPathToServiceMap.get(projPath)
       projectPathToServiceMap.set(projPath, newService)
+      warnIfConfigMissing(projPath, newService)
 
       // Dispose old service after a short grace period so in-flight requests finish
       if oldService

--- a/lsp/server/test/lsp-protocol.test.civet
+++ b/lsp/server/test/lsp-protocol.test.civet
@@ -223,5 +223,10 @@ describe "LSP missing tsconfig warning", ->
       p.type is 2 and String(p.message).includes "No tsconfig.json found"
 
     assert msg, "expected a window/showMessage warning for missing tsconfig"
-    assert String(msg.message).includes(tmpDir),
-      `expected warning to mention the project path ${tmpDir}, got: ${msg.message}`
+    // Check basename (unique mkdtempSync suffix) rather than full tmpDir: on
+    // Windows the displayed fsPath uses backslashes and a lowercased drive
+    // letter, so the raw tmpDir from mkdtempSync ("C:\\...") won't substring-
+    // match the message ("c:\\..."). Basename uniquely identifies the project.
+    projectName := path.basename tmpDir
+    assert String(msg.message).includes(projectName),
+      `expected warning to mention the project ${projectName} (from ${tmpDir}), got: ${msg.message}`

--- a/lsp/server/test/lsp-protocol.test.civet
+++ b/lsp/server/test/lsp-protocol.test.civet
@@ -8,6 +8,8 @@
 // its capture closure doesn't see other tests' publishes.
 
 { spawnLspServer, docUri, type LspClient } from ./lsp-harness.civet
+{ mkdtempSync, rmSync, writeFileSync } from node:fs
+{ tmpdir } from node:os
 path from node:path
 assert from assert
 
@@ -182,3 +184,44 @@ describe "LSP protocol", ->
     errorDiags := tail.diagnostics.filter(hasError)
     assert.equal errorDiags.length, 0,
       `expected last publish to have no errors (final text is valid), got ${JSON.stringify errorDiags}`
+
+describe "LSP missing tsconfig warning", ->
+  @timeout 15000
+
+  let client: LspClient
+  let tmpDir: string
+
+  before ->
+    tmpDir = mkdtempSync path.join(tmpdir(), 'civet-lsp-no-tsconfig-')
+    // .civet file the editor opens — drives ensureServiceForSourcePath, which
+    // surfaces the missing-tsconfig warning via window/showMessage.
+    writeFileSync path.join(tmpDir, 'sample.civet'), "x := 1\n"
+    client = spawnLspServer()
+    rootUri := docUri tmpDir
+    await client.request "initialize", {
+      processId: process.pid
+      rootUri
+      capabilities: {}
+      workspaceFolders: [{ uri: rootUri, name: "no-tsconfig" }]
+    }
+    client.notify "initialized", {}
+
+  after ->
+    await client.stop() if client
+    rmSync(tmpDir, { recursive: true, force: true }) if tmpDir
+
+  it "sends window/showMessage when project has no tsconfig.json", ->
+    samplePath := path.join tmpDir, 'sample.civet'
+    uri := docUri samplePath
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text: "x := 1\n" }
+    }
+
+    // LSP MessageType.Warning is 2.  Match on the well-known prefix the
+    // server emits so a future copy edit doesn't silently break this test.
+    msg := await client.waitFor "window/showMessage", (p) =>
+      p.type is 2 and String(p.message).includes "No tsconfig.json found"
+
+    assert msg, "expected a window/showMessage warning for missing tsconfig"
+    assert String(msg.message).includes(tmpDir),
+      `expected warning to mention the project path ${tmpDir}, got: ${msg.message}`

--- a/lsp/server/test/service.civet
+++ b/lsp/server/test/service.civet
@@ -397,6 +397,35 @@ describe "ts service module resolution", ->
     finally
       rmSync(tmpDir, { recursive: true, force: true })
 
+describe "ts service configFound flag", ->
+  it "is true when the project ships a tsconfig.json", async ->
+    service := await TSService(projectURL, nullLogger)
+    assert.equal service.configFound, true
+
+  it "is false when no tsconfig.json exists at the project path", async ->
+    tmpDir := mkdtempSync(path.join(tmpdir(), 'civet-no-tsconfig-'))
+    try
+      service := await TSService(pathToFileURL(tmpDir + path.sep).href, nullLogger)
+      assert.equal service.configFound, false
+    finally
+      rmSync(tmpDir, { recursive: true, force: true })
+
+  it "uses TS default include when missing tsconfig + no transpilers (SharedTSService direct)", ->
+    // Covers the else arm of parseTsConfigForCivet's
+    // `extraExtensions.length > 0` check from the LSP-coverage side
+    // (the root suite hits the .civet source directly, but the merged
+    // dist coverage needs a JS-side hit too).
+    tmpDir := mkdtempSync(path.join(tmpdir(), 'civet-no-cfg-no-plugins-'))
+    try
+      service := SharedTSService tmpDir + path.sep, {
+        docFactory: createInMemoryDocFactory()
+        logger: nullLogger
+        discoverProjectFiles: false
+      }
+      assert.equal service.configFound, false
+    finally
+      rmSync(tmpDir, { recursive: true, force: true })
+
 describe "ts service without civet dependencies", ->
   let tmpDir: string
   before ->

--- a/source/ts-service/config.civet
+++ b/source/ts-service/config.civet
@@ -71,17 +71,33 @@ export interface ParseTsConfigOptions
    */
   system?: ts.System
 
+export interface ParsedCivetConfig extends ts.ParsedCommandLine
+  /**
+   * False when no `tsconfig.json` was found at `<projectPath>` and no inline
+   * `tsConfig` was supplied — the parsed config is a Civet-only fallback
+   * narrowed to transpiler extensions (see #240).  Consumers should surface
+   * this to the user (the LSP shows a one-shot warning) so the missing
+   * tsconfig isn't a silent failure mode.
+   */
+  configFound: boolean
+
 /**
  * Parse `<projectPath>/tsconfig.json` (or the inline `tsConfig`),
  * applying Civet-aware defaults (`allowNonTsExtensions`, JSX preserve).
  * The returned `parsed.fileNames` reflects the widened include walk
  * when `widenIncludeFilter` is on.
+ *
+ * When neither a tsconfig.json nor an inline `tsConfig` is available,
+ * falls back to a Civet-only include pattern (`**​/*.<ext>` for each
+ * registered transpiler) rather than TypeScript's default `**​/*` walk,
+ * which can pull a project's entire `.ts`/`.js` tree into the service
+ * and OOM it for JS-heavy projects (#240).
  */
 export function parseTsConfigForCivet(
   projectPath: string
   transpilers: Map<string, Transpiler>
   options: ParseTsConfigOptions = {}
-): ts.ParsedCommandLine
+): ParsedCivetConfig
   widen := options.widenIncludeFilter ?? true
   system := options.system ?? ts.sys
   extraExtensions := Array.from transpilers.keys()
@@ -106,7 +122,25 @@ export function parseTsConfigForCivet(
   } else system
 
   tsConfigPath := path.join projectPath, "tsconfig.json"
-  config := options.tsConfig ?? ts.readConfigFile(tsConfigPath, system.readFile).config
+  let config: any
+  let configFound: boolean
+  if options.tsConfig?
+    config = options.tsConfig
+    configFound = true
+  else
+    configFound = system.fileExists tsConfigPath
+    config = if configFound
+      ts.readConfigFile(tsConfigPath, system.readFile).config
+    else
+      // Narrow to the registered transpiler extensions so a JS-heavy project
+      // without a tsconfig doesn't pull its whole tree through TS (#240).
+      // With no transpilers registered there's nothing meaningful to scope to,
+      // so keep TS's default `["**/*"]` walk.
+      if extraExtensions.length > 0
+        include: extraExtensions.map (ext) => `**/*${ext}`
+      else
+        {}
+
   parsed := ts.parseJsonConfigFileContent(
     config
     configSys
@@ -114,8 +148,9 @@ export function parseTsConfigForCivet(
     {}
     tsConfigPath
     undefined
-  )
+  ) as ParsedCivetConfig
   parsed.options.allowNonTsExtensions ??= true
   parsed.options.jsx ??= ts.JsxEmit.Preserve
   parsed.options.rootDir ??= projectPath
+  parsed.configFound = configFound
   parsed

--- a/source/ts-service/service.civet
+++ b/source/ts-service/service.civet
@@ -68,6 +68,14 @@ export interface TSServiceOptions
 
 export interface ResolvedService extends LanguageService
   host: Host
+  /**
+   * False when no `tsconfig.json` was found at the project path and no inline
+   * `tsConfig` was supplied — the service is running on a narrowed Civet-only
+   * fallback (see `ParsedCivetConfig.configFound`).  The LSP surfaces this to
+   * the user as a one-shot warning so silent partial analysis doesn't look
+   * like a Civet bug (#240).
+   */
+  configFound: boolean
   /** Map a TypeScript file name (e.g. `foo.civet.tsx`) to its source path (`foo.civet`). */
   getSourceFileName(fileName: string): string
   /** Register a plugin's transpilers at runtime.  Existing snapshots are not invalidated. */
@@ -143,6 +151,7 @@ export function TSService(projectPath: string, options: TSServiceOptions): Resol
 
   return Object.assign {}, service, {
     host
+    configFound: parsedConfig.configFound
     /** `foo.civet.tsx` → `foo.civet`; passthrough for non-transpiled files. */
     getSourceFileName(fileName: string)
       getCanonicalFileName remapFileName(fileName, transpilers)

--- a/test/infra/ts-service-config.civet
+++ b/test/infra/ts-service-config.civet
@@ -1,0 +1,83 @@
+{ describe, it } from mocha
+assert from assert
+
+* as fs from node:fs
+* as os from node:os
+* as path from node:path
+
+{ buildTranspilers, parseTsConfigForCivet } from "../../source/ts-service/config.civet"
+{ type Plugin } from "../../source/ts-service/types.civet"
+
+makeCivetTranspiler := () =>
+  buildTranspilers [
+    transpilers: [
+      extension: ".civet"
+      target: ".tsx"
+      compile: (_path: string, _source: string) => code: ""
+    ]
+  ] as Plugin[]
+
+describe "parseTsConfigForCivet missing-tsconfig fallback", ->
+  it "sets configFound=true when tsconfig.json exists on disk", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-cfg-found-'
+    try
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020"}}'
+      parsed := parseTsConfigForCivet tmpDir, makeCivetTranspiler()
+      assert.equal parsed.configFound, true
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "sets configFound=true when an inline tsConfig is supplied", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-cfg-inline-'
+    try
+      parsed := parseTsConfigForCivet tmpDir, makeCivetTranspiler(), {
+        tsConfig: { compilerOptions: target: 'es2020' }
+      }
+      assert.equal parsed.configFound, true
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "sets configFound=false and narrows include to transpiler extensions when tsconfig is missing", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-cfg-missing-'
+    try
+      // Two .civet files (in scope) and one stray .ts file (out of scope under
+      // the narrowed fallback include).
+      fs.writeFileSync path.join(tmpDir, 'a.civet'), 'x := 1\n'
+      fs.writeFileSync path.join(tmpDir, 'b.civet'), 'y := 2\n'
+      fs.writeFileSync path.join(tmpDir, 'stray.ts'), 'const z = 3\n'
+
+      parsed := parseTsConfigForCivet tmpDir, makeCivetTranspiler()
+      assert.equal parsed.configFound, false
+
+      // .civet files are discovered (reported as their .tsx siblings via the
+      // widened readDirectory).
+      assert parsed.fileNames.some(.endsWith 'a.civet.tsx'),
+        `expected a.civet in fallback scope; got ${parsed.fileNames.join(', ')}`
+      assert parsed.fileNames.some(.endsWith 'b.civet.tsx'),
+        `expected b.civet in fallback scope; got ${parsed.fileNames.join(', ')}`
+
+      // The stray .ts file is NOT included — that's the whole point of the
+      // narrowed fallback (issue #240: huge JS/TS trees OOM the service).
+      assert not parsed.fileNames.some(.endsWith 'stray.ts'),
+        `expected stray.ts to be excluded from fallback scope; got ${parsed.fileNames.join(', ')}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "falls back to TS's default include when missing tsconfig + no transpilers registered", ->
+    // Edge case: no Civet/Hera plugin registered means there's no meaningful
+    // narrower scope, so we leave TS to its default `["**/*"]` walk rather
+    // than synthesizing an empty include that would discover zero files.
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-cfg-empty-'
+    try
+      fs.writeFileSync path.join(tmpDir, 'plain.ts'), 'export const a = 1\n'
+
+      emptyTranspilers := buildTranspilers ([] as Plugin[])
+      parsed := parseTsConfigForCivet tmpDir, emptyTranspilers
+      assert.equal parsed.configFound, false
+      // With no transpilers, the .ts walk is still active — confirms the
+      // empty-include arm was taken (otherwise this would be empty).
+      assert parsed.fileNames.some(.endsWith 'plain.ts'),
+        `expected plain.ts in default walk; got ${parsed.fileNames.join(', ')}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }


### PR DESCRIPTION
## Summary

- `parseTsConfigForCivet` now reports `configFound: false` when neither a disk `tsconfig.json` nor an inline `tsConfig` is supplied, and falls back to a Civet-only include (`**/*.civet`, `**/*.hera`) instead of TS's default `**/*` walk.
- `TSService` exposes the flag on `ResolvedService`; the LSP server fires a one-shot `window/showMessage` warning per project pointing the user at the missing config, plus a `window/logMessage` for the output channel.
- Closes the loop on the silent-OOM symptom in #240: a JS-heavy project without a tsconfig pulled the entire JS tree through the TS LanguageService and crashed it without any feedback to the user.

The narrowed include is the smallest fix that's still useful for Civet-only authoring — it doesn't prevent every possible OOM (a giant Civet tree could still blow up), but it removes the JS-tree explosion #240 hit and makes the missing-tsconfig case loud instead of fatal.

## Test plan

- [x] New `test/infra/ts-service-config.civet` covers `configFound` true/false and the narrowed-include vs. default-walk branches.
- [x] `lsp/server/test/service.civet` asserts `configFound` propagates through the LSP wrapper for both states.
- [x] `lsp/server/test/lsp-protocol.test.civet` drives the built LSP server over JSON-RPC and asserts it sends `window/showMessage` (type=2 Warning) for a project with no tsconfig.
- [x] `pnpm test` (3990 passing), `pnpm -C lsp/server test` (264 passing).
- [x] `pnpm typecheck --max-errors 888` clean (887, no regression).
- [x] `pnpm coverage:check` passes at 100/100/100/100.

Closes #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)