### PR TITLE
Fix Sublime support via JSON to XML conversion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
           pnpm -C lsp/server test
           pnpm -C lsp/monaco test
           pnpm -C lsp/server build-dev
+          pnpm -C lsp/sublime build
           pnpm -C lsp/vscode build-dev
           pnpm -C lsp/vscode test:e2e
 

--- a/lsp/sublime/Civet.tmLanguage.json
+++ b/lsp/sublime/Civet.tmLanguage.json
@@ -1,1 +1,0 @@
-../vscode/syntaxes/civet.json

--- a/lsp/sublime/README.md
+++ b/lsp/sublime/README.md
@@ -4,38 +4,36 @@ Sublime Text 4 package providing Civet syntax highlighting and LSP wiring.
 
 ## Features
 
-- Syntax highlighting via the TextMate grammar at [`Civet.tmLanguage.json`](./Civet.tmLanguage.json) (a symlink to `../vscode/syntaxes/civet.json` — single source of truth shared with the VS Code extension)
+- Syntax highlighting via a generated TextMate plist grammar, built from the VS Code grammar at `../vscode/syntaxes/civet.json`
 - Optional LSP integration via the [Sublime LSP package](https://lsp.sublimetext.io/) and `civet-lsp` (diagnostics, completions, hover, go-to-definition)
 
 ## Requirements
 
-- Sublime Text 4 (build 4075 or later — needed for `.tmLanguage.json` support)
+- Sublime Text 4
 - For LSP: the [LSP package](https://packagecontrol.io/packages/LSP) from Package Control
 - For LSP: `civet-lsp` on your `PATH`
 
 ## Installing as a dev package
 
-Sublime Text loads any folder placed under its `Packages/` directory as a package. Symlink this directory in:
+Build a local package directory first. This converts the shared VS Code JSON grammar into Sublime's TextMate plist format:
+
+```bash
+pnpm -C lsp/sublime build
+```
+
+Sublime Text loads any folder placed under its `Packages/` directory as a package. Symlink the generated `dist` directory in:
 
 **macOS**
 ```bash
-ln -s "$(pwd)/lsp/sublime" "$HOME/Library/Application Support/Sublime Text/Packages/Civet"
+ln -s "$(pwd)/lsp/sublime/dist" "$HOME/Library/Application Support/Sublime Text/Packages/Civet"
 ```
 
 **Linux**
 ```bash
-ln -s "$(pwd)/lsp/sublime" "$HOME/.config/sublime-text/Packages/Civet"
+ln -s "$(pwd)/lsp/sublime/dist" "$HOME/.config/sublime-text/Packages/Civet"
 ```
 
 **Windows**
-
-Build a local package directory first. This materializes the grammar file so the package does not depend on Git file symlink support on Windows:
-
-```cmd
-civet lsp\sublime\build.civet
-```
-
-Then link the built package with a directory junction:
 
 ```cmd
 mklink /J "%APPDATA%\Sublime Text\Packages\Civet" "%CD%\lsp\sublime\dist"
@@ -61,6 +59,12 @@ export PATH="/path/to/Civet/lsp/server/bin:$PATH"
 
 (The in-repo binary requires `pnpm -C lsp/server build` first.)
 
+On Windows, if you use the in-repo binary instead of a global npm install, point Sublime at Node explicitly because `lsp\server\bin\civet-lsp.js` is not a Windows command shim:
+
+```js
+"command": ["node", "C:\\path\\to\\Civet\\lsp\\server\\bin\\civet-lsp.js", "--stdio"]
+```
+
 ## Wiring up LSP
 
 1. Install the [LSP package](https://packagecontrol.io/packages/LSP) from Package Control.
@@ -74,10 +78,27 @@ This package is intended for dev / local install. It is not yet on [Package Cont
 
 ## Updating the grammar
 
-The source grammar is a symlink to `../vscode/syntaxes/civet.json`. Edits to the VS Code grammar take effect in source installs automatically — no copy step. Restart Sublime Text (or run *View → Syntax → Reload Syntax*) to pick up changes.
-
-For Windows or packaged installs that use `dist`, rebuild after grammar changes:
+The Sublime grammar is generated from `../vscode/syntaxes/civet.json`. Rebuild after grammar changes:
 
 ```bash
-civet lsp/sublime/build.civet
+pnpm -C lsp/sublime build
 ```
+
+## Debugging in Sublime Text
+
+Open the Sublime console with <kbd>Ctrl</kbd>+<kbd>`</kbd> and check for package load errors. With a `.civet` file focused, these console checks are useful:
+
+```py
+view.settings().get("syntax")
+view.scope_name(0)
+sublime.find_resources("Civet.tmLanguage")
+sublime.load_resource("Packages/Civet/Civet.tmLanguage")[:200]
+```
+
+Expected results:
+
+- `view.settings().get("syntax")` points at `Packages/Civet/Civet.tmLanguage`
+- `view.scope_name(0)` includes `source.civet`
+- `find_resources` includes `Packages/Civet/Civet.tmLanguage`
+
+For LSP issues after syntax highlighting works, run **LSP: Toggle Log Panel** and **LSP: Restart Servers** from the command palette. The LSP client only starts when the focused view's selector matches `source.civet`, so syntax highlighting must work first.

--- a/lsp/sublime/build.civet
+++ b/lsp/sublime/build.civet
@@ -1,19 +1,196 @@
-{ copyFileSync, mkdirSync, rmSync } from node:fs
+// This script converts the VS Code TextMate JSON grammar to plist/XML format
+// that Sublime Text's legacy grammar loader can read.
+//
+// Some VS Code TextMate constructs are accepted by vscode-textmate but not by
+// Sublime's legacy grammar loader. Normalize only those known incompatibilities
+// while keeping the source grammar as the single source of truth.
+
+{ copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from node:fs
 { dirname, join, relative } from node:path
 { fileURLToPath } from node:url
 
-sublimeDir := dirname fileURLToPath import.meta.url
-repoRoot := join sublimeDir, "../.."
-outDir := join sublimeDir, "dist"
+// JSON -> XML conversion
 
-rmSync outDir, recursive: true, force: true
-mkdirSync outDir, recursive: true
+xmlEscapes: Record<string, string> :=
+  "&": "&amp;"
+  "<": "&lt;"
+  ">": "&gt;"
 
-copyFileSync
-  join repoRoot, "lsp", "vscode", "syntaxes", "civet.json"
-  join outDir, "Civet.tmLanguage.json"
-copyFileSync
-  join sublimeDir, "LSP.sublime-settings.example"
-  join outDir, "LSP.sublime-settings.example"
+function escapeXml(value: string): string
+  value.replace /[&<>]/g, xmlEscapes[&]
 
-console.log `Built ${relative repoRoot, outDir}`
+function plistValue(value: ???, indent = ""): string
+  if Array.isArray value
+    out .= `${indent}<array>\n`
+    for item of value
+      out += plistValue item, `${indent}  `
+    out += `${indent}</array>\n`
+    out
+  else if value? <? "object"
+    out .= `${indent}<dict>\n`
+    for key, item in value as Record<string, ???>
+      out += `${indent}  <key>${escapeXml key}</key>\n`
+      out += plistValue item, `${indent}  `
+    out += `${indent}</dict>\n`
+    out
+  else if value <? "boolean"
+    `${indent}<${value}/>\n`
+  else if value <? "number"
+    if Number.isInteger value
+      `${indent}<integer>${value}</integer>\n`
+    else
+      `${indent}<real>${value}</real>\n`
+  else
+    `${indent}<string>${escapeXml String(value ?? "")}</string>\n`
+
+function plist(value: ???): string
+  ```
+  <?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+  ${plistValue value, "  "}</plist>
+  ```
+
+// Grammar normalization to sidestep Sublime's lack of support
+
+unboundedLookbehindErrors .= 0
+
+type TextMatePattern =
+  include?: string
+
+type TextMateCapture =
+  name?: string
+  patterns?: TextMatePattern[]
+
+type TextMateCaptures = Record<string, TextMateCapture>
+
+type TextMateRule = Record<string, ???> &
+  match?: string
+  begin?: string
+  end?: string
+  captures?: TextMateCaptures
+  name?: string
+
+function normalizeForSublime(value: ???, path = "grammar"): void
+  if Array.isArray value
+    for item, index of value
+      normalizeForSublime item, `${path}[${index}]`
+  else if value? <? "object"
+    normalizeRuleForSublime value as TextMateRule, path
+    for key, item in value as Record<string, ???>
+      if key.match /^(?:captures|(?:begin|end|while)Captures)$/
+        normalizeCapturesForSublime item as TextMateCaptures
+      else
+        normalizeForSublime item, `${path}.${key}`
+
+function normalizeRuleForSublime(rule: TextMateRule, path: string): void
+  // Sublime's legacy TextMate loader rejects variable-length lookbehind.
+  // Rewrite such rules while capturing parts we can.
+  switch rule.match
+    when "(?<=^\\s*((import|export)\\s+)?(type\\s+)?((\\w+\\s*,\\s*)?\\{[^{}]*\\}|\\w+(\\s*,\\s*\\w+)*|\\*(\\s+as\\s+\\w+)?|operator(?:\\s+[^{}\\n]+)?\\s+\\{[^{}]*\\})\\s+from\\s+)([^\\(\\{\\[\"';\\s=>][^\"';\\s=>]*)(?=[^()]|$)"
+      rule.match = "^\\s*(?:(import|export)\\s+)?(?:(type)\\s+)?(?:(?:\\w+\\s*,\\s*)?\\{[^{}]*\\}|\\w+(?:\\s*,\\s*\\w+)*|\\*(?:\\s+(as)\\s+\\w+)?|(operator)(?:\\s+[^{}\\n]+)?\\s+\\{[^{}]*\\})\\s+(from)\\s+([^\\(\\{\\[\"';\\s=>][^\"';\\s=>]*)(?=[^()]|$)"
+      rule.captures =
+        1:
+          name: "keyword.control.civet"
+        2:
+          name: "keyword.reserved.civet"
+        3:
+          name: "keyword.control.civet"
+        4:
+          name: "keyword.operator.civet"
+        5:
+          name: "keyword.control.civet"
+        6:
+          name: "string.unquoted.module-reference.civet"
+      delete rule.name
+    when "(?<=^\\s*from\\s+)([^\\(\\{\\[\"';\\s=>][^\"';\\s=>]*)(?=\\s+((with|assert)\\s+\\{[^{}]*\\}\\s+)?(import|export)\\s*[^()])"
+      rule.match = "^\\s*(from)\\s+([^\\(\\{\\[\"';\\s=>][^\"';\\s=>]*)(?=\\s+(?:(?:with|assert)\\s+\\{[^{}]*\\}\\s+)?(?:import|export)\\s*[^()])"
+      rule.captures =
+        1:
+          name: "keyword.control.civet"
+        2:
+          name: "string.unquoted.module-reference.civet"
+      delete rule.name
+    when "(?<=^\\s*import\\s+)([^\\(\\{\\[\"';\\s=>][^\"';\\s=>]*)(?=\\s*((with|assert)\\s+\\{[^{}]*\\})?\\s*$)"
+      rule.match = "^\\s*(import)\\s+([^\\(\\{\\[\"';\\s=>][^\"';\\s=>]*)(?=\\s*(?:(?:with|assert)\\s+\\{[^{}]*\\})?\\s*$)"
+      rule.captures =
+        1:
+          name: "keyword.control.civet"
+        2:
+          name: "string.unquoted.module-reference.civet"
+      delete rule.name
+
+  // Check for remaining unbounded lookbehind after rewriting of known cases.
+  for key of ["match", "begin", "end"]
+    item := rule[key]
+    if item <? "string"
+      if hasUnboundedLookbehind item
+        unboundedLookbehindErrors++
+        console.log `ERROR: ${path}.${key} has unbounded lookbehind: ${item}`
+
+function normalizeCapturesForSublime(captures: TextMateCaptures): void
+  for _, capture in captures
+    if capture.patterns
+      // Sublime capture values can name scopes, but cannot contain
+      // nested pattern includes. Collapse known function/method-name
+      // capture includes to the broad scope used by their fallback rule.
+      name := capturePatternName capture.patterns
+      capture.name = name if name
+      delete capture.patterns
+
+function capturePatternName(patterns: TextMatePattern[]): string?
+  switch patterns?[0]?.include
+    when "#function_names", "#method_names"
+      "entity.name.function.civet"
+    else undefined
+
+function hasUnboundedLookbehind(pattern: string): boolean
+  for match of pattern.matchAll /\(\?<[=!]/g
+    depth .= 1
+    :LOOKBEHIND for position .= match.index + 4; position < pattern#; position++
+      switch pattern[position]
+        when "\\"
+          position++ // skip escaped character
+        when "[" // character class
+          while ++position < pattern# and pattern[position] is not "]"
+            position++ if pattern[position] is "\\"
+        when "+", "*" // unbounded quantifiers
+          return true
+        when "{" // potentially unbounded quantifier
+          return true if /^\{\d*,\}/.test pattern[position..]
+        when "("
+          depth++
+        when ")"
+          depth--
+          // Reached the end of the lookbehind
+          break LOOKBEHIND unless depth
+  false
+
+// Build script
+
+function build(): void
+  sublimeDir := dirname fileURLToPath import.meta.url
+  repoRoot := join sublimeDir, "../.."
+  outDir := join sublimeDir, "dist"
+
+  rmSync outDir, recursive: true, force: true
+  mkdirSync outDir, recursive: true
+
+  grammarPath := join repoRoot, "lsp", "vscode", "syntaxes", "civet.json"
+  grammar := JSON.parse readFileSync grammarPath, "utf8"
+  normalizeForSublime grammar
+  writeFileSync
+    join outDir, "Civet.tmLanguage"
+    plist grammar
+  copyFileSync
+    join sublimeDir, "LSP.sublime-settings.example"
+    join outDir, "LSP.sublime-settings.example"
+
+  console.log `Built ${relative repoRoot, outDir}`
+
+  if unboundedLookbehindErrors
+    console.log `ERROR: Sublime grammar build failed: ${unboundedLookbehindErrors} unbounded lookbehind error${if unboundedLookbehindErrors is 1 then "" else "s"}`
+    console.log "Update lsp/sublime/build.civet to rewrite the offending rules."
+    process.exitCode = 1
+
+build()

--- a/lsp/sublime/build.civet
+++ b/lsp/sublime/build.civet
@@ -53,7 +53,7 @@ function plist(value: ???): string
 
 // Grammar normalization to sidestep Sublime's lack of support
 
-unboundedLookbehindErrors .= 0
+errors .= 0
 
 type TextMatePattern =
   include?: string
@@ -79,7 +79,7 @@ function normalizeForSublime(value: ???, path = "grammar"): void
     normalizeRuleForSublime value as TextMateRule, path
     for key, item in value as Record<string, ???>
       if key.match /^(?:captures|(?:begin|end|while)Captures)$/
-        normalizeCapturesForSublime item as TextMateCaptures
+        normalizeCapturesForSublime item as TextMateCaptures, `${path}.${key}`
       else
         normalizeForSublime item, `${path}.${key}`
 
@@ -125,18 +125,23 @@ function normalizeRuleForSublime(rule: TextMateRule, path: string): void
     item := rule[key]
     if item <? "string"
       if hasUnboundedLookbehind item
-        unboundedLookbehindErrors++
+        errors++
         console.log `ERROR: ${path}.${key} has unbounded lookbehind: ${item}`
 
-function normalizeCapturesForSublime(captures: TextMateCaptures): void
-  for _, capture in captures
+function normalizeCapturesForSublime(captures: TextMateCaptures, path: string): void
+  for key, capture in captures
     if capture.patterns
       // Sublime capture values can name scopes, but cannot contain
       // nested pattern includes. Collapse known function/method-name
-      // capture includes to the broad scope used by their fallback rule.
-      name := capturePatternName capture.patterns
-      capture.name = name if name
-      delete capture.patterns
+      // capture includes to the broad scope used by their fallback rule;
+      // fail on unknown includes so future grammar changes are not dropped
+      // silently.
+      if name := capturePatternName capture.patterns
+        capture.name = name
+        delete capture.patterns
+      else
+        errors++
+        console.log `ERROR: ${path}.${key}.patterns has unsupported capture patterns: ${JSON.stringify capture.patterns}`
 
 function capturePatternName(patterns: TextMatePattern[]): string?
   switch patterns?[0]?.include
@@ -188,9 +193,9 @@ function build(): void
 
   console.log `Built ${relative repoRoot, outDir}`
 
-  if unboundedLookbehindErrors
-    console.log `ERROR: Sublime grammar build failed: ${unboundedLookbehindErrors} unbounded lookbehind error${if unboundedLookbehindErrors is 1 then "" else "s"}`
-    console.log "Update lsp/sublime/build.civet to rewrite the offending rules."
+  if errors
+    console.log `ERROR: Sublime grammar build failed with ${errors} error${if errors is 1 then "" else "s"}`
+    console.log "Update lsp/sublime/build.civet to handle the errors above."
     process.exitCode = 1
 
 build()

--- a/lsp/sublime/package.json
+++ b/lsp/sublime/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@danielx/civet-sublime",
+  "description": "Sublime Text package build for Civet",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "build": "civet build.civet",
+    "test": "pnpm typecheck",
+    "typecheck": "civet --typecheck --no-config build.civet"
+  },
+  "devDependencies": {
+    "@danielx/civet": "workspace:*",
+    "@types/node": "^25.5.2",
+    "typescript": "^6.0.2"
+  }
+}

--- a/lsp/vscode/syntaxes/civet.json
+++ b/lsp/vscode/syntaxes/civet.json
@@ -1,5 +1,9 @@
 {
+  "name": "Civet",
   "scopeName": "source.civet",
+  "fileTypes": [
+    "civet"
+  ],
   "patterns": [
     {
       "match": "(new)\\s+(?:(?:(class)\\s+(\\w+(?:\\.\\w*)*)?)|(\\w+(?:\\.\\w*)*))",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docs:preview": "pnpm build && pnpm -C lsp/server build && pnpm -C lsp/monaco build && pnpm -C civet.dev preview",
     "prepublishOnly": "pnpm build && pnpm test:coverage && pnpm changelog --verify",
     "test": "bash ./build/test.sh",
-    "typecheck": "./dist/civet --typecheck --tsbuildinfo .cache/typecheck.tsbuildinfo",
+    "typecheck": "node ./dist/civet --typecheck --tsbuildinfo .cache/typecheck.tsbuildinfo",
     "typecheck:diff": "civet scripts/typecheck-diff.civet",
     "probe-shapes": "civet scripts/probe-shapes.civet",
     "test:coverage": "cross-env CIVET_COVERAGE=1 bash ./build/test.sh",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,18 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
 
+  lsp/sublime:
+    devDependencies:
+      '@danielx/civet':
+        specifier: workspace:*
+        version: link:../..
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.5.2
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
   lsp/tree-sitter:
     devDependencies:
       tree-sitter-cli:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,5 @@ packages:
   - lsp/server
   - lsp/monaco
   - lsp/vscode
+  - lsp/sublime
   - lsp/tree-sitter


### PR DESCRIPTION
Followup to #2097.
It turns out we do need a build step because Sublime supports only `.tmLanguage` XML, not `.tmLanguage.json`.
Also it doesn't support some features.

## Changes

- Generate `lsp/sublime/dist/Civet.tmLanguage` XML/plist from the shared VS Code grammar.
- Add Sublime-specific grammar normalization:
  - rewrite known unbounded lookbehind module-reference patterns
  - preserve captures for `import`, `export`, `type`, `as`, `operator`, `from`, and module paths
  - flatten unsupported nested capture `patterns`
  - fail the build if remaining unbounded lookbehind is detected
- Add `lsp/sublime` as a pnpm workspace package with `build` and `typecheck` scripts.
- Add Sublime build to CI alongside the other LSP build steps.
- Add `name` and `fileTypes` metadata to the shared TextMate grammar.
- Update Sublime README with the `dist` install flow, Windows notes, and debugging commands.
- Prefix root `typecheck` script with `node` so it works on Windows.

## Syntax Highlighting Demo

<img width="2406" height="1947" alt="image" src="https://github.com/user-attachments/assets/cc7cca81-1e61-497b-aea4-dd7af38d1b1b" />

## LSP Demo

<img width="2406" height="1947" alt="image" src="https://github.com/user-attachments/assets/fb1e6a7a-b593-4cd0-adb1-9e7b3d3e3765" />
