### PR TITLE
CI typecheck: rebuild base in its own worktree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,6 @@ jobs:
           base_dir="$RUNNER_TEMP/typecheck-base"
           base_log="$RUNNER_TEMP/typecheck-before.log"
           head_log="$RUNNER_TEMP/typecheck-after.log"
-          typecheck_bin="$PWD/dist/civet"
 
           trap 'git worktree remove --force "$base_dir" >/dev/null 2>&1 || true' EXIT
           rm -rf "$base_dir"
@@ -180,13 +179,27 @@ jobs:
           git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
           git worktree add --detach "$base_dir" FETCH_HEAD
 
+          # Install and build inside the base worktree so the base typecheck
+          # runs main's compiler against main's source.  Symlinking HEAD's
+          # node_modules/dist into the base produced a version skew (e.g. a
+          # Hera bump on HEAD) that could crash TS on main's source and yield
+          # an empty base log — making every HEAD error look like a regression.
           (
             cd "$base_dir"
-            ln -s "$GITHUB_WORKSPACE/node_modules" node_modules
-            ln -s "$GITHUB_WORKSPACE/dist" dist
+            echo "Installing base dependencies"
+            pnpm install --frozen-lockfile
+            echo "Building base"
+            pnpm build
             echo "Running base typecheck"
-            "$typecheck_bin" --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
+            ./dist/civet --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
           )
+
+          if ! sed -E 's/\x1b\[[0-9;]*m//g' "$base_log" | grep -qE 'error TS[0-9]+'; then
+            echo "::error title=Typecheck diff::Base typecheck produced no TS diagnostics — likely crashed."
+            echo "--- base log (tail) ---"
+            tail -n 50 "$base_log"
+            exit 1
+          fi
 
           echo "Running head typecheck"
           pnpm typecheck --max-errors 99999 >"$head_log" 2>&1 || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,6 +184,7 @@ jobs:
           # node_modules/dist into the base produced a version skew (e.g. a
           # Hera bump on HEAD) that could crash TS on main's source and yield
           # an empty base log — making every HEAD error look like a regression.
+          base_status=0
           (
             cd "$base_dir"
             echo "Installing base dependencies"
@@ -191,18 +192,18 @@ jobs:
             echo "Building base"
             pnpm build
             echo "Running base typecheck"
-            ./dist/civet --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
-          )
+            ./dist/civet --typecheck --max-errors 99999 >"$base_log" 2>&1
+          ) || base_status=$?
 
-          # Strip ANSI to a tempfile, then grep from the file (not a pipe) so
-          # grep -q's early exit doesn't SIGPIPE sed under `set -o pipefail`
-          # and make the check misfire on large logs.
-          base_log_clean="$RUNNER_TEMP/typecheck-before.clean.log"
-          sed -E 's/\x1b\[[0-9;]*m//g' "$base_log" > "$base_log_clean"
-          if ! grep -qE 'error TS[0-9]+' "$base_log_clean"; then
-            echo "::error title=Typecheck diff::Base typecheck produced no TS diagnostics — likely crashed."
+          # With --max-errors 99999, civet --typecheck only exits non-zero on
+          # a hard failure (Node crash, missing tsconfig, etc.) — any number
+          # of TS diagnostics still exits 0, including zero.  Non-zero here
+          # means install/build/typecheck failed and the log isn't a real
+          # diff baseline, so every HEAD error would look like a regression.
+          if [ "$base_status" -ne 0 ]; then
+            echo "::error title=Typecheck diff::Base setup or typecheck failed (exit $base_status) — cannot compute diff."
             echo "--- base log (tail) ---"
-            tail -n 50 "$base_log"
+            tail -n 50 "$base_log" 2>/dev/null || echo "(base log not produced)"
             exit 1
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,12 @@ jobs:
             ./dist/civet --typecheck --max-errors 99999 >"$base_log" 2>&1 || true
           )
 
-          if ! sed -E 's/\x1b\[[0-9;]*m//g' "$base_log" | grep -qE 'error TS[0-9]+'; then
+          # Strip ANSI to a tempfile, then grep from the file (not a pipe) so
+          # grep -q's early exit doesn't SIGPIPE sed under `set -o pipefail`
+          # and make the check misfire on large logs.
+          base_log_clean="$RUNNER_TEMP/typecheck-before.clean.log"
+          sed -E 's/\x1b\[[0-9;]*m//g' "$base_log" > "$base_log_clean"
+          if ! grep -qE 'error TS[0-9]+' "$base_log_clean"; then
             echo "::error title=Typecheck diff::Base typecheck produced no TS diagnostics — likely crashed."
             echo "--- base log (tail) ---"
             tail -n 50 "$base_log"


### PR DESCRIPTION
## Summary

The Typecheck-diff job symlinks HEAD's `node_modules` and `dist` into the base worktree so the base run can reuse the freshly built CLI. That assumes HEAD and base agree on every runtime dependency — which breaks the moment a PR bumps a dep loaded by the CLI (e.g. `@danielx/hera` 0.9.2 → 0.9.6 in #2038).

When that happens, the base typecheck is really HEAD's compiler/parser running against main's `.civet` source. In #2038 that combination crashes TypeScript 6.0.2:

```
RangeError: Maximum call stack size exceeded
    at checkExpression / checkAssertionWorker / checkAssertion …
```

The base log captures only the Node stack trace — zero TS diagnostics. The diff script then sees `Old: 0 → New: 1730` and reports every HEAD error as a regression. [Failing run](https://github.com/DanielXMoore/Civet/actions/runs/26128880281/job/76849202537).

## Fix

- `pnpm install --frozen-lockfile && pnpm build` inside the base worktree so main's source is typechecked with main's own compiler (no version skew).
- Guard step: if the base log contains no `error TS…` lines at all, fail with a clear notice instead of silently treating the whole HEAD error set as new.

This reverts the speed optimization from e1f1f0b8 / 4ff21657 — the symlink-HEAD-CLI approach is correctness-fragile, and the extra install+build cost (~30s install, ~30s build locally) is the price of an apples-to-apples diff.

## Test plan

- [x] Local repro: with `pnpm install + pnpm build` in a base worktree at the same SHA CI used (`8c7794c`), `./dist/civet --typecheck` produces 883 TS diagnostics (matches main's natural error count under `pnpm typecheck`).
- [x] Local repro: with HEAD's `dist`/`node_modules` symlinked in (old recipe), the same step crashes with `RangeError` and writes 0 TS-error lines — guard correctly fires.
- [ ] CI: PR's own Typecheck-diff job runs against `main` as base. Since this PR doesn't change source, expected diff is `0 / 0 / 0`.
- [ ] Verify on #2038 (rebase or merge to pick up this fix) that the base step now produces non-zero diagnostics and the diff reflects only genuinely-new errors.