### PR TITLE
Dev: add `pnpm test:grep` script and document bootstrapping binaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,17 @@ To use multiple cores while building:
 CIVET_THREADS=4 pnpm build
 ```
 
+### Two Civet binaries
+
+Civet is bootstrapped: the previously-released compiler builds the current
+source. So the repo has two binaries with different roles:
+
+* `./dist/civet` — the locally-built compiler. Reflects your changes after
+  `pnpm build`. Use this to test source/parser edits.
+* `./node_modules/.bin/civet` — the previously-released `@danielx/civet` from
+  npm. Used to compile `source/` into `dist/` during the build, so it does
+  *not* reflect your changes. Useful for perf comparisons (see below).
+
 ## Testing
 
 You can run all tests via
@@ -79,6 +90,12 @@ to add a broken test, and temporarily add `.only`, so that you can repeatedly
 run the test via `pnpm test`. (You do not need to `pnpm build` in between.)
 With only one test running, you can reasonably add `console.log` and other
 debugging statements to figure out what's going on.
+
+For a one-off run from the CLI without editing the test file:
+
+```sh
+pnpm test:grep "name of test"
+```
 
 ## Coverage
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "coverage:show": "civet scripts/show-uncovered.civet",
     "show-uncovered": "civet scripts/show-uncovered.civet",
     "test:self": "cross-env CIVET_SOURCE=./dist/main.js pnpm test",
+    "test:grep": "cross-env CIVET_THREADS=0 pnpm test --grep",
     "test:brk": "cross-env CIVET_THREADS=0 pnpm test --inspect-brk",
     "changelog": "civet build/changelog.civet",
     "release": "pnpm changelog --release"


### PR DESCRIPTION
## Summary

- New `test:grep` script wraps `CIVET_THREADS=0 pnpm test --grep`, giving a short canonical form for one-off single-test runs from the CLI (complements the existing `.only` pattern for active dev).
- CONTRIBUTING.md gains a "Two Civet binaries" subsection explaining why both `./dist/civet` and `./node_modules/.bin/civet` exist — the previously-released compiler bootstraps the current source into `dist/`, so the npm-installed binary does not reflect in-progress changes.
- CONTRIBUTING.md's Testing section gets a one-line callout pointing at `pnpm test:grep "name of test"` next to the existing `.only` guidance.

## Test plan

- [ ] `pnpm test:grep "some test name"` runs only matching tests with `CIVET_THREADS=0`
- [ ] `pnpm test:grep` with no argument fails cleanly (no silent full-suite run)
- [ ] CONTRIBUTING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)