### PR TITLE
CI: Clarify typecheck-diff output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,20 @@ jobs:
 
       - name: Fail typecheck
         if: github.event_name == 'pull_request' && steps.typecheck-diff.outputs.status != '' && steps.typecheck-diff.outputs.status != '0'
-        run: exit "${{ steps.typecheck-diff.outputs.status }}"
+        run: |
+          if [ -s "$RUNNER_TEMP/typecheck-diff.log" ]; then
+            failure_message=$(grep -E '^(Typecheck diff failed:|Typecheck error limit exceeded:)' "$RUNNER_TEMP/typecheck-diff.log" || true)
+            failure_message=${failure_message//$'\n'/ }
+            failure_message=${failure_message:-"Typecheck diff failed; see the repeated output below."}
+
+            echo "::error title=Typecheck failed::$failure_message"
+            echo
+            echo "Typecheck diff output:"
+            sed '/^::notice title=Typecheck diff::/d' "$RUNNER_TEMP/typecheck-diff.log"
+          else
+            echo "::error title=Typecheck failed::Missing typecheck diff output. Open the preceding Typecheck diff step for the full diagnostics."
+          fi
+          exit "${{ steps.typecheck-diff.outputs.status }}"
 
   self-test:
     name: Self-Test (${{ matrix.os }})


### PR DESCRIPTION
- Clarify failing typecheck CI output by making the final failing step emit a specific GitHub error annotation based on the actual failure mode: new regressions, exceeded error limit, or both.
- Reprint the saved plain-text typecheck diff output in the failing step, filtering out the internal `::notice` line, so the red CI step includes the actionable diagnostics instead of only showing `exit 1`.

## [Example CI run](https://github.com/DanielXMoore/Civet/actions/runs/26144208433/job/76895842185?pr=2087)

<img width="3467" height="1695" alt="image" src="https://github.com/user-attachments/assets/ae8768fa-16e9-4446-b784-31e2badee817" />
