### PR TITLE
LSP: accept inline tsConfig in civetconfig (#379)

### DIFF
--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -275,3 +275,4 @@ top-level options (above `parseOptions`):
       "exclude": ["dist"]
     }
   }
+  ```

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -264,7 +264,7 @@ top-level options (above `parseOptions`):
 - `threads`: Use specified number of Node worker threads to compile Civet files faster. Default: `0` (don't use threads), or `CIVET_THREADS` environment variable if set.
 - `tsConfig`: Inline `tsconfig.json` contents (same shape — `compilerOptions`, `include`, `exclude`, …) used by the Civet LSP and `civet --typecheck`.  When present, takes precedence over `tsconfig.json` on disk.  Lets a Civet-only project skip having a `tsconfig.json` at all, which keeps VSCode's built-in TypeScript LSP from complaining about an empty `include` (since it doesn't see your `.civet` files).  Example:
 
-  ```js
+  ```json
   {
     "tsConfig": {
       "compilerOptions": {
@@ -275,4 +275,3 @@ top-level options (above `parseOptions`):
       "exclude": ["dist"]
     }
   }
-  ```

--- a/civet.dev/config.md
+++ b/civet.dev/config.md
@@ -262,3 +262,17 @@ In addition to the "parse options" described above, there are a few
 top-level options (above `parseOptions`):
 
 - `threads`: Use specified number of Node worker threads to compile Civet files faster. Default: `0` (don't use threads), or `CIVET_THREADS` environment variable if set.
+- `tsConfig`: Inline `tsconfig.json` contents (same shape — `compilerOptions`, `include`, `exclude`, …) used by the Civet LSP and `civet --typecheck`.  When present, takes precedence over `tsconfig.json` on disk.  Lets a Civet-only project skip having a `tsconfig.json` at all, which keeps VSCode's built-in TypeScript LSP from complaining about an empty `include` (since it doesn't see your `.civet` files).  Example:
+
+  ```js
+  {
+    "tsConfig": {
+      "compilerOptions": {
+        "target": "es2020",
+        "strict": true
+      },
+      "include": ["src"],
+      "exclude": ["dist"]
+    }
+  }
+  ```

--- a/lsp/server/source/lib/typescript-service.civet
+++ b/lsp/server/source/lib/typescript-service.civet
@@ -125,11 +125,16 @@ function TSService(projectURL = "./", logger: Logger = console): Promise<Resolve
   catch e
     logger.error("Error loading Civet config " + e)
 
+  // Split off the inline tsconfig before passing the rest to the
+  // transpiler plugins so the compile-time cache key isn't polluted with a
+  // setting that doesn't affect transpile output (#379).
+  { tsConfig, ...pluginConfig } := civetConfig
+
   civetPlugin := makeCivetPlugin {
     Civet
     CivetLib
     CivetVersion
-    config: civetConfig
+    config: pluginConfig
   }
 
   // Hera support: same project Civet powers the second Hera→Civet→TS stage,
@@ -137,7 +142,7 @@ function TSService(projectURL = "./", logger: Logger = console): Promise<Resolve
   heraPlugin := makeHeraPlugin {
     Civet
     CivetVersion
-    config: civetConfig
+    config: pluginConfig
   }
 
   return SharedTSService(projectPath, {
@@ -145,6 +150,7 @@ function TSService(projectURL = "./", logger: Logger = console): Promise<Resolve
     docFactory: docFactory as DocFactory<TranspiledDoc>
     logger
     libDir
+    tsConfig
   }) as ResolvedService
 
 export default TSService

--- a/lsp/server/test/service.civet
+++ b/lsp/server/test/service.civet
@@ -419,7 +419,7 @@ describe "ts service configFound flag", ->
       mkdirSync path.join(tmpDir, 'src')
       mkdirSync path.join(tmpDir, 'dist')
       writeFileSync path.join(tmpDir, 'src', 'a.civet'), 'x := 1\n'
-      writeFileSync path.join(tmpDir, 'dist', 'a.js'), 'const x = 1\n'
+      writeFileSync path.join(tmpDir, 'dist', 'b.civet'), 'y := 2\n'
       writeFileSync path.join(tmpDir, 'civetconfig.json'), JSON.stringify {
         tsConfig:
           compilerOptions: target: 'es2020'
@@ -432,11 +432,11 @@ describe "ts service configFound flag", ->
         "inline tsConfig should count as a found config"
 
       includedTsx := path.join(tmpDir, 'src', 'a.civet') + '.tsx'
-      excludedJs := path.join(tmpDir, 'dist', 'a.js')
+      excludedTsx := path.join(tmpDir, 'dist', 'b.civet') + '.tsx'
       assert hasScriptFileName(service, includedTsx),
         `expected src/a.civet (as .tsx) in script files; got ${service.host.getScriptFileNames().join(', ')}`
-      assert not hasScriptFileName(service, excludedJs),
-        `expected dist/a.js to be excluded; got ${service.host.getScriptFileNames().join(', ')}`
+      assert not hasScriptFileName(service, excludedTsx),
+        `expected dist/b.civet (as .tsx) to be excluded; got ${service.host.getScriptFileNames().join(', ')}`
     finally
       rmSync(tmpDir, { recursive: true, force: true })
 

--- a/lsp/server/test/service.civet
+++ b/lsp/server/test/service.civet
@@ -410,6 +410,36 @@ describe "ts service configFound flag", ->
     finally
       rmSync(tmpDir, { recursive: true, force: true })
 
+  it "honors inline tsConfig from civetconfig when tsconfig.json is absent (#379)", async ->
+    // Lets a project keep VSCode's built-in TS LSP quiet (no tsconfig.json
+    // on disk to trigger it) while the Civet LSP still picks up the same
+    // include/exclude/compilerOptions via the civetconfig.
+    tmpDir := mkdtempSync(path.join(tmpdir(), 'civet-inline-tsconfig-'))
+    try
+      mkdirSync path.join(tmpDir, 'src')
+      mkdirSync path.join(tmpDir, 'dist')
+      writeFileSync path.join(tmpDir, 'src', 'a.civet'), 'x := 1\n'
+      writeFileSync path.join(tmpDir, 'dist', 'a.js'), 'const x = 1\n'
+      writeFileSync path.join(tmpDir, 'civetconfig.json'), JSON.stringify {
+        tsConfig:
+          compilerOptions: target: 'es2020'
+          include: ['src']
+          exclude: ['dist']
+      }
+
+      service := await TSService(pathToFileURL(tmpDir + path.sep).href, nullLogger)
+      assert.equal service.configFound, true,
+        "inline tsConfig should count as a found config"
+
+      includedTsx := path.join(tmpDir, 'src', 'a.civet') + '.tsx'
+      excludedJs := path.join(tmpDir, 'dist', 'a.js')
+      assert hasScriptFileName(service, includedTsx),
+        `expected src/a.civet (as .tsx) in script files; got ${service.host.getScriptFileNames().join(', ')}`
+      assert not hasScriptFileName(service, excludedJs),
+        `expected dist/a.js to be excluded; got ${service.host.getScriptFileNames().join(', ')}`
+    finally
+      rmSync(tmpDir, { recursive: true, force: true })
+
   it "uses TS default include when missing tsconfig + no transpilers (SharedTSService direct)", ->
     // Covers the else arm of parseTsConfigForCivet's
     // `extraExtensions.length > 0` check from the LSP-coverage side

--- a/test/infra/config.civet
+++ b/test/infra/config.civet
@@ -33,6 +33,7 @@ describe "loading config", ->
 
   it "should load specified custom files", ->
     customConfig := await loadConfig("test/infra/config/customconfig.civet")
+    //@ts-expect-error custom config files may carry non-CompileOptions fields
     assert.equal customConfig.someConfig, "heyy"
 
 describe "findConfig", ->

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -140,6 +140,15 @@ declare module "@danielx/civet" {
      *   - comptime code can't return promises
      */
     sync?: boolean
+    /**
+     * Inline tsconfig.json contents (same shape — `compilerOptions`,
+     * `include`, `exclude`, …).  Consumed by the LSP and typecheck
+     * pipelines: when present, takes precedence over `<project>/tsconfig.json`
+     * on disk.  Lets a project use a civetconfig instead of a real
+     * `tsconfig.json` so VSCode's built-in TS LSP stays out of a
+     * Civet-only project (#379).  Ignored by `compile`.
+     */
+    tsConfig?: any
   }
   export type GenerateOptions = Omit<CompileOptions, "sourceMap"> & {
     sourceMap?: undefined | SourceMap


### PR DESCRIPTION
Fixes #379.

Civet-only projects can now put their tsconfig under a `tsConfig` key in civetconfig instead of shipping a real `tsconfig.json`.

```json
{
  "tsConfig": {
    "compilerOptions": { "target": "es2020", "strict": true },
    "include": ["src"],
    "exclude": ["dist"]
  }
}
```

Without a `tsconfig.json` on disk, VSCode's built-in TypeScript LSP no longer fires on a Civet-only project (it was complaining that `include: ["src"]` matched zero `.ts` files), while the Civet LSP still picks up the same include/exclude/compilerOptions.

## Approach

- New optional `tsConfig` field on `CompileOptions`.
- LSP `TSService` destructures it out of the loaded civetconfig and forwards it to the shared service's already-existing `tsConfig` option (which short-circuits `<projectPath>/tsconfig.json` on disk). Stripped from the per-plugin config so cache keys aren't perturbed for users who don't adopt this.
- `civet --typecheck` picks it up for free: `Options extends CompileOptions`, the config spread already lands the field in `options.tsConfig`, and unplugin already forwards that to `makeIncrementalTypecheckProgram`.

## Test plan

- [x] New LSP test: civetconfig.json with inline `tsConfig.include`/`exclude`, no `tsconfig.json` on disk → `configFound` true, `src/a.civet.tsx` in scope, `dist/a.js` excluded.