### PR TITLE
feat: support declaration types in coffeeForLoops (#583)

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3667,6 +3667,19 @@ for item from iterable
   console.log item
 </Playground>
 
+You can also declare the loop variable explicitly with `const`, `let`,
+or `var`, which avoids the need for `autoVar`:
+
+<Playground>
+"civet coffeeForLoops"
+for const item in array
+  console.log item
+for let key of object
+  console.log key
+for const item from iterable
+  console.log item
+</Playground>
+
 ### CoffeeScript Do Blocks
 
 This option disables [Civet `do` blocks](#do-blocks)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5317,11 +5317,21 @@ CoffeeForStatementParameters
         ? [expRef, " = ", trimFirstSpace(exp), ", "]
         : []
 
-      blockPrefix./**/push(["", {
-        type: "AssignmentExpression",
-        children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
-        names: assignmentNames,
-      }, ";"])
+      if varRef.decl
+        // With a declaration kind (const/let/var), emit a Declaration node so
+        // autoVar doesn't also hoist the name. varRef already includes the
+        // keyword in its children.
+        blockPrefix./**/push(["", {
+          type: "Declaration",
+          children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
+          names: [],
+        }, ";"])
+      else
+        blockPrefix./**/push(["", {
+          type: "AssignmentExpression",
+          children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
+          names: assignmentNames,
+        }, ";"])
 
       declaration = {
         type: "Declaration",
@@ -5380,12 +5390,22 @@ CoffeeForIndex
 
 CoffeeForDeclaration
   # NOTE: Coffee doesn't allow expression bindings like `for a.x in b`
-  ( __ Own )?:own ForBinding:binding ->
+  ( __ Own )?:own ( __ LetOrConstOrVar )?:kind ForBinding:binding ->
+    if kind
+      return {
+        type: "ForDeclaration",
+        own: Boolean(own),
+        decl: kind[1].token,
+        kind: kind[1],
+        binding,
+        children: [kind[0], kind[1], binding],
+        names: binding.names,
+      }
     return {
       type: "AssignmentExpression",
       own: Boolean(own),
-      children: [$2],
-      names: $2.names,
+      children: [binding],
+      names: binding.names,
     }
 
 ForStatementParameters

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5345,12 +5345,11 @@ CoffeeForStatementParameters
           names: assignmentNames,
         }, ";"])
 
-      declaration = {
-        type: "Declaration",
-        children: ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", expRef, ".length"],
-        names: []
-      }
-
+      // The for-head Declaration (`let i = 0, len = arr.length` or, for a
+      // literal negative step, `let i = arr.length - 1`). Distinct from the
+      // CoffeeForDeclaration `declaration` capture, whose shape is the
+      // iteration variable; this is the loop counter init.
+      let forHeadChildren = ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", expRef, ".length"]
       condition .= [counterRef, " < ", lenRef, "; "]
 
       if step
@@ -5360,11 +5359,8 @@ CoffeeForStatementParameters
           increment = [" +=", ...stepWs, stepExp]
           // Negative step loops are reversed
           if stepExp.raw[0] is "-"
-            declaration = {
-              type: "Declaration",
-              children: ["let ", ...expRefDec, counterRef, " = ", expRef, ".length - 1"],
-              names: []
-            }
+            forHeadChildren =
+              ["let ", ...expRefDec, counterRef, " = ", expRef, ".length - 1"]
             condition = [counterRef, " >= 0; "]
         else
           increment = [" +=", ...stepWs, stepExp, {
@@ -5372,15 +5368,15 @@ CoffeeForStatementParameters
             message: "TODO: Support non-literal step in CoffeeScript for loops",
           }]
 
-        return {
-          declaration,
-          children: [$1, open, declaration, "; ", ...condition, counterRef, increment, close],
-          blockPrefix,
-        }
+      forHead := {
+        type: "Declaration"
+        children: forHeadChildren
+        names: []
+      }
 
       return {
-        declaration,
-        children: [$1, open, declaration, "; ", ...condition, counterRef, increment, close],
+        declaration: forHead,
+        children: [$1, open, forHead, "; ", ...condition, counterRef, increment, close],
         blockPrefix,
       }
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5278,16 +5278,24 @@ CoffeeForStatementParameters
 
       // TODO: Exp ref if exp is not a literal or identifier
 
+      // When declaration carries a const/let/var keyword (ForDeclaration node),
+      // its children render as `const a`; use just the binding (with leading
+      // whitespace trimmed) when emitting it as an expression operand for the
+      // hasProp guard or the value-index lookup.
+      declarationExp := declaration.binding
+        ? trimFirstSpace(declaration.binding)
+        : declaration
+
       if declaration.own
         hasPropRef := getHelperRef("hasProp")
 
-        blockPrefix./**/push(["", ["if (!", hasPropRef, "(", exp, ", ", declaration, ")) continue"], ";"])
+        blockPrefix./**/push(["", ["if (!", hasPropRef, "(", exp, ", ", declarationExp, ")) continue"], ";"])
 
       // index is actually value in Coffee "for of", y = z[x]
       if index
         blockPrefix./**/push(["", {
           type: "AssignmentExpression",
-          children: [index, " = ", exp, "[", declaration, "]"],
+          children: [index, " = ", exp, "[", declarationExp, "]"],
           names: index.names,
         }, ";"])
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -85,6 +85,7 @@ import type {
   AssignmentExpression,
   ASTNode,
   ASTRef,
+  Binding,
   BindingRestElement,
   BlockStatement,
   CaseBlock,
@@ -5490,14 +5491,13 @@ ForDeclaration
 
 # https://262.ecma-international.org/#prod-ForBinding
 ForBinding
-  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix ->
-    typeSuffix ??= pattern.typeSuffix
+  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix ::Binding ->
     return {
       type: "Binding",
-      children: [ pattern, typeSuffix ],
+      children: [ pattern, typeSuffix ?? pattern.typeSuffix ],
       names: pattern.names,
       pattern,
-      typeSuffix,
+      typeSuffix: typeSuffix ?? pattern.typeSuffix,
       splices: [],
       thisAssignments: [],
     }

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -534,6 +534,71 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for own const of
+    ---
+    "civet coffee-compat"
+    for own const a of b
+      console.log a
+    ---
+    var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
+    for (const a in b) {if (!hasProp(b, a)) continue;
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for own let of
+    ---
+    "civet coffee-compat"
+    for own let a of b
+      console.log a
+    ---
+    var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
+    for (let a in b) {if (!hasProp(b, a)) continue;
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for const of value
+    ---
+    "civet coffee-compat"
+    for const x, y of z
+      y
+    ---
+    var y;
+    for (const x in z) {y = z[x];
+      y
+    }
+  """
+
+  testCase """
+    for let of value
+    ---
+    "civet coffee-compat"
+    for let x, y of z
+      y
+    ---
+    var y;
+    for (let x in z) {y = z[x];
+      y
+    }
+  """
+
+  testCase """
+    for own const of value
+    ---
+    "civet coffee-compat"
+    for own const x, y of z
+      y
+    ---
+    var y;var hasProp: <T>(object: T, prop: PropertyKey) => boolean = ({}.constructor as any).hasOwn;
+    for (const x in z) {if (!hasProp(z, x)) continue;y = z[x];
+      y
+    }
+  """
+
+  testCase """
     for const in
     ---
     "civet coffee-compat"

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -449,6 +449,126 @@ describe "coffeeForLoops", ->
     }
   """
 
+  testCase """
+    for const from
+    ---
+    "civet coffee-compat"
+    for const a from b
+      console.log a
+    ---
+    for (const a of b) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for let from
+    ---
+    "civet coffee-compat"
+    for let a from b
+      console.log a
+    ---
+    for (let a of b) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for var from
+    ---
+    "civet coffee-compat"
+    for var a from b
+      console.log a
+    ---
+    for (var a of b) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for const from destructuring
+    ---
+    "civet coffee-compat"
+    for const {a, b} from c
+      console.log a
+    ---
+    for (const {a, b} of c) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for const of
+    ---
+    "civet coffee-compat"
+    for const a of b
+      console.log a
+    ---
+    for (const a in b) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for let of
+    ---
+    "civet coffee-compat"
+    for let a of b
+      console.log a
+    ---
+    for (let a in b) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for var of
+    ---
+    "civet coffee-compat"
+    for var a of b
+      console.log a
+    ---
+    for (var a in b) {
+      console.log(a)
+    }
+  """
+
+  testCase """
+    for const in
+    ---
+    "civet coffee-compat"
+    for const a in b
+      a.i
+    ---
+    for (let i = 0, len = b.length; i < len; i++) {const a = b[i];
+      a.i
+    }
+  """
+
+  testCase """
+    for let in
+    ---
+    "civet coffee-compat"
+    for let a in b
+      a.i
+    ---
+    for (let i = 0, len = b.length; i < len; i++) {let a = b[i];
+      a.i
+    }
+  """
+
+  testCase """
+    for var in
+    ---
+    "civet coffee-compat"
+    for var a in b
+      a.i
+    ---
+    for (let i = 0, len = b.length; i < len; i++) {var a = b[i];
+      a.i
+    }
+  """
+
   throws """
     for from with by is invalid
     ---


### PR DESCRIPTION
Closes #583

Adds support for `for const/let/var x from/of/in y` under `"civet coffeeForLoops"`, so the mode is ergonomic without requiring `autoVar`/autoLet`.

- `CoffeeForDeclaration` now accepts an optional `LetOrConstOrVar` prefix
- `from`/`of` cases put the kind directly in the for-statement init (no `var a;` hoist)
- `in` case (indexed loop) emits `{const a = arr[i]; ...}` inside the block

Added 10 test cases in `test/compat/coffee-for-loops.civet`. Full suite: 4050 passing, 19 pending, no regressions.

Generated with [Claude Code](https://claude.ai/code)