### PR TITLE
Add `array[?]` shorthand for random element selection

### DIFF
--- a/civet.dev/cheatsheet.md
+++ b/civet.dev/cheatsheet.md
@@ -325,7 +325,7 @@ and [non-identifier Unicode codepoints in identifiers](/reference#unicode-identi
 | Symbol | Meanings |
 |--------|----------|
 | space | Function call `f x`; TypeScript argument `Set T` |
-| `?` | Non-null test `x?`, `if x? := foo()`; non-null access `x?.y`, `x?y`, `x?(...)`, `x?[...]`; null coalescing `x ?? y` (`x ? y` with `coffeeBinaryExistential`); TypeScript optionals `(x?: T) => x`; optional declaration `let x?: T`; optional types `T?`, `T??`; instanceof shorthand `x <? Class`; typeof shorthand `x <? "string"`; if/then/else ternary `x ? y : z` |
+| `?` | Non-null test `x?`, `if x? := foo()`; non-null access `x?.y`, `x?y`, `x?(...)`, `x?[...]`; random indexing `x[?]`; null coalescing `x ?? y` (`x ? y` with `coffeeBinaryExistential`); TypeScript optionals `(x?: T) => x`; optional declaration `let x?: T`; optional types `T?`, `T??`; instanceof shorthand `x <? Class`; typeof shorthand `x <? "string"`; if/then/else ternary `x ? y : z` |
 | `!` | Negation `!x`; negated operators `!=`, `!==`, `!in`, `!instanceof`, `is !like`, `!custom`, `!<?`, `!^`, `!^^`; object flag `{!x}`; JSX flag `<div !draggable>`; TypeScript non-null assertion `x!`; non-null assertion access `x!.y`, `x!y`; non-null type `T!`; forced type assertion `as!`; negated extends shorthand `!<` |
 | `@` | this shorthand `@`; this properties `@x`; method bind `x@y`, `x@.y`, `@@x`; decorators `@@d` |
 | `#` | private properties `x.#y`, `#y`; length shorthand `x#`, `#`; block comments `### ... ###`; one-line comments `# ...` with `coffeeComment`; CoffeeScript string interpolations `"x#{y}"` with `coffeeInterpolation` |

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -519,6 +519,15 @@ for i of [0...a#]
 
 See also [length shorthand](#length-shorthand).
 
+### Random Indexing
+
+You can use `a[?]` to select a random element from an array:
+
+<Playground>
+greeting := greetings[?]
+getGrid()[?] = newValue
+</Playground>
+
 ## Strings
 
 Strings can span multiple lines:

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1882,6 +1882,13 @@ MemberBracketContent
       expression,
       mod: true,
     }
+  # NOTE: `x[?]` shorthand for `x[Math.floor(Math.random() * x.length)]`
+  OpenBracket:open __:ws1 "?" __:ws2 CloseBracket:close ->
+    return {
+      type: "Index",
+      children: [open, ws1, ws2, close],
+      random: true,
+    }
 
 SliceParameters
   Loc:ls Expression?:start __:ws RangeDots:dots Loc:le Expression?:end ->

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -829,6 +829,28 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
           ...children[>i]
         ]
       })
+    else if glob is like {type: "Index", random: true}
+      assert.notEqual i, 0, "Index access must be preceded by an expression"
+      prefix := i is 1 ? children[0] : children[<i]
+      { ref, refAssignment } := maybeRefAssignment prefix
+      expression := [ "Math.floor(Math.random() * ", ref, ".length)" ]
+      return processCallMemberExpression({  // in case there are more
+        ...node
+        children: [
+          makeLeftHandSideExpression refAssignment ?? prefix
+          makeNode {
+            ...glob
+            random: false
+            expression
+            children: [
+              glob.children[0] // "[" token
+              expression
+              glob.children.-1 // "]" token
+            ]
+          }
+          ...children[>i]
+        ]
+      })
     else if glob is like {type: "SliceExpression", reversed: true}
       args := [
         { ...node, children: node.children[...i] }

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -596,3 +596,46 @@ describe "property access", ->
       var modulo = ((a: number, b: number) => (a % b + b) % b) as ((a: number, b: number) => number) & ((a: bigint, b: bigint) => bigint);
       let ref;(ref = x())[modulo(i+j, ref.length)] = rhs
     """
+
+  describe "random shorthand", ->
+    testCase """
+      simple
+      ---
+      x[?]
+      x[ ?]
+      x[? ]
+      x[ ? ]
+      ---
+      x[Math.floor(Math.random() * x.length)]
+      x[Math.floor(Math.random() * x.length)]
+      x[Math.floor(Math.random() * x.length)]
+      x[Math.floor(Math.random() * x.length)]
+    """
+
+    testCase """
+      complex
+      ---
+      x()[?]
+      x.y[?]
+      (x+y)[?]
+      ---
+      let ref;(ref = x())[Math.floor(Math.random() * ref.length)]
+      let ref1;(ref1 = x.y)[Math.floor(Math.random() * ref1.length)]
+      let ref2;(ref2 = (x+y))[Math.floor(Math.random() * ref2.length)]
+    """
+
+    testCase """
+      assigned
+      ---
+      x()[?] = rhs
+      ---
+      let ref;(ref = x())[Math.floor(Math.random() * ref.length)] = rhs
+    """
+
+    testCase """
+      chained
+      ---
+      arr[?].foo
+      ---
+      arr[Math.floor(Math.random() * arr.length)].foo
+    """


### PR DESCRIPTION
Closes #909

Expands `array[?]` to `array[Math.floor(Math.random() * array.length)]`, hoisting a ref when the prefix is a complex expression so it evaluates once.

```coffee
greeting := greetings[?]
getGrid()[?] = newValue
```

compiles to

```js
const greeting = greetings[Math.floor(Math.random() * greetings.length)];
let ref;(ref = getGrid())[Math.floor(Math.random() * ref.length)] = newValue
```

## Test plan
- [x] `simple` / `complex` / `assigned` / `chained` cases in `test/property-access.civet`
- [x] Full suite + self-test green
- [x] Typecheck within baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)