### PR TITLE
Support destructuring-style imports with rest and nested patterns

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3196,6 +3196,23 @@ import {X: LocalX, Y: LocalY} from "./util"
 {X: LocalX, Y: LocalY} from "./util"
 </Playground>
 
+You can also use `...rest` (in any position — Civet normalizes it to the
+tail) and nested object/array patterns.  Since native ESM can't express
+these directly, the import rewrites to a namespace import plus a
+following `const` destructure:
+
+<Playground>
+import {a, b, ...rest} from "./y"
+import {a: {b, c}} from "./y"
+</Playground>
+
+Per-spec `type` imports are split into their own native type-import so
+the runtime destructure still binds cleanly:
+
+<Playground>
+import {a, type T, ...rest} from "./y"
+</Playground>
+
 ### Dynamic Import
 
 If it's not the start of a statement,

--- a/notes/parser-types-guide.md
+++ b/notes/parser-types-guide.md
@@ -45,6 +45,8 @@ Hera 0.9.6+ emits real TypeScript types for each grammar rule's return value. Lo
 
 - **Vague array types in unions are a refactoring signal.** When `children` is part of a union (`Children | Foo | undefined`), TS won't expose `.push`/`.slice`/`.indexOf` because the brand on `Children` doesn't lift through union members. A cast to `ASTNode[]` at the call site unblocks immediate work, but the better long-term move is replacing the vague `ASTNode[]`/`Children` arm with a fixed-arity tuple of known types. Treat each cast as a marker for a follow-up refactor.
 
+- **`is` / `is not` are real TS narrowing.** Civet's `is` compiles to `===` (`is not` → `!==`), so TypeScript narrows discriminated unions on them exactly like any other equality check. `arr.filter .type is "Foo"` or `arr.find (item) => item.type is "Foo"` produce a typed `Foo[]` / `Foo | undefined` with no `as Extract<…>` cast or explicit `: item is Foo` predicate needed. If you find yourself adding one, check whether your input array type is the problem instead — the right fix is usually annotating the source array, not papering over the filter result.
+
 ## Workflow
 
 ### Build / typecheck

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -133,6 +133,10 @@ function normalizeMessage(s: string): string
     .replace /\.\.\. \d+ more \.\.\./g, "…"
     .replace /\{[^{}]{40,}\}/g, "{…}"
     .replace /\([^()]{40,}\)/g, "(…)"
+    // Strip the TS2719-specific tail so reshuffles between TS2322 and TS2719
+    // (same underlying assignment failure, different error class) match via
+    // the loose pass.
+    .replace /[ ]Two different types with this name exist, but they are unrelated\./g, ""
   sortQuotedUnions scrubbed
 
 function strictKey(d: Diag): string

--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -8,16 +8,23 @@
  *
  * This is the right tool for "did my PR add type errors?" — naive line-by-line
  * diffs flag every shifted preexisting error as new.  Diagnostics here are
- * matched in two passes:
+ * matched in three passes:
  *
  *   1. strict: (file, code, normalized message)
  *   2. message-only: (file, normalized message)
+ *   3. source-type-only: (file, code, source-side of "Type X is not
+ *      assignable to type Y" — ignores Y)
  *
  * Pass 2 catches errors where the code changed but the underlying message
  * didn't — e.g. when adding a function overload reclassifies many TS2345
  * "Argument not assignable" calls as TS2769 "No overload matches" with the
- * same embedded reason.  We deliberately do NOT match by (file, line, col)
- * alone — that paired genuinely-different errors at the same site.
+ * same embedded reason.  Pass 3 catches assignability errors whose target
+ * type (Y) shifted printout because an adjacent type widened — e.g.
+ * `Type '…' is not assignable to type 'ASTNode'` becoming
+ * `Type '…' is not assignable to type '…'` (target now >40 chars) when a
+ * field's type changes to a longer union.  We deliberately do NOT match by
+ * (file, line, col) alone — that paired genuinely-different errors at the
+ * same site.
  *
  * Normalization also alphabetizes union members within short quoted type
  * literals so that `'"let" | "const" | "var"'` and `'"const" | "let" | "var"'`
@@ -134,6 +141,17 @@ function strictKey(d: Diag): string
 function messageKey(d: Diag): string
   `${d.file}:${normalizeMessage d.message}`
 
+// Source-type pass: matches "Type 'X' is not assignable to type 'Y'"
+// errors by (file, code, source X) ignoring target Y.  TS narrows or widens
+// target-type printouts when nearby types gain fields, which would otherwise
+// rebucket the same underlying error across passes.  Returns a non-matching
+// sentinel for diagnostics that don't fit the assignability pattern so they
+// never cross-pair.
+function sourceTypeKey(d: Diag): string
+  m := normalizeMessage(d.message).match /^Type ('…'|'[^']*') is not assignable to type '/
+  return `${d.file}:${d.code}:no-source-pattern:${d.line}` unless m
+  `${d.file}:${d.code}:source=${m[1]}`
+
 function indexBy<T>(items: T[], keyFn: (item: T) => string): Map<string, T[]>
   m := new Map<string, T[]>
   for item of items
@@ -154,12 +172,18 @@ type DiffResult =
   // without-code) pass.  Non-zero means the dedup is catching code-class
   // shuffles (TS2345 ↔ TS2769 from added overloads, etc.).
   loosePairs: number
+  // How many matched only via the source-type pass.  Non-zero means
+  // baseline assignability errors had their target-type printouts rewritten
+  // by adjacent type changes (e.g. ASTNode widening to a union).
+  sourcePairs: number
 
 function diff(left: Diag[], right: Diag[]): DiffResult
-  // Two-pass match: strict (file+code+msg), then message-only (file+msg).
-  // Each match consumes a `right` item so it's never used twice.
+  // Three-pass match: strict (file+code+msg), message-only (file+msg),
+  // source-type-only (file+code+source).  Each match consumes a `right`
+  // item so it's never used twice.
   byStrict := indexBy right, strictKey
   byMessage := indexBy right, messageKey
+  bySource := indexBy right, sourceTypeKey
   consumed := new Set<Diag>
 
   function findMatch(buckets: Map<string, Diag[]>, key: string): boolean
@@ -173,13 +197,17 @@ function diff(left: Diag[], right: Diag[]): DiffResult
 
   unmatched: Diag[] := []
   loose .= 0
+  source .= 0
   for d of left
     continue if findMatch byStrict, strictKey d
     if findMatch byMessage, messageKey d
       loose++
       continue
+    if findMatch bySource, sourceTypeKey d
+      source++
+      continue
     unmatched.push d
-  { unmatched, loosePairs: loose }
+  { unmatched, loosePairs: loose, sourcePairs: source }
 
 regressions := diff newDiags, oldDiags
 fixed := diff oldDiags, newDiags
@@ -230,7 +258,9 @@ console.log `Old: ${oldDiags#} diagnostics  →  New: ${newDiags#} diagnostics`
 netText := `${net >= 0 ? "+" : ""}${net}`
 console.log `Net: ${netText}`
 loose := regressions.loosePairs + fixed.loosePairs
-console.log `Deduped ${loose} noise pair${loose is 1 ? '' : 's'} (code-class reshuffles, union reordering).` if loose > 0
+source := regressions.sourcePairs + fixed.sourcePairs
+noise := loose + source
+console.log `Deduped ${noise} noise pair${noise is 1 ? '' : 's'} (code-class reshuffles, union reordering, target-type rewrites).` if noise > 0
 console.log `Regressions: ${regressions.unmatched#}`
 console.log `Fixed: ${fixed.unmatched#}`
 if process.env.GITHUB_ACTIONS

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6231,9 +6231,7 @@ ImpliedImport
 ImportClause
   ImportedBinding:binding ( __ Comma __ ( NameSpaceImport / NamedImports ) )?:rest ->
     if rest
-      // Spread `named` so its optional fields (specifiers / rest / needsDesugar
-      // from NamedImports; star from NameSpaceImport) flow through without
-      // tripping exactOptionalPropertyTypes on explicit `: undefined` sets.
+      // Spread to forward NamedImports/NameSpaceImport optional fields.
       named := rest[3]
       return {
         ...named,
@@ -6266,16 +6264,10 @@ NameSpaceImport
 # https://262.ecma-international.org/#prod-NamedImports
 NamedImports
   OpenBrace ( NamedImportRest / TypeAndImportSpecifier )*:items ( __ Comma )? __ CloseBrace ->
-    // Accept `...rest` anywhere (matching Civet object destructuring), then
-    // reorderBindingRestProperty swaps delimiters and moves rest to the tail.
-    // We ignore the returned `names` and compute our own below from each
-    // specifier's binding (item.names isn't populated for ImportSpecifiers).
+    // Rest can appear anywhere; reorder moves it to the tail.
     reordered := (reorderBindingRestProperty items).children as (NamedImportElement | { type: "Error", message: string })[]
-    // reorderBindingRestProperty appends an Error node when restCount > 1.
-    // We exclude it from `specifiers` (it has no `binding`) so the parser can
-    // backtrack cleanly out of speculative implied-import matches like
-    // `{...c, ...d} = e`; we still surface it through `children` so real
-    // multi-rest imports report the error.
+    // reorder appends an Error on multi-rest; surface via children, skip in
+    // specifiers so speculative `{...c, ...d} = e` matches can backtrack.
     error := reordered.find .type is "Error"
     specifiers := reordered.filter .type is undefined
     rest := reordered.find .type is "BindingRestProperty"
@@ -6293,10 +6285,7 @@ NamedImports
       needsDesugar,
     }
 
-# `...rest` inside named imports — only meaningful with desugaring, since
-# native ESM doesn't allow rest in `import {…}`. Position-flexible to match
-# Civet's destructuring (e.g. `{...rest, a}`); the desugar emits it at the
-# tail of the resulting const pattern.
+# `...rest` in named imports — triggers namespace+const desugar.
 NamedImportRest
   __:ws DotDotDot:dots BindingIdentifier:binding ObjectPropertyDelimiter:delim ->
     return {
@@ -6380,12 +6369,10 @@ TypeAndImportSpecifier
     }
 
 # https://262.ecma-international.org/#prod-ImportSpecifier
-# `delim` exposed so reorderBindingRestProperty can shuffle a misplaced
-# `...rest` against these like a regular destructuring property.
+# `delim` exposed for reorderBindingRestProperty.
 ImportSpecifier
   __:ws1 ModuleExportName:source ImportAsToken:as __:ws2 ( BindingPattern / ImportedBinding ):binding ObjectPropertyDelimiter:delim ->
-    // `import { x: {y} }` / `import { x as {y} }` — pattern binding forces
-    // desugaring to namespace import + const destructuring.
+    // Pattern binding forces desugar — native ESM can't nest.
     pattern := binding.type is "ObjectBindingPattern" or binding.type is "ArrayBindingPattern"
     // `import { 😊 as x }` → `"😊" as x` (module-side is the source name).
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -22,6 +22,7 @@ import {
   dedentBlockString,
   dedentBlockSubstitutions,
   deepCopy,
+  desugarStaticImport,
   dynamizeImportDeclaration,
   dynamizeImportDeclarationExpression,
   escapeIdentifier,
@@ -115,6 +116,7 @@ import type {
   Label,
   LabelledStatement,
   NamedBindingPattern,
+  NamedImportElement,
   NamespaceDeclaration,
   NonNullAssertion,
   ObjectBindingPattern,
@@ -4820,7 +4822,8 @@ AwaitOp
 
 # https://262.ecma-international.org/#prod-ModuleItem
 ModuleItem
-  IsBare ( ImportDeclaration / ExportDeclaration ) ::ASTNode -> $2
+  IsBare ImportDeclaration:decl ::ASTNode -> desugarStaticImport(decl)
+  IsBare ExportDeclaration ::ASTNode -> $2
   StatementListItem ::ASTNode
 
 # https://262.ecma-international.org/#prod-StatementListItem
@@ -6228,12 +6231,17 @@ ImpliedImport
 ImportClause
   ImportedBinding:binding ( __ Comma __ ( NameSpaceImport / NamedImports ) )?:rest ->
     if rest
+      // `named` is NameSpaceImport or NamedImports — both shapes share these
+      // optional fields so we can forward them uniformly.
+      named := rest[3]
       return {
         type: "Declaration",
         children: [binding, ...rest],
-        names: [...binding.names, ...rest[3].names],
+        names: [...binding.names, ...named.names],
         binding,
-        specifiers: rest[3].specifiers,
+        specifiers: named.specifiers,
+        rest: named.rest,
+        needsDesugar: named.needsDesugar,
       }
 
     return {
@@ -6254,18 +6262,55 @@ NameSpaceImport
       names: binding.names,
       binding,
       star,
+      // Present so the NamedImports/NameSpaceImport union exposes a uniform
+      // shape to ImportClause callers.
+      specifiers: undefined,
+      rest: undefined,
+      needsDesugar: undefined,
     }
 
 # https://262.ecma-international.org/#prod-NamedImports
 NamedImports
-  OpenBrace TypeAndImportSpecifier*:specifiers ( __ Comma )? __ CloseBrace ->
-    names := specifiers.flatMap(({binding}) => binding.names)
+  OpenBrace ( NamedImportRest / TypeAndImportSpecifier )*:items ( __ Comma )? __ CloseBrace ->
+    // Accept `...rest` anywhere (matching Civet object destructuring), then
+    // reorderBindingRestProperty swaps delimiters and moves rest to the tail.
+    // We ignore the returned `names` and compute our own below from each
+    // specifier's binding (item.names isn't populated for ImportSpecifiers).
+    reordered := (reorderBindingRestProperty items).children as (NamedImportElement | { type: "Error", message: string })[]
+    // reorderBindingRestProperty appends an Error node when restCount > 1.
+    // We exclude it from `specifiers` (it has no `binding`) so the parser can
+    // backtrack cleanly out of speculative implied-import matches like
+    // `{...c, ...d} = e`; we still surface it through `children` so real
+    // multi-rest imports report the error.
+    error := reordered.find .type is "Error"
+    specifiers := reordered.filter .type is undefined
+    rest := reordered.find .type is "BindingRestProperty"
+    names := specifiers.flatMap .binding.names
+    if rest
+      names.push(...rest.binding.names)
+    needsDesugar := !!rest || specifiers.some .pattern
 
     return {
       type: "Declaration",
-      children: $0,
+      children: error ? [...$0, error] : $0,
       names,
       specifiers,
+      rest,
+      needsDesugar,
+    }
+
+# `...rest` inside named imports — only meaningful with desugaring, since
+# native ESM doesn't allow rest in `import {…}`. Position-flexible to match
+# Civet's destructuring (e.g. `{...rest, a}`); the desugar emits it at the
+# tail of the resulting const pattern.
+NamedImportRest
+  __:ws DotDotDot:dots BindingIdentifier:binding ObjectPropertyDelimiter:delim ->
+    return {
+      type: "BindingRestProperty",
+      children: [ws, dots, binding, delim],
+      dots,
+      binding,
+      delim,
     }
 
 OperatorNamedImports
@@ -6325,7 +6370,7 @@ ImportAssertion
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier
   __ TypeKeyword ImportSpecifier ->
-    return { ts: true, children: $0, binding: $3.binding }
+    return { ts: true, children: $0, binding: $3.binding, pattern: $3.pattern }
   ImportSpecifier
   # `operator id` blesses `id` as operator; doesn't make sense with `type`
   __:ws Operator OperatorImportSpecifier:spec ->
@@ -6333,6 +6378,7 @@ TypeAndImportSpecifier
     setOperatorBehavior(spec.binding.name, spec.behavior)
     return {
       ...spec,
+      pattern: false,
       children: [
         ws, trimFirstSpace((spec as any)[0]),
         spec.children.slice(1),
@@ -6340,12 +6386,19 @@ TypeAndImportSpecifier
     }
 
 # https://262.ecma-international.org/#prod-ImportSpecifier
+# `delim` exposed so reorderBindingRestProperty can shuffle a misplaced
+# `...rest` against these like a regular destructuring property.
 ImportSpecifier
-  __:ws1 ModuleExportName:source ImportAsToken:as __:ws2 ImportedBinding:binding ObjectPropertyDelimiter:delim ->
+  __:ws1 ModuleExportName:source ImportAsToken:as __:ws2 ( BindingPattern / ImportedBinding ):binding ObjectPropertyDelimiter:delim ->
+    // `import { x: {y} }` / `import { x as {y} }` — pattern binding forces
+    // desugaring to namespace import + const destructuring.
+    pattern := binding.type is "ObjectBindingPattern" or binding.type is "ArrayBindingPattern"
     // `import { 😊 as x }` → `"😊" as x` (module-side is the source name).
     return {
       source,
       binding,
+      pattern,
+      delim,
       children: [ws1, propertyKey(source), as, ws2, binding, delim],
     }
   __:ws ImportedBinding:binding ObjectPropertyDelimiter:delim ->
@@ -6354,11 +6407,15 @@ ImportSpecifier
       return {
         source: binding,
         binding,
+        pattern: false,
+        delim,
         children: [ws, propertyKey(binding), " as ", binding, delim],
       }
     return {
       source: binding,
       binding,
+      pattern: false,
+      delim,
       children: [ws, binding, delim],
     }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6231,17 +6231,16 @@ ImpliedImport
 ImportClause
   ImportedBinding:binding ( __ Comma __ ( NameSpaceImport / NamedImports ) )?:rest ->
     if rest
-      // `named` is NameSpaceImport or NamedImports — both shapes share these
-      // optional fields so we can forward them uniformly.
+      // Spread `named` so its optional fields (specifiers / rest / needsDesugar
+      // from NamedImports; star from NameSpaceImport) flow through without
+      // tripping exactOptionalPropertyTypes on explicit `: undefined` sets.
       named := rest[3]
       return {
+        ...named,
         type: "Declaration",
         children: [binding, ...rest],
         names: [...binding.names, ...named.names],
         binding,
-        specifiers: named.specifiers,
-        rest: named.rest,
-        needsDesugar: named.needsDesugar,
       }
 
     return {
@@ -6262,11 +6261,6 @@ NameSpaceImport
       names: binding.names,
       binding,
       star,
-      // Present so the NamedImports/NameSpaceImport union exposes a uniform
-      // shape to ImportClause callers.
-      specifiers: undefined,
-      rest: undefined,
-      needsDesugar: undefined,
     }
 
 # https://262.ecma-international.org/#prod-NamedImports

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6353,7 +6353,9 @@ ImportAssertion
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier
   __ TypeKeyword ImportSpecifier ->
-    return { ts: true, children: $0, binding: $3.binding, pattern: $3.pattern, delim: $3.delim }
+    // Flatten inner ImportSpecifier's children so reorderBindingRestProperty's
+    // last-child-is-delim invariant holds when `...rest` shuffles past us.
+    return { ts: true, children: [$1, $2, ...$3.children], binding: $3.binding, pattern: $3.pattern, delim: $3.delim }
   ImportSpecifier
   # `operator id` blesses `id` as operator; doesn't make sense with `type`
   __:ws Operator OperatorImportSpecifier:spec ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -22,7 +22,7 @@ import {
   dedentBlockString,
   dedentBlockSubstitutions,
   deepCopy,
-  desugarStaticImport,
+  processStaticImport,
   dynamizeImportDeclaration,
   dynamizeImportDeclarationExpression,
   escapeIdentifier,
@@ -4822,7 +4822,7 @@ AwaitOp
 
 # https://262.ecma-international.org/#prod-ModuleItem
 ModuleItem
-  IsBare ImportDeclaration:decl ::ASTNode -> desugarStaticImport(decl)
+  IsBare ImportDeclaration:decl ::ASTNode -> processStaticImport(decl)
   IsBare ExportDeclaration ::ASTNode -> $2
   StatementListItem ::ASTNode
 
@@ -6266,23 +6266,21 @@ NamedImports
   OpenBrace ( NamedImportRest / TypeAndImportSpecifier )*:items ( __ Comma )? __ CloseBrace ->
     // Rest can appear anywhere; reorder moves it to the tail.
     reordered := (reorderBindingRestProperty items).children as (NamedImportElement | { type: "Error", message: string })[]
-    // reorder appends an Error on multi-rest; surface via children, skip in
-    // specifiers so speculative `{...c, ...d} = e` matches can backtrack.
-    error := reordered.find .type is "Error"
+    // reorder may append Error node(s) on multi-rest; surface via children,
+    // skip in specifiers so speculative `{...c, ...d} = e` matches can backtrack.
+    errors := reordered.filter .type is "Error"
     specifiers := reordered.filter .type is undefined
     rest := reordered.find .type is "BindingRestProperty"
     names := specifiers.flatMap .binding.names
     if rest
       names.push(...rest.binding.names)
-    needsDesugar := !!rest || specifiers.some .pattern
 
     return {
       type: "Declaration",
-      children: error ? [...$0, error] : $0,
+      children: errors# ? [...$0, ...errors] : $0,
       names,
       specifiers,
       rest,
-      needsDesugar,
     }
 
 # `...rest` in named imports — triggers namespace+const desugar.
@@ -6355,7 +6353,7 @@ TypeAndImportSpecifier
   __ TypeKeyword ImportSpecifier ->
     // Flatten inner ImportSpecifier's children so reorderBindingRestProperty's
     // last-child-is-delim invariant holds when `...rest` shuffles past us.
-    return { ts: true, children: [$1, $2, ...$3.children], binding: $3.binding, pattern: $3.pattern, delim: $3.delim }
+    return { ts: true, children: [$1, $2, ...$3.children], ...$3.{binding, pattern, delim} }
   ImportSpecifier
   # `operator id` blesses `id` as operator; doesn't make sense with `type`
   __:ws Operator OperatorImportSpecifier:spec ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6353,7 +6353,7 @@ ImportAssertion
 # https://devblogs.microsoft.com/typescript/announcing-typescript-3-8-beta/#type-only-imports-exports
 TypeAndImportSpecifier
   __ TypeKeyword ImportSpecifier ->
-    return { ts: true, children: $0, binding: $3.binding, pattern: $3.pattern }
+    return { ts: true, children: $0, binding: $3.binding, pattern: $3.pattern, delim: $3.delim }
   ImportSpecifier
   # `operator id` blesses `id` as operator; doesn't make sense with `type`
   __:ws Operator OperatorImportSpecifier:spec ->

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -487,18 +487,12 @@ function dynamizeFromClause(from: any)
     from.push ", {", assert.keyword, ":", assert.object, "}"
   ["(", ...from, ")"]
 
-// Top-level `import {…, ...rest} from "x"` / `import {a: {b}} from "x"`
-// — rewrite to `import * as ref from "x"` plus a following `const {…} = ref`,
-// since native ESM `import {…}` doesn't allow rest or nested destructuring.
-// Returns the input unchanged when no desugar is needed.
+// Rewrite `import {…rest|nested}` to namespace import + const destructure.
 function desugarStaticImport(decl: ImportDeclaration)
   { imports, from, children } := decl
-  // `needsDesugar` only lives on ImportClauseNode (OperatorImportClauseNode
-  // never desugars), so the `in` check narrows the union to that branch.
+  // `in` narrows the union — only ImportClauseNode has `needsDesugar`.
   return decl unless imports and "needsDesugar" in imports and imports.needsDesugar
 
-  // The NamedImports node carrying `specifiers`/`rest` is either `imports`
-  // itself (no default) or its last child (default + named: `y, {…}`).
   namedImports := (imports.binding ? imports.children!.at(-1)! : imports) as ImportClauseNode
 
   ref := makeRef "imports"
@@ -512,7 +506,6 @@ function desugarStaticImport(decl: ImportDeclaration)
     star
   }
 
-  // Preserve `default,` prefix when present (e.g. `import y, {…}` → `import y, * as ref`).
   newImportsClause := if imports.binding
     {
       type: "Declaration"

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -492,12 +492,10 @@ function dynamizeFromClause(from: any)
 // since native ESM `import {…}` doesn't allow rest or nested destructuring.
 // Returns the input unchanged when no desugar is needed.
 function desugarStaticImport(decl: ImportDeclaration)
-  // `decl.imports` is typed as ASTNode at the parser level (OperatorNamedImports
-  // / NameSpaceImport variants have different specifier shapes) — narrow once
-  // so the rest of the function can read the import-clause fields directly.
-  { from, children } := decl
-  imports := decl.imports as ImportClauseNode?
-  return decl unless imports?.needsDesugar
+  { imports, from, children } := decl
+  // `needsDesugar` only lives on ImportClauseNode (OperatorImportClauseNode
+  // never desugars), so the `in` check narrows the union to that branch.
+  return decl unless imports and "needsDesugar" in imports and imports.needsDesugar
 
   // The NamedImports node carrying `specifiers`/`rest` is either `imports`
   // itself (no default) or its last child (default + named: `y, {…}`).

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -500,7 +500,7 @@ function desugarStaticImport(decl: ImportDeclaration)
   ref := makeRef "imports"
   star := { type: "Star", token: "*" }
 
-  allSpecs := namedImports.specifiers ?? []
+  allSpecs := namedImports.specifiers!
   tsSpecs := allSpecs.filter (s) => s.ts
   runtimeSpecs := allSpecs.filter (s) => not s.ts
 

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -10,6 +10,8 @@ import type {
   Declaration
   ExpressionNode
   IfStatement
+  ImportClauseNode
+  ImportDeclaration
   Initializer
   IterationStatement
   ParenthesizedExpression
@@ -489,13 +491,16 @@ function dynamizeFromClause(from: any)
 // — rewrite to `import * as ref from "x"` plus a following `const {…} = ref`,
 // since native ESM `import {…}` doesn't allow rest or nested destructuring.
 // Returns the input unchanged when no desugar is needed.
-function desugarStaticImport(decl: any)
-  { imports, from } := decl
+function desugarStaticImport(decl: ImportDeclaration)
+  // `decl.imports` is typed as ASTNode at the parser level — narrow once
+  // so the rest of the function can read the import-clause fields directly.
+  { from, children } := decl
+  imports := decl.imports as ImportClauseNode?
   return decl unless imports?.needsDesugar
 
   // The NamedImports node carrying `specifiers`/`rest` is either `imports`
   // itself (no default) or its last child (default + named: `y, {…}`).
-  namedImports := imports.binding ? imports.children.at(-1) : imports
+  namedImports := (imports.binding ? imports.children!.at(-1)! : imports) as ImportClauseNode
 
   ref := makeRef "imports"
   star := { type: "Star", token: "*" }
@@ -520,7 +525,7 @@ function desugarStaticImport(decl: any)
   else
     namespaceClause
 
-  newImportChildren := decl.children.map (c: any) => c is imports ? newImportsClause : c
+  newImportChildren := children!.map (c) => c is imports ? newImportsClause : c
 
   importDecl := {
     type: "ImportDeclaration"
@@ -544,7 +549,7 @@ function desugarStaticImport(decl: any)
     imports: newImportsClause
     from
     ts: decl.ts
-  }
+  } as ImportDeclaration
 
 function dynamizeImportDeclaration(decl: any)
   { imports } := decl

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -485,6 +485,67 @@ function dynamizeFromClause(from: any)
     from.push ", {", assert.keyword, ":", assert.object, "}"
   ["(", ...from, ")"]
 
+// Top-level `import {…, ...rest} from "x"` / `import {a: {b}} from "x"`
+// — rewrite to `import * as ref from "x"` plus a following `const {…} = ref`,
+// since native ESM `import {…}` doesn't allow rest or nested destructuring.
+// Returns the input unchanged when no desugar is needed.
+function desugarStaticImport(decl: any)
+  { imports, from } := decl
+  return decl unless imports?.needsDesugar
+
+  // The NamedImports node carrying `specifiers`/`rest` is either `imports`
+  // itself (no default) or its last child (default + named: `y, {…}`).
+  namedImports := imports.binding ? imports.children.at(-1) : imports
+
+  ref := makeRef "imports"
+  star := { type: "Star", token: "*" }
+
+  namespaceClause := {
+    type: "Declaration"
+    children: [star, " as ", ref]
+    names: [ref.id]
+    binding: ref
+    star
+  }
+
+  // Preserve `default,` prefix when present (e.g. `import y, {…}` → `import y, * as ref`).
+  newImportsClause := if imports.binding
+    {
+      type: "Declaration"
+      children: [imports.binding, ", ", namespaceClause]
+      names: [...imports.binding.names, ref.id]
+      binding: imports.binding
+      star
+    }
+  else
+    namespaceClause
+
+  newImportChildren := decl.children.map (c: any) => c is imports ? newImportsClause : c
+
+  importDecl := {
+    type: "ImportDeclaration"
+    children: newImportChildren
+    imports: newImportsClause
+    from
+    ts: decl.ts
+  }
+
+  pattern := convertNamedImportsToObject namedImports, true, "destructuring"
+  constDecl := {
+    type: "Declaration"
+    children: ["\nconst ", pattern, " = ", ref]
+    names: namedImports.names
+    decl: "const"
+  }
+
+  {
+    type: "ImportDeclaration"
+    children: [importDecl, constDecl]
+    imports: newImportsClause
+    from
+    ts: decl.ts
+  }
+
 function dynamizeImportDeclaration(decl: any)
   { imports } := decl
   { star, binding, specifiers } .= imports
@@ -638,6 +699,7 @@ function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSN
 
 export {
   convertWithClause
+  desugarStaticImport
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -490,17 +490,19 @@ function dynamizeFromClause(from: any)
 // Rewrite `import {…rest|nested}` to namespace import + const destructure.
 // Per-spec `type` imports get pulled into a separate native `import {type X}`
 // since a const-destructure can't bind types.
-function desugarStaticImport(decl: ImportDeclaration)
+function processStaticImport(decl: ImportDeclaration)
   { imports, from, children } := decl
-  // `in` narrows the union — only ImportClauseNode has `needsDesugar`.
-  return decl unless imports and "needsDesugar" in imports and imports.needsDesugar
+  // `"rest" in imports` narrows the union — only ImportClauseNode declares it.
+  return decl unless imports and "rest" in imports
 
   namedImports := (imports.binding ? imports.children!.at(-1)! : imports) as ImportClauseNode
+  allSpecs := namedImports.specifiers!
+  // Rewrite only when native ESM can't express the shape: rest or pattern bindings.
+  return decl unless namedImports.rest or allSpecs.some (s) => s.pattern
 
   ref := makeRef "imports"
   star := { type: "Star", token: "*" }
 
-  allSpecs := namedImports.specifiers!
   tsSpecs := allSpecs.filter (s) => s.ts
   runtimeSpecs := allSpecs.filter (s) => not s.ts
 
@@ -726,7 +728,7 @@ function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSN
 
 export {
   convertWithClause
-  desugarStaticImport
+  processStaticImport
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -488,6 +488,8 @@ function dynamizeFromClause(from: any)
   ["(", ...from, ")"]
 
 // Rewrite `import {…rest|nested}` to namespace import + const destructure.
+// Per-spec `type` imports get pulled into a separate native `import {type X}`
+// since a const-destructure can't bind types.
 function desugarStaticImport(decl: ImportDeclaration)
   { imports, from, children } := decl
   // `in` narrows the union — only ImportClauseNode has `needsDesugar`.
@@ -497,6 +499,19 @@ function desugarStaticImport(decl: ImportDeclaration)
 
   ref := makeRef "imports"
   star := { type: "Star", token: "*" }
+
+  allSpecs := namedImports.specifiers ?? []
+  tsSpecs := allSpecs.filter (s) => s.ts
+  runtimeSpecs := allSpecs.filter (s) => not s.ts
+
+  runtimeNames := runtimeSpecs.flatMap (s) => s.binding.names
+  if namedImports.rest
+    runtimeNames.push(...namedImports.rest.binding.names)
+  runtimeNamed := {
+    ...namedImports
+    specifiers: runtimeSpecs
+    names: runtimeNames
+  }
 
   namespaceClause := {
     type: "Declaration"
@@ -527,17 +542,32 @@ function desugarStaticImport(decl: ImportDeclaration)
     ts: decl.ts
   }
 
-  pattern := convertNamedImportsToObject namedImports, true, "destructuring"
+  pattern := convertNamedImportsToObject runtimeNamed, true, "destructuring"
   constDecl := {
     type: "Declaration"
     children: ["\nconst ", pattern, " = ", ref]
-    names: namedImports.names
+    names: runtimeNames
     decl: "const"
   }
 
+  typeImportDecl := if tsSpecs#
+    tsImports := {
+      type: "Declaration"
+      children: ["{", tsSpecs, "}"]
+      names: []
+      specifiers: tsSpecs
+    }
+    {
+      type: "ImportDeclaration"
+      children: ["import ", tsImports, " ", from, "\n"]
+      imports: tsImports
+      from
+      ts: true
+    }
+
   {
     type: "ImportDeclaration"
-    children: [importDecl, constDecl]
+    children: typeImportDecl ? [typeImportDecl, importDecl, constDecl] : [importDecl, constDecl]
     imports: newImportsClause
     from
     ts: decl.ts

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -492,7 +492,8 @@ function dynamizeFromClause(from: any)
 // since native ESM `import {…}` doesn't allow rest or nested destructuring.
 // Returns the input unchanged when no desugar is needed.
 function desugarStaticImport(decl: ImportDeclaration)
-  // `decl.imports` is typed as ASTNode at the parser level — narrow once
+  // `decl.imports` is typed as ASTNode at the parser level (OperatorNamedImports
+  // / NameSpaceImport variants have different specifier shapes) — narrow once
   // so the rest of the function can read the import-clause fields directly.
   { from, children } := decl
   imports := decl.imports as ImportClauseNode?

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -122,7 +122,7 @@ import {
 
 import {
   convertWithClause
-  desugarStaticImport
+  processStaticImport
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
@@ -2172,7 +2172,7 @@ export {
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
-  desugarStaticImport
+  processStaticImport
   duplicateBlock
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -122,6 +122,7 @@ import {
 
 import {
   convertWithClause
+  desugarStaticImport
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
@@ -970,10 +971,10 @@ function convertArrowFunctionToMethod(id: any, exp: any)
   exp
 
 // Convert NamedImports into equivalent ObjectExpression or ObjectBindingPattern
-function convertNamedImportsToObject(node: any, pattern?: boolean)
+function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynamic" | "destructuring" = "dynamic")
   properties := node.specifiers.map (specifier: any) =>
     if specifier.ts
-      { type: "Error", message: "cannot use `type` in dynamic import" }
+      { type: "Error", message: `cannot use \`type\` in ${kind} import` }
     else
       { source, binding } := specifier
       delim := specifier.children.-1
@@ -986,6 +987,10 @@ function convertNamedImportsToObject(node: any, pattern?: boolean)
           ? [ source, delim ]
           : [ source, ":", binding, delim ]
       }
+
+  // `{a, ...rest}` — the rest binding is only meaningful as a pattern.
+  if node.rest and pattern
+    properties.push node.rest
 
   {
     type: pattern ? "ObjectBindingPattern" : "ObjectExpression"
@@ -2168,6 +2173,7 @@ export {
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
+  desugarStaticImport
   duplicateBlock
   dynamizeImportDeclaration
   dynamizeImportDeclarationExpression

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -988,7 +988,6 @@ function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynami
           : [ source, ":", binding, delim ]
       }
 
-  // `{a, ...rest}` — the rest binding is only meaningful as a pattern.
   if node.rest and pattern
     properties.push node.rest
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -727,49 +727,32 @@ export type BlockStatement = ASTParent &
 export type ImportDeclaration = ASTParent &
   type: "ImportDeclaration"
   ts?: boolean
-  // Two clause flavors: standard ESM imports vs Civet's `import operator …`
-  // syntax which uses a separate specifier shape.
   imports?: ImportClauseNode | OperatorImportClauseNode
   from?: ASTNode
-  /**
-   * Set by the bare `import "./mod"` parser alternative (no clause, no
-   * bindings) — carries the module specifier directly so downstream code
-   * can detect side-effect imports without re-parsing `children`.
-   */
+  /** Set only for bare side-effect imports (`import "./mod"`). */
   module?: ModuleSpecifier
 
-/**
- * One element inside `import {…}` — either a `{name}` / `{name: alias}` /
- * `{name as alias}` specifier (possibly with a `BindingPattern` alias for
- * the destructuring-style form) or a `...rest`.  Used as the parsed
- * intermediate; `pattern: true` signals to ImportDeclaration that the
- * import needs the namespace-import + const-destructure desugaring.
- * Only the fields the NamedImports action reads are modeled here;
- * `delim` etc. flow through reorderBindingRestProperty's `any` input.
- */
+/** Element inside `import {…}` — a specifier or `...rest`. */
 export type NamedImportElement =
   & ASTParent
   & { binding: ASTNodeObject & { names: string[] } }
   & ( { type: "BindingRestProperty", dots: ASTLeaf }
-    | { type?: undefined, pattern: boolean, source?: ASTNodeObject, ts?: boolean } )
+    | {
+        type?: undefined
+        /** True when `binding` is a BindingPattern; forces desugar. */
+        pattern: boolean
+        source?: ASTNodeObject
+        ts?: boolean
+      } )
 
-/**
- * One element inside `import operator {…}` — a Civet-specific shape.
- * `behavior` carries the parsed precedence/associativity (or undefined
- * when the cluster-level OperatorBehavior applies).
- */
+/** Element inside `import operator {…}`. */
 export type OperatorImportSpecifier =
   ASTParent &
     binding: ASTNodeObject & { names: string[] }
+    /** Per-specifier precedence/associativity; falls back to cluster's. */
     behavior?: ASTNodeObject
 
-/**
- * The clause between `import` and `from` — the union of NameSpaceImport,
- * NamedImports, and ImportClause (default + named/namespace) shapes. All
- * have `type: "Declaration"` with overlapping optional fields.
- * `needsDesugar` is set by NamedImports / ImportClause when the contents
- * need namespace+const desugaring.
- */
+/** Clause between `import` and `from` (default, namespace, named, or combos). */
 export type ImportClauseNode = ASTParent &
   type: "Declaration"
   names: string[]
@@ -777,13 +760,10 @@ export type ImportClauseNode = ASTParent &
   star?: Star
   specifiers?: NamedImportElement[]
   rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
+  /** True when contents need namespace-import + const-destructure rewrite. */
   needsDesugar?: boolean
 
-/**
- * The clause produced by OperatorNamedImports — `import operator {…}`.
- * Distinct from ImportClauseNode because the specifier shape differs
- * (no `source`, `pattern`, `delim`, `ts`; has `behavior`).
- */
+/** Clause for `import operator {…}` — separate specifier shape from ImportClauseNode. */
 export type OperatorImportClauseNode = ASTParent &
   type: "Declaration"
   names: string[]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -727,7 +727,7 @@ export type BlockStatement = ASTParent &
 export type ImportDeclaration = ASTParent &
   type: "ImportDeclaration"
   ts?: boolean
-  imports?: ASTNode
+  imports?: ASTNode  // see ImportClauseNode below — kept as ASTNode for now because OperatorNamedImports / NameSpaceImport carry different specifier shapes
   from?: ASTNode
   /**
    * Set by the bare `import "./mod"` parser alternative (no clause, no

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -760,8 +760,6 @@ export type ImportClauseNode = ASTParent &
   star?: Star
   specifiers?: Extract<NamedImportElement, { type?: undefined }>[]
   rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
-  /** True when contents need namespace-import + const-destructure rewrite. */
-  needsDesugar?: boolean
 
 /** Clause for `import operator {…}` — separate specifier shape from ImportClauseNode. */
 export type OperatorImportClauseNode = ASTParent &

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -745,9 +745,9 @@ export type ImportDeclaration = ASTParent &
  */
 export type NamedImportElement =
   & ASTParent
-  & ( { type: "BindingRestProperty", binding: ASTNodeObject, dots: ASTLeaf, delim: ASTNode }
-    | { type?: undefined, binding: ASTNodeObject, pattern: boolean, delim: ASTNode,
-        source?: ASTNodeObject, ts?: boolean } )
+  & { binding: ASTNodeObject & { names: string[] }, delim: ASTNode }
+  & ( { type: "BindingRestProperty", dots: ASTLeaf }
+    | { type?: undefined, pattern: boolean, source?: ASTNodeObject, ts?: boolean } )
 
 export type ExportDeclaration = ASTParent &
   type: "ExportDeclaration"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -736,6 +736,19 @@ export type ImportDeclaration = ASTParent &
    */
   module?: ModuleSpecifier
 
+/**
+ * One element inside `import {…}` — either a `{name}` / `{name: alias}` /
+ * `{name as alias}` specifier (possibly with a `BindingPattern` alias for
+ * the destructuring-style form) or a `...rest`.  Used as the parsed
+ * intermediate; `pattern: true` signals to ImportDeclaration that the
+ * import needs the namespace-import + const-destructure desugaring.
+ */
+export type NamedImportElement =
+  & ASTParent
+  & ( { type: "BindingRestProperty", binding: ASTNodeObject, dots: ASTLeaf, delim: ASTNode }
+    | { type?: undefined, binding: ASTNodeObject, pattern: boolean, delim: ASTNode,
+        source?: ASTNodeObject, ts?: boolean } )
+
 export type ExportDeclaration = ASTParent &
   type: "ExportDeclaration"
   ts?: boolean

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -742,10 +742,12 @@ export type ImportDeclaration = ASTParent &
  * the destructuring-style form) or a `...rest`.  Used as the parsed
  * intermediate; `pattern: true` signals to ImportDeclaration that the
  * import needs the namespace-import + const-destructure desugaring.
+ * Only the fields the NamedImports action reads are modeled here;
+ * `delim` etc. flow through reorderBindingRestProperty's `any` input.
  */
 export type NamedImportElement =
   & ASTParent
-  & { binding: ASTNodeObject & { names: string[] }, delim: ASTNode }
+  & { binding: ASTNodeObject & { names: string[] } }
   & ( { type: "BindingRestProperty", dots: ASTLeaf }
     | { type?: undefined, pattern: boolean, source?: ASTNodeObject, ts?: boolean } )
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -751,6 +751,22 @@ export type NamedImportElement =
   & ( { type: "BindingRestProperty", dots: ASTLeaf }
     | { type?: undefined, pattern: boolean, source?: ASTNodeObject, ts?: boolean } )
 
+/**
+ * The clause between `import` and `from` — the union of NameSpaceImport,
+ * NamedImports, and ImportClause (default + named/namespace) shapes. All
+ * have `type: "Declaration"` with overlapping optional fields.
+ * `needsDesugar` is set by NamedImports / ImportClause when the contents
+ * need namespace+const desugaring.
+ */
+export type ImportClauseNode = ASTParent &
+  type: "Declaration"
+  names: string[]
+  binding?: ASTNodeObject & { names: string[] }
+  star?: Star
+  specifiers?: NamedImportElement[]
+  rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
+  needsDesugar?: boolean
+
 export type ExportDeclaration = ASTParent &
   type: "ExportDeclaration"
   ts?: boolean

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -758,7 +758,7 @@ export type ImportClauseNode = ASTParent &
   names: string[]
   binding?: ASTNodeObject & { names: string[] }
   star?: Star
-  specifiers?: NamedImportElement[]
+  specifiers?: Extract<NamedImportElement, { type?: undefined }>[]
   rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
   /** True when contents need namespace-import + const-destructure rewrite. */
   needsDesugar?: boolean

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -727,7 +727,9 @@ export type BlockStatement = ASTParent &
 export type ImportDeclaration = ASTParent &
   type: "ImportDeclaration"
   ts?: boolean
-  imports?: ASTNode  // see ImportClauseNode below — kept as ASTNode for now because OperatorNamedImports / NameSpaceImport carry different specifier shapes
+  // Two clause flavors: standard ESM imports vs Civet's `import operator …`
+  // syntax which uses a separate specifier shape.
+  imports?: ImportClauseNode | OperatorImportClauseNode
   from?: ASTNode
   /**
    * Set by the bare `import "./mod"` parser alternative (no clause, no
@@ -752,6 +754,16 @@ export type NamedImportElement =
     | { type?: undefined, pattern: boolean, source?: ASTNodeObject, ts?: boolean } )
 
 /**
+ * One element inside `import operator {…}` — a Civet-specific shape.
+ * `behavior` carries the parsed precedence/associativity (or undefined
+ * when the cluster-level OperatorBehavior applies).
+ */
+export type OperatorImportSpecifier =
+  ASTParent &
+    binding: ASTNodeObject & { names: string[] }
+    behavior?: ASTNodeObject
+
+/**
  * The clause between `import` and `from` — the union of NameSpaceImport,
  * NamedImports, and ImportClause (default + named/namespace) shapes. All
  * have `type: "Declaration"` with overlapping optional fields.
@@ -766,6 +778,16 @@ export type ImportClauseNode = ASTParent &
   specifiers?: NamedImportElement[]
   rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
   needsDesugar?: boolean
+
+/**
+ * The clause produced by OperatorNamedImports — `import operator {…}`.
+ * Distinct from ImportClauseNode because the specifier shape differs
+ * (no `source`, `pattern`, `delim`, `ts`; has `behavior`).
+ */
+export type OperatorImportClauseNode = ASTParent &
+  type: "Declaration"
+  names: string[]
+  specifiers: OperatorImportSpecifier[]
 
 export type ExportDeclaration = ASTParent &
   type: "ExportDeclaration"

--- a/test/import.civet
+++ b/test/import.civet
@@ -511,6 +511,61 @@ describe "import", ->
     """
 
     testCase """
+      dynamic import declaration with rest
+      ---
+      =>
+        {a, ...rest} from bar
+      ---
+      async () => {
+        const {a, ...rest} = await import ("bar");return {a, ...rest}
+      }
+    """
+
+    testCase """
+      dynamic import declaration with nested destructuring
+      ---
+      =>
+        {a: {b, c}} from bar
+      ---
+      async () => {
+        const {a:{b, c}} = await import ("bar");return {a:{b, c}}
+      }
+    """
+
+    testCase """
+      dynamic import declaration with nested and rest
+      ---
+      =>
+        {a, b: {c, d}, ...rest} from bar
+      ---
+      async () => {
+        const {a,b:{c, d}, ...rest} = await import ("bar");return {a,b:{c, d}, ...rest}
+      }
+    """
+
+    testCase """
+      dynamic import declaration with rest in any position
+      ---
+      =>
+        {...rest, a, b} from bar
+      ---
+      async () => {
+        const {a,b,...rest} = await import ("bar");return {a,b,...rest}
+      }
+    """
+
+    testCase """
+      dynamic import declaration with default and rest
+      ---
+      =>
+        foo, {a, ...rest} from bar
+      ---
+      async () => {
+        const ref = await import ("bar"), foo = ref.default, {a, ...rest} = ref;return {a, ...rest}
+      }
+    """
+
+    testCase """
       one-line dynamic import declaration, implicit
       ---
       => foo from bar

--- a/test/import.civet
+++ b/test/import.civet
@@ -57,6 +57,128 @@ describe "import", ->
     import {x as a, y as b} from "./y"
   """
 
+  describe "destructuring-style", ->
+    testCase """
+      rest only
+      ---
+      import {...rest} from "./y"
+      ---
+      import * as imports from "./y"
+      const {...rest} = imports
+    """
+
+    testCase """
+      named with rest
+      ---
+      import {a, b, ...rest} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a,b, ...rest} = imports
+    """
+
+    testCase """
+      rest in any position (leading)
+      ---
+      import {...rest, a, b} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a,b,...rest} = imports
+    """
+
+    testCase """
+      rest in any position (middle)
+      ---
+      import {a, ...rest, b} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a,b, ...rest} = imports
+    """
+
+    testCase """
+      renamed with rest
+      ---
+      import {a: a1, b: b1, ...rest} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a:a1,b:b1, ...rest} = imports
+    """
+
+    testCase """
+      default plus named with rest
+      ---
+      import y, {a, ...rest} from "./y"
+      ---
+      import y, * as imports from "./y"
+      const {a, ...rest} = imports
+    """
+
+    testCase """
+      nested destructuring
+      ---
+      import {a: {b, c}} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a:{b, c}} = imports
+    """
+
+    testCase """
+      nested destructuring with `as`
+      ---
+      import {a as {b, c}} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a:{b, c}} = imports
+    """
+
+    testCase """
+      nested array destructuring
+      ---
+      import {a: [b, c]} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a:[b, c]} = imports
+    """
+
+    testCase """
+      deep nested destructuring
+      ---
+      import {a: {b: {c}}} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a:{b: {c}}} = imports
+    """
+
+    testCase """
+      named, nested, and rest combined
+      ---
+      import {a, b: {c, d}, ...rest} from "./y"
+      ---
+      import * as imports from "./y"
+      const {a,b:{c, d}, ...rest} = imports
+    """
+
+    testCase """
+      multi-line with rest
+      ---
+      import {
+        a
+        b
+        ...rest
+      } from "./y"
+      ---
+      import * as imports from "./y"
+      const {a,b,
+        ...rest} = imports
+    """
+
+    throws """
+      type specifier with rest is rejected
+      ---
+      import {a, type T, ...rest} from "./y"
+      ---
+      ParseErrors: unknown:1:11 cannot use `type` in destructuring import
+    """
+
   testCase """
     multi-line import block
     ---

--- a/test/import.civet
+++ b/test/import.civet
@@ -179,6 +179,14 @@ describe "import", ->
       ParseErrors: unknown:1:11 cannot use `type` in destructuring import
     """
 
+    throws """
+      type specifier after rest is rejected
+      ---
+      import {...rest, type T} from "./y"
+      ---
+      ParseErrors: unknown:1:9 cannot use `type` in destructuring import
+    """
+
   testCase """
     multi-line import block
     ---

--- a/test/import.civet
+++ b/test/import.civet
@@ -171,20 +171,34 @@ describe "import", ->
         ...rest} = imports
     """
 
-    throws """
-      type specifier with rest is rejected
+    testCase """
+      type specifier with rest split into native type import
       ---
       import {a, type T, ...rest} from "./y"
       ---
-      ParseErrors: unknown:1:11 cannot use `type` in destructuring import
+      import { type T,} from "./y"
+      import * as imports from "./y"
+      const {a, ...rest} = imports
     """
 
-    throws """
-      type specifier after rest is rejected
+    testCase """
+      type specifier after rest
       ---
       import {...rest, type T} from "./y"
       ---
-      ParseErrors: unknown:1:9 cannot use `type` in destructuring import
+      import { type T,} from "./y"
+      import * as imports from "./y"
+      const {...rest} = imports
+    """
+
+    testCase """
+      renamed type specifier with rest
+      ---
+      import {type T: T2, ...rest} from "./y"
+      ---
+      import {type T as T2,} from "./y"
+      import * as imports from "./y"
+      const { ...rest} = imports
     """
 
   testCase """


### PR DESCRIPTION
Closes #175.

## Summary

`import {a, ...rest, b} from "./y"` and `import {a: {b, c}} from "./y"` desugar to a namespace import plus a const destructure, since native ESM can't express rest or nested destructuring inside `import {…}`:

```civet
import {a: a1, b: b1, ...rest} from "./y"
↓
import * as imports from "./y"
const {a:a1,b:b1, ...rest} = imports
```

Plain `import {x, y}` and `import {x: y}` still emit native ESM — the desugar only fires when a rest element or pattern-binding is present.

Rest can appear in any position (`{...rest, a}`, `{a, ...rest, b}`); the parser reuses Civet's existing `reorderBindingRestProperty` to normalize it to the tail, matching the destructuring convention.

## Scope

Implements the rest and nested cases. Deferred (would be follow-ups):
- `rest.T` rewriting in type position
- `type {T} = module` syntax
- `import "./x" as {…}` (overlaps with #320)

## Test plan

- [x] `pnpm test` — 4032 passing (12 new cases in `test/import.civet` under `describe "destructuring-style"`)
- [x] `pnpm test:self` — 4032 passing (Civet compiles itself)
- [x] `pnpm typecheck` — net +0 vs main