### PR TITLE
LSP: improve compatibility by renaming duplicate named groups in import-path regex

### DIFF
--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -45,20 +45,31 @@ export function likelyImportContext(text: string): boolean
 
 // -- import-path extraction --------------------------------------------------
 
-// Extract information about an import statement under the cursor.
-export importPathExtractor := /\b(?<statement>from|import|require)\b[ \t]*(?:[\(][ \t]*)?(?:(?<qt>')(?<path>[^']*)(?<endqt>'?)|(?<qt>")(?<path>[^"]*)(?<endqt>")?|(?<path>[^;"'\s=>]*))/gd
-
-export type ImportPathMatchIterator = RegExpStringIterator< RegExpExecArray & {
-  groups: { statement: ('from'|'import'|'require'), path: string, qt: '"'|"'"|undefined , endqt: '"'|"'"|undefined }
-  indices: { groups: { statement: [number, number], path: [number, number], qt: [number, number], endqt: [number, number] } }
-}>
+// Extract information about an import statement under the cursor.  The three
+// path-shape branches use per-branch names (sq*/dq*/uq* for single-quoted,
+// double-quoted, unquoted) because duplicate named capture groups in a
+// disjunction only parse on Node >= 23 (V8 12.9, ES2025).  extractImportPath
+// normalizes the branches back into { statement, qt, path, endqt }.
+export importPathExtractor := /\b(?<statement>from|import|require)\b[ \t]*(?:\([ \t]*)?(?:(?<sqQt>')(?<sqPath>[^']*)(?<sqEnd>'?)|(?<dqQt>")(?<dqPath>[^"]*)(?<dqEnd>")?|(?<uqPath>[^;"'\s=>]*))/gd
 
 export function extractImportPath(lineText: string, cursorOffset: number)
-  matches := lineText.matchAll(importPathExtractor) as ImportPathMatchIterator
-  for match of matches
-    if cursorOffset >= match.indices.groups.path[0]
-        and cursorOffset <= match.indices.groups.path[1]
-      return match.groups
+  for raw of lineText.matchAll(importPathExtractor)
+    indexGroups := raw.indices?.groups as
+      { sqPath?: [number, number], dqPath?: [number, number], uqPath?: [number, number] } | undefined
+    pathRange := indexGroups?.sqPath ?? indexGroups?.dqPath ?? indexGroups?.uqPath
+    continue unless pathRange
+    if cursorOffset >= pathRange[0] and cursorOffset <= pathRange[1]
+      g := raw.groups as
+        { statement: 'from'|'import'|'require'
+          sqQt?: "'", sqPath?: string, sqEnd?: "'"|''
+          dqQt?: '"', dqPath?: string, dqEnd?: '"'
+          uqPath?: string }
+      return {
+        statement: g.statement
+        path:  g.sqPath ?? g.dqPath ?? g.uqPath ?? ''
+        qt:    g.sqQt   ?? g.dqQt
+        endqt: g.sqEnd  ?? g.dqEnd
+      }
   return // undefined means no match
 
 // -- current-line text fetching ----------------------------------------------

--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -66,7 +66,9 @@ export function extractImportPath(lineText: string, cursorOffset: number)
           uqPath?: string }
       return {
         statement: g.statement
-        path:  g.sqPath ?? g.dqPath ?? g.uqPath ?? ''
+        // uqPath always matches (`[^…]*` accepts empty) when sq/dq didn't,
+        // so the chain is non-null at runtime — assert past the type.
+        path:  (g.sqPath ?? g.dqPath ?? g.uqPath)!
         qt:    g.sqQt   ?? g.dqQt
         endqt: g.sqEnd  ?? g.dqEnd
       }


### PR DESCRIPTION
## Cause

`importPathExtractor` in `lsp/server/source/lib/completions.civet` declares `qt`, `path`, and `endqt` in three branches of a disjunction. Duplicate named capture groups inside a disjunction is an ES2025 feature (V8 12.9, Node >= 23); on older Node the regex throws `SyntaxError: Duplicate capture group name` at module load.

The package's root `engines.node` declares `>=19 || ^18.6.0 || ^16.17.0`, so the LSP server was unloadable on the lower end of its own supported range.

## Approach

Rename each branch's groups (`sq*` / `dq*` / `uq*` for single-quoted, double-quoted, unquoted) so all names are unique. `extractImportPath` collapses them back into the same `{ statement, qt, path, endqt }` shape the caller in `server.civet` already destructures, so external behavior is unchanged.

The unused `ImportPathMatchIterator` export goes too.