### PR TITLE
Cache side-effectful index in named-function assignment

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1283,41 +1283,41 @@ function processAssignments(statements: ASTNode): void
       { call, omitLhs } := op
       callLhs .= lhs
       // For non-omitLhs operators (e.g. `min=`, `xor=`), `lhs` is referenced
-      // twice (assignment target and inside the call). Cache any
-      // side-effectful terminal Index expression so it isn't re-evaluated.
-      // Critical for `arr[?]` (each Math.random() yields a different
-      // index) and for `obj[i++]` / `obj[f()]`. MemberExpression is the
-      // only lhs shape that can carry a meaningful terminal Index.
+      // twice (assignment target and inside the call). Cache the last
+      // side-effectful Index expression so it isn't re-evaluated. Critical
+      // for `arr[?]` (each Math.random() yields a different index) and for
+      // `obj[i++]` / `obj[f()]`. Trailing PropertyAccess after the Index
+      // (e.g. `obj[f()].prop min= 3`) is fine — the suffix is shared by
+      // reference between the two `lhs` occurrences.
       if not omitLhs and (lhs as MemberExpression).type is "MemberExpression"
         memberLhs := lhs as MemberExpression
         { children: memberChildren } := memberLhs
-        j := memberChildren.findLastIndex (c) =>
-          c?.type is like "PropertyAccess", "Index"
+        j := memberChildren.findLastIndex (c) => c?.type is "Index"
         if j > 0
           terminal := memberChildren[j] as Index
-          if terminal.type is "Index"
-            { ref, refAssignment } := maybeRefAssignment terminal.expression
-            if refAssignment
-              // Original lhs (assignment target): inline `ref = idx` so it
-              // runs as part of evaluating the LHS reference.
-              replaceNode terminal.expression, refAssignment, terminal
-              terminal.expression = refAssignment
-              // Call-side copy: new terminal Index with bare ref, sharing
-              // the base children (preexisting bug if the base has side
-              // effects — separate issue from #2110).
-              outerTerminal: Index := makeNode {
-                type: "Index"
-                children: ["[", ref, "]"]
-                expression: ref
-              }
-              callLhs = makeNode {
-                ...memberLhs
-                children: [
-                  ...memberChildren[..<j]
-                  outerTerminal
-                  ...memberChildren[>j]
-                ]
-              }
+          { ref, refAssignment } := maybeRefAssignment terminal.expression
+          if refAssignment
+            // Original lhs (assignment target): inline `ref = idx` in the
+            // Index — runs first as part of evaluating the LHS reference.
+            // replaceNode also updates `terminal.expression` since it's an
+            // alias for `terminal.children[1]`.
+            replaceNode terminal.expression, refAssignment, terminal
+            // Call-side copy: new terminal Index with bare ref, sharing
+            // the base/suffix children (preexisting bug if the base has
+            // side effects — separate from #2110).
+            outerTerminal: Index := makeNode {
+              type: "Index"
+              children: ["[", ref, "]"]
+              expression: ref
+            }
+            callLhs = makeNode {
+              ...memberLhs
+              children: [
+                ...memberChildren[..<j]
+                outerTerminal
+                ...memberChildren[>j]
+              ]
+            }
       // Wrap right-hand side with call
       index := exp.children.indexOf($2)
       assert.notEqual index, -1, "processAssignments: $2 must be directly in exp.children"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -33,6 +33,7 @@ import type {
   ForStatement
   FunctionSignature
   IfStatement
+  Index
   Initializer
   IterationExpression
   IterationStatement
@@ -1280,11 +1281,48 @@ function processAssignments(statements: ASTNode): void
     if $1.some((x: any) => x.-1.special)
       [, lhs, , op] := $1[0]
       { call, omitLhs } := op
+      callLhs .= lhs
+      // For non-omitLhs operators (e.g. `min=`, `xor=`), `lhs` is referenced
+      // twice (assignment target and inside the call). Cache any
+      // side-effectful terminal Index expression so it isn't re-evaluated.
+      // Critical for `arr[?]` (each Math.random() yields a different
+      // index) and for `obj[i++]` / `obj[f()]`. MemberExpression is the
+      // only lhs shape that can carry a meaningful terminal Index.
+      if not omitLhs and (lhs as MemberExpression).type is "MemberExpression"
+        memberLhs := lhs as MemberExpression
+        { children: memberChildren } := memberLhs
+        j := memberChildren.findLastIndex (c) =>
+          c?.type is like "PropertyAccess", "Index"
+        if j > 0
+          terminal := memberChildren[j] as Index
+          if terminal.type is "Index"
+            { ref, refAssignment } := maybeRefAssignment terminal.expression
+            if refAssignment
+              // Original lhs (assignment target): inline `ref = idx` so it
+              // runs as part of evaluating the LHS reference.
+              replaceNode terminal.expression, refAssignment, terminal
+              terminal.expression = refAssignment
+              // Call-side copy: new terminal Index with bare ref, sharing
+              // the base children (preexisting bug if the base has side
+              // effects — separate issue from #2110).
+              outerTerminal: Index := makeNode {
+                type: "Index"
+                children: ["[", ref, "]"]
+                expression: ref
+              }
+              callLhs = makeNode {
+                ...memberLhs
+                children: [
+                  ...memberChildren[..<j]
+                  outerTerminal
+                  ...memberChildren[>j]
+                ]
+              }
       // Wrap right-hand side with call
       index := exp.children.indexOf($2)
       assert.notEqual index, -1, "processAssignments: $2 must be directly in exp.children"
       exp.children.splice index, 1,
-        exp.expression = $2 = [call, "(", lhs, ", ", $2, ")"]
+        exp.expression = $2 = [call, "(", callLhs, ", ", $2, ")"]
       if omitLhs
         replaceNode exp, $2
         continue

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1283,41 +1283,38 @@ function processAssignments(statements: ASTNode): void
       { call, omitLhs } := op
       callLhs .= lhs
       // For non-omitLhs operators (e.g. `min=`, `xor=`), `lhs` is referenced
-      // twice (assignment target and inside the call). Cache the last
-      // side-effectful Index expression so it isn't re-evaluated. Critical
-      // for `arr[?]` (each Math.random() yields a different index) and for
-      // `obj[i++]` / `obj[f()]`. Trailing PropertyAccess after the Index
-      // (e.g. `obj[f()].prop min= 3`) is fine — the suffix is shared by
-      // reference between the two `lhs` occurrences.
+      // twice (assignment target and inside the call). Cache every
+      // side-effectful Index expression so each runs once. Critical for
+      // `arr[?]` (Math.random) and for `obj[i++]` / `obj[f()][g()]`. Non-
+      // Index children (base Identifier, PropertyAccess) are shared by
+      // reference between the two `lhs` occurrences — pre-existing
+      // limitation if the base itself has side effects.
       if not omitLhs and (lhs as MemberExpression).type is "MemberExpression"
         memberLhs := lhs as MemberExpression
         { children: memberChildren } := memberLhs
-        j := memberChildren.findLastIndex (c) => c?.type is "Index"
-        if j > 0
-          terminal := memberChildren[j] as Index
-          { ref, refAssignment } := maybeRefAssignment terminal.expression
-          if refAssignment
-            // Original lhs (assignment target): inline `ref = idx` in the
-            // Index — runs first as part of evaluating the LHS reference.
-            // replaceNode also updates `terminal.expression` since it's an
-            // alias for `terminal.children[1]`.
-            replaceNode terminal.expression, refAssignment, terminal
-            // Call-side copy: new terminal Index with bare ref, sharing
-            // the base/suffix children (preexisting bug if the base has
-            // side effects — separate from #2110).
-            outerTerminal: Index := makeNode {
-              type: "Index"
-              children: ["[", ref, "]"]
-              expression: ref
-            }
-            callLhs = makeNode {
-              ...memberLhs
-              children: [
-                ...memberChildren[..<j]
-                outerTerminal
-                ...memberChildren[>j]
-              ]
-            }
+        mutated .= false
+        callChildren := memberChildren.map (child) =>
+          return child unless child?.type is "Index"
+          indexNode := child as Index
+          { ref, refAssignment } := maybeRefAssignment indexNode.expression
+          return child unless refAssignment
+          mutated = true
+          // Assignment-target side: inline `ref = idx` in the Index —
+          // runs first as part of evaluating the LHS reference.
+          // replaceNode also updates `indexNode.expression` since it
+          // aliases `indexNode.children[1]`.
+          replaceNode indexNode.expression, refAssignment, indexNode
+          // Call-side copy: new Index with bare ref.
+          makeNode {
+            type: "Index"
+            children: ["[", ref, "]"]
+            expression: ref
+          }
+        if mutated
+          callLhs = makeNode {
+            ...memberLhs
+            children: callChildren
+          }
       // Wrap right-hand side with call
       index := exp.children.indexOf($2)
       assert.notEqual index, -1, "processAssignments: $2 must be directly in exp.children"

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -920,6 +920,23 @@ describe "assignment", ->
       let ref;(ref = a.b()) != null ? ref.c = min(ref.c, val) : void 0
     """
 
+    // https://github.com/DanielXMoore/Civet/issues/2110
+    testCase """
+      caches side-effectful index
+      ---
+      obj[i++] min= 3
+      ---
+      let ref;obj[ref = i++] = min(obj[ref], 3)
+    """
+
+    testCase """
+      caches function-call index
+      ---
+      obj[f()] min= 3
+      ---
+      let ref;obj[ref = f()] = min(obj[ref], 3)
+    """
+
   describe "++=", ->
     testCase """
       ++=

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -937,6 +937,14 @@ describe "assignment", ->
       let ref;obj[ref = f()] = min(obj[ref], 3)
     """
 
+    testCase """
+      caches index when followed by property access
+      ---
+      obj[f()].prop min= 3
+      ---
+      let ref;obj[ref = f()].prop = min(obj[ref].prop, 3)
+    """
+
   describe "++=", ->
     testCase """
       ++=

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -932,9 +932,9 @@ describe "assignment", ->
     testCase """
       caches function-call index
       ---
-      obj[f()] min= 3
+      obj[f()][g()] min= 3
       ---
-      let ref;obj[ref = f()] = min(obj[ref], 3)
+      let ref;let ref1;obj[ref = f()][ref1 = g()] = min(obj[ref][ref1], 3)
     """
 
     testCase """

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -639,3 +639,22 @@ describe "property access", ->
       ---
       arr[Math.floor(Math.random() * arr.length)].foo
     """
+
+    // https://github.com/DanielXMoore/Civet/issues/2110
+    testCase """
+      named-function assignment caches index
+      ---
+      arr[?] min= 3
+      ---
+      let ref;arr[ref = Math.floor(Math.random() * arr.length)] = min(arr[ref], 3)
+    """
+
+    testCase """
+      named-function assignment caches index (xor=)
+      ---
+      arr[?] xor= 3
+      ---
+      type Falsy = false | 0 | '' | 0n | null | undefined;
+      var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? A : (false | (A & Falsy extends never ? never : B) | (B & Falsy extends never ? never : A)) = (a, b) => (a ? !b && a : b) as any;
+      let ref;arr[ref = Math.floor(Math.random() * arr.length)] = xor(arr[ref], 3)
+    """

--- a/test/property-access.civet
+++ b/test/property-access.civet
@@ -658,3 +658,11 @@ describe "property access", ->
       var xor: <A, B>(a: A, b: B) => A extends Falsy ? B : B extends Falsy ? A : (false | (A & Falsy extends never ? never : B) | (B & Falsy extends never ? never : A)) = (a, b) => (a ? !b && a : b) as any;
       let ref;arr[ref = Math.floor(Math.random() * arr.length)] = xor(arr[ref], 3)
     """
+
+    testCase """
+      named-function assignment caches index with trailing access
+      ---
+      arr[?].x min= 3
+      ---
+      let ref;arr[ref = Math.floor(Math.random() * arr.length)].x = min(arr[ref].x, 3)
+    """

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
     /* Language and Environment */
-    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2023",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     "lib": [
-      "ES2022",
+      "ES2023",
       "ES2025.Float16",
       "DOM"
     ],


### PR DESCRIPTION
Fixes #2110.

## Cause

`arr[?] min= 3` compiled to:

```js
arr[Math.floor(Math.random() * arr.length)] = min(arr[Math.floor(Math.random() * arr.length)], 3)
```

— two independent random indices, so the assignment target and the read are different array positions. The special-op handler in `processAssignments` shared `lhs` by reference between the assignment target and the call argument, so any side-effectful terminal Index expression ran twice.

## Fix

Cache the Index expression via `maybeRefAssignment`: inline `ref = idx` in the original lhs (runs first as part of evaluating the LHS reference) and use a fresh Index with the bare ref in a shallow-copy used inside the call.

```js
let ref;arr[ref = Math.floor(Math.random() * arr.length)] = min(arr[ref], 3)
```

Also fixes the same pattern for `obj[i++] min= 3` and `obj[f()] min= 3`, which had identical double-evaluation issues.

Bumps tsconfig `target`/`lib` ES2022 → ES2023 so `Array.findLastIndex` is typed (net 0 typecheck regressions).

## Test plan

- [x] New tests in `test/property-access.civet` (random shorthand) and `test/assignment.civet` (function-assignment operator).
- [x] Full suite: 4129 passing.
- [x] `pnpm typecheck`: 0 regressions vs main.