### PR TITLE
Dev: Property children false-leak + literal-leaf type tags

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -742,9 +742,9 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
             delim: part.delim
             names: part.names
             children: [
-              isWhitespaceOrEmpty(part.children[0]) and part.children[0]
+              isWhitespaceOrEmpty(part.children[0]) ? part.children[0] : ""
               name
-              isWhitespaceOrEmpty(part.children[2]) and part.children[2]
+              isWhitespaceOrEmpty(part.children[2]) ? part.children[2] : ""
               part.children[3]?.token is ":" ? part.children[3] : ":"
               value
               part.delim // comma delimiter

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1257,9 +1257,11 @@ export type Literal =
 
 export type LiteralContentNode =
   | ASTLeaf
-  | ASTLeafWithType "NumericLiteral" | "StringLiteral"
+  | ASTLeafWithType "BooleanLiteral" | "NullLiteral" | "NumericLiteral" | "StringLiteral"
   | string
 
+export type BooleanLiteral = ASTLeafWithType "BooleanLiteral"
+export type NullLiteral = ASTLeafWithType "NullLiteral"
 export type NumericLiteral = ASTLeafWithType "NumericLiteral"
 export type StringLiteral = ASTLeafWithType "StringLiteral"
 


### PR DESCRIPTION
Two cherry-picks from #2009 that still apply on top of #2038.

- **lib**: `processCallMemberExpression` was leaking `false` into the synth Property's children via `cond and x` short-circuits.  Harmless today (no predicate uses strict `'foo' in node`), but ce990c88 removed the traversal-level boolean filter that hid it.  Replaced with `... or ""` so the failing arm becomes ASTString.
- **types**: parser emits `BooleanLiteral` / `NullLiteral` leaves but `LiteralContentNode` only listed `NumericLiteral` / `StringLiteral`.  Added both to the union and exported named aliases.