### PR TITLE
fix: `try … catch` in expression position crashes insertReturn (#2093)

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3116,11 +3116,10 @@ ThenBlock
 
 BracedThenClause
   &Then InsertOpenBrace:open ThenClause:exp InsertCloseBrace:close ::BlockStatement ->
-    expressions := [exp]
     return {
       type: "BlockStatement",
-      expressions,
-      children: [open, expressions, " ", close],
+      expressions: exp.expressions,
+      children: [open, exp, " ", close],
       bare: false,
     }
 

--- a/test/try.civet
+++ b/test/try.civet
@@ -239,6 +239,30 @@ describe "try", ->
       let ref;try { ref = await foo() } catch(e) {ref = void 0;};thing = ref
     """
 
+    testCase """
+      try/catch with then in call argument
+      ---
+      foo(try a catch e then "x")
+      ---
+      foo((()=>{try { return a } catch (e) { return "x" }})())
+    """
+
+    testCase """
+      try/catch with then in binary expression
+      ---
+      1 + try a catch e then 0
+      ---
+      1 + (()=>{try { return a } catch (e) { return 0 }})()
+    """
+
+    testCase """
+      try/catch with then in array literal
+      ---
+      [try { a() } catch e then "fail"]
+      ---
+      [(()=>{try { return a() } catch (e) { return "fail" }})()]
+    """
+
   describe "try else", ->
     testCase """
       just else


### PR DESCRIPTION
Fixes #2093.

## Summary
- `BracedThenClause` was building a `BlockStatement` whose `expressions` array held the inner `BlockStatement` directly rather than a `StatementTuple`. `insertReturn`'s `[, exp]` destructure crashed when a `try … catch e then …` ended up in expression position and the IIFE wrap recursed into it.
- Mirror the `BracedBlock` pattern: keep the inner block in `children` for rendering, but point `expressions` at the inner block's `expressions` array so traversals see real tuples.

## Test plan
- [x] Three new red tests in `test/try.civet` (call / binary / array contexts) now pass.
- [x] Full suite green: `4022 passing, 19 pending`.

🤖 Generated with [Claude Code](https://claude.ai/code)