### PR TITLE
Sublime Text: add `lsp/sublime/` dev-install package

### DIFF
--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -6,10 +6,16 @@ title: Integrations
 
 ## Text Editors
 
-### VSCode
+### VS Code
 
-- [Civet VSCode extension](https://marketplace.visualstudio.com/items?itemName=DanielX.civet)
+- [Civet VS Code extension](https://marketplace.visualstudio.com/items?itemName=DanielX.civet), also available on [Open VSX](https://open-vsx.org/extension/DanielX/civet)
 - [Monaco / VS Code for the Web](https://github.com/DanielXMoore/Civet/tree/main/lsp/monaco) via `@danielx/civet-monaco`; see the [Playground](/playground) for a working example.
+
+### Sublime Text
+
+The [Civet Sublime Text package](https://github.com/DanielXMoore/Civet/tree/main/lsp/sublime) provides syntax highlighting and optional LSP integration via the [Sublime LSP package](https://lsp.sublimetext.io/) and `civet-lsp`.
+
+It is currently intended for dev / local install and is not yet on Package Control.
 
 ### Zed
 

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -9,6 +9,7 @@ Language server and editor integrations for Civet.
 | `server/` | `@danielx/civet-language-server` | Standalone, editor-agnostic Language Server |
 | `monaco/` | `@danielx/civet-monaco` | Monaco language registration, token, and LSP provider helpers |
 | `vscode/` | `@danielx/civet-vscode` | VS Code extension |
+| `sublime/` | — | Sublime Text package |
 | `zed/` | — | Zed editor extension (Rust/WASM) |
 | `tree-sitter/` | — | Tree-sitter grammar for syntax highlighting |
 
@@ -25,5 +26,6 @@ pnpm -C lsp/monaco build
 
 - **VS Code** — install from the [marketplace](https://marketplace.visualstudio.com/items?itemName=DanielX.civet), or see `vscode/` to develop locally
 - **Monaco** — use `@danielx/civet-monaco` with `@danielx/civet-language-server/browser`; see `monaco/`
+- **Sublime Text** — see `sublime/`
 - **Zed** — see `zed/`
 - **Neovim / other LSP clients** — run `civet-lsp --stdio`; see [integrations docs](https://civet.dev/integrations)

--- a/lsp/sublime/Civet.tmLanguage.json
+++ b/lsp/sublime/Civet.tmLanguage.json
@@ -1,0 +1,1 @@
+../vscode/syntaxes/civet.json

--- a/lsp/sublime/LSP.sublime-settings.example
+++ b/lsp/sublime/LSP.sublime-settings.example
@@ -1,0 +1,12 @@
+// Snippet to merge into your Sublime Text LSP package settings.
+// Open: Preferences -> Package Settings -> LSP -> Settings
+// Add the "civet-lsp" entry under "clients" (or create the block if absent).
+{
+  "clients": {
+    "civet-lsp": {
+      "enabled": true,
+      "command": ["civet-lsp", "--stdio"],
+      "selector": "source.civet"
+    }
+  }
+}

--- a/lsp/sublime/LSP.sublime-settings.example
+++ b/lsp/sublime/LSP.sublime-settings.example
@@ -6,7 +6,8 @@
     "civet-lsp": {
       "enabled": true,
       "command": ["civet-lsp", "--stdio"],
-      "selector": "source.civet"
+      "selector": "source.civet",
+      "languageId": "civet"
     }
   }
 }

--- a/lsp/sublime/README.md
+++ b/lsp/sublime/README.md
@@ -28,10 +28,20 @@ ln -s "$(pwd)/lsp/sublime" "$HOME/.config/sublime-text/Packages/Civet"
 ```
 
 **Windows**
+
+Build a local package directory first. This materializes the grammar file so the package does not depend on Git file symlink support on Windows:
+
 ```cmd
-mklink /D "%APPDATA%\Sublime Text\Packages\Civet" "%CD%\lsp\sublime"
+civet lsp\sublime\build.civet
 ```
 
+Then link the built package with a directory junction:
+
+```cmd
+mklink /J "%APPDATA%\Sublime Text\Packages\Civet" "%CD%\lsp\sublime\dist"
+```
+
+**All**
 Restart Sublime Text. `.civet` files should now syntax-highlight.
 
 ## Installing `civet-lsp`
@@ -64,4 +74,10 @@ This package is intended for dev / local install. It is not yet on [Package Cont
 
 ## Updating the grammar
 
-The grammar is a symlink to `../vscode/syntaxes/civet.json`. Edits to the VS Code grammar take effect in Sublime automatically — no copy step. Restart Sublime Text (or run *View → Syntax → Reload Syntax*) to pick up changes.
+The source grammar is a symlink to `../vscode/syntaxes/civet.json`. Edits to the VS Code grammar take effect in source installs automatically — no copy step. Restart Sublime Text (or run *View → Syntax → Reload Syntax*) to pick up changes.
+
+For Windows or packaged installs that use `dist`, rebuild after grammar changes:
+
+```bash
+civet lsp/sublime/build.civet
+```

--- a/lsp/sublime/README.md
+++ b/lsp/sublime/README.md
@@ -1,0 +1,67 @@
+# Civet Sublime Text Package
+
+Sublime Text 4 package providing Civet syntax highlighting and LSP wiring.
+
+## Features
+
+- Syntax highlighting via the TextMate grammar at [`Civet.tmLanguage.json`](./Civet.tmLanguage.json) (a symlink to `../vscode/syntaxes/civet.json` — single source of truth shared with the VS Code extension)
+- Optional LSP integration via the [Sublime LSP package](https://lsp.sublimetext.io/) and `civet-lsp` (diagnostics, completions, hover, go-to-definition)
+
+## Requirements
+
+- Sublime Text 4 (build 4075 or later — needed for `.tmLanguage.json` support)
+- For LSP: the [LSP package](https://packagecontrol.io/packages/LSP) from Package Control
+- For LSP: `civet-lsp` on your `PATH`
+
+## Installing as a dev package
+
+Sublime Text loads any folder placed under its `Packages/` directory as a package. Symlink this directory in:
+
+**macOS**
+```bash
+ln -s "$(pwd)/lsp/sublime" "$HOME/Library/Application Support/Sublime Text/Packages/Civet"
+```
+
+**Linux**
+```bash
+ln -s "$(pwd)/lsp/sublime" "$HOME/.config/sublime-text/Packages/Civet"
+```
+
+**Windows**
+```cmd
+mklink /D "%APPDATA%\Sublime Text\Packages\Civet" "%CD%\lsp\sublime"
+```
+
+Restart Sublime Text. `.civet` files should now syntax-highlight.
+
+## Installing `civet-lsp`
+
+Either install globally via npm:
+
+```bash
+npm install -g @danielx/civet-language-server
+```
+
+Or add the in-repo binary to `PATH`:
+
+```bash
+# ~/.bashrc / ~/.zshrc
+export PATH="/path/to/Civet/lsp/server/bin:$PATH"
+```
+
+(The in-repo binary requires `pnpm -C lsp/server build` first.)
+
+## Wiring up LSP
+
+1. Install the [LSP package](https://packagecontrol.io/packages/LSP) from Package Control.
+2. Open **Preferences → Package Settings → LSP → Settings**.
+3. Merge the snippet from [`LSP.sublime-settings.example`](./LSP.sublime-settings.example) into the user settings on the right. If a `clients` block already exists, add the `civet-lsp` entry inside it.
+4. Open a `.civet` file. The LSP status should appear in the bottom bar.
+
+## Known limitations
+
+This package is intended for dev / local install. It is not yet on [Package Control](https://packagecontrol.io/). PC requires the package to live at the root of its own repository, so submission means publishing a separate `sublime-civet` repo populated from `lsp/sublime/`. Tracked separately from issue #422.
+
+## Updating the grammar
+
+The grammar is a symlink to `../vscode/syntaxes/civet.json`. Edits to the VS Code grammar take effect in Sublime automatically — no copy step. Restart Sublime Text (or run *View → Syntax → Reload Syntax*) to pick up changes.

--- a/lsp/sublime/build.civet
+++ b/lsp/sublime/build.civet
@@ -1,0 +1,19 @@
+{ copyFileSync, mkdirSync, rmSync } from node:fs
+{ dirname, join, relative } from node:path
+{ fileURLToPath } from node:url
+
+sublimeDir := dirname fileURLToPath import.meta.url
+repoRoot := join sublimeDir, "../.."
+outDir := join sublimeDir, "dist"
+
+rmSync outDir, recursive: true, force: true
+mkdirSync outDir, recursive: true
+
+copyFileSync
+  join repoRoot, "lsp", "vscode", "syntaxes", "civet.json"
+  join outDir, "Civet.tmLanguage.json"
+copyFileSync
+  join sublimeDir, "LSP.sublime-settings.example"
+  join outDir, "LSP.sublime-settings.example"
+
+console.log `Built ${relative repoRoot, outDir}`


### PR DESCRIPTION
Closes #422.

## Summary

Mirrors `lsp/zed/`. Ships three files:

- `Civet.tmLanguage.json` — relative symlink (git mode `120000`) to `../vscode/syntaxes/civet.json`. Single source of truth shared with the VS Code extension; edits to the VS Code grammar flow through automatically with no copy step.
- `LSP.sublime-settings.example` — snippet wiring the existing `civet-lsp` (`--stdio`) into the [sublimelsp/LSP](https://lsp.sublimetext.io/) package.
- `README.md` — install instructions for macOS/Linux/Windows (symlink the dir into `Packages/`), `civet-lsp` setup, and LSP wiring steps.

## Why this shape

The 2023 attempt in #422 failed because Sublime doesn't load JSON TextMate grammars under arbitrary names — but ST4 (build ≥ 4075) loads files ending in `.tmLanguage.json` natively. A renamed symlink is enough; no conversion, no second grammar to maintain.

## Out of scope (deferred)

- **Package Control submission.** PC has no monorepo subpath support — the package must live at the root of its own repo. Submission means publishing a separate `sublime-civet` repo populated from this directory. Worth a follow-up issue once the dev-install path has some users.
- **Python helper plugin** in the sublimelsp-org style (auto-installs `civet-lsp` via npm, lifecycle hooks). The settings snippet is the simpler entry point; a helper plugin can come with PC submission.