### PR TITLE
Add comptime Float16Array support

### DIFF
--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -268,7 +268,8 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
               `new URL(${JSON.stringify (val as URL).href})`
             when null
               `Object.create(null,${recurse Object.getOwnPropertyDescriptors val})`
-            when Int8Array::, Uint8Array::, Int16Array::, Uint16Array::, Int32Array::, Uint32Array::, Float32Array::, Float64Array::, Uint8ClampedArray::, context?.Int8Array::, context?.Uint8Array::, context?.Int16Array::, context?.Uint16Array::, context?.Int32Array::, context?.Uint32Array::, context?.Float32Array::, context?.Float64Array::, context?.Uint8ClampedArray::
+            // Float16Array is spelled differently to support older runtimes that don't have it
+            when Int8Array::, Uint8Array::, Int16Array::, Uint16Array::, Int32Array::, Uint32Array::, Float32Array::, Float64Array::, Uint8ClampedArray::, context?.Int8Array::, context?.Uint8Array::, context?.Int16Array::, context?.Uint16Array::, context?.Int32Array::, context?.Uint32Array::, context?.Float32Array::, context?.Float64Array::, context?.Uint8ClampedArray::, globalThis.Float16Array?::, context?.Float16Array?::
               // There's no "TypedArray" interface in TS
               `new ${val.constructor.name}([${(val as any).join ','}])`
             when BigInt64Array::, BigUint64Array::, context?.BigInt64Array::, context?.BigUint64Array::

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -411,6 +411,8 @@ describe "serialize", ->
     assert.equal serialize(new BigUint64Array [1n, 2n, 3n]), "new BigUint64Array([1n,2n,3n])"
     assert.equal serialize(Buffer.from [1, 2, 3]), "Buffer.from([1,2,3])"
     assert.equal serialize(new Uint8ClampedArray [-1, 0, 2, 256]), "new Uint8ClampedArray([0,0,2,255])"
+    if globalThis.Float16Array?
+      assert.equal serialize(new Float16Array [1, 1.5, NaN]), "new Float16Array([1,1.5,NaN])"
   it "classes", =>
     class C
       toString()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": [
       "ES2022",
+      "ES2025.Float16",
       "DOM"
     ],
     /* Specify a set of bundled library declaration files that describe the target runtime environment. */


### PR DESCRIPTION
[`Float16Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float16Array) is a new kind of TypedArray introduced in ES2025. node.green doesn't list it, so I can't say for certain what node versions do and don't have it, but given how new it is I used the same trick we use for `Buffer` to make the comptime serializer not error out when it doesn't exist.