### PR TITLE
Dev: Exclude lsp/zed/grammars from coverage scans

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,8 @@
     "exclude": [
       "source/parser/types.civet",
       "source/bun-civet.civet",
-      "source/node-worker.civet"
+      "source/node-worker.civet",
+      "lsp/zed/grammars/**"
     ]
   },
   "packageManager": "pnpm@10.33.0",

--- a/scripts/coverage-merge.civet
+++ b/scripts/coverage-merge.civet
@@ -89,4 +89,5 @@ execFileSync process.execPath, [
   '--exclude', '**/source/node-worker.civet'
   '--exclude', '**/lsp/server/source/browser.civet'
   '--exclude', '**/integration/**'
+  '--exclude', '**/lsp/zed/grammars/**'
 ], { cwd: root, stdio: 'inherit' }


### PR DESCRIPTION
## Summary
- Zed's grammar fetch lands a full Civet repo checkout at `lsp/zed/grammars/civet/` (pinned via `extension.toml`). Its `source/` subtree was being matched by the c8 include globs and reported as 0% covered.
- Excluded `lsp/zed/grammars/**` in both the root `c8` config (`package.json`) and the `coverage:merge` invocation (`scripts/coverage-merge.civet`) so `pnpm coverage` ignores the cache.

## Test plan
- [ ] `rm -rf coverage/` then `pnpm coverage && pnpm coverage:check` — confirm no `lsp/zed/grammars` entries in `coverage-summary.json` / `lcov.info` and no stale dirs under `coverage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)