### PR TITLE
Fix unicode identifiers in shorthand object forms

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2528,7 +2528,10 @@ BindingProperty
   _?:ws1 PropertyName:name Caret?:bind _?:ws2 Colon:colon _?:ws3 ( BindingPattern / BindingIdentifier ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     // Convert `name^: pattern` into `name: name^pattern`
     if bind
-      binding := name
+      // For unicode `name`, PropertyName rewrote it to render as `"src"`.
+      // The binding side (collapsed shorthand on LHS, subbinding `= name`
+      // on RHS) needs the mangled JS identifier — `name.identifier`.
+      binding := name.identifier ?? name
       pattern := value
       value = {
         type: "NamedBindingPattern",
@@ -4103,7 +4106,12 @@ PropertyDefinition
           implicit: true,
         }
     else
-      ({name} = last)
+      // `{ 😊() }` → `{ "😊": u$1F60A$() }`: unicode names render as quoted
+      // property keys; value side keeps the mangled CallExpression.
+      if last.type is "Identifier" and last.unicode
+        name = propertyKey(last)
+      else
+        ({name} = last)
       return $skip unless name
 
     // Private name becomes public

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -717,6 +717,13 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
               type: "Index"
               children: [ trimFirstSpace value ]
             ]
+          else if value.type is "Identifier" and value.unicode?
+            // Unicode identifier: dot access of mangled `u$…$` is the wrong
+            // property — use bracket access with the source name.
+            value = [ ...prefix,
+              type: "Index"
+              children: [ "[", propertyKey(value), "]" ]
+            ]
           else
             value = [ ...prefixDot, trimFirstSpace value ]
           // Switch from refAssignment to ref

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -161,6 +161,55 @@ describe "identifier", ->
       data?.["😊"]
     """
 
+    // -- Property glob `obj.{a,b}` / `obj{a,b}` uses bracket access with
+    //    the user-visible name for unicode properties (issue #2100).
+
+    testCase """
+      property glob shorthand with unicode property
+      ---
+      obj{😊}
+      ---
+      ({"😊":obj["😊"]})
+    """
+
+    testCase """
+      property glob with explicit dot and unicode property
+      ---
+      obj.{😊}
+      ---
+      ({"😊":obj["😊"]})
+    """
+
+    testCase """
+      property glob with mixed unicode and ascii properties
+      ---
+      obj{😊, ascii}
+      ---
+      ({"😊":obj["😊"], ascii:obj.ascii})
+    """
+
+    // -- Call shorthand `{ x() }` → `{ x: x() }` uses user-visible name
+    //    as quoted key for unicode (issue #2100).
+
+    testCase """
+      call shorthand with unicode name
+      ---
+      x := { 😊() }
+      ---
+      const x = { "😊": u$1F60A$() }
+    """
+
+    // -- Multi-destructuring `{name^: pattern}` keeps unicode name as
+    //    quoted key but uses the mangled identifier for binding/sub-binding.
+
+    testCase """
+      multi-destructuring with unicode key
+      ---
+      {😊^: {first, last}} = person
+      ---
+      ({"😊": u$1F60A$} = person), {first, last} = u$1F60A$
+    """
+
     // -- `@`-bind and CoffeeScript `::` prototype access also use the
     //    user-visible name as a quoted bracket key for unicode properties.
 


### PR DESCRIPTION
Closes #2100.

Three object-shorthand forms emitted the mangled `u$<HEX>$` name where the source name belonged as a quoted property key.

## Cause

Each form has its own shorthand expansion that picks up the property name from a node where unicode handling diverged.

- **`obj{🍊}` → `obj.u$1F34A$`**: `PropertyGlob` (in `processCallMemberExpression`) appends the value as a dot access. For unicode shorthand the value is the original `Identifier` (token `u$1F34A$`), so it fell through the `StringLiteral` / `ComputedPropertyName` branches into plain dot access — but `obj.u$1F34A$` is the wrong property.
- **`{ 🍊() }` → `{ u$1F34A$: u$1F34A$() }`**: the call-shorthand `{x.y()}` → `{y: x.y()}` rule extracts `name` from `lastAccessInCallExpression`. On a unicode Identifier that string is the mangled form.
- **`{🍊^: {first, last}} = person` → `({"🍊"} = person), {first, last} = "🍊"`**: `BindingProperty` expands `name^: pattern` to `name: name^pattern` and uses `name` for the binding. `PropertyName` had already rewritten the unicode id to render as `"🍊"`, so both the collapsed-shorthand LHS and the `subbinding` reference rendered as a string literal.

## Fix

- `source/parser/lib.civet` — `PropertyGlob` handler: new branch when value is an `Identifier` with `.unicode`, emit bracket access with `propertyKey(value)`.
- `source/parser.hera` (call-shorthand rule): when `lastAccessInCallExpression` returns a unicode Identifier, set `name = propertyKey(last)` so the property key renders quoted; the value side keeps the mangled `CallExpression`.
- `source/parser.hera` (`name^: pattern` rule): use `name.identifier ?? name` for the binding so the JS variable reference stays mangled while the property key renders as `"🍊"`. As a side effect `simplifyBindingProperties` no longer collapses the LHS to shorthand, which is correct (`{ "🍊" }` isn't legal JS shorthand).

## Test plan

- [x] 5 new test cases under `test/identifier.civet` `unicode` describe block (glob shorthand, explicit-dot glob, mixed unicode/ASCII glob, call shorthand, multi-destructuring).
- [x] `pnpm test` — 4074 passing.
- [x] `pnpm test:self` — 4074 passing.
- [x] Typecheck total 913, under 931 baseline; no new errors in modified files.
- [x] New code paths covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)