### PR TITLE
Dev: typecheck-diff in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
           base_dir="$RUNNER_TEMP/typecheck-base"
           base_log="$RUNNER_TEMP/typecheck-before.log"
           head_log="$RUNNER_TEMP/typecheck-after.log"
+          typecheck_bin="$PWD/dist/civet"
 
           trap 'git worktree remove --force "$base_dir" >/dev/null 2>&1 || true' EXIT
           rm -rf "$base_dir"
@@ -102,9 +103,8 @@ jobs:
 
           (
             cd "$base_dir"
-            pnpm install --frozen-lockfile
-            pnpm build
-            pnpm typecheck --max-errors 99999 >"$base_log" 2>&1 || true
+            ln -s "$GITHUB_WORKSPACE/node_modules" node_modules
+            "$typecheck_bin" --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
           )
 
           pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ name: Build
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
+  CIVET_TYPECHECK_MAX_ERRORS: 888
 
 jobs:
   build:
@@ -80,9 +81,34 @@ jobs:
           pnpm -C lsp/vscode test:e2e
 
       - name: Typecheck
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && github.event_name != 'pull_request'
         run: |
-          pnpm typecheck --max-errors 888
+          pnpm typecheck
+
+      - name: Typecheck diff
+        if: runner.os == 'Linux' && github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+
+          base_dir="$RUNNER_TEMP/typecheck-base"
+          base_log="$RUNNER_TEMP/typecheck-before.log"
+          head_log="$RUNNER_TEMP/typecheck-after.log"
+
+          trap 'git worktree remove --force "$base_dir" >/dev/null 2>&1 || true' EXIT
+          rm -rf "$base_dir"
+          git worktree prune
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          git worktree add --detach "$base_dir" FETCH_HEAD
+
+          (
+            cd "$base_dir"
+            pnpm install --frozen-lockfile
+            pnpm build
+            pnpm typecheck --max-errors 99999 >"$base_log" 2>&1 || true
+          )
+
+          pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true
+          pnpm typecheck:diff --fail-on-regressions "$base_log" "$head_log"
 
       - name: Prune stale cache entries
         run: pnpm clean:cache:prune

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -86,6 +89,7 @@ jobs:
           pnpm typecheck --max-errors "$CI_TYPECHECK_MAX_ERRORS"
 
       - name: Typecheck diff
+        id: typecheck-diff
         if: runner.os == 'Linux' && github.event_name == 'pull_request'
         run: |
           set -euo pipefail
@@ -108,7 +112,41 @@ jobs:
           )
 
           pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true
+          set +e
           pnpm typecheck:diff --fail-on-regressions --max-errors "$CI_TYPECHECK_MAX_ERRORS" "$base_log" "$head_log"
+          diff_status=$?
+          set -e
+
+          summary_file="$RUNNER_TEMP/typecheck-diff-summary.md"
+          cp "$GITHUB_STEP_SUMMARY" "$summary_file"
+
+          conclusion=success
+          if [ "$diff_status" -ne 0 ]; then
+            conclusion=failure
+          fi
+
+          {
+            echo "status=$diff_status"
+            echo "conclusion=$conclusion"
+            echo "check_output<<TYPECHECK_DIFF_JSON"
+            jq -Rs --arg title "Typecheck diff" '{title: $title, summary: .}' "$summary_file"
+            echo "TYPECHECK_DIFF_JSON"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish typecheck diff check
+        if: always() && runner.os == 'Linux' && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.check_output != ''
+        continue-on-error: true
+        uses: LouisBrunner/checks-action@v3.1.0
+        with:
+          token: ${{ github.token }}
+          name: Typecheck diff
+          conclusion: ${{ steps.typecheck-diff.outputs.conclusion }}
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: ${{ steps.typecheck-diff.outputs.check_output }}
+
+      - name: Fail typecheck diff
+        if: runner.os == 'Linux' && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.status != '' && steps.typecheck-diff.outputs.status != '0'
+        run: exit "${{ steps.typecheck-diff.outputs.status }}"
 
       - name: Prune stale cache entries
         run: pnpm clean:cache:prune

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: Build
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  CIVET_TYPECHECK_MAX_ERRORS: 888
+  CI_TYPECHECK_MAX_ERRORS: 888
 
 jobs:
   build:
@@ -83,7 +83,7 @@ jobs:
       - name: Typecheck
         if: runner.os == 'Linux' && github.event_name != 'pull_request'
         run: |
-          pnpm typecheck
+          pnpm typecheck --max-errors "$CI_TYPECHECK_MAX_ERRORS"
 
       - name: Typecheck diff
         if: runner.os == 'Linux' && github.event_name == 'pull_request'
@@ -108,7 +108,7 @@ jobs:
           )
 
           pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true
-          pnpm typecheck:diff --fail-on-regressions "$base_log" "$head_log"
+          pnpm typecheck:diff --fail-on-regressions --max-errors "$CI_TYPECHECK_MAX_ERRORS" "$base_log" "$head_log"
 
       - name: Prune stale cache entries
         run: pnpm clean:cache:prune

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,29 +200,26 @@ jobs:
           notice_text=$(sed -n 's/^::notice title=Typecheck diff:://p' "$diff_log" | tail -n 1)
           check_title=${notice_text:-Typecheck diff}
 
-          conclusion=success
-          if [ "$diff_status" -ne 0 ]; then
-            conclusion=failure
-          fi
-
           {
             echo "status=$diff_status"
-            echo "conclusion=$conclusion"
-            echo "check_output<<TYPECHECK_DIFF_JSON"
-            jq -Rs --arg title "$check_title" '{title: $title, summary: .}' "$summary_file"
-            echo "TYPECHECK_DIFF_JSON"
+            echo "check_title=$check_title"
           } >> "$GITHUB_OUTPUT"
 
       - name: Publish typecheck check
-        if: always() && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.check_output != ''
+        if: always() && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.check_title != ''
         continue-on-error: true
-        uses: LouisBrunner/checks-action@v3.1.0
-        with:
-          token: ${{ github.token }}
-          check_id: ${{ job.check_run_id }}
-          conclusion: ${{ steps.typecheck-diff.outputs.conclusion }}
-          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          output: ${{ steps.typecheck-diff.outputs.check_output }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECK_TITLE: ${{ steps.typecheck-diff.outputs.check_title }}
+          DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg title "$CHECK_TITLE" \
+            --arg details_url "$DETAILS_URL" \
+            --rawfile summary "$RUNNER_TEMP/typecheck-diff-summary.md" \
+            '{details_url: $details_url, output: {title: $title, summary: $summary}}' \
+            > "$RUNNER_TEMP/typecheck-check.json"
+          gh api -X PATCH "repos/$GITHUB_REPOSITORY/check-runs/${{ job.check_run_id }}" --input "$RUNNER_TEMP/typecheck-check.json" > /dev/null
 
       - name: Fail typecheck
         if: github.event_name == 'pull_request' && steps.typecheck-diff.outputs.status != '' && steps.typecheck-diff.outputs.status != '0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,6 +144,14 @@ jobs:
           cache: pnpm
           node-version: 24
 
+      - uses: actions/cache/restore@v4
+        with:
+          path: .cache
+          key: ${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ github.ref_name }}-
+            main-
+
       - name: Install and Build
         run: |
           pnpm install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,7 @@ jobs:
           (
             cd "$base_dir"
             ln -s "$GITHUB_WORKSPACE/node_modules" node_modules
+            ln -s "$GITHUB_WORKSPACE/dist" dist
             echo "Running base typecheck"
             "$typecheck_bin" --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
           )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
       - name: Typecheck
         if: github.event_name != 'pull_request'
         run: |
+          echo "Running typecheck"
           pnpm typecheck --max-errors "$CI_TYPECHECK_MAX_ERRORS"
 
       - name: Typecheck diff
@@ -182,9 +183,11 @@ jobs:
           (
             cd "$base_dir"
             ln -s "$GITHUB_WORKSPACE/node_modules" node_modules
+            echo "Running base typecheck"
             "$typecheck_bin" --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
           )
 
+          echo "Running head typecheck"
           pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true
           diff_log="$RUNNER_TEMP/typecheck-diff.log"
           set +e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
 
 name: Build
 
+permissions:
+  contents: read
+
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
   CI_TYPECHECK_MAX_ERRORS: 888
@@ -14,9 +17,6 @@ jobs:
   build:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      checks: write
     strategy:
       fail-fast: false
       matrix:
@@ -83,71 +83,6 @@ jobs:
           pnpm -C lsp/vscode build-dev
           pnpm -C lsp/vscode test:e2e
 
-      - name: Typecheck
-        if: runner.os == 'Linux' && github.event_name != 'pull_request'
-        run: |
-          pnpm typecheck --max-errors "$CI_TYPECHECK_MAX_ERRORS"
-
-      - name: Typecheck diff
-        id: typecheck-diff
-        if: runner.os == 'Linux' && github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-
-          base_dir="$RUNNER_TEMP/typecheck-base"
-          base_log="$RUNNER_TEMP/typecheck-before.log"
-          head_log="$RUNNER_TEMP/typecheck-after.log"
-          typecheck_bin="$PWD/dist/civet"
-
-          trap 'git worktree remove --force "$base_dir" >/dev/null 2>&1 || true' EXIT
-          rm -rf "$base_dir"
-          git worktree prune
-          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
-          git worktree add --detach "$base_dir" FETCH_HEAD
-
-          (
-            cd "$base_dir"
-            ln -s "$GITHUB_WORKSPACE/node_modules" node_modules
-            "$typecheck_bin" --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
-          )
-
-          pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true
-          set +e
-          pnpm typecheck:diff --fail-on-regressions --max-errors "$CI_TYPECHECK_MAX_ERRORS" "$base_log" "$head_log"
-          diff_status=$?
-          set -e
-
-          summary_file="$RUNNER_TEMP/typecheck-diff-summary.md"
-          cp "$GITHUB_STEP_SUMMARY" "$summary_file"
-
-          conclusion=success
-          if [ "$diff_status" -ne 0 ]; then
-            conclusion=failure
-          fi
-
-          {
-            echo "status=$diff_status"
-            echo "conclusion=$conclusion"
-            echo "check_output<<TYPECHECK_DIFF_JSON"
-            jq -Rs --arg title "Typecheck diff" '{title: $title, summary: .}' "$summary_file"
-            echo "TYPECHECK_DIFF_JSON"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Publish typecheck diff check
-        if: always() && runner.os == 'Linux' && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.check_output != ''
-        continue-on-error: true
-        uses: LouisBrunner/checks-action@v3.1.0
-        with:
-          token: ${{ github.token }}
-          name: Typecheck diff
-          conclusion: ${{ steps.typecheck-diff.outputs.conclusion }}
-          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          output: ${{ steps.typecheck-diff.outputs.check_output }}
-
-      - name: Fail typecheck diff
-        if: runner.os == 'Linux' && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.status != '' && steps.typecheck-diff.outputs.status != '0'
-        run: exit "${{ steps.typecheck-diff.outputs.status }}"
-
       - name: Prune stale cache entries
         run: pnpm clean:cache:prune
 
@@ -182,6 +117,105 @@ jobs:
             coverage/coverage-final.json
             coverage/coverage-summary.json
             coverage/lcov.info
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    defaults:
+      run:
+        shell: bash
+    env:
+      npm_config_script_shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+          run_install: false
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: 24
+
+      - name: Install and Build
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Typecheck
+        if: github.event_name != 'pull_request'
+        run: |
+          pnpm typecheck --max-errors "$CI_TYPECHECK_MAX_ERRORS"
+
+      - name: Typecheck diff
+        id: typecheck-diff
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+
+          base_dir="$RUNNER_TEMP/typecheck-base"
+          base_log="$RUNNER_TEMP/typecheck-before.log"
+          head_log="$RUNNER_TEMP/typecheck-after.log"
+          typecheck_bin="$PWD/dist/civet"
+
+          trap 'git worktree remove --force "$base_dir" >/dev/null 2>&1 || true' EXIT
+          rm -rf "$base_dir"
+          git worktree prune
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          git worktree add --detach "$base_dir" FETCH_HEAD
+
+          (
+            cd "$base_dir"
+            ln -s "$GITHUB_WORKSPACE/node_modules" node_modules
+            "$typecheck_bin" --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
+          )
+
+          pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true
+          diff_log="$RUNNER_TEMP/typecheck-diff.log"
+          set +e
+          pnpm typecheck:diff --fail-on-regressions --max-errors "$CI_TYPECHECK_MAX_ERRORS" "$base_log" "$head_log" 2>&1 | tee "$diff_log"
+          diff_status=${PIPESTATUS[0]}
+          set -e
+
+          summary_file="$RUNNER_TEMP/typecheck-diff-summary.md"
+          cp "$GITHUB_STEP_SUMMARY" "$summary_file"
+          notice_text=$(sed -n 's/^::notice title=Typecheck diff:://p' "$diff_log" | tail -n 1)
+          check_title=${notice_text:-Typecheck diff}
+
+          conclusion=success
+          if [ "$diff_status" -ne 0 ]; then
+            conclusion=failure
+          fi
+
+          {
+            echo "status=$diff_status"
+            echo "conclusion=$conclusion"
+            echo "check_output<<TYPECHECK_DIFF_JSON"
+            jq -Rs --arg title "$check_title" '{title: $title, summary: .}' "$summary_file"
+            echo "TYPECHECK_DIFF_JSON"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish typecheck check
+        if: always() && github.event_name == 'pull_request' && steps.typecheck-diff.outputs.check_output != ''
+        continue-on-error: true
+        uses: LouisBrunner/checks-action@v3.1.0
+        with:
+          token: ${{ github.token }}
+          check_id: ${{ job.check_run_id }}
+          conclusion: ${{ steps.typecheck-diff.outputs.conclusion }}
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: ${{ steps.typecheck-diff.outputs.check_output }}
+
+      - name: Fail typecheck
+        if: github.event_name == 'pull_request' && steps.typecheck-diff.outputs.status != '' && steps.typecheck-diff.outputs.status != '0'
+        run: exit "${{ steps.typecheck-diff.outputs.status }}"
 
   self-test:
     name: Self-Test (${{ matrix.os }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ matches CI's, the failure reproduces locally and you can fix it properly.
 
 ## Typecheck
 
-CI gates type errors against a baseline (`pnpm typecheck --max-errors N` in
+CI gates type errors against a baseline (`CIVET_TYPECHECK_MAX_ERRORS=N` in
 [`.github/workflows/build.yml`](.github/workflows/build.yml)).  A PR must not
 introduce new errors — fix them at the source rather than bumping the
 baseline.  Identifying what's new can be tricky because adding code shifts
@@ -143,10 +143,10 @@ line numbers, so a naive `diff` flags every shifted preexisting error as
 ```sh
 git stash && git checkout origin/main -- '*.civet' '*.hera'
 pnpm build
-CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/before.log
+pnpm typecheck --max-errors 99999 &>/tmp/before.log
 git checkout HEAD -- '*.civet' '*.hera' && git stash pop
 pnpm build
-CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/after.log
+pnpm typecheck --max-errors 99999 &>/tmp/after.log
 civet scripts/typecheck-diff.civet /tmp/before.log /tmp/after.log
 ```
 
@@ -154,6 +154,8 @@ civet scripts/typecheck-diff.civet /tmp/before.log /tmp/after.log
 shifted-but-otherwise-identical errors don't show as drift — only genuinely
 new diagnostics appear under "Regressions".  Once those are at zero, no
 baseline bump is needed.
+CI also does this diff for you, so you can check its output for regressions
+(and fixes).
 
 For a one-off summary of where errors live, `bash scripts/typecheck-summary.sh`
 prints per-file and per-error-code counts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ matches CI's, the failure reproduces locally and you can fix it properly.
 
 ## Typecheck
 
-CI gates type errors against a baseline (`CIVET_TYPECHECK_MAX_ERRORS=N` in
+CI gates type errors against a baseline (`CI_TYPECHECK_MAX_ERRORS=N` in
 [`.github/workflows/build.yml`](.github/workflows/build.yml)).  A PR must not
 introduce new errors — fix them at the source rather than bumping the
 baseline.  Identifying what's new can be tricky because adding code shifts

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -176,7 +176,7 @@ console.log `Net: ${netText}`
 console.log `Regressions: ${regressions#}`
 console.log `Fixed: ${fixed#}`
 if process.env.GITHUB_ACTIONS
-  console.log `::notice title=Typecheck diff::Old ${oldDiags#}, New ${newDiags#}, Net ${netText}, Regressions ${regressions#}, Fixed ${fixed#}`
+  console.log `::notice title=Typecheck diff::Net ${netText}, Regressions ${regressions#}, Fixed ${fixed#}`
 console.log ""
 summarize "Regressions", regressions
 console.log "" if regressions# and fixed#

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -14,21 +14,46 @@
  * Typical workflow (full version in CONTRIBUTING.md "Typecheck"):
  *   git stash && git checkout origin/main -- '*.civet' '*.hera'
  *   pnpm build
- *   CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/before.log
+ *   pnpm typecheck --max-errors 99999 &>/tmp/before.log
  *   git checkout HEAD -- '*.civet' '*.hera' && git stash pop
  *   pnpm build
- *   CIVET_TYPECHECK_MAX_ERRORS=99999 pnpm typecheck &>/tmp/after.log
+ *   pnpm typecheck --max-errors 99999 &>/tmp/after.log
  *   civet scripts/typecheck-diff.civet /tmp/before.log /tmp/after.log
  *
  * (`&>` captures both stdout and stderr — diagnostics go to stderr.)
+ *
+ * Options:
+ *   --fail-on-regressions  Exit nonzero if <new> has unmatched diagnostics.
+ *   --max-errors N         Exit nonzero if <new> has more than N diagnostics.
+ *       Also settable via `CIVET_TYPECHECK_MAX_ERRORS` environment variable.
+ *       (Command-line option wins over environment variable.)
  */
 
-{ readFileSync } from "node:fs"
+{ appendFileSync, readFileSync } from "node:fs"
 
-[oldPath, newPath] := process.argv.slice 2
-unless oldPath and newPath
-  console.error "usage: typecheck-diff <old.log> <new.log>"
+args := process.argv.slice 2
+failOnRegressions .= false
+maxErrorsArg .= process.env.CIVET_TYPECHECK_MAX_ERRORS
+paths: string[] := []
+i .= 0
+while i < args.length
+  arg := args[i]
+  switch arg
+    when "--fail-on-regressions"
+      failOnRegressions = true
+    when "--max-errors"
+      maxErrorsArg = args[++i]
+    else
+      paths.push arg
+  i++
+unless paths# is 2
+  console.error "usage: typecheck-diff [--fail-on-regressions] [--max-errors N] <old.log> <new.log>"
   process.exit 1
+maxErrors := if maxErrorsArg then parseInt maxErrorsArg, 10
+if maxErrors? and (Number.isNaN(maxErrors) or maxErrors < 0)
+  console.error "max errors must be a non-negative number"
+  process.exit 1
+[oldPath, newPath] := paths
 
 type Diag =
   file: string
@@ -107,24 +132,74 @@ function diff(left: Diag[], right: Diag[]): Diag[]
 
 regressions := diff newDiags, oldDiags
 fixed := diff oldDiags, newDiags
+net := newDiags# - oldDiags#
 
 function summarize(label: string, diags: Diag[])
-  return if diags.length is 0
-  console.log `${label} (${diags.length}):`
-  // Group by file for readability.
+  return unless diags#
+  console.log `${label} (${diags#}):`
+  for line of groupedLines diags
+    console.log line
+
+// Group by file for readability.
+function groupedLines(diags: Diag[], maxDiags?: number): string[]
+  lines: string[] := []
   byFile := new Map<string, Diag[]>
   for d of diags
     bucket := byFile.get(d.file) ?? []
     bucket.push d
     byFile.set d.file, bucket
-  for [file, list] of byFile
-    console.log `  ${file}`
+  shown .= 0
+  :fileLoop for [file, list] of byFile
+    lines.push `  ${file}`
     for d of list
-      console.log `    ${d.line}:${d.column} ${d.code} ${d.message}`
+      lines.push `    ${d.line}:${d.column} ${d.code} ${d.message}`
+      shown++
+      break :fileLoop if shown >= maxDiags?
+  lines.push `  ... ${diags# - shown} more` if shown < diags#
+  lines
 
-console.log `Old: ${oldDiags.length} diagnostics  →  New: ${newDiags.length} diagnostics`
-console.log `Net: ${newDiags.length - oldDiags.length >= 0 ? "+" : ""}${newDiags.length - oldDiags.length}`
+function appendDetails(summary: string[], label: string, diags: Diag[])
+  return unless diags#
+  summary.push `<details><summary>${label} (${diags#})</summary>`
+  summary.push ""
+  summary.push "```text"
+  for line of groupedLines diags, 100
+    summary.push line
+  summary.push "```"
+  summary.push ""
+  summary.push "</details>"
+  summary.push ""
+
+console.log `Old: ${oldDiags#} diagnostics  →  New: ${newDiags#} diagnostics`
+console.log `Net: ${net >= 0 ? "+" : ""}${net}`
+console.log `Regressions: ${regressions#}`
+console.log `Fixed: ${fixed#}`
 console.log ""
 summarize "Regressions", regressions
-console.log "" if regressions.length and fixed.length
+console.log "" if regressions# and fixed#
 summarize "Fixed", fixed
+
+if process.env.GITHUB_STEP_SUMMARY
+  summary := [
+    "## Typecheck diff",
+    "",
+    `| Old | New | Net | Regressions | Fixed |`,
+    `| ---: | ---: | ---: | ---: | ---: |`,
+    `| ${oldDiags#} | ${newDiags#} | ${net >= 0 ? "+" : ""}${net} | ${regressions#} | ${fixed#} |`,
+    ""
+  ]
+  appendDetails summary, "Regressions", regressions
+  appendDetails summary, "Fixed", fixed
+  appendFileSync process.env.GITHUB_STEP_SUMMARY, summary.join("\n") + "\n"
+
+failed .= false
+if failOnRegressions and regressions#
+  console.error `Typecheck diff failed: ${regressions#} regression${regressions# is 1 ? "" : "s"} found.`
+  failed = true
+
+if maxErrors? and newDiags# > maxErrors
+  console.error `Typecheck error limit exceeded: ${newDiags#} diagnostics found, max is ${maxErrors}.`
+  failed = true
+
+if failed
+  process.exit 1

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -171,9 +171,12 @@ function appendDetails(summary: string[], label: string, diags: Diag[])
   summary.push ""
 
 console.log `Old: ${oldDiags#} diagnostics  →  New: ${newDiags#} diagnostics`
-console.log `Net: ${net >= 0 ? "+" : ""}${net}`
+netText := `${net >= 0 ? "+" : ""}${net}`
+console.log `Net: ${netText}`
 console.log `Regressions: ${regressions#}`
 console.log `Fixed: ${fixed#}`
+if process.env.GITHUB_ACTIONS
+  console.log `::notice title=Typecheck diff::Old ${oldDiags#}, New ${newDiags#}, Net ${netText}, Regressions ${regressions#}, Fixed ${fixed#}`
 console.log ""
 summarize "Regressions", regressions
 console.log "" if regressions# and fixed#
@@ -185,7 +188,7 @@ if process.env.GITHUB_STEP_SUMMARY
     "",
     `| Old | New | Net | Regressions | Fixed |`,
     `| ---: | ---: | ---: | ---: | ---: |`,
-    `| ${oldDiags#} | ${newDiags#} | ${net >= 0 ? "+" : ""}${net} | ${regressions#} | ${fixed#} |`,
+    `| ${oldDiags#} | ${newDiags#} | ${netText} | ${regressions#} | ${fixed#} |`,
     ""
   ]
   appendDetails summary, "Regressions", regressions

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -176,7 +176,7 @@ console.log `Net: ${netText}`
 console.log `Regressions: ${regressions#}`
 console.log `Fixed: ${fixed#}`
 if process.env.GITHUB_ACTIONS
-  console.log `::notice title=Typecheck diff::Net ${netText}, Regressions ${regressions#}, Fixed ${fixed#}`
+  console.log `::notice title=Typecheck diff::Net ${netText}, Broke ${regressions#}, Fixed ${fixed#}`
 console.log ""
 summarize "Regressions", regressions
 console.log "" if regressions# and fixed#


### PR DESCRIPTION
On pull requests, Linux CI now compares a full typecheck log from the PR base against a full typecheck log from the PR head. The diff highlights new diagnostics under `Regressions`, fixed diagnostics under `Fixed`, and reports the net diagnostic count change.

- Add PR CI output for typecheck regressions using `scripts/typecheck-diff.civet`
- Extend `typecheck-diff` script with regression failure, max-error failure (to avoid type checking twice), and GitHub step summary output
- Split typechecking into its own `Typecheck` CI job so it runs in parallel with coverage/tests. On the latest PR run, typecheck diff took about 1m46s after Linux coverage completed, so this should reduce PR wall time by roughly 1.5-2 minutes while reusing the same pnpm and `.cache` build caches.
- Publish the typecheck diff summary onto the `Typecheck` job’s own check run via `gh api`.
  <img width="859" height="54" alt="image" src="https://github.com/user-attachments/assets/e7e0645c-a415-4025-8a57-409e0eff9870" />
- Factor out `CI_TYPECHECK_MAX_ERRORS` as the shared typecheck baseline limit, so it can be upped/downed in one place
- Update typecheck contribution docs to use cleaner `--max-errors 99999` for full local logs and mention CI diff output
