### PR TITLE
Fix BigInt ranges as values and in exclusive for-of forms

### DIFF
--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -248,7 +248,9 @@ function forRange(
   condition :=
     infinite or stepValue is 0 or stepValue is 0n ? [] :
     asc? ? (asc ? counterPart[0...3] : counterPart[4..]) :
-    stepRef ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"] :
+    // `!= 0` (loose) so a dynamic 0n step is also treated as zero — `0n !== 0`
+    // is always true, which would let `i += 0n` infinite-loop.
+    stepRef ? [stepRef, " != 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"] :
     [ascRef, " ? ", ...counterPart]
 
   increment :=

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -13,6 +13,7 @@ import type {
 
 import {
   checkValidLHS
+  isBigIntLiteral
   literalValue
   makeLeftHandSideExpression
   makeNode
@@ -30,10 +31,6 @@ import {
 import {
   getHelperRef
 } from ./helper.civet
-
-function isBigIntLiteral(node: ASTNode): boolean
-  node is like {type: "Literal", subtype: "NumericLiteral"} and
-    node.raw.endsWith "n"
 
 function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, end: ASTNode)
   ws1 = [ws1, range.children[0]] // whitespace before ..

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -31,6 +31,10 @@ import {
   getHelperRef
 } from ./helper.civet
 
+function isBigIntLiteral(node: ASTNode): boolean
+  node is like {type: "Literal", subtype: "NumericLiteral"} and
+    node.raw.endsWith "n"
+
 function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, end: ASTNode)
   ws1 = [ws1, range.children[0]] // whitespace before ..
   ws2 := range.children[1]       // whitespace after ..
@@ -91,32 +95,52 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
             .join ", "
           . "]"
         children.unshift range.error if range.error?
+    else if startValue <? "bigint" and endValue <? "bigint" and range.increasing?
+      step := range.increasing ? 1n : -1n
+      signedDiff := range.increasing ? endValue - startValue : startValue - endValue
+      length := Number(signedDiff) + lengthAdjust
+      startValue += step unless range.left.inclusive
+      if length <= 20
+        // Use array of literal bigint values
+        startBig := startValue as bigint
+        children =
+          . "["
+          . Array.from({ length }, (_, i) => `${startBig + BigInt(i) * step}n`)
+            .join ", "
+          . "]"
+        children.unshift range.error if range.error?
 
   unless children?
+    bigint := isBigIntLiteral(start) or isBigIntLiteral(end)
+    one := bigint ? "1n" : "1"
     if range.increasing?
       sign := range.increasing ? "+" : "-"
+      ascHelper := bigint ? 'bigintRange' : 'range'
+      descHelper := bigint ? 'bigintRevRange' : 'revRange'
       end = makeLeftHandSideExpression end
       children =
-        . getHelperRef range.increasing ? 'range' : 'revRange'
+        . getHelperRef range.increasing ? ascHelper : descHelper
         . "("
         . if range.left.inclusive
             start
           else
-            [makeLeftHandSideExpression(start), ` ${sign} 1`]
+            [makeLeftHandSideExpression(start), ` ${sign} ${one}`]
         . ","
         . if range.right.inclusive
-            [makeLeftHandSideExpression(end), ` ${sign} 1`]
+            [makeLeftHandSideExpression(end), ` ${sign} ${one}`]
           else
             end
         . ...ws1, ")"
     else
+      ascHelper := bigint ? 'bigintRange' : 'range'
+      descHelper := bigint ? 'bigintRevRange' : 'revRange'
       children =
         . "((s, e) => s > e ? "
-        . getHelperRef("revRange"), "(s, e"
-        . if range.right.inclusive then " - 1"
+        . getHelperRef(descHelper), "(s, e"
+        . if range.right.inclusive then ` - ${one}`
         . ") : "
-        . getHelperRef("range"), "(s, e"
-        . if range.right.inclusive then " + 1"
+        . getHelperRef(ascHelper), "(s, e"
+        . if range.right.inclusive then ` + ${one}`
         . "))"
         . "(", start, ...ws1, comma, ws2, end, ")"
 
@@ -142,23 +166,26 @@ function forRange(
   counterRef := makeRef("i")
 
   infinite := end is like {type: "Identifier", name: "Infinity"}
+  bigint := isBigIntLiteral(start) or isBigIntLiteral(end)
+  one := bigint ? 1n : 1
+  negOne := bigint ? -1n : -1
 
   let stepRef, asc: boolean?
   if stepExp
     stepExp = trimFirstSpace(stepExp)
     stepRef = maybeRef(stepExp, "step")
   else if infinite
-    stepExp = stepRef = makeNumericLiteral 1
+    stepExp = stepRef = makeNumericLiteral one
   else if increasing?
     if increasing
-      stepExp = stepRef = makeNumericLiteral 1
+      stepExp = stepRef = makeNumericLiteral one
       asc = true
     else
-      stepExp = stepRef = makeNumericLiteral -1
+      stepExp = stepRef = makeNumericLiteral negOne
       asc = false
   stepValue := if stepExp?.type is "Literal"
     literalValue stepExp
-  if stepValue <? "number"
+  if stepValue <? "number" or stepValue <? "bigint"
     asc = stepValue > 0
 
   // start needs to be ref'd to compute start <= end, unless we know direction
@@ -222,14 +249,14 @@ function forRange(
     : [counterRef, " < ", endRef, " : ", counterRef, " > ", endRef]
 
   condition :=
-    infinite or stepValue is 0 ? [] :
+    infinite or stepValue is 0 or stepValue is 0n ? [] :
     asc? ? (asc ? counterPart[0...3] : counterPart[4..]) :
     stepRef ? [stepRef, " !== 0 && (", stepRef, " > 0 ? ", ...counterPart, ")"] :
     [ascRef, " ? ", ...counterPart]
 
   increment :=
-    stepValue is +1 ? [...varAssign, "++", counterRef] :
-    stepValue is -1 ? [...varAssign, "--", counterRef] :
+    stepValue is +1 or stepValue is 1n ? [...varAssign, "++", counterRef] :
+    stepValue is -1 or stepValue is -1n ? [...varAssign, "--", counterRef] :
     stepRef
       ? [...varAssign, counterRef, " += ", stepRef]
       : ascRef

--- a/source/parser/helper.civet
+++ b/source/parser/helper.civet
@@ -120,6 +120,42 @@ declareHelper := {
       }
       """
     ], ";\n"]
+  bigintRange(bigintRangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      bigintRangeRef
+      ts [ ": (start: bigint, end: bigint) => bigint[]" ]
+      " "
+      """
+      = (start, end) => {
+        const length = Number(end - start);
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = BigInt(i) + start;
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
+  bigintRevRange(bigintRevRangeRef): void
+    state.prelude.push ["", [
+      preludeVar
+      bigintRevRangeRef
+      ts [ ": (start: bigint, end: bigint) => bigint[]" ]
+      " "
+      """
+      = (start, end) => {
+        const length = Number(start - end);
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - BigInt(i);
+        }
+        return arr;
+      }
+      """
+    ], ";\n"]
   stringRange(stringRangeRef): void
     state.prelude.push ["", [
       preludeVar

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -495,8 +495,8 @@ function typeSuffixForExpression(expression: ASTNode): TypeSuffix?
     children: [": ", t]
   }
 
-function makeNumericLiteral(n: number): Literal
-  s := n.toString()
+function makeNumericLiteral(n: number | bigint): Literal
+  s := n <? "bigint" ? `${n}n` : n.toString()
   type: "Literal"
   subtype: "NumericLiteral"
   raw: s

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -495,6 +495,10 @@ function typeSuffixForExpression(expression: ASTNode): TypeSuffix?
     children: [": ", t]
   }
 
+function isBigIntLiteral(node: ASTNode): boolean
+  node is like {type: "Literal", subtype: "NumericLiteral"} and
+    node.raw.endsWith "n"
+
 function makeNumericLiteral(n: number | bigint): Literal
   s := n <? "bigint" ? `${n}n` : n.toString()
   type: "Literal"
@@ -975,6 +979,7 @@ export {
   inplacePrepend
   insertTrimmingSpace
   isASTNodeObject
+  isBigIntLiteral
   isComma
   isEmptyBareBlock
   isExit

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -189,7 +189,7 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a;
-    for (let i = a = x; z !== 0 && (z > 0 ? i < y : i > y); a = i += z) {
+    for (let i = a = x; z != 0 && (z > 0 ? i < y : i > y); a = i += z) {
       console.log(a)
     }
   """
@@ -202,7 +202,7 @@ describe "coffeeForLoops", ->
       console.log a
     ---
     var a;
-    for (let end = y(), i = a = x(), step = z(); step !== 0 && (step > 0 ? i < end : i > end); a = i += step) {
+    for (let end = y(), i = a = x(), step = z(); step != 0 && (step > 0 ? i < end : i > end); a = i += step) {
       console.log(a)
     }
   """
@@ -217,7 +217,7 @@ describe "coffeeForLoops", ->
     ---
     var start, end, step, a;
     start = end = step = null
-    for (let end1 = y(), i = a = x(), step1 = z(); step1 !== 0 && (step1 > 0 ? i < end1 : i > end1); a = i += step1) {
+    for (let end1 = y(), i = a = x(), step1 = z(); step1 != 0 && (step1 > 0 ? i < end1 : i > end1); a = i += step1) {
       console.log(a)
     }
   """

--- a/test/compat/coffee-range.civet
+++ b/test/compat/coffee-range.civet
@@ -5,7 +5,7 @@ describe "coffeeRange", ->
     // Expected values are plain literal arrays because the test loader uses
     // an older Civet release that doesn't compile bigint ranges yet.
     asc := Array.from({ length: 28 }, (_, i) => BigInt(i + 1))   // [1n..28n]
-    desc := asc.toReversed()                                      // [28n..1n]
+    desc := [...asc].reverse()                                    // [28n..1n]
     evalsTo """
       "civet coffeeRange"
       [1n..28n]

--- a/test/compat/coffee-range.civet
+++ b/test/compat/coffee-range.civet
@@ -1,6 +1,20 @@
 { testCase, evalsTo } from "../helper.civet"
 
 describe "coffeeRange", ->
+  it "coffeeRange picks bigint helpers for bigint literal endpoints", ->
+    // Expected values are plain literal arrays because the test loader uses
+    // an older Civet release that doesn't compile bigint ranges yet.
+    asc := Array.from({ length: 28 }, (_, i) => BigInt(i + 1))   // [1n..28n]
+    desc := asc.toReversed()                                      // [28n..1n]
+    evalsTo """
+      "civet coffeeRange"
+      [1n..28n]
+    """, asc
+    evalsTo """
+      "civet coffeeRange"
+      [28n..1n]
+    """, desc
+
   it "coffeeRange behaves like range", ->
     evalsTo """
       "civet coffeeRange"

--- a/test/for.civet
+++ b/test/for.civet
@@ -1544,7 +1544,7 @@ describe "for", ->
       for a of [x...y] by z
         console.log a
       ---
-      for (let i = x; z !== 0 && (z > 0 ? i < y : i > y); i += z) {const a = i;
+      for (let i = x; z != 0 && (z > 0 ? i < y : i > y); i += z) {const a = i;
         console.log(a)
       }
     """
@@ -1555,7 +1555,7 @@ describe "for", ->
       for a of [x()...y()] by z()
         console.log a
       ---
-      for (let end = y(), i = x(), step = z(); step !== 0 && (step > 0 ? i < end : i > end); i += step) {const a = i;
+      for (let end = y(), i = x(), step = z(); step != 0 && (step > 0 ? i < end : i > end); i += step) {const a = i;
         console.log(a)
       }
     """

--- a/test/range.civet
+++ b/test/range.civet
@@ -293,6 +293,145 @@ describe "range", ->
     range(0,n)
   """
 
+  describe "bigint", ->
+    testCase """
+      small literal range emits inline array
+      ---
+      [1n..5n]
+      ---
+      [1n, 2n, 3n, 4n, 5n]
+    """
+
+    testCase """
+      small reversed literal range
+      ---
+      [5n>..1n]
+      ---
+      [4n, 3n, 2n, 1n]
+    """
+
+    testCase """
+      underscored bigint literal
+      ---
+      [1_000n..1_002n]
+      ---
+      [1000n, 1001n, 1002n]
+    """
+
+    testCase """
+      large literal range uses bigintRange helper
+      ---
+      [1n..28n]
+      ---
+      var bigintRange: (start: bigint, end: bigint) => bigint[] = (start, end) => {
+        const length = Number(end - start);
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = BigInt(i) + start;
+        }
+        return arr;
+      };
+      bigintRange(1n,28n + 1n)
+    """
+
+    testCase """
+      large decreasing literal range uses bigintRevRange
+      ---
+      [28n>..1n]
+      ---
+      var bigintRevRange: (start: bigint, end: bigint) => bigint[] = (start, end) => {
+        const length = Number(start - end);
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = start - BigInt(i);
+        }
+        return arr;
+      };
+      bigintRevRange(28n - 1n,1n - 1n)
+    """
+
+    testCase """
+      mixed literal + variable still picks bigint helper
+      ---
+      [1n..end]
+      ---
+      var bigintRange: (start: bigint, end: bigint) => bigint[] = (start, end) => {
+        const length = Number(end - start);
+        if (length <= 0) return [];
+        const arr = Array(length);
+        for (let i = 0; i < length; ++i) {
+          arr[i] = BigInt(i) + start;
+        }
+        return arr;
+      };
+      bigintRange(1n,end + 1n)
+    """
+
+    testCase """
+      for of bigint range increments with ++
+      ---
+      for i of [1n..28n]
+        ;
+      ---
+      for (let i1 = 1n; i1 <= 28n; ++i1) {const i = i1;
+        ;
+      }
+    """
+
+    testCase """
+      for of exclusive-left bigint range bumps with 1n
+      ---
+      for i of [1n<..28n]
+        ;
+      ---
+      for (let i1 = 1n + 1n; i1 <= 28n; ++i1) {const i = i1;
+        ;
+      }
+    """
+
+    testCase """
+      for of decreasing bigint range decrements with --
+      ---
+      for i of [28n>..1n]
+        ;
+      ---
+      for (let i1 = 28n + -1n; i1 >= 1n; --i1) {const i = i1;
+        ;
+      }
+    """
+
+    it "evals to the correct bigint ranges", ->
+      evalsTo '[1n..5n]', [1n, 2n, 3n, 4n, 5n]
+      evalsTo '[1n<..<5n]', [2n, 3n, 4n]
+      evalsTo '[5n>..1n]', [4n, 3n, 2n, 1n]
+      // length > 20 to exercise the bigintRange helper
+      evalsTo '[1n..28n].includes(15n)', true
+      evalsTo '[1n..28n].includes(50n)', false
+      evalsTo '[1n..28n].length', 28
+      evalsTo '[28n>..1n].length', 27
+
+    it "for-of evaluates bigint ranges correctly", ->
+      evalsTo """
+        let sum = 0n
+        for i of [1n..28n]
+          sum += i
+        sum
+      """, 406n
+      evalsTo """
+        let sum = 0n
+        for i of [1n<..<28n]
+          sum += i
+        sum
+      """, 377n
+      evalsTo """
+        let arr: bigint[] = []
+        for i of [28n>..1n]
+          arr.push i
+        arr
+      """, [27n, 26n, 25n, 24n, 23n, 22n, 21n, 20n, 19n, 18n, 17n, 16n, 15n, 14n, 13n, 12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n, 4n, 3n, 2n, 1n]
+
   describe "inequalities on range", ->
     testCase """
       ..< with numbers

--- a/test/range.civet
+++ b/test/range.civet
@@ -432,6 +432,16 @@ describe "range", ->
         arr
       """, [27n, 26n, 25n, 24n, 23n, 22n, 21n, 20n, 19n, 18n, 17n, 16n, 15n, 14n, 13n, 12n, 11n, 10n, 9n, 8n, 7n, 6n, 5n, 4n, 3n, 2n, 1n]
 
+      // Dynamic 0n step must be treated as zero (skip loop) rather than
+      // infinite-looping. The loose `!= 0` guard catches both 0 and 0n.
+      evalsTo """
+        const x = 1n, y = 10n, z = 0n
+        let count = 0
+        for i of [x..y] by z
+          if ++count > 100 then break
+        count
+      """, 0
+
   describe "inequalities on range", ->
     testCase """
       ..< with numbers


### PR DESCRIPTION
Closes #1605.

`[1n..28n]` as a value emitted `range(1n, 28n + 1)`, which is a TypeError because `28n + 1` mixes BigInt and Number. Even with the adjustment fixed, the `range` helper itself does `Array(length)` and `i + start`, both of which fail on BigInt operands.

## Approach

- New `bigintRange` / `bigintRevRange` helpers: same shape as the Number ones but use `Number(end - start)` for the Array length and `BigInt(i)` for the per-element step.
- At the call site, when either endpoint is a bigint literal, route to the new helpers and emit `+ 1n` / `- 1n` adjustments. Number-range output and existing snapshot tests are unchanged.
- Literal-bigint fast path emits inline `[1n, 2n, ...]` for ranges of length ≤ 20, matching the existing behavior for Number ranges.
- `forRange` picks `1n` / `-1n` for the implicit step when bounds are bigint literals (fixes the preexisting `for i of [1n<..28n]` bug surfaced while investigating). The `++` / `--` and `stepValue is 0` optimizations are widened to also recognize the bigint equivalents.
- `isBigIntLiteral` predicate lives in `util.civet` alongside the other AST predicates.

## Verified working

- `is in [1n..28n]` (the reported case) and all inclusivity variants
- `for i of [1n..28n]` and all inclusivity variants (`<..`, `<..<`, `>..`, etc.)
- Range comprehensions: `i*i for i of [1n..5n]`
- `for of [1n..Infinity]` with `break`
- `by step` clauses with bigint step (`for i of [1n..10n] by 2n`)
- Spread: `[...[1n..5n]]`
- Negative bigint literals: `[-2n..2n]`

## Out of scope

- `a[1n..3n]` slice — `Array.prototype.slice` itself rejects bigint indices regardless of any adjustment fix, and TypeScript already catches this at compile time. Silently wrapping in `Number()` would be a surprising semantic change, so left alone.
- `[a..b]` where both endpoints are bigint *variables* with no literal hint — the compiler can't detect bigint without type info, so emits the Number helper. Workaround: use one literal endpoint, or use `for of [a..b]` with the default `..` (works because `++` is bigint-safe).