### PR TITLE
Fix crash on optional-chain LHS with custom `oper=` (#2109)

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1387,7 +1387,9 @@ function processAssignments(statements: ASTNode): void
               children: ["let ", optionalChainRef]
               names: []
 
-          replaceNode $2, newMemberExp
+          // $2 may have been replaced by a parent-less array earlier (custom
+          // `oper=`, line ~1287) so pass `exp` as explicit parent.
+          replaceNode $2, newMemberExp, exp
           $2 = newMemberExp
 
       i--

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -896,6 +896,30 @@ describe "assignment", ->
       x(!(min= y))
     """
 
+    testCase """
+      optional member access (issue #2109)
+      ---
+      obj?.x min= val
+      ---
+      obj != null ? obj.x = min(obj.x, val) : void 0
+    """
+
+    testCase """
+      optional bracket access (issue #2109)
+      ---
+      obj?[prop] min= val
+      ---
+      obj != null ? obj[prop] = min(obj[prop], val) : void 0
+    """
+
+    testCase """
+      optional chain with side-effectful base
+      ---
+      a.b()?.c min= val
+      ---
+      let ref;(ref = a.b()) != null ? ref.c = min(ref.c, val) : void 0
+    """
+
   describe "++=", ->
     testCase """
       ++=


### PR DESCRIPTION
Fixes #2109.

## Cause

In `processAssignments`, the custom-operator-assignment branch (`oper=`,
`xor=`, `//=`, `++=`) wraps the RHS:

```civet
exp.children.splice index, 1,
  exp.expression = $2 = [call, "(", lhs, ", ", $2, ")"]
```

`$2` is now a bare array with no `.parent`. When the LHS also uses
optional chaining (`obj?[prop]`, `obj?.x`), the later optional-chain
handler called `replaceNode $2, newMemberExp` — which derefs
`node.parent` and asserted out.

## Fix

Pass `exp` as the explicit parent. `replaceNode`'s `recurse` finds the
array by identity inside `exp.children`. For the pre-existing non-`oper=`
path, `$2.parent === exp` already, so behavior is unchanged.

## Tests

Three new cases in `test/assignment.civet` under "function assignment
operator": simple `?.`, `?[…]`, and a side-effectful base that exercises
the `usesRef` ref-hoist path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)