### PR TITLE
Grammar: align `const`/`let`/`var` and template-expression scopes with JS

### DIFF
--- a/lsp/vscode/CHANGELOG.md
+++ b/lsp/vscode/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Civet VS Code Extension Changelog
+
+Changes to the VS Code extension and its bundled language server.
+For pre-0.3.36 history, see the [root changelog](../../CHANGELOG.md),
+where LSP and VS Code PRs are tracked alongside compiler changes.
+
+## 0.3.36 (2026-05-22)
+* Grammar: align `const`/`let`/`var` and template-expression scopes with JS [[#2094](https://github.com/DanielXMoore/Civet/pull/2094)]

--- a/lsp/vscode/CHANGELOG.md
+++ b/lsp/vscode/CHANGELOG.md
@@ -1,8 +1,102 @@
 # Civet VS Code Extension Changelog
 
-Changes to the VS Code extension and its bundled language server.
-For pre-0.3.36 history, see the [root changelog](../../CHANGELOG.md),
-where LSP and VS Code PRs are tracked alongside compiler changes.
-
 ## 0.3.36 (2026-05-22)
 * Grammar: align `const`/`let`/`var` and template-expression scopes with JS [[#2094](https://github.com/DanielXMoore/Civet/pull/2094)]
+* Add `vscode-tmgrammar-test` harness for TextMate grammar regressions
+
+## 0.3.35 (2026-05-18)
+* LSP: implement `workspace/symbol` [[#2049](https://github.com/DanielXMoore/Civet/pull/2049)]
+* LSP: skip semantic tokens in unmapped TS prelude code [[#2070](https://github.com/DanielXMoore/Civet/pull/2070)]
+* LSP: emit semantic tokens for import binding names [[#2071](https://github.com/DanielXMoore/Civet/pull/2071)]
+* LSP: fix missing line/column info by unwrapping `ParseErrors` [[#2075](https://github.com/DanielXMoore/Civet/pull/2075)]
+* LSP: warn + narrow scope when project has no `tsconfig.json` [[#2078](https://github.com/DanielXMoore/Civet/pull/2078)]
+* LSP: add handlers for `signatureHelp`, `prepareRename`, `documentHighlight`, `typeDefinition`, `implementation`, `foldingRange`, `selectionRange`, `linkedEditingRange` [[#2069](https://github.com/DanielXMoore/Civet/pull/2069)]
+
+## 0.3.34 (2026-05-08)
+* VS Code: support `lang="civet"` in Svelte components [[#2021](https://github.com/DanielXMoore/Civet/pull/2021)]
+* VS Code: basic syntax highlighting for `type` and `interface` [[#2022](https://github.com/DanielXMoore/Civet/pull/2022)]
+* LSP: fix `@` shorthand incorrectly completing as `@this.member` [[#2032](https://github.com/DanielXMoore/Civet/pull/2032)]
+* LSP: fix `@` completion in implicit-return context [[#2034](https://github.com/DanielXMoore/Civet/pull/2034)]
+* LSP: auto-indent on Enter for Civet block-openers [[#2043](https://github.com/DanielXMoore/Civet/pull/2043)]
+* Monaco and browser LSP support; LSP in the Playground [[#2044](https://github.com/DanielXMoore/Civet/pull/2044)]
+  * **Breaking** for direct LSP users (e.g. Neovim): use `dist/node.js` instead of `dist/server.js`.
+
+## 0.3.33 (2026-04-25)
+* Auto-publish to VS Code Marketplace and Open VSX on version bump [[#1963](https://github.com/DanielXMoore/Civet/pull/1963)]
+* Extract LSP into standalone `@danielx/civet-language-server` package [[#1950](https://github.com/DanielXMoore/Civet/pull/1950)]
+* LSP: auto-import when selecting completions [[#1956](https://github.com/DanielXMoore/Civet/pull/1956)]
+* LSP: TypeScript-classifier-based semantic tokens [[#1881](https://github.com/DanielXMoore/Civet/pull/1881)]
+* LSP: semantic tokens for comments, fixing `coffeeComment` highlighting [[#2011](https://github.com/DanielXMoore/Civet/pull/2011)]
+* LSP: auto-reload `TSService` when `tsconfig.json` changes [[#1965](https://github.com/DanielXMoore/Civet/pull/1965)]
+* LSP: clear stale diagnostics on document close/delete [[#1980](https://github.com/DanielXMoore/Civet/pull/1980)]
+* Bump VS Code engine and Node requirements (Node ≥ 23, VS Code ≥ 1.115)
+
+## 0.3.30 (2026-03-07)
+* Use `vscode-uri` to canonicalize file paths consistently across platforms
+* Improve LSP behavior on Windows
+
+## 0.3.29 (2025-12-10)
+* Update `@types/node` and refactor `setTimeout` import for compatibility
+* New setting: `civet.langServer.includeTypescript` controls whether the
+  LSP attaches to `.js`/`.ts` files (set to `false` to avoid duplicate
+  definitions when another TypeScript server is active)
+* TextMate grammar refinements driven by configuration
+
+## 0.3.28 (2025-02-24)
+* Set extension category for VS Code marketplace listing
+* LSP: async config loads so restarting `tsserver` no longer surfaces transient `parseOptions` errors
+
+## 0.3.27 (2024-12-31)
+* Update bundled TypeScript
+
+## 0.3.26 (2024-11-11)
+* Maintenance release
+
+## 0.3.25 (2024-11-01)
+* Maintenance release
+
+## 0.3.24 (2024-10-30)
+* Maintenance release
+
+## 0.3.23 (2024-10-26)
+* Maintenance release
+
+## 0.3.22 (2024-10-25)
+* Maintenance release
+
+## 0.3.21 (2024-10-16)
+* Maintenance release
+
+## 0.3.20 (2024-10-16)
+* Maintenance release
+
+## 0.3.19 (2024-10-06)
+* New Civet icon
+* Dependency updates (mocha, etc.)
+
+## 0.3.17 (2024-06-26)
+* LSP improvements
+
+## 0.3.16 (2024-05-28)
+* LSP improvements
+
+## 0.3.15 (2024-05-07)
+* LSP improvements
+
+## 0.3.14 (2024-02-26)
+* LSP improvements
+
+## 0.3.13 (2024-02-22)
+* LSP improvements
+
+## 0.3.7 (2023-07-30)
+* LSP improvements
+
+## 0.3.6 (2023-02-04)
+* LSP improvements
+
+## 0.3.3 (2022-12-29)
+* LSP improvements
+
+## 0.3.0 (2022-12-13)
+* Initial 0.3 release: standalone Civet Language Server backing the VS Code extension

--- a/lsp/vscode/CHANGELOG.md
+++ b/lsp/vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Civet VS Code Extension Changelog
 
+> Pre-0.3.33 releases were published from the `lsp/` directory (which
+> contained the combined extension + language server). From 2026-04-13
+> the layout was reorganized to separate packages: `lsp/server/` for the
+> language server, `lsp/vscode/` for this extension, `lsp/monaco/`,
+> `lsp/zed/`, and `lsp/tree-sitter/`.
+
 ## 0.3.36 (2026-05-22)
 * Grammar: align `const`/`let`/`var` and template-expression scopes with JS [[#2094](https://github.com/DanielXMoore/Civet/pull/2094)]
 * Add `vscode-tmgrammar-test` harness for TextMate grammar regressions
@@ -23,80 +29,126 @@
 
 ## 0.3.33 (2026-04-25)
 * Auto-publish to VS Code Marketplace and Open VSX on version bump [[#1963](https://github.com/DanielXMoore/Civet/pull/1963)]
-* Extract LSP into standalone `@danielx/civet-language-server` package [[#1950](https://github.com/DanielXMoore/Civet/pull/1950)]
-* LSP: auto-import when selecting completions [[#1956](https://github.com/DanielXMoore/Civet/pull/1956)]
+* Extract language server into standalone `@danielx/civet-language-server` package [[#1950](https://github.com/DanielXMoore/Civet/pull/1950)]
+* Reorganize repository: extension moves from `lsp/` → `lsp/vscode/`
 * LSP: TypeScript-classifier-based semantic tokens [[#1881](https://github.com/DanielXMoore/Civet/pull/1881)]
 * LSP: semantic tokens for comments, fixing `coffeeComment` highlighting [[#2011](https://github.com/DanielXMoore/Civet/pull/2011)]
+* LSP: auto-import when selecting completions [[#1956](https://github.com/DanielXMoore/Civet/pull/1956)]
 * LSP: auto-reload `TSService` when `tsconfig.json` changes [[#1965](https://github.com/DanielXMoore/Civet/pull/1965)]
 * LSP: clear stale diagnostics on document close/delete [[#1980](https://github.com/DanielXMoore/Civet/pull/1980)]
 * Bump VS Code engine and Node requirements (Node ≥ 23, VS Code ≥ 1.115)
 
 ## 0.3.30 (2026-03-07)
-* Use `vscode-uri` to canonicalize file paths consistently across platforms
-* Improve LSP behavior on Windows
+
+> Last release published from the legacy `lsp/` directory.
+
+* LSP: use `vscode-uri` to canonicalize file paths consistently across platforms
+* LSP: import completion for module exports, TypeScript path aliases, and relative paths
+* LSP: autocomplete closing quote, fix quote closing and space triggering
+* LSP: handle TypeScript service crashes gracefully
+* LSP: completion at end of file
+* Improve import/export keyword highlighting
+* Bump VS Code and Node engine requirements
 
 ## 0.3.29 (2025-12-10)
-* Update `@types/node` and refactor `setTimeout` import for compatibility
-* New setting: `civet.langServer.includeTypescript` controls whether the
-  LSP attaches to `.js`/`.ts` files (set to `false` to avoid duplicate
-  definitions when another TypeScript server is active)
-* TextMate grammar refinements driven by configuration
+* LSP: rename-symbol support
+* LSP: new setting `civet.langServer.includeTypescript` (default `true`) — set to `false` to prevent duplicate definitions when another TypeScript server is attached to `.js`/`.ts` files
+* LSP: refactor `executeQueue` to group document updates by project, reducing conflicts
+* LSP: async `TSService` so restarting `tsserver` no longer surfaces transient errors
+* LSP: ensure immediate diagnostic updates for dependent files on change
+* TextMate grammar re-applies on config change without needing a reload
 
 ## 0.3.28 (2025-02-24)
+* LSP: fix opening files without a workspace
 * Set extension category for VS Code marketplace listing
-* LSP: async config loads so restarting `tsserver` no longer surfaces transient `parseOptions` errors
+* LSP: async config loads to eliminate startup `parseOptions` errors
+* Document how to use the VS Code plugin
 
 ## 0.3.27 (2024-12-31)
 * Update bundled TypeScript
+* Preserve `SourceMap` class through the Civet worker
 
 ## 0.3.26 (2024-11-11)
-* Maintenance release
+* Fix autocompletion details error message
+* Highlight import expression and module reference for `export`/`import`
+* Numeric syntax allows underscore separators (e.g. `9_999_999`)
 
 ## 0.3.25 (2024-11-01)
-* Maintenance release
+* LSP completions show details and documentation
 
 ## 0.3.24 (2024-10-30)
-* Maintenance release
+* LSP restarts when `package.json` or Civet config file changes
+* Fix `WithResolver` return type
 
 ## 0.3.23 (2024-10-26)
-* Maintenance release
+* Remove completion `triggerCharacters` (didn't tolerate fault-tolerant compile)
 
 ## 0.3.22 (2024-10-25)
-* Maintenance release
+* Fix completions and hover quickinfo regressions
+* Fix `tsconfig.json` naming issue
+* Wait for document update across all hooks
+* Show correct LSP version number in logs
+* Fix CLI with complex `NODE_OPTIONS`
 
 ## 0.3.21 (2024-10-16)
-* Maintenance release
+* Add `skipLibCheck` in lib `tsconfig`
 
 ## 0.3.20 (2024-10-16)
-* Maintenance release
+* Improve project root detection in LSP
 
 ## 0.3.19 (2024-10-06)
-* New Civet icon
-* Dependency updates (mocha, etc.)
+* New Civet extension icon
+* Fix unplugin `parseOptions`; fix ESLint plugin on Node 22
+* Stop registering for `.coffee` files
+* Update dependencies
 
 ## 0.3.17 (2024-06-26)
-* LSP improvements
+* Upgrade bundled TypeScript
 
 ## 0.3.16 (2024-05-28)
-* LSP improvements
+* Show diagnostics for nonfatal Civet parse errors with location info in the editor
+* Fix source mapping for Civet parse errors
+* Update Civet and TypeScript dependencies
 
 ## 0.3.15 (2024-05-07)
-* LSP improvements
+* Add LSP warning when running against a dev build of Civet
+* Improve log feedback in VS Code plugin
+* `sync: true` Civet API option
 
 ## 0.3.14 (2024-02-26)
-* LSP improvements
+* Improve source mapping
 
 ## 0.3.13 (2024-02-22)
-* LSP improvements
+* Improve forward mapping (fixes #1053)
+* Experimental Hera types in Civet LSP
+* Fix non-transpiled files not being added to the path map (so they refresh on update)
+* Snapshot model similar to Vue language tools
+* Report error nodes in LSP
+* Richer completion info
+* Support importing directories with `index.civet`
+
+## 0.3.11 (2024-01-16)
+* Support TypeScript `paths` alias
+* Add angle brackets to surrounding pairs
+* Bracket/comments matching
+* Reset service when `tsconfig` changes (fixes #72)
+* Implement `references` (Find All References) [[#801](https://github.com/DanielXMoore/Civet/pull/801)]
 
 ## 0.3.7 (2023-07-30)
-* LSP improvements
+* Maintenance release
 
 ## 0.3.6 (2023-02-04)
-* LSP improvements
+* Maintenance release
 
 ## 0.3.3 (2022-12-29)
-* LSP improvements
+* Maintenance release
 
 ## 0.3.0 (2022-12-13)
-* Initial 0.3 release: standalone Civet Language Server backing the VS Code extension
+
+> Initial 0.3 release of the standalone Civet Language Server backing the
+> VS Code extension. Earlier exploratory commits trace back to the first
+> "Starting vscode extension" commit on 2022-08-23.
+
+* Standalone Civet Language Server
+* Civet syntax highlighting (originally adapted from CoffeeScript)
+* Basic hover and completion via the TypeScript service

--- a/lsp/vscode/CHANGELOG.md
+++ b/lsp/vscode/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Civet VS Code Extension Changelog
 
-> Pre-0.3.33 releases were published from the `lsp/` directory (which
-> contained the combined extension + language server). From 2026-04-13
-> the layout was reorganized to separate packages: `lsp/server/` for the
-> language server, `lsp/vscode/` for this extension, `lsp/monaco/`,
-> `lsp/zed/`, and `lsp/tree-sitter/`.
-
 ## 0.3.36 (2026-05-22)
 * Grammar: align `const`/`let`/`var` and template-expression scopes with JS [[#2094](https://github.com/DanielXMoore/Civet/pull/2094)]
 * Add `vscode-tmgrammar-test` harness for TextMate grammar regressions
@@ -30,7 +24,6 @@
 ## 0.3.33 (2026-04-25)
 * Auto-publish to VS Code Marketplace and Open VSX on version bump [[#1963](https://github.com/DanielXMoore/Civet/pull/1963)]
 * Extract language server into standalone `@danielx/civet-language-server` package [[#1950](https://github.com/DanielXMoore/Civet/pull/1950)]
-* Reorganize repository: extension moves from `lsp/` → `lsp/vscode/`
 * LSP: TypeScript-classifier-based semantic tokens [[#1881](https://github.com/DanielXMoore/Civet/pull/1881)]
 * LSP: semantic tokens for comments, fixing `coffeeComment` highlighting [[#2011](https://github.com/DanielXMoore/Civet/pull/2011)]
 * LSP: auto-import when selecting completions [[#1956](https://github.com/DanielXMoore/Civet/pull/1956)]
@@ -39,9 +32,6 @@
 * Bump VS Code engine and Node requirements (Node ≥ 23, VS Code ≥ 1.115)
 
 ## 0.3.30 (2026-03-07)
-
-> Last release published from the legacy `lsp/` directory.
-
 * LSP: use `vscode-uri` to canonicalize file paths consistently across platforms
 * LSP: import completion for module exports, TypeScript path aliases, and relative paths
 * LSP: autocomplete closing quote, fix quote closing and space triggering
@@ -144,11 +134,6 @@
 * Maintenance release
 
 ## 0.3.0 (2022-12-13)
-
-> Initial 0.3 release of the standalone Civet Language Server backing the
-> VS Code extension. Earlier exploratory commits trace back to the first
-> "Starting vscode extension" commit on 2022-08-23.
-
-* Standalone Civet Language Server
+* Initial release of the Civet Language Server backing the VS Code extension
 * Civet syntax highlighting (originally adapted from CoffeeScript)
 * Basic hover and completion via the TypeScript service

--- a/lsp/vscode/grammar-tests/numeric.civet
+++ b/lsp/vscode/grammar-tests/numeric.civet
@@ -1,0 +1,20 @@
+// SYNTAX TEST "source.civet" "numeric literals with underscore separators"
+
+// Issue #266: `9_999_999_999_999` was being scoped as `invalid.illegal.identifier`
+// instead of `constant.numeric.decimal`. The decimal rule already supports
+// underscore separators in its regex, but the `\d[\w$]*` invalid-identifier
+// rule must not preempt it.
+
+x := 9_999_999_999_999
+//   ^^^^^^^^^^^^^^^^^ constant.numeric.decimal.civet
+//   ^^^^^^^^^^^^^^^^^ - invalid.illegal.identifier.civet
+
+y := 1_000
+//   ^^^^^ constant.numeric.decimal.civet
+//   ^^^^^ - invalid.illegal.identifier.civet
+
+z := 1_000_000.5
+//   ^^^^^^^^^^^ constant.numeric.decimal.civet
+
+hex := 0xFF_FF
+//     ^^^^^^^ constant.numeric.hex.civet

--- a/lsp/vscode/grammar-tests/storage-type.civet
+++ b/lsp/vscode/grammar-tests/storage-type.civet
@@ -1,0 +1,20 @@
+// SYNTAX TEST "source.civet" "storage.type for declaration keywords"
+
+// Issue #266: `const` should be `storage.type` (matching JS), not generic
+// `keyword.reserved`. Same for `let` and `var`.
+
+const a = 1
+// <----- storage.type.civet
+// <----- - keyword.reserved.civet
+
+let b = 2
+// <--- storage.type.civet
+
+var c = 3
+// <--- storage.type.civet
+
+// Other reserved words that are not declarations stay as keyword.reserved.
+// (`function` is also a declaration keyword in JS but is intentionally left
+// alone here — Civet rarely uses it.)
+enum E
+// <---- keyword.reserved.civet

--- a/lsp/vscode/grammar-tests/template-expression.civet
+++ b/lsp/vscode/grammar-tests/template-expression.civet
@@ -1,0 +1,18 @@
+// SYNTAX TEST "source.civet" "template-expression punctuation"
+
+// Issue #266: `${` and `}` inside a template literal should be
+// `punctuation.definition.template-expression.{begin,end}.civet` matching JS,
+// not the generic `punctuation.section.embedded`.
+
+s := `hi ${name}!`
+//       ^^ punctuation.definition.template-expression.begin.civet
+//             ^ punctuation.definition.template-expression.end.civet
+//       ^^ - punctuation.section.embedded.civet
+//             ^ - punctuation.section.embedded.civet
+
+// Nested template literals: the inner `${...}` also gets the new scopes.
+n := `outer ${`inner ${x}`}`
+//          ^^ punctuation.definition.template-expression.begin.civet
+//                   ^^ punctuation.definition.template-expression.begin.civet
+//                      ^ punctuation.definition.template-expression.end.civet
+//                        ^ punctuation.definition.template-expression.end.civet

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "publisher": "DanielX",
   "repository": {
     "type": "git",

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -93,9 +93,10 @@
     "build-dev": "bash ./build/build.sh development",
     "package": "bash ./build/build.sh && vsce package --no-dependencies",
     "vsce-publish": "bash ./build/build.sh && vsce publish --no-dependencies",
-    "test": "pnpm test:e2e",
+    "test": "pnpm test:grammar && pnpm test:e2e",
     "test:coverage": "pnpm -C ../server test:coverage && pnpm test:e2e:coverage && ../../dist/civet scripts/merge-coverage.civet",
     "test:e2e": "node e2e/dist/runTest",
+    "test:grammar": "vscode-tmgrammar-test -g syntaxes/civet.json 'grammar-tests/**/*.civet'",
     "test:e2e:coverage": "pnpm build-dev && pnpm -C ../server build-dev && rm -rf coverage/e2e-tmp && cross-env NODE_V8_COVERAGE=coverage/e2e-tmp node e2e/dist/runTest",
     "show-uncovered": "../../dist/civet ../../scripts/show-uncovered.civet"
   },
@@ -115,6 +116,7 @@
     "esbuild": "^0.27.7",
     "esbuild-visualizer": "^0.7.0",
     "ovsx": "0.10.11",
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "vscode-tmgrammar-test": "0.1.3"
   }
 }

--- a/lsp/vscode/syntaxes/civet.json
+++ b/lsp/vscode/syntaxes/civet.json
@@ -242,7 +242,11 @@
       "name": "keyword.operator.$1.civet"
     },
     {
-      "match": "\\b(?<![\\.\\$])(case|function|var|void|with|const|let|enum|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|type|package|private|protected|public|static)(?!\\s*:)\\b",
+      "match": "\\b(?<![\\.\\$])(var|let|const)(?!\\s*:)\\b",
+      "name": "storage.type.civet"
+    },
+    {
+      "match": "\\b(?<![\\.\\$])(case|function|void|with|enum|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|type|package|private|protected|public|static)(?!\\s*:)\\b",
       "name": "keyword.reserved.civet"
     },
     {
@@ -842,9 +846,14 @@
       "patterns": [
         {
           "begin": "\\$\\{",
-          "captures": {
+          "beginCaptures": {
             "0": {
-              "name": "punctuation.section.embedded.civet"
+              "name": "punctuation.definition.template-expression.begin.civet"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.template-expression.end.civet"
             }
           },
           "end": "\\}",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
       vscode-languageclient:
         specifier: ^9.0.1
         version: 9.0.1
+      vscode-tmgrammar-test:
+        specifier: 0.1.3
+        version: 0.1.3
 
 packages:
 
@@ -2676,6 +2679,10 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -2833,6 +2840,9 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
@@ -2939,6 +2949,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3060,9 +3074,15 @@ packages:
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -3095,6 +3115,10 @@ packages:
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
@@ -3469,6 +3493,10 @@ packages:
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
@@ -3891,6 +3919,10 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -5872,6 +5904,10 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6480,6 +6516,16 @@ packages:
 
   vscode-languageserver@9.0.1:
     resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+
+  vscode-textmate@7.0.4:
+    resolution: {integrity: sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==}
+
+  vscode-tmgrammar-test@0.1.3:
+    resolution: {integrity: sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==}
     hasBin: true
 
   vscode-uri@3.1.0:
@@ -9160,6 +9206,10 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -9402,6 +9452,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  bottleneck@2.19.5: {}
+
   boundary@2.0.0: {}
 
   bplist-parser@0.2.0:
@@ -9509,6 +9561,12 @@ snapshots:
   caniuse-lite@1.0.30001784: {}
 
   ccount@2.0.1: {}
+
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
 
   chalk@4.1.2:
     dependencies:
@@ -9629,9 +9687,15 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
+
+  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -9652,6 +9716,8 @@ snapshots:
   commander@2.20.3: {}
 
   commander@6.2.1: {}
+
+  commander@9.5.0: {}
 
   common-ancestor-path@2.0.0: {}
 
@@ -10004,6 +10070,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
+
+  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -10472,6 +10540,8 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.3
       uncrypto: 0.1.3
+
+  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -13059,6 +13129,10 @@ snapshots:
     dependencies:
       copy-anything: 4.0.5
 
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -13620,6 +13694,20 @@ snapshots:
   vscode-languageserver@9.0.1:
     dependencies:
       vscode-languageserver-protocol: 3.17.5
+
+  vscode-oniguruma@1.7.0: {}
+
+  vscode-textmate@7.0.4: {}
+
+  vscode-tmgrammar-test@0.1.3:
+    dependencies:
+      bottleneck: 2.19.5
+      chalk: 2.4.2
+      commander: 9.5.0
+      diff: 8.0.4
+      glob: 7.2.3
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 7.0.4
 
   vscode-uri@3.1.0: {}
 


### PR DESCRIPTION
Fixes #266

## Cause
`syntaxes/civet.json` lumped `var`/`let`/`const` into a generic `keyword.reserved.civet` rule alongside unrelated reserved words, and template-literal `${…}` boundaries used `punctuation.section.embedded.civet` rather than JS's `punctuation.definition.template-expression.{begin,end}`. Themes that style these JS scopes specifically were falling through to default colors for Civet.

## Approach
- Split `var|let|const` out of the reserved-keywords match and give them `storage.type.civet`.
- Switch the template-interpolation rule from a unified `captures` block to `beginCaptures`/`endCaptures` so the opening and closing punctuation can use the JS-aligned names. Nested template literals inherit both scopes.
- Add `vscode-tmgrammar-test` as a dev dep and a `pnpm test:grammar` script. Tests are in `lsp/vscode/grammar-tests/` and run before the e2e suite as part of `pnpm test`. Regression test added for the underscore-separator numeric case from the issue (already handled correctly by the existing decimal rule).

Other items from #266 (`console`, `Date`, `require`) are surfaced by the LSP's semantic tokens via TS's `defaultLibrary` modifier and don't need TextMate changes.