### PR TITLE
Switch declaration: bind directly to user-named identifier (#840)

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -293,6 +293,22 @@ function processDeclarationCondition(condition: any, rootCondition: any, parent:
     }
   else
     { expression } := initializer
+    // For switches binding to a simple identifier, use that identifier as
+    // the ref everywhere — no temp ref needed.  This lets TypeScript narrow
+    // the binding across case clauses.  (#840)
+    if parent.type is "SwitchStatement" and pattern.type is "Identifier" and not nullCheck
+      ref = trimFirstSpace pattern
+      Object.assign condition, {
+        type: "AssignmentExpression"
+        children: [ref]
+        pattern
+        ref
+        statementDeclaration: true
+      }
+      updateParentPointers condition, parent
+      rootCondition.blockPrefix = getPatternBlockPrefix(pattern, trimFirstSpace(expression), decl, typeSuffix)
+      return
+
     ref = maybeRef expression
     simple := ref is expression
     let children

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -695,7 +695,7 @@ describe "switch", ->
       1
         2
     ---
-    {let ref = x();const  data = ref;if(ref === 1) {
+    {const  data = x();if(data === 1) {
         2}}
   """
 
@@ -718,7 +718,7 @@ describe "switch", ->
       case 1
         2
     ---
-    {let ref = x();const  data = ref;switch(ref) {
+    {const  data = x();switch(data) {
       case 1:
         2
     }}
@@ -731,7 +731,7 @@ describe "switch", ->
       case 0
         1
     ---
-    {const  code = 0;switch(0) {
+    {const  code = 0;switch(code) {
       case 0:
         1
     }}
@@ -746,7 +746,7 @@ describe "switch", ->
       else
         0
     ---
-    let ref;{let ref1 = f();const  code = ref1;switch(ref1) {
+    let ref;{const  code = f();switch(code) {
       case 1: {
         ref = code;break;
       }
@@ -763,11 +763,23 @@ describe "switch", ->
       when 0
         code
     ---
-    let ref;{const  code = 0;switch(0) {
+    let ref;{const  code = 0;switch(code) {
       case 0: {
         ref = code;break;
       }
     }};x = ref
+  """
+
+  // #840
+  testCase """
+    declaration condition preserves type narrowing on member access
+    ---
+    switch ref := test.union
+      <? "number"
+        console.log ref
+    ---
+    {const  ref = test.union;if(typeof ref === "number") {
+        console.log(ref)}}
   """
 
   describe "expression", ->
@@ -1950,9 +1962,9 @@ describe "switch", ->
         <? UsefulType
           utilize u
       ---
-      {let ref = funReturningEither();const  u = ref;if(ref instanceof Error) {
+      {const  u = funReturningEither();if(u instanceof Error) {
           handle(u)}
-      else if(ref instanceof UsefulType) {
+      else if(u instanceof UsefulType) {
           utilize(u)}}
     """
 


### PR DESCRIPTION
Closes #840.

`switch name := expr` was hoisting a temp variable that received the value, with the user's binding aliased to it. TypeScript narrowed the temp across case clauses but not the aliased binding, so member-access initializers like `switch ref := test.union` lost narrowing in the case bodies.

When the switch's pattern is a simple identifier, use that identifier as the ref everywhere — no temp. Destructuring patterns (`switch [a, b] := …`) still need the temp and are unchanged.

Before:
```
{let ref1 = test.union; const ref = ref1; if(typeof ref1 === "number") { console.log(ref) }}
```
After:
```
{const ref = test.union; if(typeof ref === "number") { console.log(ref) }}
```

## Test plan
- [x] `pnpm test` — 4130 passing
- [x] `typecheck-diff` — 0 regressions, 1 fixed
- [x] new testCase covers the issue's narrowing example

🤖 Generated with [Claude Code](https://claude.com/claude-code)