### PR TITLE
Polyfill private-field glob assignment (#966)

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -8,6 +8,7 @@
 
 import type {
   AccessStart
+  ASTError
   ASTLeaf
   ASTNode
   ASTNodeObject
@@ -47,6 +48,8 @@ import type {
   ParametersNode
   ParenthesizedExpression
   Placeholder
+  Property
+  SpreadProperty
   StatementTuple
   SwitchStatement
   TypeArgument
@@ -1303,25 +1306,28 @@ function processAssignments(statements: ASTNode): void
     // Expand to comma-separated direct assignments: `(obj.#x = src.#x, obj.#y = src.#y)`.
     if $1.length is 1
       [, soleLhs, , soleOp] := $1[0]
+      isPrivateGlobProp := (p: Property | SpreadProperty | MethodDefinition | ASTError): p is Property =>
+        p?.type is "Property" and !!p.privateField
       if soleOp.token is "=" and soleLhs.type is "ObjectExpression" and
-         soleLhs.properties?.some((p) => p?.privateField?) and
+         soleLhs.properties?.some(isPrivateGlobProp) and
          not soleLhs.properties.some((p) => p?.type is "SpreadProperty")
-        properties := soleLhs.properties.filter (p) => p?.type is "Property"
+        properties := soleLhs.properties.filter (p): p is Property => p?.type is "Property"
         // Use a ref for the source if there are multiple properties and it
         // has side effects, so we don't re-evaluate it for each assignment.
-        let prefix, sourceExpr
+        let prefix: ASTNode[], sourceExpr: ASTNode
         if properties.length > 1 and needsRef $2
           srcRef := makeRef()
           prefix = [srcRef, " = ", $2, ", "]
           sourceExpr = srcRef
-          // Hoist `let ref` declaration on this AssignmentExpression
-          if exp.hoistDec
-            exp.hoistDec.children.push ",", srcRef
-          else
-            exp.hoistDec =
-              type: "Declaration"
-              children: ["let ", srcRef]
-              names: []
+          // Hoist `let ref` declaration; nothing else sets `exp.hoistDec`
+          // before this point and we `continue` past everything that would.
+          exp.hoistDec = {
+            type: "Declaration"
+            children: ["let ", srcRef]
+            names: []
+            bindings: []
+            decl: "let"
+          }
         else
           prefix = []
           sourceExpr = $2

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -704,6 +704,14 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         value .= part.value ?? name
         wValue := getTrimmingSpace part.value
 
+        // Capture private-field shorthand info before handleThisPrivateShorthands
+        // strips the synthetic `this.` wrapper. Used in processAssignments to
+        // polyfill `obj.{#x} = src` as `obj.#x = src.#x` since JS destructuring
+        // can't target private fields.
+        privateField .= undefined as string?
+        if value?.privateShorthand
+          privateField = value.privateId?.name
+
         [value, suppressPrefix] = handleThisPrivateShorthands value
 
         // Not yet needed:
@@ -750,6 +758,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
             type: part.type
             name
             value
+            privateField
             delim: part.delim
             names: part.names
             children: [
@@ -1287,6 +1296,41 @@ function processAssignments(statements: ASTNode): void
         exp.expression = $2 = [call, "(", lhs, ", ", $2, ")"]
       if omitLhs
         replaceNode exp, $2
+        continue
+
+    // Polyfill private-field glob assignment: `obj.{#x, #y} = src` cannot use
+    // JS destructuring because private fields aren't valid destructuring targets.
+    // Expand to comma-separated direct assignments: `(obj.#x = src.#x, obj.#y = src.#y)`.
+    if $1.length is 1
+      [, soleLhs, , soleOp] := $1[0]
+      if soleOp.token is "=" and soleLhs.type is "ObjectExpression" and
+         soleLhs.properties?.some((p) => p?.privateField?) and
+         not soleLhs.properties.some((p) => p?.type is "SpreadProperty")
+        properties := soleLhs.properties.filter (p) => p?.type is "Property"
+        // Use a ref for the source if there are multiple properties and it
+        // has side effects, so we don't re-evaluate it for each assignment.
+        let prefix, sourceExpr
+        if properties.length > 1 and needsRef $2
+          srcRef := makeRef()
+          prefix = [srcRef, " = ", $2, ", "]
+          sourceExpr = srcRef
+          // Hoist `let ref` declaration on this AssignmentExpression
+          if exp.hoistDec
+            exp.hoistDec.children.push ",", srcRef
+          else
+            exp.hoistDec =
+              type: "Declaration"
+              children: ["let ", srcRef]
+              names: []
+        else
+          prefix = []
+          sourceExpr = $2
+        assignments := properties.map (prop) =>
+          sourceName := prop.privateField ?? prop.name
+          [prop.value, " = ", sourceExpr, ".", sourceName]
+        joined := assignments.flatMap (a, idx) => idx ? [", ", a] : [a]
+        exp.children = [["(", prefix, joined, ")"]]
+        exp.names = []
         continue
 
     // Force parens around destructuring object assignments

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1106,6 +1106,11 @@ export type Property = ASTParent &
   value: ASTNode
   implicitName?: boolean
   usesRef?: boolean
+  // Source name when the value is a `#privateField` shorthand inside a
+  // PropertyGlob; consumed by processAssignments to polyfill the assignment
+  // (`obj.{#x} = src` → `obj.#x = src.#x`) since JS destructuring cannot
+  // target private fields.
+  privateField?: string
 
 export type ArrayExpression = ASTParent &
   type: "ArrayExpression"

--- a/test/object.civet
+++ b/test/object.civet
@@ -1637,6 +1637,14 @@ describe "object", ->
     """, wrapper: ""
 
     testCase """
+      private field assignment with side-effecting source
+      ---
+      ret.{#x, #y} = compute()
+      ---
+      let ref;(ref = compute(), ret.#x = ref.#x, ret.#y = ref.#y)
+    """, wrapper: ""
+
+    testCase """
       private field clone from issue #966
       ---
       class Foo

--- a/test/object.civet
+++ b/test/object.civet
@@ -1613,6 +1613,52 @@ describe "object", ->
     """
 
     testCase """
+      private field assignment
+      ---
+      ret.{#x} = src
+      ---
+      (ret.#x = src.#x)
+    """, wrapper: ""
+
+    testCase """
+      multiple private field assignment
+      ---
+      ret.{#x, #y} = src
+      ---
+      (ret.#x = src.#x, ret.#y = src.#y)
+    """, wrapper: ""
+
+    testCase """
+      mixed private and public field assignment
+      ---
+      ret.{a, #x} = src
+      ---
+      (ret.a = src.a, ret.#x = src.#x)
+    """, wrapper: ""
+
+    testCase """
+      private field clone from issue #966
+      ---
+      class Foo
+        #x = 0
+        #y = 0
+        clone()
+          other := new Foo
+          other.{#x, #y} = @
+          other
+      ---
+      class Foo {
+        #x = 0
+        #y = 0
+        clone() {
+          const other = new Foo;
+          (other.#x = this.#x, other.#y = this.#y)
+          return other
+        }
+      }
+    """
+
+    testCase """
       ref in function call
       ---
       f a.b.{x,y}


### PR DESCRIPTION
Fixes #966.

`obj.{#x, #y} = src` previously compiled to `({x: obj.#x, y: obj.#y} = src)`, which is invalid JS — private fields aren't valid destructuring targets.

This PR detects private-field shorthand during PropertyGlob expansion (marking the property with `privateField`) and has `processAssignments` emit a comma-sequence of direct assignments instead: `(obj.#x = src.#x, obj.#y = src.#y)`, using a hoisted ref when the RHS has side effects.

Implements the approach [STRd6 suggested](https://github.com/DanielXMoore/Civet/issues/966#issuecomment-1950406046) on the issue.

Generated with [Claude Code](https://claude.ai/code)