### PR TITLE
Add esBraceBlock flag so `=> {…}` is a block, not an object

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -73,6 +73,7 @@ You can also turn on/off individual compatibility features.
 |---------------------|---------------------------------------|
 | [`esCompat`](reference#ecmascript-compatibility) | enable all of the following ECMAScript compatibility flags |
 | [`esArrowFunction`](reference#single-argument-arrow-functions) | `x => x+1` as shorthand for `(x) => x+1`; does not affect `->` |
+| [`esBraceBlock`](reference#brace-block-bodies) | treat `{...}` after `=>`/`->` as a block, never an object literal |
 | [`-implicit-returns`](reference#no-implicit-returns) | turn off implicit return of last value in functions, except in one-line `=>` |
 
 ## CoffeeScript Compatibility

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3647,6 +3647,25 @@ greet := (name) => `Hello, ${name}!`
 noArgs := => console.log "Hello, world!"
 </Playground>
 
+### Brace Block Bodies
+
+By default, Civet reinterprets a braced body after `=>` or `->`
+as an object literal, so `=> { foo(x) }` becomes `=> ({foo: foo(x)})`
+via Civet's `{expr.foo()}` → `{foo: expr.foo()}` shorthand.
+With `"civet esBraceBlock"` (or `"civet esCompat"`),
+braces after `=>` and `->` are always parsed as block bodies,
+matching ECMAScript. Use explicit parentheses `() => ({a: 1})`
+to return an object literal from an arrow function.
+
+<Playground>
+"civet esBraceBlock"
+run := x => {
+  log x
+  process x
+}
+makeObj := () => ({ a: 1, b: 2 })
+</Playground>
+
 ### Strict Mode
 
 Output from Civet runs by default in JavaScript's sloppy mode,

--- a/source/main.civet
+++ b/source/main.civet
@@ -94,6 +94,7 @@ export type CompilerOptions
     comptime?: boolean
     globals?: string[]?
     esArrowFunction?: boolean
+    esBraceBlock?: boolean
     esCompat?: boolean
     operators?: (string[] | Record<string, string?>)?
     symbols?: string[]

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1046,6 +1046,9 @@ FatArrowBody
   # NOTE: Skip expressionized statements, so they get braced instead
   # NOTE: Skip declarations (e.g. `{ foo } from bar`), so they get braced instead
   !EOS !( _? ExpressionizedStatement ) !( _? Declaration ) NonPipelineExpression:exp !TrailingDeclaration !TrailingPipe !TrailingPostfix !SemicolonDelimiter ->
+    // Under esBraceBlock, a body starting with `{` must be a block, not an
+    // object literal. Skip so we fall through to NoCommaBracedOrEmptyBlock.
+    return $skip if config.esBraceBlock and exp!.type is "ObjectExpression"
     // Ensure object literal is wrapped in parens
     exp = makeExpressionStatement(exp)
     expressions := [["", exp]]
@@ -3276,6 +3279,8 @@ SingleLineStatements
 # literal, which should potentially be unwrapped if not used as a value.
 ObjectSingleLineStatements
   &( _? BracedObjectLiteral ) SingleLineStatements:block ::BlockStatement ->
+    // Under esBraceBlock, braced bodies are always blocks, never reinterpreted as objects.
+    return $skip if config.esBraceBlock
     if block.bare and block.expressions# is 1
       expression := block.expressions[0]![1]
       if expression!.type is "ParenthesizedExpression" and
@@ -9546,6 +9551,11 @@ ESArrowFunctionEnabled
     if(config.esArrowFunction) return
     return $skip
 
+ESBraceBlockEnabled
+  "" ->
+    if(config.esBraceBlock) return
+    return $skip
+
 JSXCodeNestedEnabled
   "" ->
     if(config.jsxCodeNested) return
@@ -9614,6 +9624,7 @@ Reset
       iife: false,
       implicitReturns: true,
       esArrowFunction: false,
+      esBraceBlock: false,
       jsxCode: false,
       objectIs: false,
       react: false,
@@ -9671,6 +9682,7 @@ Reset
       set(b) {
         for (const option of [
           "esArrowFunction",
+          "esBraceBlock",
         ]) {
           config[option] = b
         }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3279,8 +3279,6 @@ SingleLineStatements
 # literal, which should potentially be unwrapped if not used as a value.
 ObjectSingleLineStatements
   &( _? BracedObjectLiteral ) SingleLineStatements:block ::BlockStatement ->
-    // Under esBraceBlock, braced bodies are always blocks, never reinterpreted as objects.
-    return $skip if config.esBraceBlock
     if block.bare and block.expressions# is 1
       expression := block.expressions[0]![1]
       if expression!.type is "ParenthesizedExpression" and
@@ -3291,6 +3289,9 @@ ObjectSingleLineStatements
 
 BracedObjectSingleLineStatements
   ObjectSingleLineStatements:block ->
+    // Under esBraceBlock, arrow bodies skip this reinterpretation entirely so
+    // `=> { f(y) }` falls through to NoCommaBracedOrEmptyBlock as a real block.
+    return $skip if config.esBraceBlock
     return bracedBlock(block)
 
 PostfixedSingleLineStatements
@@ -9549,11 +9550,6 @@ CoffeePrototypeEnabled
 ESArrowFunctionEnabled
   "" ->
     if(config.esArrowFunction) return
-    return $skip
-
-ESBraceBlockEnabled
-  "" ->
-    if(config.esBraceBlock) return
     return $skip
 
 JSXCodeNestedEnabled

--- a/test/compat/es-brace-block.civet
+++ b/test/compat/es-brace-block.civet
@@ -1,0 +1,74 @@
+{testCase} from ../helper.civet
+
+describe "esBraceBlock", ->
+  testCase """
+    arrow with braced body is a block, not an object literal
+    ---
+    "civet esBraceBlock"
+    x => {
+      f(y)
+    }
+    ---
+    x(() => {
+      return f(y)
+    })
+  """
+
+  testCase """
+    single-line braced arrow body is a block
+    ---
+    "civet esBraceBlock"
+    fn := () => { f(y) }
+    ---
+    const fn = () => { return f(y) }
+  """
+
+  testCase """
+    thin arrow with braced body is a block
+    ---
+    "civet esBraceBlock"
+    x -> { f(y) }
+    ---
+    x(function() { return f(y) })
+  """
+
+  testCase """
+    parenthesized object return still works
+    ---
+    "civet esBraceBlock"
+    fn := () => ({ a: 1 })
+    ---
+    const fn = () => ({ a: 1 })
+  """
+
+  testCase """
+    single expression body unaffected
+    ---
+    "civet esBraceBlock"
+    fn := () => "single"
+    ---
+    const fn = () => "single"
+  """
+
+  testCase """
+    esBraceBlock does not enable esArrowFunction
+    ---
+    "civet esBraceBlock"
+    x => x + 1
+    ---
+    x(() => x + 1)
+  """
+
+describe "esCompat enables esBraceBlock", ->
+  testCase """
+    arrow with braced body becomes a block
+    ---
+    "civet esCompat"
+    x => {
+      f(y)
+    }
+    ---
+    (x) => {
+      f(y)
+    }
+  """

--- a/test/compat/es-brace-block.civet
+++ b/test/compat/es-brace-block.civet
@@ -59,6 +59,33 @@ describe "esBraceBlock", ->
     x(() => x + 1)
   """
 
+  testCase """
+    empty braced arrow body
+    ---
+    "civet esBraceBlock"
+    fn := () => {}
+    ---
+    const fn = () => {}
+  """
+
+  testCase """
+    if/then with braced body (ThenBlock path)
+    ---
+    "civet esBraceBlock"
+    if x then { f(y) }
+    ---
+    if (x) { f(y) }
+  """
+
+  testCase """
+    if with same-line braced body (BlockOrEmpty path)
+    ---
+    "civet esBraceBlock"
+    if x { f(y) }
+    ---
+    if (x) { f(y) }
+  """
+
 describe "esCompat enables esBraceBlock", ->
   testCase """
     arrow with braced body becomes a block


### PR DESCRIPTION
Closes #667.

## Cause

Civet's `{x.y?.z()}` → `{z: x.y?.z()}` property-shorthand fires on
braced arrow bodies, so `x => { f(y) }` compiles to
`x(() => ({f: f(y)}))` instead of a block body.

## Approach

New `esBraceBlock` sub-flag (also rolled into `esCompat`) gates
two parser paths so a body starting with `{` is always a block:

- `ObjectSingleLineStatements` `$skip`s under the flag — covers
  `BracedObjectSingleLineStatements` (fat + thin arrow bodies),
  `ThenBlock`, and `BlockOrEmpty`.
- `FatArrowBody`'s expression alt `$skip`s when the parsed
  expression is an `ObjectExpression`, falling through to
  `NoCommaBracedOrEmptyBlock`.

Use `() => ({…})` to return an object literal explicitly.

`implicitReturns` stays orthogonal — `esCompat` continues to disable
it via the existing umbrella, but `esBraceBlock` alone does not.