### PR TITLE
LSP: add `--version` / `--help` flags, default to `--stdio`

### DIFF
--- a/lsp/server/bin/civet-lsp.js
+++ b/lsp/server/bin/civet-lsp.js
@@ -3,44 +3,11 @@
 const fs = require('node:fs')
 const path = require('node:path')
 
-const args = process.argv.slice(2)
-const pkg = require('../package.json')
-
-if (args.includes('--version') || args.includes('-v')) {
-  console.log(pkg.version)
-  process.exit(0)
-}
-
-if (args.includes('--help') || args.includes('-h')) {
-  console.log(`${pkg.name} ${pkg.version}`)
-  console.log(pkg.description)
-  console.log()
-  console.log('Usage: civet-lsp [options]')
-  console.log()
-  console.log('Options:')
-  console.log('  -v, --version  Print version and exit')
-  console.log('  -h, --help     Print this help and exit')
-  console.log('  --stdio        Communicate over stdio (default)')
-  console.log()
-  console.log('Run without arguments to start the language server on stdio.')
-  console.log(`See ${pkg.repository.url} for documentation.`)
-  process.exit(0)
-}
-
 const serverPath = path.join(__dirname, '..', 'dist', 'node.js')
 
 if (!fs.existsSync(serverPath)) {
   console.error('civet-lsp has not been built yet. Run `pnpm -C lsp/server build` first.')
   process.exit(1)
 }
-
-// vscode-languageserver demands an explicit connection mode; default to --stdio
-// when none of --stdio / --node-ipc / --socket / --pipe is present.
-const hasConnectionMode = args.some(a =>
-  a === '--stdio' || a === '--node-ipc' ||
-  a === '--socket' || a.startsWith('--socket=') ||
-  a === '--pipe' || a.startsWith('--pipe=')
-)
-if (!hasConnectionMode) process.argv.push('--stdio')
 
 require(serverPath)

--- a/lsp/server/bin/civet-lsp.js
+++ b/lsp/server/bin/civet-lsp.js
@@ -3,11 +3,44 @@
 const fs = require('node:fs')
 const path = require('node:path')
 
+const args = process.argv.slice(2)
+const pkg = require('../package.json')
+
+if (args.includes('--version') || args.includes('-v')) {
+  console.log(pkg.version)
+  process.exit(0)
+}
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(`${pkg.name} ${pkg.version}`)
+  console.log(pkg.description)
+  console.log()
+  console.log('Usage: civet-lsp [options]')
+  console.log()
+  console.log('Options:')
+  console.log('  -v, --version  Print version and exit')
+  console.log('  -h, --help     Print this help and exit')
+  console.log('  --stdio        Communicate over stdio (default)')
+  console.log()
+  console.log('Run without arguments to start the language server on stdio.')
+  console.log(`See ${pkg.repository.url} for documentation.`)
+  process.exit(0)
+}
+
 const serverPath = path.join(__dirname, '..', 'dist', 'node.js')
 
 if (!fs.existsSync(serverPath)) {
   console.error('civet-lsp has not been built yet. Run `pnpm -C lsp/server build` first.')
   process.exit(1)
 }
+
+// vscode-languageserver demands an explicit connection mode; default to --stdio
+// when none of --stdio / --node-ipc / --socket / --pipe is present.
+const hasConnectionMode = args.some(a =>
+  a === '--stdio' || a === '--node-ipc' ||
+  a === '--socket' || a.startsWith('--socket=') ||
+  a === '--pipe' || a.startsWith('--pipe=')
+)
+if (!hasConnectionMode) process.argv.push('--stdio')
 
 require(serverPath)

--- a/lsp/server/source/node.civet
+++ b/lsp/server/source/node.civet
@@ -7,6 +7,36 @@
 { startServer } from ./server.civet
 TSService from ./lib/typescript-service.civet
 ts from typescript
+pkg from ../package.json
+
+args := process.argv.slice 2
+
+if args.includes('--version') or args.includes('-v')
+  console.log pkg.version
+  process.exit 0
+
+if args.includes('--help') or args.includes('-h')
+  console.log `${pkg.name} ${pkg.version}`
+  console.log pkg.description
+  console.log()
+  console.log 'Usage: civet-lsp [options]'
+  console.log()
+  console.log 'Options:'
+  console.log '  -v, --version  Print version and exit'
+  console.log '  -h, --help     Print this help and exit'
+  console.log '  --stdio        Communicate over stdio (default)'
+  console.log()
+  console.log 'Run without arguments to start the language server on stdio.'
+  console.log `See ${pkg.repository.url} for documentation.`
+  process.exit 0
+
+// vscode-languageserver demands an explicit connection mode; default to --stdio
+// when none of --stdio / --node-ipc / --socket / --pipe is present.
+hasConnectionMode := args.some (a) =>
+  a is '--stdio' or a is '--node-ipc' or
+  a is '--socket' or a.startsWith('--socket=') or
+  a is '--pipe' or a.startsWith('--pipe=')
+process.argv.push '--stdio' unless hasConnectionMode
 
 startServer createConnection(ProposedFeatures.all), {
   TSService

--- a/lsp/server/source/node.civet
+++ b/lsp/server/source/node.civet
@@ -16,27 +16,26 @@ if args.includes('--version') or args.includes('-v')
   process.exit 0
 
 if args.includes('--help') or args.includes('-h')
-  console.log `${pkg.name} ${pkg.version}`
-  console.log pkg.description
-  console.log()
-  console.log 'Usage: civet-lsp [options]'
-  console.log()
-  console.log 'Options:'
-  console.log '  -v, --version  Print version and exit'
-  console.log '  -h, --help     Print this help and exit'
-  console.log '  --stdio        Communicate over stdio (default)'
-  console.log()
-  console.log 'Run without arguments to start the language server on stdio.'
-  console.log `See ${pkg.repository.url} for documentation.`
+  console.log ```
+    ${pkg.name} ${pkg.version}
+    ${pkg.description}
+
+    Usage: civet-lsp [options]
+
+    Options:
+      -v, --version  Print version and exit
+      -h, --help     Print this help and exit
+      --stdio        Communicate over stdio (default)
+
+    Run without arguments to start the language server on stdio.
+    See ${pkg.repository.url} for documentation.
+  ```
   process.exit 0
 
 // vscode-languageserver demands an explicit connection mode; default to --stdio
 // when none of --stdio / --node-ipc / --socket / --pipe is present.
-hasConnectionMode := args.some (a) =>
-  a is '--stdio' or a is '--node-ipc' or
-  a is '--socket' or a.startsWith('--socket=') or
-  a is '--pipe' or a.startsWith('--pipe=')
-process.argv.push '--stdio' unless hasConnectionMode
+connectionModeRe := /^--(?:stdio|node-ipc|socket(?:=.*)?|pipe(?:=.*)?)$/
+process.argv.push '--stdio' unless args.some &.match connectionModeRe
 
 startServer createConnection(ProposedFeatures.all), {
   TSService

--- a/lsp/server/test/bin.test.civet
+++ b/lsp/server/test/bin.test.civet
@@ -27,18 +27,36 @@ describe "civet-lsp CLI", ->
     // Regression: vscode-languageserver throws "Connection input stream is
     // not set" if none of --stdio / --node-ipc / --socket / --pipe is given.
     // bin/civet-lsp.js injects --stdio in that case.
+    //
+    // Prove the injection worked by completing an LSP initialize handshake
+    // over stdio — only possible when the connection is wired up.  If the
+    // server crashes instead, the `exit` listener rejects the promise with
+    // the captured stderr so we get a useful failure (and don't depend on a
+    // wall-clock window that could be too tight on a loaded runner).
     proc := spawn 'node', [binPath], stdio: ['pipe', 'pipe', 'pipe']
     let stderr = ''
     proc.stderr!.on 'data', (chunk: Buffer) => stderr += chunk.toString()
-    earlyExit := new Promise<number?> (resolve) =>
-      proc.once 'exit', (code) => resolve code
-    timeout := new Promise<number?> (resolve) =>
-      setTimeout (=> resolve null), 500
+    // Swallow EPIPE if the server has already exited when we write.
+    proc.stdin!.on 'error', => {}
+
+    gotFramedReply := new Promise<void> (resolve, reject) =>
+      let buf = ''
+      proc.stdout!.on 'data', (chunk: Buffer) =>
+        buf += chunk.toString 'utf8'
+        if /^Content-Length: \d+\r\n/.test buf
+          resolve()
+      proc.once 'exit', (code) =>
+        reject new Error
+          `civet-lsp exited (code=${code}) before responding to initialize; stderr: ${stderr}`
+
+    body := JSON.stringify
+      jsonrpc: '2.0'
+      id: 1
+      method: 'initialize'
+      params: { processId: process.pid, rootUri: null, capabilities: {} }
+    proc.stdin!.write `Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`
+
     try
-      result := await Promise.race [earlyExit, timeout]
-      assert.equal result, null,
-        `server exited early with code ${result}; stderr: ${stderr}`
-      assert.ok not stderr.includes('Connection input stream is not set'),
-        `unexpected stderr: ${stderr}`
+      await gotFramedReply
     finally
       proc.kill 'SIGTERM'

--- a/lsp/server/test/bin.test.civet
+++ b/lsp/server/test/bin.test.civet
@@ -1,0 +1,44 @@
+{ spawn, spawnSync } from node:child_process
+{ readFileSync } from node:fs
+{ fileURLToPath } from node:url
+path from node:path
+assert from assert
+
+testDir := path.dirname fileURLToPath(import.meta.url)
+binPath := path.resolve testDir, '..', 'bin', 'civet-lsp.js'
+pkg := JSON.parse readFileSync(path.resolve(testDir, '..', 'package.json'), 'utf8')
+
+describe "civet-lsp CLI", ->
+  for flag of ['--version', '-v']
+    it `prints the version and exits 0 with ${flag}`, ->
+      result := spawnSync 'node', [binPath, flag], encoding: 'utf8'
+      assert.equal result.status, 0
+      assert.equal result.stdout.trim(), pkg.version
+
+  for flag of ['--help', '-h']
+    it `prints a usage blurb and exits 0 with ${flag}`, ->
+      result := spawnSync 'node', [binPath, flag], encoding: 'utf8'
+      assert.equal result.status, 0
+      assert.match result.stdout, /Usage: civet-lsp/
+      assert.ok result.stdout.includes(pkg.version),
+        `expected ${flag} output to mention version ${pkg.version}`
+
+  it "defaults to --stdio when no connection-mode flag is passed", ->
+    // Regression: vscode-languageserver throws "Connection input stream is
+    // not set" if none of --stdio / --node-ipc / --socket / --pipe is given.
+    // bin/civet-lsp.js injects --stdio in that case.
+    proc := spawn 'node', [binPath], stdio: ['pipe', 'pipe', 'pipe']
+    let stderr = ''
+    proc.stderr!.on 'data', (chunk: Buffer) => stderr += chunk.toString()
+    earlyExit := new Promise<number?> (resolve) =>
+      proc.once 'exit', (code) => resolve code
+    timeout := new Promise<number?> (resolve) =>
+      setTimeout (=> resolve null), 500
+    try
+      result := await Promise.race [earlyExit, timeout]
+      assert.equal result, null,
+        `server exited early with code ${result}; stderr: ${stderr}`
+      assert.ok not stderr.includes('Connection input stream is not set'),
+        `unexpected stderr: ${stderr}`
+    finally
+      proc.kill 'SIGTERM'


### PR DESCRIPTION
## Summary

`civet-lsp` previously had no CLI handling — the bin script just required the server module, which threw `Connection input stream is not set` when run interactively without `--stdio`.

- `-v` / `--version`: print package version
- `-h` / `--help`: print a short usage blurb
- Inject `--stdio` when no connection-mode flag (`--stdio` / `--node-ipc` / `--socket` / `--pipe`) is passed, so bare `civet-lsp` works (matching what the help text says).

## Test plan
- [x] `civet-lsp --version` prints `0.3.35`
- [x] `civet-lsp --help` prints usage
- [x] `civet-lsp` (no args) starts the server cleanly on stdio
- [x] `lsp/server/test/bin.test.civet` covers all three paths (5 new tests, all passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)