### PR TITLE
Dev: Reduce type errors by 50

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  CI_TYPECHECK_MAX_ERRORS: 888
+  CI_TYPECHECK_MAX_ERRORS: 827
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  CI_TYPECHECK_MAX_ERRORS: 827
+  CI_TYPECHECK_MAX_ERRORS: 826
 
 jobs:
   build:

--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -29,10 +29,7 @@ onmessage = async (e) => {
     if (Civet.isCompileError(error)) {
       console.info('Snippet compilation error!', error);
 
-      const linesUntilError = code.split('\n').slice(0, error.line).join('\n');
-      const errorLine = `${' '.repeat(error.column - 1)}^ ${error.header}`;
-      const errorCode = `${linesUntilError}\n${errorLine}`;
-      const outputHtml = highlighter.codeToHtml(errorCode, { lang: 'civet' });
+      const outputHtml = errorHtml(error);
 
       postMessage({ uid, inputHtml, outputHtml, errors, fatal });
     } else {
@@ -47,10 +44,20 @@ onmessage = async (e) => {
   }
 
   function errorHtml(error) {
-    const linesUntilError = code.split('\n').slice(0, error.line).join('\n');
-    const errorLine = `${' '.repeat(error.column - 1)}^ ${error.header}`;
+    const { line, column } = errorPosition(error);
+    const linesUntilError = code.split('\n').slice(0, line).join('\n');
+    const errorLine = `${' '.repeat(column - 1)}^ ${error.header}`;
     const errorCode = `${linesUntilError}\n${errorLine}`;
     return highlighter.codeToHtml(errorCode, { lang: 'civet' });
+  }
+
+  function errorPosition(error) {
+    const line = parseInt(error.line, 10);
+    const column = parseInt(error.column, 10);
+    return {
+      line: Number.isFinite(line) && line > 0 ? line : 1,
+      column: Number.isFinite(column) && column > 0 ? column : 1,
+    };
   }
 
   let jsCode = '';

--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -307,8 +307,10 @@ export function parseErrorRange(e: ParseError): {
   end: Position := { line: 0, character: 10 }
   // Remove leading filename:line:column from message
   message := e.message.replace(/^\S+ /, "")
-  line := e.line? ? (e.line <? "number" ? e.line : parseInt(e.line, 10)) : 1
-  column := e.column? ? (e.column <? "number" ? e.column : parseInt(e.column, 10)) : 1
+  line .= e.line? ? (e.line <? "number" ? e.line : parseInt(e.line, 10)) : 1
+  line = 1 unless Number.isFinite line
+  column .= e.column? ? (e.column <? "number" ? e.column : parseInt(e.column, 10)) : 1
+  column = 1 unless Number.isFinite column
   // Convert 1-based to 0-based
   start.line = end.line = line - 1
   start.character = column - 1

--- a/lsp/server/test/completions.civet
+++ b/lsp/server/test/completions.civet
@@ -321,6 +321,17 @@ describe "completions helpers", ->
       assert.equal start.character, 1
       assert.equal end.line, 4
 
+    it "falls back for nonnumeric string line/column", ->
+      err := {
+        name: "ParseError"
+        message: "x"
+        line: "?"
+        column: "?"
+      } as any
+      { start, end } := parseErrorRange(err)
+      assert.deepEqual start, { line: 0, character: 0 }
+      assert.deepEqual end, { line: 0, character: 4 }
+
     it "defaults missing line/column to the start of the file", ->
       err := {
         name: "ParseError"

--- a/source/babel-plugin.civet
+++ b/source/babel-plugin.civet
@@ -18,7 +18,10 @@
 type ParserOverrideOptions
   sourceFileName: string
 
-type ParserOverrideParse = (src: string, opts: ParserOverrideOptions) => unknown
+type ParserOverrideAST
+  type?: string
+
+type ParserOverrideParse = (src: string, opts: ParserOverrideOptions) => ParserOverrideAST
 
 export default (_api: unknown, civetOptions: CompilerOptions = {}) -> {
   parserOverride(code: string, opts: ParserOverrideOptions, parse: ParserOverrideParse) {

--- a/source/babel-plugin.civet
+++ b/source/babel-plugin.civet
@@ -13,13 +13,18 @@
 
 */
 
-{ compile } from "./main.civet"
+{ compile, type CompilerOptions } from "./main.civet"
 
-export default (api, civetOptions) -> {
-  parserOverride(code, opts, parse) {
+type ParserOverrideOptions
+  sourceFileName: string
+
+type ParserOverrideParse = (src: string, opts: ParserOverrideOptions) => unknown
+
+export default (_api: unknown, civetOptions: CompilerOptions = {}) -> {
+  parserOverride(code: string, opts: ParserOverrideOptions, parse: ParserOverrideParse) {
     let src
     if opts.sourceFileName.endsWith ".civet"
-      config := {
+      config: CompilerOptions & { sync: true } := {
         ...civetOptions
         filename: opts.sourceFileName
         sourceMap: false

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,5 +1,5 @@
 { compile, generate, parse, lib, isCompileError, SourceMap } from ./main.civet
-type { ASTError, BlockStatement, ParseError, ParseErrors } from ./main.civet
+type { ASTError, BlockStatement, CompilerOptions, ParseError, ParseErrors } from ./main.civet
 { findConfig, loadConfig } from ./config.civet
 
 type Unplugin =
@@ -652,7 +652,7 @@ You can override this behavior via: --civet rewriteCivetImports=.ext
     else if options.run
       esm := do
         if output is like /\b(await|import|export)\b/  // potentially ESM
-          ast := await compile content!, {...options, ast: true, filename}
+          ast := await compile content!, {...options as CompilerOptions, ast: true, filename}
           (or)
             lib.hasAwait ast
             lib.hasImportDeclaration ast

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -360,11 +360,15 @@ export function repl(args: string[], options: Options)
             // Unwrap ParseErrors to first error
             if (error as ParseErrors).errors?
               error = (error as ParseErrors).errors[0]
+            parseError := error as ParseError
+            /* c8 ignore next 2 -- defensive fallback for generated/legacy ParseError shapes without numeric positions */
+            line := if parseError.line <? "number" then parseError.line else 1
+            column := if parseError.column <? "number" then parseError.column else 1
             console.log ```
-              ${input.split('\n')[0...(error as ParseError).line].join '\n'}
-              ${' '.repeat (error as ParseError).column - 1}^ ${(error as ParseError).header}
+              ${input.split('\n')[0...line].join '\n'}
+              ${' '.repeat column - 1}^ ${parseError.header}
             ```
-          /* c8 ignore next 2 — defensive; compile only throws ParseError/ParseErrors */
+          /* c8 ignore next 2 -- defensive; compile only throws ParseError/ParseErrors */
           else
             console.error error
 

--- a/source/error.civet
+++ b/source/error.civet
@@ -1,0 +1,25 @@
+// Hera's runtime ParseError builds messages from line/column directly, so it
+// types them as `number`.  Civet creates generated-code errors that use "?"
+// when no source position is available.  LSP translation can also sometimes
+// stringify the numbers.  This wrapper preserves the runtime class
+// while widening the exported type to match all values Civet can produce.
+
+{ ParseError as HeraParseError } from ./parser.hera
+
+export interface ParseError extends Omit<InstanceType<typeof HeraParseError>, "line" | "column" | "offset">
+  line: number | string
+  column: number | string
+  offset?: number
+
+type ParseErrorConstructor =
+  new (
+    header: string
+    body: string?
+    filename: string
+    line: number | string
+    column: number | string
+    offset?: number
+  ) => ParseError
+
+export const ParseError: ParseErrorConstructor =
+  HeraParseError as! ParseErrorConstructor

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -1,6 +1,6 @@
 type { ASTNode } from './parser/types.civet'
 { isParent, isToken, removeParentPointers } from './parser/util.civet'
-{ ParseError } from './parser.hera'
+{ ParseError } from './error.civet'
 
 export type Options =
   sourceMap?: undefined |

--- a/source/main.civet
+++ b/source/main.civet
@@ -1,4 +1,5 @@
-import { parse, parseProgram, ParseError, getConfig, getStateKey } from ./parser.hera
+import { parse, parseProgram, getConfig, getStateKey } from ./parser.hera
+import { ParseError } from ./error.civet
 import generate, { prune } from ./generate.civet
 import * as lib from ./parser/lib.civet
 import * as sourcemap from ./sourcemap.civet

--- a/source/main.civet
+++ b/source/main.civet
@@ -92,10 +92,10 @@ export type CompilerOptions
   parseOptions?:
     coffeeCompat?: boolean
     comptime?: boolean
-    globals?: string[]
+    globals?: string[]?
     esArrowFunction?: boolean
     esCompat?: boolean
-    operators?: string[] | Record<string, string>
+    operators?: (string[] | Record<string, string?>)?
     symbols?: string[]
   /** Specifying an empty array will prevent ParseErrors from being thrown */
   errors?: ParseError[]

--- a/source/node-worker.civet
+++ b/source/node-worker.civet
@@ -19,7 +19,14 @@ async do
       // If we pass in an `errors` option, its modification is part of output
       parentPort!.postMessage {id, result, errors: args[1]?.errors}
     catch error
-      parentPort!.postMessage {id, error: {
-        type: error.constructor.name
-        error.{name,message}
-      }}
+      if error instanceof Error
+        parentPort!.postMessage {id, error: {
+          type: error.constructor.name
+          error.{name,message}
+        }}
+      else
+        parentPort!.postMessage {id, error:
+          type: typeof error
+          name: "Error"
+          message: String error
+        }

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -4,10 +4,6 @@ type { ASTNode, ASTRef, StatementTuple } from './types.civet'
 { makeRef } from './ref.civet'
 { gatherRecursive } from './traversal.civet'
 { state } from "../parser.hera"
-declare var state: {
-  prelude: StatementTuple[]
-  helperRefs: Record<HelperName, ASTRef>
-}
 
 preludeVar := "var "
 
@@ -272,7 +268,7 @@ function extractPreludeFor(node: ASTNode): StatementTuple[]
   usedHelpers := new Set gatherRecursive node, isHelper
   // Find helpers used within helpers
   loop
-    prelude .= state.prelude.filter (s) =>
+    prelude .= state.prelude.filter (s: StatementTuple) =>
       (gatherRecursive s, usedHelpers@has as (node: ASTNode) => node is ASTRef)#
     changed .= false
     for each helper of gatherRecursive prelude, isHelper

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -135,17 +135,23 @@ export class SourceMap
 
   /** Compose this downstream source map with an upstream source map, modifying this */
   composeUpstream(upstreamMap: string | SourceMapJSON | SourceMapJSONWithLines): void
-    if upstreamMap <? "string" or "lines" not in upstreamMap
-      upstreamMap = SourceMap.parseWithLines upstreamMap
-    @lines = SourceMap.composeLines upstreamMap.lines, @lines
-    @source = upstreamMap.sourcesContent[0] if upstreamMap.sourcesContent
-    @sourceFileName = upstreamMap.sources[0] if upstreamMap.sources
+    upstreamMapWithLines: SourceMapJSONWithLines :=
+      if upstreamMap <? "string" or "lines" not in upstreamMap
+        SourceMap.parseWithLines upstreamMap
+      else
+        upstreamMap
+    @lines = SourceMap.composeLines upstreamMapWithLines.lines, @lines
+    @source = upstreamMapWithLines.sourcesContent[0] if upstreamMapWithLines.sourcesContent
+    @sourceFileName = upstreamMapWithLines.sources[0] if upstreamMapWithLines.sources
 
   /** Compose this upstream source map with a downstream source map, modifying this */
   composeDownstream(downstreamMap: string | SourceMapJSON | SourceMapJSONWithLines): void
-    if downstreamMap <? "string" or "lines" not in downstreamMap
-      downstreamMap = SourceMap.parseWithLines downstreamMap
-    @lines = SourceMap.composeLines @lines, downstreamMap.lines
+    downstreamMapWithLines: SourceMapJSONWithLines :=
+      if downstreamMap <? "string" or "lines" not in downstreamMap
+        SourceMap.parseWithLines downstreamMap
+      else
+        downstreamMap
+    @lines = SourceMap.composeLines @lines, downstreamMapWithLines.lines
 
   /**
   Remap compiled code with an inline source map to use an upstream source map.

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -451,7 +451,7 @@ describe 'CLI makeOutputFilename', ->
     assert.equal path.dirname(result), 'build'
     assert.doesNotMatch result, /\.civet/
 
-function captureProcess(fn: => Promise<unknown>): Promise<{exitCode: number?, stdOut: string, stdErr: string}>
+function captureProcess(fn: => unknown | Promise<unknown>): Promise<{exitCode: number?, stdOut: string, stdErr: string}>
   orig := {
     stdout: process.stdout.write
     stderr: process.stderr.write
@@ -715,6 +715,9 @@ describe "CLI piped stdin", ->
 describe "CLI --config", ->
   let tmpDir: string
   fileNum .= 0
+  function nextConfigPath(): string
+    path.join tmpDir, `config-${fileNum++}.json`
+
   before ->
     tmpDir = path.join tmpdir(), "civet-cli-config-test-" + Math.random().toString(36).substring(2, 15)
     await mkdir tmpDir, { recursive: true }
@@ -722,14 +725,14 @@ describe "CLI --config", ->
     await rm tmpDir, { recursive: true, force: true }
 
   it "loads --config JSON file with parseOptions", ->
-    configPath := path.join tmpDir, "config-${fileNum++}.json"
+    configPath := nextConfigPath()
     await writeFile configPath, JSON.stringify({parseOptions: {autoLet: true}})
     { stdOut } := await captureProcess =>
       await cli ['-c', '--config', configPath, '-e', 'x = 1']
     assert stdOut.includes('let'), "autoLet from config applied: " + stdOut
 
   it "deep merges --config parseOptions with --civet flag", ->
-    configPath := path.join tmpDir, "config-${fileNum++}.json"
+    configPath := nextConfigPath()
     await writeFile configPath, JSON.stringify({parseOptions: {autoLet: true}})
     // Use --civet to supply an additional parseOption; config's autoLet should remain
     { stdOut, exitCode } := await captureProcess =>
@@ -1076,4 +1079,3 @@ describe "CLI --typecheck", ->
       assert declFiles.length > 0, `.d.ts emitted; got: ${JSON.stringify files}; exitCode=${exitCode}; stdErr=${stdErr}; stdOut=${stdOut}`
     finally
       process.chdir origCwd
-

--- a/test/comment.civet
+++ b/test/comment.civet
@@ -1,4 +1,4 @@
-{testCase, throws} from ./helper.civet
+{testCase} from ./helper.civet
 
 describe "comment", ->
   testCase """

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -1,5 +1,5 @@
 { testCase, throws } from ./helper.civet
-{ compile } from ../source/main.civet
+{ compile, type ParseError } from ../source/main.civet
 { serialize } from ../source/parser/comptime.civet
 vm from node:vm
 assert from assert
@@ -294,7 +294,7 @@ describe "comptime", ->
   it "skips comptime evaluation when compile already has errors", =>
     // When the pre-comptime generate surfaces errors, comptime leaves the
     // subtree alone so the error still appears in the output.
-    errors := []
+    errors: ParseError[] := []
     output := await compile """
       x := comptime x.
     """, { ...options, errors }
@@ -351,7 +351,7 @@ describe "serialize", ->
   it "regular functions", =>
     assert.equal serialize((x: ???) -> x), "function(x) { return x }"
   it "functions with properties", =>
-    func: any := (x: ???) => x
+    func: any := &: ???
     func.a = 1
     assert.equal
       serialize func
@@ -376,7 +376,7 @@ describe "serialize", ->
     array: any := []
     array.push array
     assert.throws (=> serialize array), /circular reference detected/
-    func: any := &
+    func: any := (x: ???) => x
     func.func = func
     assert.throws (=> serialize func), /circular reference detected/
   it "aliasing", =>

--- a/test/comptime.civet
+++ b/test/comptime.civet
@@ -351,7 +351,7 @@ describe "serialize", ->
   it "regular functions", =>
     assert.equal serialize((x: ???) -> x), "function(x) { return x }"
   it "functions with properties", =>
-    func: any := &: ???
+    func: any := (x: ???) => x
     func.a = 1
     assert.equal
       serialize func

--- a/test/infra/babel/babel-plugin.civet
+++ b/test/infra/babel/babel-plugin.civet
@@ -5,11 +5,14 @@ import * as babel from "@babel/core"
 import * as babelParser from "@babel/parser"
 babelPlugin from "../../../source/babel-plugin.civet"
 
+type ParserOverrideOptions
+  sourceFileName: string
+
 // Minimal AST stub returned by mock parse functions
 fakeAST := { type: "File", program: { type: "Program", body: [], directives: [], sourceType: "script" }, errors: [] }
 
 // Real parse wrapper used for integration-style tests
-realParse := (src, opts) -> babelParser.parse(src, { ...opts, sourceType: "module" })
+realParse := (src: string, opts: ParserOverrideOptions) -> babelParser.parse(src, { ...opts, sourceType: "module" })
 
 describe "babel-plugin", ->
   describe "plugin factory", ->
@@ -63,18 +66,17 @@ describe "babel-plugin", ->
       parserOverride("y := 2\n", { sourceFileName: "myFile.civet" }, (src) -> compiledSrc = src; fakeAST)
       match := compiledSrc.match(/sourceMappingURL=data:application\/json;base64,(.+)/)
       assert match, "should embed inline source map"
-      sourceMap := JSON.parse(Buffer.from(match[1], "base64").toString("utf8"))
+      sourceMap: {sources?: string[]} := JSON.parse(Buffer.from(match[1], "base64").toString("utf8"))
       assert sourceMap.sources?.some((s) -> s.includes("myFile.civet")), "source map should reference myFile.civet"
 
   describe "parserOverride: non-.civet files", ->
     for extension of [".ts", ".js", ".tsx"]
-      do (extension) ->
-        it `passes code through unchanged for ${extension} files`, ->
-          { parserOverride } := babelPlugin(null, {})
-          receivedSrc .= ""
-          input := `const x = 1;`
-          parserOverride(input, { sourceFileName: `input${extension}` }, (src) -> receivedSrc = src; fakeAST)
-          assert.equal receivedSrc, input
+      it `passes code through unchanged for ${extension} files`, ->
+        { parserOverride } := babelPlugin(null, {})
+        receivedSrc .= ""
+        input := `const x = 1;`
+        parserOverride(input, { sourceFileName: `input${extension}` }, (src) -> receivedSrc = src; fakeAST)
+        assert.equal receivedSrc, input
 
   describe "parserOverride: error handling", ->
     it "throws on invalid civet syntax", ->

--- a/test/infra/browser.civet
+++ b/test/infra/browser.civet
@@ -135,6 +135,15 @@ describe "browser-shim", ->
 
 { runScript, runScripts, autoRunScripts } from ../../source/browser.civet
 
+type ScriptMutation =
+  type: string
+  addedNodes: HTMLScriptElement[]
+type ScriptMutationCallback = (mutations: ScriptMutation[]) => unknown | Promise<unknown>
+
+function requireCapturedCallback(callback: ScriptMutationCallback?): ScriptMutationCallback
+  assert callback?, "callback should have been captured"
+  callback
+
 function makeScript(opts: {
   src?: string
   dataSrc?: string
@@ -283,7 +292,7 @@ describe "browser", ->
 
   describe "autoRunScripts", ->
     it "returns a MutationObserver", ->
-      withMockObserver (observed, MockObserver) ->
+      withMockObserver (_observed, MockObserver) ->
         root1 := { nodeType: 1 } as unknown as HTMLElement
         observer := autoRunScripts [root1]
         assert observer instanceof MockObserver
@@ -305,10 +314,10 @@ describe "browser", ->
         assert observed[0][1].subtree, "extra options should be preserved"
 
     it "mutation callback ignores non-childList mutations", ->
-      let capturedCallback: Function | null = null
+      let capturedCallback: ScriptMutationCallback?
       origObserver := (globalThis as any).MutationObserver
       class MockObserver
-        constructor(cb: Function)
+        constructor(cb: ScriptMutationCallback)
           capturedCallback = cb
         observe(_target: any, _opts: any) {}
         disconnect() {}
@@ -316,12 +325,12 @@ describe "browser", ->
       try
         root := { nodeType: 1 } as unknown as HTMLElement
         autoRunScripts [root]
-        assert capturedCallback?, "callback should have been captured"
         scriptNode := makeScript { innerHTML: "unrun := true" }
         mutation :=
           type: "attributes"  // not "childList" — should be skipped
           addedNodes: [scriptNode]
-        await capturedCallback [mutation]
+        callback := requireCapturedCallback capturedCallback
+        await callback [mutation]
         assert.equal evalledCode.length, 0, "should NOT eval for non-childList mutation"
       finally
         (globalThis as any).MutationObserver = origObserver
@@ -414,10 +423,10 @@ describe "browser", ->
 
     it "mutation callback runs scripts on added SCRIPT nodes", ->
       @timeout 10000
-      let capturedCallback: Function | null = null
+      let capturedCallback: ScriptMutationCallback?
       origObserver := (globalThis as any).MutationObserver
       class MockObserver
-        constructor(cb: Function)
+        constructor(cb: ScriptMutationCallback)
           capturedCallback = cb
         observe(_target: any, _opts: any) {}
         disconnect() {}
@@ -425,12 +434,12 @@ describe "browser", ->
       try
         root := { nodeType: 1 } as unknown as HTMLElement
         autoRunScripts [root]
-        assert capturedCallback?, "callback should have been captured"
         scriptNode := makeScript { innerHTML: "mutated := true" }
         mutation :=
           type: "childList"
           addedNodes: [scriptNode]
-        await capturedCallback [mutation]
+        callback := requireCapturedCallback capturedCallback
+        await callback [mutation]
         assert evalledCode.length > 0, "should have evaled the added script"
       finally
         (globalThis as any).MutationObserver = origObserver

--- a/test/infra/esm.civet
+++ b/test/infra/esm.civet
@@ -31,7 +31,7 @@ describe "esm", =>
   it "calls next for non-civet URLs (load passthrough)", =>
     // Covers lines 97-98 of esm.civet: `return next url, context`
     called .= false
-    nextFn := (u: string, ctx: unknown) =>
+    nextFn := (_u: string, _ctx: unknown) =>
       called = true
       {}
     await load "file:///some/file.js", { format: "module" }, nextFn

--- a/test/infra/main.civet
+++ b/test/infra/main.civet
@@ -231,7 +231,7 @@ describe "compile hits/trace options", ->
       // Wait for the async import("node:fs").then(...) handler to run
       await new Promise (r) => setTimeout r, 200
       content := await fs.readFile hitsFile, "utf8"
-      assert content.includes "Total:", "hits file should contain totals"
+      assert content.includes("Total:"), "hits file should contain totals"
     finally
       await fs.rm hitsFile, { force: true }
 

--- a/test/infra/ts-diagnostic.civet
+++ b/test/infra/ts-diagnostic.civet
@@ -1,6 +1,16 @@
 assert from assert
+{ type DiagnosticMessageChain } from typescript
 
 { remapPosition, remapPositionStrict, remapRange, flattenDiagnosticMessageText, type SourcemapLines } from ../../source/ts-diagnostic.civet
+
+function chain(messageText: string, next?: DiagnosticMessageChain[]): DiagnosticMessageChain
+  result: DiagnosticMessageChain :=
+    messageText: messageText
+    category: 1 // ts.DiagnosticCategory.Error
+    code: 0
+  if next
+    result.next = next
+  result
 
 describe "ts-diagnostic", ->
   describe "remapPosition", ->
@@ -137,22 +147,16 @@ describe "ts-diagnostic", ->
       assert.equal flattenDiagnosticMessageText(undefined), ""
 
     it "returns messageText from DiagnosticMessageChain at top level", ->
-      assert.equal flattenDiagnosticMessageText({ messageText: "type error" }), "type error"
+      assert.equal flattenDiagnosticMessageText(chain "type error"), "type error"
 
     it "appends nested chain messages with indentation", ->
-      diag :=
-        messageText: "outer"
-        next: [{ messageText: "inner" }]
+      diag := chain "outer", [chain "inner"]
       assert.equal flattenDiagnosticMessageText(diag), "outer\n  inner"
 
     it "handles deeply nested chains", ->
-      diag :=
-        messageText: "level0"
-        next: [{ messageText: "level1", next: [{ messageText: "level2" }] }]
+      diag := chain "level0", [chain("level1", [chain "level2"])]
       assert.equal flattenDiagnosticMessageText(diag), "level0\n  level1\n    level2"
 
     it "appends multiple siblings at same nesting level", ->
-      diag :=
-        messageText: "root"
-        next: [{ messageText: "child1" }, { messageText: "child2" }]
+      diag := chain "root", [chain("child1"), chain("child2")]
       assert.equal flattenDiagnosticMessageText(diag), "root\n  child1\n  child2"

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -1,6 +1,6 @@
 fs from fs
 
-{compile as civetCompile} from ../source/main.civet
+{compile as civetCompile, type ParseError} from ../source/main.civet
 
 Hera from ../source/parser.hera
 {parse} := Hera
@@ -43,7 +43,7 @@ describe "integration", ->
     assert civetCompile(src, { sourceMap: true, filename: "integration/example/compiler.civet" })
 
   it "should return errors via option", ->
-    errors .= []
+    errors: ParseError[] .= []
     await civetCompile '=> yield 5', {errors}
     assert.equal errors#, 1
 

--- a/test/jsx/objects.civet
+++ b/test/jsx/objects.civet
@@ -1,4 +1,4 @@
-{testCase, throws} from ../helper.civet
+{testCase} from ../helper.civet
 
 describe "JSX object shorthand", ->
   testCase """

--- a/test/jsx/solid.civet
+++ b/test/jsx/solid.civet
@@ -1,4 +1,4 @@
-{testCase, throws} from ../helper.civet
+{testCase} from ../helper.civet
 
 describe "JSX for Solid", ->
   testCase """

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -179,6 +179,19 @@ describe "source map", ->
 
       assertShiftedSourceMap srcMapJSON, sourceMap.lines
 
+    it "supports upstreamSourceMap as an explicit compile option (parsed object)", ->
+      // Pass upstream map with pre-parsed lines directly as options.
+      civetSource := "x := 5"
+
+      { sourceMap } := await compile civetSource,
+        sourceMap: true
+        filename: "input.civet"
+        upstreamSourceMap: SourceMap.parseWithLines base64Encode JSON.stringify upstreamMapJSON
+
+      srcMapJSON := sourceMap.json "input.ts"
+
+      assertShiftedSourceMap srcMapJSON, sourceMap.lines
+
     it "supports upstreamSourceMap as an explicit compile option (JSON)", ->
       // Pass upstream map directly as options, without embedding in the source
       civetSource := "x := 5"
@@ -418,6 +431,24 @@ describe "source map", ->
         names: []
 
       sourceMap.composeDownstream base64Encode JSON.stringify downstreamMapJSON
+      assert.ok Array.isArray(sourceMap.lines)
+      assert.ok sourceMap.lines.length > 0
+
+    it "accepts pre-parsed downstream maps", ->
+      src := "x := 5\n"
+      { sourceMap } := await compile src,
+        sourceMap: true
+        filename: "input.civet"
+
+      downstreamMapJSON :=
+        version: 3
+        file: "output.ts"
+        sources: ["input.civet"]
+        mappings: "AAAA"
+        names: []
+
+      parsedDownstreamMap := SourceMap.parseWithLines base64Encode JSON.stringify downstreamMapJSON
+      sourceMap.composeDownstream parsedDownstreamMap
       assert.ok Array.isArray(sourceMap.lines)
       assert.ok sourceMap.lines.length > 0
 

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -290,16 +290,14 @@ describe "source map", ->
 
       """
 
-      {code, sourceMap} := await compile src,
+      {sourceMap} := await compile src,
         js: true
         sourceMap: true
         filename: "test.civet"
 
       srcLines := src.split('\n')
-      outLines := code.split('\n')
-
       // Walk every mapped segment and verify source positions are in bounds
-      for smLine, lineIdx of sourceMap.lines
+      for smLine of sourceMap.lines
         continue unless smLine
         for seg of smLine
           continue unless seg.length is 4

--- a/test/util/traversal.civet
+++ b/test/util/traversal.civet
@@ -1,28 +1,41 @@
 assert from assert
 { findChildIndex } from ../../source/parser/traversal.civet
+{ type ASTNode, type ASTNodeObject, type Children } from ../../source/parser/types.civet
+
+type TestNodeFields
+  id?: string
+  a?: number
+  b?: number
+  c?: number
+
+function node(fields: TestNodeFields = {}): ASTNodeObject
+  Object.assign { children: [] as Children }, fields
+
+function parentNode(...items: ASTNode[]): ASTNodeObject
+  children: items as Children
 
 describe "findChildIndex", ->
   it "returns -1 when child is not in parent.children", ->
-    parent := { children: [{ a: 1 }, { b: 2 }] }
-    foreign := { c: 3 }
+    parent := parentNode node(a: 1), node(b: 2)
+    foreign := node c: 3
     assert.equal findChildIndex(parent, foreign), -1
 
   it "finds child directly in children array", ->
-    target := { id: "t" }
-    parent := { children: ["ws", target, "!"] }
+    target := node id: "t"
+    parent := parentNode "ws", target, "!"
     assert.equal findChildIndex(parent, target), 1
 
   it "finds child nested in a child-array (StatementTuple shape)", ->
-    target := { id: "stmt" }
-    tuple := ["\n  ", target, ";"]
-    parent := { children: [tuple] }
+    target := node id: "stmt"
+    tuple := ["\n  ", target, ";"] as Children
+    parent := parentNode tuple
     assert.equal findChildIndex(parent, target), 0
 
   it "recurses through deeply nested arrays", ->
-    target := { id: "deep" }
-    parent := { children: [[[target]]] }
+    target := node id: "deep"
+    parent := parentNode [[target] as Children] as Children
     assert.equal findChildIndex(parent, target), 0
 
   it "accepts an array directly as parent", ->
-    target := { id: "x" }
-    assert.equal findChildIndex(["a", target, "b"], target), 1
+    target := node id: "x"
+    assert.equal findChildIndex(["a", target, "b"] as Children, target), 1


### PR DESCRIPTION
I did a round of type error reduction, focusing on smaller files outside `source/parser`. Hopefully no conflict with #2038.
Overall a modest reduction from 883 to 827 (net –56).

The most interesting change is a cleanup with how we handle `ParseError`. Hera's `ParseError` requires `line` and `column` to be a `number`, which makes sense in a Hera context. Its implementation works well with strrings though, and we exploited that by writing `"?"` sometimes when we don't have sourcemaps. Some call sites knew that and dealt with it; others (notably CLI) did not. Now the type is overridden within Civet to allow for `string`, and everyone should deal with it.

**Commits**

- `Fix types in source/babel-plugin.civet` (net -9)
  - Typed the Babel parser override path more precisely.
  - Removed parser override return/argument type errors in the Babel plugin.

- `Fix types in source/sourcemap.civet` (net -2)
  - Tightened source map JSON/line typing.
  - Removed remaining sourcemap type mismatches.

- `Fix types in source/node-worker.civet` (net -3)
  - Narrowed thrown worker errors before reading `Error` fields.
  - Added fallback serialization for non-`Error` thrown values.

- `Fix types in source/generate.civet; ParseError wrapper` (net -1)
  - Imported and used the internal `ParseError` wrapper type.
  - Preserved fallback behavior for older/looser error shapes.

- `Fix types in source/parser/helper.civet` (net -1)
  - Removed the conflicting ambient `state` declaration.
  - Added a concrete `StatementTuple` annotation in prelude filtering.

- `Reduce type errors in test files` (net -31)
  - Removed unused imports/parameters in small test files.
  - Typed test error arrays and Babel/browser helper fixtures.
  - Widened compiler option types for explicit `undefined` globals/operators.
  - Left remaining larger test type clusters for separate follow-up work.

- `Fix types in test/infra/ts-diagnostic.civet` (net -4)
  - Added typed `DiagnosticMessageChain` fixtures.
  - Avoided runtime `typescript` imports while satisfying the chain shape.

- `Fix types in test/util/traversal.civet` (net -5)
  - Added typed synthetic AST node fixtures for `findChildIndex` tests.
  - Kept the tests focused on traversal behavior while matching parser node shapes.

- Lowered `CI_TYPECHECK_MAX_ERRORS` to the current count: 827.

<details>
<summary>typecheck-diff</summary>

```
Old: 883 diagnostics  →  New: 826 diagnostics
Net: -57
Regressions: 0
Fixed: 57
Notice: Net -57, Broke 0, Fixed 57

Fixed (57):
  source/babel-plugin.civet
    18:17 TS6133 'api' is declared but its value is never read.
    18:17 TS7006 Parameter 'api' implicitly has an 'any' type.
    18:22 TS7006 Parameter 'civetOptions' implicitly has an 'any' type.
    19:18 TS7006 Parameter 'code' implicitly has an 'any' type.
    19:24 TS7006 Parameter 'opts' implicitly has an 'any' type.
    19:30 TS7006 Parameter 'parse' implicitly has an 'any' type.
  source/cli.civet
    386:51 TS2375 Type '{ repl: boolean; autoConst?: boolean; autoLet?: boolean; autoVar?: boolean; coffeeBinaryExistential?: boolean; coffeeBooleans?: boolean; coffeeClasses?: boolean; coffeeComment?: boolean; ... 32 more ...; iife?: boolean; }' is not assignable to type '{ coffeeCompat?: boolean; comptime?: boolean; globals?: string[]; esArrowFunction?: boolean; esCompat?: boolean; operators?: string[] | Record<string, string>; symbols?: string[]; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  source/esm.civet
    82:7 TS2375 Type 'Partial<{ autoConst: boolean; autoLet: boolean; autoVar: boolean; coffeeBinaryExistential: boolean; coffeeBooleans: boolean; coffeeClasses: boolean; coffeeComment: boolean; coffeeCompat: boolean; ... 32 more ...; repl: boolean; }>' is not assignable to type '{ coffeeCompat?: boolean; comptime?: boolean; globals?: string[]; esArrowFunction?: boolean; esCompat?: boolean; operators?: string[] | Record<string, string>; symbols?: string[]; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    84:7 TS2375 Type '{ autoConst?: boolean; autoLet?: boolean; autoVar?: boolean; coffeeBinaryExistential?: boolean; coffeeBooleans?: boolean; coffeeClasses?: boolean; coffeeComment?: boolean; coffeeCompat?: boolean; ... 32 more ...; repl?: boolean; }' is not assignable to type '{ coffeeCompat?: boolean; comptime?: boolean; globals?: string[]; esArrowFunction?: boolean; esCompat?: boolean; operators?: string[] | Record<string, string>; symbols?: string[]; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  source/generate.civet
    65:11 TS2345 Argument of type 'string | number' is not assignable to parameter of type 'number'.
  source/node-worker.civet
    23:15 TS18046 'error' is of type 'unknown'.
    24:9 TS18046 'error' is of type 'unknown'.
    24:9 TS18046 'error' is of type 'unknown'.
  source/parser/helper.civet
    6:3 TS2440 Import declaration conflicts with local declaration of 'state'.
  source/sourcemap.civet
    140:49 TS2339 Property 'lines' does not exist on type 'SourceMapJSON | SourceMapJSONWithLines'.
    148:59 TS2339 Property 'lines' does not exist on type 'SourceMapJSON | SourceMapJSONWithLines'.
  test/binary-op.civet
    1369:24 TS2322 Type '{ min: undefined; max: string; }' is not assignable to type 'string[] | Record<string, string> | undefined'.
  test/cli.civet
    667:41 TS2345 Argument of type '() => void' is not assignable to parameter of type '() => Promise<unknown>'.
    674:41 TS2345 Argument of type '() => void' is not assignable to parameter of type '() => Promise<unknown>'.
    681:49 TS2345 Argument of type '() => void' is not assignable to parameter of type '() => Promise<unknown>'.
    717:3 TS6133 'fileNum' is declared but its value is never read.
  test/comment.civet
    1:12 TS6133 'throws' is declared but its value is never read.
  test/compat/auto-var.civet
    522:8 TS2375 Type '{ globals: undefined; }' is not assignable to type '{ coffeeCompat?: boolean; comptime?: boolean; globals?: string[]; esArrowFunction?: boolean; esCompat?: boolean; operators?: string[] | Record<string, string>; symbols?: string[]; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  test/comptime.civet
    297:5 TS7034 Variable 'errors' implicitly has type 'any[]' in some locations where its type cannot be determined.
    300:24 TS7005 Variable 'errors' implicitly has an 'any[]' type.
    379:17 TS7006 Parameter '$1' implicitly has an 'any' type.
  test/infra/babel/babel-plugin.civet
    12:15 TS7006 Parameter 'src' implicitly has an 'any' type.
    12:20 TS7006 Parameter 'opts' implicitly has an 'any' type.
    45:74 TS7006 Parameter 'src' implicitly has an 'any' type.
    51:66 TS7006 Parameter 'src' implicitly has an 'any' type.
    57:66 TS7006 Parameter 'src' implicitly has an 'any' type.
    63:71 TS7006 Parameter 'src' implicitly has an 'any' type.
    67:39 TS7006 Parameter 's' implicitly has an 'any' type.
    70:9 TS6133 'extension' is declared but its value is never read.
    71:11 TS7006 Parameter 'extension' implicitly has an 'any' type.
    76:75 TS7006 Parameter 'src' implicitly has an 'any' type.
  test/infra/browser.civet
    286:25 TS6133 'observed' is declared but its value is never read.
    324:15 TS2349 This expression is not callable.
    433:15 TS2349 This expression is not callable.
  test/infra/esm.civet
    34:16 TS6133 'u' is declared but its value is never read.
    34:27 TS6133 'ctx' is declared but its value is never read.
  test/infra/main.civet
    234:41 TS2345 Argument of type 'string' is not assignable to parameter of type 'number'.
  test/infra/ts-diagnostic.civet
    140:49 TS2345 Argument of type '{ messageText: string; }' is not assignable to parameter of type 'string | DiagnosticMessageChain | undefined'.
    146:49 TS2345 Argument of type '{ messageText: string; next: { messageText: string; }[]; }' is not assignable to parameter of type 'string | DiagnosticMessageChain | undefined'.
    152:49 TS2345 Argument of type '{ messageText: string; next: { messageText: string; next: { messageText: string; }[]; }[]; }' is not assignable to parameter of type 'string | DiagnosticMessageChain | undefined'.
    158:49 TS2345 Argument of type '{ messageText: string; next: { messageText: string; }[]; }' is not assignable to parameter of type 'string | DiagnosticMessageChain | undefined'.
  test/integration.civet
    46:5 TS7034 Variable 'errors' implicitly has type 'any[]' in some locations where its type cannot be determined.
    47:39 TS7005 Variable 'errors' implicitly has an 'any[]' type.
  test/jsx/objects.civet
    1:12 TS6133 'throws' is declared but its value is never read.
  test/jsx/solid.civet
    1:12 TS6133 'throws' is declared but its value is never read.
  test/sourcemap.civet
    286:7 TS6133 'outLines' is declared but its value is never read.
    289:19 TS6133 'lineIdx' is declared but its value is never read.
  test/util/traversal.civet
    8:33 TS2345 Argument of type '{ children: ({ a: number; b?: never; } | { b: number; a?: never; })[]; }' is not assignable to parameter of type 'Children | ASTNodeObject'.
    13:33 TS2345 Argument of type '{ children: (string | { id: string; })[]; }' is not assignable to parameter of type 'Children | ASTNodeObject'.
    19:33 TS2345 Argument of type '{ children: (string | { id: string; })[][]; }' is not assignable to parameter of type 'Children | ASTNodeObject'.
    24:33 TS2345 Argument of type '{ children: { id: string; }[][][]; }' is not assignable to parameter of type 'Children | ASTNodeObject'.
    28:39 TS2322 Type '{ id: string; }' is not assignable to type 'ASTNode'.
```

</details>