### PR TITLE
Drop results accumulator from postfix-for when value is discarded

### DIFF
--- a/scripts/typecheck-diff.civet
+++ b/scripts/typecheck-diff.civet
@@ -109,15 +109,39 @@ function parse(logPath: string): Diag[]
   out.push current if current
   out
 
-// Sort union members within short quoted literals so that
-// reorderings don't masquerade as new errors.  Skip literals with `<`
-// (generic type parameters) where naive splitting on ` | ` would corrupt.
+// Sort union members within short quoted literals so that reorderings don't
+// masquerade as new errors.  Sort both parenthesized sub-unions (so
+// `'(B | A)[]'` matches `'(A | B)[]'`) and top-level unions.  Skip literals
+// with `<` (generic type parameters) where naive splitting on ` | ` would
+// corrupt nested arguments.
 function sortQuotedUnions(s: string): string
   s.replace /'([^']+)'/g, (full, inner) =>
-    return full unless inner.includes " | "
     return full if inner.includes "<"
-    parts := inner.split(" | ").sort()
-    `'${parts.join " | "}'`
+    // Sort parenthesized sub-unions first
+    inner = inner.replace /\(([^()]+)\)/g, (sub, parts) =>
+      return sub unless parts.includes " | "
+      `(${parts.split(" | ").sort().join(" | ")})`
+    return `'${inner}'` unless inner.includes " | "
+    // Split on top-level ` | ` (outside parens) so the outer sort doesn't
+    // shred parenthesized groups.
+    tops: string[] := []
+    buf .= ""
+    depth .= 0
+    i .= 0
+    while i < inner.length
+      ch := inner[i]
+      if ch is "(" then depth++
+      else if ch is ")" then depth--
+      else if depth is 0 and inner.startsWith(" | ", i)
+        tops.push buf
+        buf = ""
+        i += 3
+        continue
+      buf += ch
+      i++
+    tops.push buf
+    return `'${inner}'` unless tops# > 1
+    `'${tops.sort().join " | "}'`
 
 function normalizeMessage(s: string): string
   scrubbed := s
@@ -156,26 +180,52 @@ type DiffResult =
   loosePairs: number
 
 function diff(left: Diag[], right: Diag[]): DiffResult
-  // Two-pass match: strict (file+code+msg), then message-only (file+msg).
-  // Each match consumes a `right` item so it's never used twice.
+  // Three-pass match.  Each match consumes a `right` item so it's never used
+  // twice.
+  //
+  //   1. strict same-line:    file+code+msg AND same (line, column)
+  //   2. strict any-line:     file+code+msg
+  //   3. message-only:        file+msg
+  //
+  // Pass 1 first keeps reported regressions pinned to the lines that
+  // actually changed when bucket counts shift — otherwise iteration order
+  // can have a NEW error at line N consume the slot that a pre-existing
+  // error at line N would have filled.
   byStrict := indexBy right, strictKey
   byMessage := indexBy right, messageKey
   consumed := new Set<Diag>
 
-  function findMatch(buckets: Map<string, Diag[]>, key: string): boolean
+  function tryConsume(r: Diag): boolean
+    return false if consumed.has r
+    consumed.add r
+    true
+
+  function findInBucket(buckets: Map<string, Diag[]>, key: string, l: Diag, sameLineOnly: boolean): boolean
     bucket := buckets.get key
     return false unless bucket
     for r of bucket
-      if not consumed.has r
-        consumed.add r
-        return true
+      if sameLineOnly
+        continue unless r.line is l.line and r.column is l.column
+      return true if tryConsume r
     false
 
+  // Pass 1: same-line strict
+  passLeft1: Diag[] := []
+  for d of left
+    continue if findInBucket byStrict, strictKey(d), d, true
+    passLeft1.push d
+
+  // Pass 2: any-line strict
+  passLeft2: Diag[] := []
+  for d of passLeft1
+    continue if findInBucket byStrict, strictKey(d), d, false
+    passLeft2.push d
+
+  // Pass 3: message-only fallback
   unmatched: Diag[] := []
   loose .= 0
-  for d of left
-    continue if findMatch byStrict, strictKey d
-    if findMatch byMessage, messageKey d
+  for d of passLeft2
+    if findInBucket byMessage, messageKey(d), d, false
       loose++
       continue
     unmatched.push d

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3024,7 +3024,7 @@ ExplicitBlock
       ...block,
       children: [ws1, open, ...block.children, ws2, close],
       bare: false,
-    }
+    } as BlockStatement
   # For backward compatibility with JavaScript, allow open brace to start on
   # the next line, as long as it's followed by a newline or close brace
   IndentedAtLeast:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ::BlockStatement ->
@@ -3034,7 +3034,7 @@ ExplicitBlock
       ...block,
       children: [ws1, open, ...block.children, ws2, close],
       bare: false,
-    }
+    } as BlockStatement
 
 EmptyBracedContent
   &( __ "}" ) ::BlockStatement ->
@@ -3055,7 +3055,7 @@ ImplicitNestedBlock
       ...block,
       children: [open, ...block.children, ...tail],
       bare: false,
-    }
+    } as BlockStatement
 
 # NOTE: This is the body of if/else/for/when etc.
 Block
@@ -7106,7 +7106,7 @@ ClosingDelimiter
 SemicolonDelimiter
   _? Semicolon TrailingComment ->
     return {
-      type: "SemicolonDelimiter",
+      type: "SemicolonDelimiter" as const,
       children: $0
     }
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1233,9 +1233,8 @@ function processFunctions(statements: ASTNode, config: any): void
 // Issue #565: when the iteration expression's value is observably discarded,
 // `expressionizeIteration` can skip the `results = []` accumulator scaffolding.
 function iterationValueDiscarded(parentBlock: BlockStatement, index: number, consumeRoot: boolean): boolean
-  tuple := parentBlock.expressions[index]
   // Trailing `;` opts out of implicit return
-  return true if tuple[2]?.type is "SemicolonDelimiter"
+  return true if parentBlock.expressions[index][2] is like {type: "SemicolonDelimiter"}
   // Followed by another statement
   return true unless isLastMeaningful parentBlock.expressions, index
   // Module root: needed only when wrapped by --iife / --repl

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1237,37 +1237,23 @@ Used to skip building a `results` accumulator when it would only be
 collected to be thrown away (issue #565).
 */
 function iterationValueDiscarded(parentBlock: BlockStatement, index: number, consumeRoot: boolean): boolean
-  if not isLastMeaningful parentBlock.expressions, index
-    return true
+  // Not the last meaningful expression in its block → value dropped
+  return true unless isLastMeaningful parentBlock.expressions, index
 
-  let current: ASTNode = parentBlock
-  while current
-    if (current as BlockStatement).root
-      return not consumeRoot
-    parent := (current as ASTNodeObject).parent
-    return false unless parent
-    switch parent.type
-      when "BlockStatement"
-        idx := findChildIndex parent.expressions, current
-        return false if idx < 0
-        return true unless isLastMeaningful parent.expressions, idx
-        current = parent
-      when "ForStatement", "IterationStatement"
-        // Plain for/while/loop body — body value is discarded
-        return true
-      else
-        // Conservative default: assume value is consumed
-        return false
-  return false
+  // At module root → value dropped unless wrapped by --iife / --repl
+  return not consumeRoot if parentBlock.root
+
+  // Inside a for/while/loop body the value is dropped; for everything else
+  // (function bodies, if/switch/try, declarations, …) stay conservative
+  // and assume the value is consumed.
+  parentBlock.parent?.type is like "ForStatement", "IterationStatement"
 
 function isLastMeaningful(expressions: StatementTuple[], index: number): boolean
   let i = expressions.length - 1
   while i > index
     [, exp] := expressions[i]
-    if exp? <? "object" and exp.type is "EmptyStatement"
-      i--
-    else
-      return false
+    return false unless exp? <? "object" and exp.type is "EmptyStatement"
+    i--
   true
 
 function expressionizeIteration(exp: IterationExpression, consumeRoot: boolean): void
@@ -1314,7 +1300,9 @@ function expressionizeIteration(exp: IterationExpression, consumeRoot: boolean):
     parentInfo := if not async and not reduction and not statement.block.empty
       blockContainingStatement exp
     if parentInfo and iterationValueDiscarded parentInfo.block, parentInfo.index, consumeRoot
-      statements = [["", statement, ";" if statement.block.bare]]
+      // Postfix-for blocks are created with bare: false, so no trailing
+      // semicolon is needed here.
+      statements = [["", statement]]
     else
       resultsRef := statement.resultsRef ??= makeRef "results"
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1230,22 +1230,17 @@ function processFunctions(statements: ASTNode, config: any): void
     processParams(f)
     processReturn(f, config.implicitReturns)
 
-/**
-Return true if the value at `parentBlock.expressions[index]` is definitely
-discarded — i.e. nothing observes the iteration expression's result.
-Used to skip building a `results` accumulator when it would only be
-collected to be thrown away (issue #565).
-*/
+// Issue #565: when the iteration expression's value is observably discarded,
+// `expressionizeIteration` can skip the `results = []` accumulator scaffolding.
 function iterationValueDiscarded(parentBlock: BlockStatement, index: number, consumeRoot: boolean): boolean
-  // Not the last meaningful expression in its block → value dropped
+  tuple := parentBlock.expressions[index]
+  // Trailing `;` opts out of implicit return
+  return true if tuple[2]?.type is "SemicolonDelimiter"
+  // Followed by another statement
   return true unless isLastMeaningful parentBlock.expressions, index
-
-  // At module root → value dropped unless wrapped by --iife / --repl
+  // Module root: needed only when wrapped by --iife / --repl
   return not consumeRoot if parentBlock.root
-
-  // Inside a for/while/loop body the value is dropped; for everything else
-  // (function bodies, if/switch/try, declarations, …) stay conservative
-  // and assume the value is consumed.
+  // for/while/loop body discards; assume everything else consumes
   parentBlock.parent?.type is like "ForStatement", "IterationStatement"
 
 function isLastMeaningful(expressions: StatementTuple[], index: number): boolean
@@ -1291,18 +1286,15 @@ function expressionizeIteration(exp: IterationExpression, consumeRoot: boolean):
       . ["", statement]
 
   else
-    // If at top level of a block and value is discarded, emit just the
-    // bare statement — skip `results = []` declaration, body push wrapping
-    // and trailing reference (issue #565).
-    // Exclude reductions and empty-body comprehensions: those are explicit
-    // syntactic forms whose intent is to compute a specific value.
+    // #565: skip `results` accumulator when value is discarded. Reductions
+    // and empty bodies are explicit value-computing forms — leave them be.
     reduction := statement.type is "ForStatement" and statement.reduction
     parentInfo := if not async and not reduction and not statement.block.empty
       blockContainingStatement exp
     if parentInfo and iterationValueDiscarded parentInfo.block, parentInfo.index, consumeRoot
-      // Postfix-for blocks are created with bare: false, so no trailing
-      // semicolon is needed here.
-      statements = [["", statement]]
+      // Preserve original trailing semi so insertReturn skips this statement
+      origSemi := parentInfo.block.expressions[parentInfo.index][2]
+      statements = [["", statement, origSemi]]
     else
       resultsRef := statement.resultsRef ??= makeRef "results"
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1230,7 +1230,47 @@ function processFunctions(statements: ASTNode, config: any): void
     processParams(f)
     processReturn(f, config.implicitReturns)
 
-function expressionizeIteration(exp: IterationExpression): void
+/**
+Return true if the value at `parentBlock.expressions[index]` is definitely
+discarded — i.e. nothing observes the iteration expression's result.
+Used to skip building a `results` accumulator when it would only be
+collected to be thrown away (issue #565).
+*/
+function iterationValueDiscarded(parentBlock: BlockStatement, index: number, consumeRoot: boolean): boolean
+  if not isLastMeaningful parentBlock.expressions, index
+    return true
+
+  let current: ASTNode = parentBlock
+  while current
+    if (current as BlockStatement).root
+      return not consumeRoot
+    parent := (current as ASTNodeObject).parent
+    return false unless parent
+    switch parent.type
+      when "BlockStatement"
+        idx := findChildIndex parent.expressions, current
+        return false if idx < 0
+        return true unless isLastMeaningful parent.expressions, idx
+        current = parent
+      when "ForStatement", "IterationStatement"
+        // Plain for/while/loop body — body value is discarded
+        return true
+      else
+        // Conservative default: assume value is consumed
+        return false
+  return false
+
+function isLastMeaningful(expressions: StatementTuple[], index: number): boolean
+  let i = expressions.length - 1
+  while i > index
+    [, exp] := expressions[i]
+    if exp? <? "object" and exp.type is "EmptyStatement"
+      i--
+    else
+      return false
+  true
+
+function expressionizeIteration(exp: IterationExpression, consumeRoot: boolean): void
   { async, generator, block, children, statement } .= exp
   i .= children.indexOf statement
   assert.notEqual i, -1, "Could not find iteration statement in iteration expression"
@@ -1265,14 +1305,25 @@ function expressionizeIteration(exp: IterationExpression): void
       . ["", statement]
 
   else
-    resultsRef := statement.resultsRef ??= makeRef "results"
+    // If at top level of a block and value is discarded, emit just the
+    // bare statement — skip `results = []` declaration, body push wrapping
+    // and trailing reference (issue #565).
+    // Exclude reductions and empty-body comprehensions: those are explicit
+    // syntactic forms whose intent is to compute a specific value.
+    reduction := statement.type is "ForStatement" and statement.reduction
+    parentInfo := if not async and not reduction and not statement.block.empty
+      blockContainingStatement exp
+    if parentInfo and iterationValueDiscarded parentInfo.block, parentInfo.index, consumeRoot
+      statements = [["", statement, ";" if statement.block.bare]]
+    else
+      resultsRef := statement.resultsRef ??= makeRef "results"
 
-    declaration := iterationDeclaration statement
+      declaration := iterationDeclaration statement
 
-    statements =
-      . ["", declaration, ";"]
-      . ["", statement, ";" if statement.block.bare]
-      . ["", resultsRef]
+      statements =
+        . ["", declaration, ";"]
+        . ["", statement, ";" if statement.block.bare]
+        . ["", resultsRef]
 
   // Don't need IIFE if iteration expression is at the top level of a block
   let done
@@ -1289,9 +1340,9 @@ function expressionizeIteration(exp: IterationExpression): void
     children.splice i, 1, wrapIIFE(statements, async, generator)
     updateParentPointers exp
 
-function processIterationExpressions(statements: ASTNode): void
+function processIterationExpressions(statements: ASTNode, consumeRoot: boolean = false): void
   for each s of gatherRecursiveAll statements, .type is "IterationExpression"
-    expressionizeIteration s
+    expressionizeIteration s, consumeRoot
 
 /**
 Utility function to check if an implicit function application should be skipped

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1792,7 +1792,7 @@ function processProgram(root: BlockStatement): void
   processAssignments(statements)
   processStatementExpressions(statements)
   processPatternMatching(statements)
-  processIterationExpressions(statements)
+  processIterationExpressions(statements, !!(config.iife or config.repl))
   processFinallyClauses(statements)
   processBreaksContinues(statements)
 

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -238,12 +238,12 @@ const asConst =
   ts: true,
   children: [" as const"]
 
-function makeAsConst(node: ASTNode)
+function makeAsConst(node: ASTNode): ASTNode
   // TS allows "as const" assertions for string, number, boolean, array,
   // and object literals (and enum members), but not for null/undefined.
   if (node!.type is "Literal" and node.raw is not "null") or
       node!.type is "ArrayExpression" or node!.type is "ObjectExpression"
-    { ...node, children: [...node!.children, asConst] }
+    { ...node, children: [...node!.children, asConst] } as ASTNode
   else
     node
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -130,6 +130,7 @@ export type OtherNode =
   | RangeExpression
   | ReturnTypeAnnotation
   | ReturnValue
+  | SemicolonDelimiter
   | SliceExpression
   | SpreadElement
   | Star
@@ -468,7 +469,22 @@ export type YieldExpression = ASTParent &
 
 export type WSNode = "" | (ASTLeaf | CommentNode)[]
 
+// Parsed `;` delimiter at the end of a statement.  Distinct from a synthetic
+// `;`/`;;`/`"\n"` string emitted by codegen — only the parsed form opts out
+// of implicit return (insertReturn short-circuits on this node type).
+export type SemicolonDelimiter = ASTParent &
+  type: "SemicolonDelimiter"
+
+// Third element of a StatementTuple — either a parsed SemicolonDelimiter, an
+// arbitrary synth string codegen splices in (`";"`, `";;"`, `"\n"`, …), or
+// absent.  Stays as the broad ASTNode alias to avoid widening the
+// StatementTuple element types throughout BlockStatement chains; use
+// `is like {type: "SemicolonDelimiter"}` to narrow at consumption sites.
 export type StatementDelimiter = ASTNode
+
+// Leading whitespace / newline for a StatementTuple.  Heterogeneous (strings,
+// whitespace/comment tokens, nested arrays — `getIndent` flattens before
+// use), so this stays an ASTNode alias.
 export type IndentNode = ASTNode
 
 export type StatementTuple = [IndentNode, ASTNode, StatementDelimiter?]

--- a/test/for.civet
+++ b/test/for.civet
@@ -926,6 +926,17 @@ describe "for", ->
     """
 
     testCase """
+      trailing semicolon opts out of implicit return
+      ---
+      fn := ->
+        (foo(x) for x of arr);
+      ---
+      const fn = function() {
+        for (const x of arr) { foo(x) };
+      }
+    """
+
+    testCase """
       trailing empty statements skipped when checking last
       ---
       (foo(x) for x of arr)

--- a/test/for.civet
+++ b/test/for.civet
@@ -865,6 +865,24 @@ describe "for", ->
     nextLine
   """
 
+  // Issue #565
+  testCase """
+    parenthesized postfix for at statement level drops results accumulator
+    ---
+    (foo(x) for x of arr)
+    ---
+    for (const x of arr) { foo(x) }
+  """
+
+  // Issue #565
+  testCase """
+    nested parenthesized postfix for at statement level drops results accumulators
+    ---
+    ((push shard for shard of bucket) for bucket of buckets)
+    ---
+    for (const bucket of buckets) { for (const shard of bucket) { push(shard) } }
+  """
+
   describe "expression", ->
     testCase """
       basic

--- a/test/for.civet
+++ b/test/for.civet
@@ -866,22 +866,76 @@ describe "for", ->
   """
 
   // Issue #565
-  testCase """
-    parenthesized postfix for at statement level drops results accumulator
-    ---
-    (foo(x) for x of arr)
-    ---
-    for (const x of arr) { foo(x) }
-  """
+  describe "drop results accumulator when value discarded", ->
+    testCase """
+      module top level
+      ---
+      (foo(x) for x of arr)
+      ---
+      for (const x of arr) { foo(x) }
+    """
 
-  // Issue #565
-  testCase """
-    nested parenthesized postfix for at statement level drops results accumulators
-    ---
-    ((push shard for shard of bucket) for bucket of buckets)
-    ---
-    for (const bucket of buckets) { for (const shard of bucket) { push(shard) } }
-  """
+    testCase """
+      nested at module top level
+      ---
+      ((push shard for shard of bucket) for bucket of buckets)
+      ---
+      for (const bucket of buckets) { for (const shard of bucket) { push(shard) } }
+    """
+
+    testCase """
+      followed by another statement
+      ---
+      (foo(x) for x of arr)
+      nextLine
+      ---
+      for (const x of arr) { foo(x) }
+      nextLine
+    """
+
+    testCase """
+      inside for-loop body
+      ---
+      for y of ys
+        (foo(x) for x of y)
+      ---
+      for (const y of ys) {
+        for (const x of y) { foo(x) }
+      }
+    """
+
+    testCase """
+      not last in function body
+      ---
+      fn := ->
+        (foo(x) for x of arr)
+        otherStmt
+      ---
+      const fn = function() {
+        for (const x of arr) { foo(x) }
+        return otherStmt
+      }
+    """
+
+    testCase """
+      kept as implicit return at end of function body
+      ---
+      fn := -> (foo(x) for x of arr)
+      ---
+      const fn = function() { const results=[];for (const x of arr) { results.push(foo(x)) }return results }
+    """
+
+    testCase """
+      trailing empty statements skipped when checking last
+      ---
+      (foo(x) for x of arr)
+      ;
+      ;
+      ---
+      for (const x of arr) { foo(x) }
+      ;
+      ;
+    """
 
   describe "expression", ->
     testCase """

--- a/test/iife.civet
+++ b/test/iife.civet
@@ -28,6 +28,17 @@ describe "iife directive", ->
     };return results;})()
   """
 
+  // Issue #565: optimization is disabled in iife mode since the root
+  // block becomes the IIFE's implicit return value
+  testCase """
+    postfix for keeps results accumulator
+    ---
+    "civet iife"
+    (foo(x) for x of arr)
+    ---
+    (()=>{const results=[];for (const x of arr) { results.push(foo(x)) }return results})()
+  """
+
   testCase """
     async
     ---


### PR DESCRIPTION
Closes #565.

Postfix-for expressions like `(foo(x) for x of arr)` always allocated and
populated a `results` array, even when nothing observed the value:

```ts
((push shard for shard of bucket) for bucket of buckets)
// →
const results=[]; for (const bucket of buckets) {
  const results1=[]; for (const shard of bucket) { results1.push(push(shard)) }
  results.push(results1)
} results
```

When the iteration expression sits at the top of its containing block and a
walk up the parent chain shows the value will never be consumed (followed by
another statement, inside a for/while body, or at module root in non-IIFE
mode), `expressionizeIteration` now emits just the bare for-statement —
skipping the `const results = []` declaration, the `results.push(...)` body
wrapping, and the trailing reference.

Reductions (`for some|every|sum|... x of y`) and empty-body comprehensions
(`(for x of y)`) keep their accumulator: those are explicit value-computing
syntactic forms whose test cases asserted the current behavior. `--iife` /
`--repl` mode also opts out, since the root block becomes the implicit
return of the wrapping IIFE.