### PR TITLE
Coffee classes: `name: value` colon form becomes prototype assignment

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1550,10 +1550,27 @@ FieldDefinition
         return convertArrowFunctionToMethod(id, exp)
       }
       default:
+        // CoffeeScript-compatible: `name: value` becomes a prototype
+        // assignment (`Class.prototype.name = value`) lifted out of the
+        // class body in processCoffeeClasses. The empty children make
+        // this entry invisible in the emitted class body.
+        // PrivateIdentifier (`#x`) is JS-only — CoffeeScript has no
+        // private fields — so leave the original class-field semantics
+        // intact rather than emit invalid `Foo.prototype.#x = ...`.
+        // The PrivateIdentifier rule normalises to type "Identifier"
+        // with a `#`-prefixed name, so detect by name prefix.
+        if (id?.name?.startsWith?.("#")) {
+          return {
+            type: "FieldDefinition",
+            id,
+            children: [id, " = ", exp],
+          }
+        }
         return {
-          type: "FieldDefinition",
+          type: "CoffeeClassPrototype",
           id,
-          children: [id, " = ", exp],
+          exp,
+          children: [],
         }
     }
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -27,6 +27,9 @@ import type {
   DoStatement
   ElseClause
   FinallyClause
+  ClassElementName
+  CoffeeClassPrototype
+  ExpressionNode
   ForStatement
   FunctionSignature
   IfStatement
@@ -1697,18 +1700,18 @@ function processBreaksContinues(statements: StatementTuple[]): void
  * identifiers, `[Symbol.foo]` for symbol-keyed elements, or `[key]`
  * for other computed forms.
  */
-function makePrototypeAssignment(className: ASTNode, id: ASTNode, exp: ASTNode): ASTNode
+function makePrototypeAssignment(className: ASTNode, id: ClassElementName, exp: ExpressionNode | ASTRef): ASTNode
   access: ASTNode .=
     // SymbolElement already has the form `["[", SymbolLiteral, "]"]`
     if Array.isArray id then id
     // ComputedPropertyName children already include the brackets.
-    else if (id as ASTNodeObject)?.type is "ComputedPropertyName" then id
+    else if id.type is "ComputedPropertyName" then id
     // Plain identifier (including LengthShorthand) gets dot access,
     // unless its name was a non-ASCII unicode identifier that had to
     // be rendered via brackets to preserve the original source name.
-    else if (id as Identifier)?.type is "Identifier"
-      if (id as Identifier).unicode
-        ["[\"", (id as Identifier).unicode, "\"]"]
+    else if id.type is "Identifier"
+      if id.unicode
+        ["[\"", id.unicode, "\"]"]
       else
         [".", id]
     // Numeric/string literals (and any other ClassElementName shape)
@@ -1779,8 +1782,13 @@ function processCoffeeClasses(statements: StatementTuple[]): void
     // function) is a prototype assignment Class.prototype.name = value,
     // also lifted out of the class body via the same IIFE wrapper.
     privates := expressions.filter &[1]?.type is "CoffeeClassPrivate"
-    prototypes := expressions.filter &[1]?.type is "CoffeeClassPrototype"
-    continue unless privates# or prototypes#
+    // Iterate-and-narrow to get a properly-typed CoffeeClassPrototype[]:
+    // `filter` can't carry a tuple-element narrowing into the result.
+    prototypeNodes: CoffeeClassPrototype[] := []
+    for [, p] of expressions
+      if p?.type is "CoffeeClassPrototype"
+        prototypeNodes.push p
+    continue unless privates# or prototypeNodes#
 
     { parent } := ce
 
@@ -1791,7 +1799,7 @@ function processCoffeeClasses(statements: StatementTuple[]): void
         expressions.splice i, 1
 
     let wrapped: ASTNode
-    if prototypes#
+    if prototypeNodes#
       // The class needs a local name to receive prototype assignments.
       // Named classes use their declared name directly; anonymous
       // classes are bound to a generated ref via `let _Class = class {}`
@@ -1810,8 +1818,8 @@ function processCoffeeClasses(statements: StatementTuple[]): void
         } as! Declaration
       body: StatementTuple[] := [...privates]
       body.push [indent, classStatement]
-      for [, p] of prototypes
-        body.push [indent, makePrototypeAssignment(className, p.id!, p.exp!)]
+      for p of prototypeNodes
+        body.push [indent, makePrototypeAssignment(className, p.id, p.exp)]
       body.push [indent, makeNode {
         type: "ReturnStatement"
         children: ["return ", className]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1691,6 +1691,39 @@ function processBreaksContinues(statements: StatementTuple[]): void
     label.children.push label.name = parent.label.name
     delete label.special
 
+/**
+ * Construct `ClassName.prototype<access> = exp` for a lifted
+ * CoffeeClassPrototype entry, where <access> is `.name` for plain
+ * identifiers, `[Symbol.foo]` for symbol-keyed elements, or `[key]`
+ * for other computed forms.
+ */
+function makePrototypeAssignment(className: ASTNode, id: ASTNode, exp: ASTNode): ASTNode
+  access: ASTNode .=
+    // SymbolElement already has the form `["[", SymbolLiteral, "]"]`
+    if Array.isArray id then id
+    // ComputedPropertyName children already include the brackets.
+    else if (id as ASTNodeObject)?.type is "ComputedPropertyName" then id
+    // Plain identifier (including LengthShorthand) gets dot access,
+    // unless its name was a non-ASCII unicode identifier that had to
+    // be rendered via brackets to preserve the original source name.
+    else if (id as Identifier)?.type is "Identifier"
+      if (id as Identifier).unicode
+        ["[\"", (id as Identifier).unicode, "\"]"]
+      else
+        [".", id]
+    // Numeric/string literals (and any other ClassElementName shape)
+    // round-trip via bracket access.
+    else
+      ["[", id, "]"]
+  return makeNode {
+    type: "AssignmentExpression"
+    children: [className, ".prototype", access, " = ", exp]
+    lhs: className as any
+    assigned: className
+    expression: exp as any
+    names: []
+  }
+
 function processCoffeeClasses(statements: StatementTuple[]): void
   for each ce of gatherRecursiveAll statements, .type is "ClassExpression"
     { expressions } := ce.body
@@ -1741,24 +1774,61 @@ function processCoffeeClasses(statements: StatementTuple[]): void
       replaceNode public_static_arrow_function_assignment, convertArrowFunctionToMethod(id, public_static_arrow_function_assignment.expression)
 
     // In a CoffeeScript class, `x = y` makes a private variable x visible
-    // only within the class scope only, implemented via IIFE wrapper
+    // only within the class scope only, implemented via IIFE wrapper.
+    // In a CoffeeScript class, `name: value` (where value is not a
+    // function) is a prototype assignment Class.prototype.name = value,
+    // also lifted out of the class body via the same IIFE wrapper.
     privates := expressions.filter &[1]?.type is "CoffeeClassPrivate"
-    continue unless privates#
+    prototypes := expressions.filter &[1]?.type is "CoffeeClassPrototype"
+    continue unless privates# or prototypes#
 
     { parent } := ce
 
-    // Remove privates from class body, in place
+    // Remove privates and prototypes from class body, in place
     for i of [expressions# >.. 0]
-      if expressions[i][1]?.type is "CoffeeClassPrivate"
+      t := expressions[i][1]?.type
+      if t is "CoffeeClassPrivate" or t is "CoffeeClassPrototype"
         expressions.splice i, 1
 
-    wrapped .= wrapIIFE
-      . ...privates
-      . [indent, wrapWithReturn ce]
+    let wrapped: ASTNode
+    if prototypes#
+      // The class needs a local name to receive prototype assignments.
+      // Named classes use their declared name directly; anonymous
+      // classes are bound to a generated ref via `let _Class = class {}`
+      // inside the IIFE.
+      let className: ASTNode
+      let classStatement: ASTNode = ce
+      if ce.binding
+        className = ce.name as! string
+      else
+        classRef := makeRef "_Class"
+        className = classRef
+        classStatement = makeNode {
+          type: "Declaration"
+          children: ["let ", classRef, " = ", ce]
+          names: []
+        } as! Declaration
+      body: StatementTuple[] := [...privates]
+      body.push [indent, classStatement]
+      for [, p] of prototypes
+        body.push [indent, makePrototypeAssignment(className, p.id!, p.exp!)]
+      body.push [indent, makeNode {
+        type: "ReturnStatement"
+        children: ["return ", className]
+        expression: className
+      }]
+      wrapped = wrapIIFE body
+    else
+      wrapped = wrapIIFE
+        . ...privates
+        . [indent, wrapWithReturn ce]
 
-    // Outer assignment
-    if { binding } .= ce
-      binding = trimFirstSpace binding
+    // Outer assignment for named classes: `class Foo` becomes
+    // `Foo = (IIFE)` so the IIFE result is captured into the binding.
+    // Anonymous classes skip this — replaceNode below puts the IIFE
+    // directly where the ClassExpression was.
+    if ce.binding
+      binding .= trimFirstSpace ce.binding
       wrapped = makeNode {
         type: "AssignmentExpression"
         children: [binding, " = ", wrapped]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -95,6 +95,7 @@ export type OtherNode =
   | CaseBlock
   | CaseClause
   | CoffeeClassPrivate
+  | CoffeeClassPrototype
   | CoffeeClassPublic
   | CommentNode
   | ComputedPropertyName
@@ -1029,7 +1030,7 @@ export type Delimiter = ASTLeaf | ASTString | Delimiter[]
 type PropertyName =
   Literal | ComputedPropertyName | Identifier
 
-type ComputedPropertyName =
+export type ComputedPropertyName =
   type: "ComputedPropertyName"
   children: Children
   parent?: Parent
@@ -1287,6 +1288,33 @@ export type CoffeeClassPrivate = ASTParent &
   id: ASTNode
   typeSuffix?: TypeSuffix?
   initializer: Initializer
+
+/**
+ * The shape returned by the ClassElementName grammar rule:
+ *   PropertyName / LengthShorthand / PrivateIdentifier / SymbolElement.
+ * PropertyName branches to bare-leaf forms (hyphenated names) plus
+ * NumericLiteral / ComputedPropertyName / StringLiteral / Identifier;
+ * LengthShorthand and PrivateIdentifier both normalise to Identifier.
+ * SymbolElement is a `[ "[", SymbolLiteral, "]" ]` tuple.
+ */
+export type ClassElementName =
+  | NumericLiteral
+  | StringLiteral
+  | ASTLeaf
+  | Identifier
+  | ComputedPropertyName
+  | SymbolElement
+
+export type SymbolElement = [
+  ASTLeaf | ASTString
+  SymbolLiteral
+  ASTLeaf | ASTString
+]
+
+export type CoffeeClassPrototype = ASTParent &
+  type: "CoffeeClassPrototype"
+  id: ClassElementName
+  exp: ExpressionNode | ASTRef
 
 export type CoffeeClassPublic = ASTParent &
   type: "CoffeeClassPublic"

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -79,10 +79,112 @@ describe "coffeeClasses", ->
       count: 42
       name: "hello"
     ---
-    class Foo {
-      count = 42
-      name = "hello"
+    Foo = (()=>{
+      class Foo {
     }
+      Foo.prototype.count = 42
+      Foo.prototype.name = "hello"
+      return Foo})()
+  """
+
+  testCase """
+    symbol-keyed colon field value
+    ---
+    "civet coffeeClasses"
+    class Foo
+      [Symbol.toStringTag]: 'Foo'
+    ---
+    Foo = (()=>{
+      class Foo {
+    }
+      Foo.prototype[Symbol.toStringTag] = 'Foo'
+      return Foo})()
+  """
+
+  testCase """
+    colon field value alongside methods
+    ---
+    "civet coffeeClasses"
+    exports.Lexer = class Lexer
+      tokenize: (code) -> code.length
+      prop: 'hello'
+    ---
+    exports.Lexer = Lexer = (()=>{
+      class Lexer {
+      tokenize(code) { return code.length }
+    }
+      Lexer.prototype.prop = 'hello'
+      return Lexer})()
+  """
+
+  testCase """
+    symbol-shorthand colon field value
+    ---
+    "civet coffeeClasses"
+    class Foo
+      :iterator: 5
+    ---
+    Foo = (()=>{
+      class Foo {
+    }
+      Foo.prototype[Symbol.iterator] = 5
+      return Foo})()
+  """
+
+  testCase """
+    string/numeric colon field value
+    ---
+    "civet coffeeClasses"
+    class Foo
+      "hello-world": 1
+      42: 'num'
+    ---
+    Foo = (()=>{
+      class Foo {
+    }
+      Foo.prototype["hello-world"] = 1
+      Foo.prototype[42] = 'num'
+      return Foo})()
+  """
+
+  testCase """
+    unicode colon field value
+    ---
+    "civet coffeeClasses"
+    class Foo
+      😊: 'happy'
+    ---
+    Foo = (()=>{
+      class Foo {
+    }
+      Foo.prototype["😊"] = 'happy'
+      return Foo})()
+  """
+
+  testCase """
+    private-field colon stays as class field
+    ---
+    "civet coffeeClasses"
+    class Foo
+      #x: 5
+    ---
+    class Foo {
+      #x = 5
+    }
+  """
+
+  testCase """
+    anonymous-class colon field value
+    ---
+    "civet coffeeClasses"
+    K = class
+      count: 42
+    ---
+    K = (()=>{
+      let _Class = class {
+    }
+      _Class.prototype.count = 42
+      return _Class})()
   """
 
   testCase """
@@ -148,6 +250,23 @@ describe "coffeeClasses", ->
       callApi() {
         return console.log(HTTP_VERBS[0])
       }
+    }})()
+  """
+
+  testCase """
+    private static class fields on anonymous class
+    ---
+    "civet coffeeCompat"
+    K = class
+      PRIV = 'priv'
+      m: -> PRIV
+    ---
+    var K;
+    K = (()=>{
+      var PRIV;
+      PRIV = 'priv'
+      return class {
+      m() { return PRIV }
     }})()
   """
 

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -271,6 +271,46 @@ describe "coffeeClasses", ->
   """
 
   testCase """
+    private statics and prototype fields together
+    ---
+    "civet coffeeCompat"
+    class Foo
+      PRIV = 10
+      count: 42
+      inc: -> PRIV + 1
+    ---
+    var Foo;
+    Foo = (()=>{
+      var PRIV;
+      PRIV = 10
+      class Foo {
+      inc() { return PRIV + 1 }
+    }
+      Foo.prototype.count = 42
+      return Foo})()
+  """
+
+  testCase """
+    private statics and prototype fields on anonymous class
+    ---
+    "civet coffeeCompat"
+    K = class
+      PRIV = 10
+      count: 42
+      inc: -> PRIV + 1
+    ---
+    var K;
+    K = (()=>{
+      var PRIV;
+      PRIV = 10
+      let _Class = class {
+      inc() { return PRIV + 1 }
+    }
+      _Class.prototype.count = 42
+      return _Class})()
+  """
+
+  testCase """
     private static class functions
     ---
     "civet coffeeCompat"


### PR DESCRIPTION
Fixes #944.

`name: value` (non-function) in a `coffeeClasses` class now compiles to `Name.prototype.name = value`, lifted into the same IIFE wrapper that already handles private statics. Matches CoffeeScript output so `Foo::[Symbol.toStringTag]` returns the assigned value instead of `undefined`.

`#x: value` keeps class-field semantics — CoffeeScript has no private fields, and emitting `.#x` on the prototype would be invalid JS.

### Bonus fix

Pre-existing IIFE-wrap bug (since [9cf76757](https://github.com/DanielXMoore/Civet/commit/9cf76757), the original `processCoffeeClasses`): `if { binding } .= ce` looks like "wrap if `ce.binding` is truthy" but `.=` is a destructure-assignment, so the block ran unconditionally. For anonymous classes, `binding` came out `undefined` and the wrapper rendered `[undefined, " = ", IIFE]` as ` = (IIFE)`, corrupting `K = class\n  PRIV = ...` into `K =  = (IIFE)`. Untested, shipped silently in v0.11.8.

Replaced with explicit `if ce.binding`. `K = class\n  count: 42` now produces the expected `K = (() => { let _Class = class {}; _Class.prototype.count = 42; return _Class })()` for anonymous-class prototype fields, and the existing anonymous-class private-statics case is also fixed with a regression test.

Separate issue filed for the broader `if { x } .= y` semantics question: #2106.