### PR TITLE
Keep trailing comments inside indented blocks

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -38,7 +38,6 @@ uncacheable := new Set [
   "PushIndent"
   "PopIndent"
   "TrackIndented"
-  "TrackCommentLine"
   "BulletIndent"
   "PushExtraIndent1"
 

--- a/source/main.civet
+++ b/source/main.civet
@@ -38,6 +38,7 @@ uncacheable := new Set [
   "PushIndent"
   "PopIndent"
   "TrackIndented"
+  "TrackCommentLine"
   "BulletIndent"
   "PushExtraIndent1"
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -9879,15 +9879,6 @@ TrackIndented
     state.indentLevels.push(indent)
     return $1
 
-# Like TrackIndented, but for a deeper-indent comment-only line. Used so an
-# indented block whose body is only comments still pushes an indent. (#832)
-TrackCommentLine
-  Indent:indent &SingleLineComment ->
-    {level} := indent
-    return $skip if level <= state.currentIndent.level
-    state.indentLevels.push(indent)
-    return $1
-
 # Indents one level deeper,
 # without consuming the indentation so it can be by Nested
 # Must be matched with PopIndent
@@ -9895,9 +9886,11 @@ PushIndent
   # TrackIndented pushes the indent level if it is deeper than the current level
   # it will skip if it is not deeper
   &( EOS TrackIndented )
-  # Fallback for comment-only block bodies (issue #832) so the body still has
-  # a pushed indent level even though it lacks a real statement to gate on.
-  &( EOL TrackCommentLine )
+  # Fallback for comment-only block bodies (issue #832): `EOS` would have
+  # consumed the comment, leaving TrackIndented with only the dedented line
+  # beyond.  `EOL` stops at the first newline, so TrackIndented sees the
+  # comment line's own indent.
+  &( EOL TrackIndented )
 
 PopIndent
   "" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3350,16 +3350,21 @@ PostfixedSingleLineNoCommaStatements
     }
 
 NestedBlockStatements
-  PushIndent NestedBlockStatement*:statements PopIndent ->
-    return $skip unless statements#
+  PushIndent NestedBlockStatement*:statements TrailingNestedComments?:trailing PopIndent ->
+    return $skip unless statements# or trailing?#
 
     // Each element of statements is a list of same-line statements. Flatten.
-    statements = statements.flat()
+    expressions: StatementTuple[] := statements.flat()
+    // Trailing same-indent comments (issue #832) live in children, NOT in
+    // expressions, so downstream walkers (assignResults / insertReturn / etc.)
+    // still see the last real statement as expressions.-1.
+    children: ASTNode[] := [expressions]
+    children.push(trailing) if trailing?#
 
     return {
       type: "BlockStatement",
-      expressions: statements,
-      children: [statements],
+      expressions,
+      children,
       bare: true,
     }
 
@@ -3369,6 +3374,27 @@ NestedBlockStatement
       [nested, ...statements[0]],
       ...statements.slice(1).map (s) => ["", ...s],
     ]
+
+# Captures trailing `// ...` comments at the end of an indented block: an
+# optional inline comment on the last statement's line, plus any number of
+# standalone same-indent comment lines. The lookahead `&EOL` keeps these from
+# eating into content that belongs to the surrounding block. (issue #832)
+TrailingNestedComments
+  TrailingInlineComment?:inline TrailingNestedCommentLine*:lines ->
+    return $skip unless inline or lines?#
+    out := []
+    out.push(inline) if inline
+    out.push(...lines) if lines?#
+    return out
+
+TrailingInlineComment
+  _?:ws SingleLineComment:c &EOL ->
+    return [ws, c]
+
+TrailingNestedCommentLine
+  EOL:eol Indent:indent SingleLineComment:c &EOL ->
+    return $skip unless indent.level is state.currentIndent.level
+    return [eol, indent, c]
 
 BlockStatementPart
   # NOTE: !EOS forces semicolon after all but last statement, forbids leading __
@@ -5625,6 +5651,12 @@ CaseClause
   }
   # NOTE: Added "when" from CoffeeScript. `when` always inserts `break;`.
   When CaseExpressionList:cases IgnoreColon InsertOpenBrace ( ThenClause / BareBlock ):block InsertBreak:b InsertNewline InsertIndent InsertCloseBrace ::WhenClause ->
+    // If the block ends with a `// ...` comment (issue #832), prefix the
+    // inserted `;break;` with a newline so it isn't swallowed by the comment.
+    if hasTrailingComment block
+      bIdx := $0.indexOf b
+      b = { ...b, token: "\n" + b.token }
+      $0[bIdx] = b
     return {
       type: "WhenClause",
       children: $0,
@@ -9838,6 +9870,15 @@ TrackIndented
     state.indentLevels.push(indent)
     return $1
 
+# Like TrackIndented, but for a deeper-indent comment-only line. Used so an
+# indented block whose body is only comments still pushes an indent. (#832)
+TrackCommentLine
+  Indent:indent &SingleLineComment ->
+    {level} := indent
+    return $skip if level <= state.currentIndent.level
+    state.indentLevels.push(indent)
+    return $1
+
 # Indents one level deeper,
 # without consuming the indentation so it can be by Nested
 # Must be matched with PopIndent
@@ -9845,6 +9886,9 @@ PushIndent
   # TrackIndented pushes the indent level if it is deeper than the current level
   # it will skip if it is not deeper
   &( EOS TrackIndented )
+  # Fallback for comment-only block bodies (issue #832) so the body still has
+  # a pushed indent level even though it lacks a real statement to gate on.
+  &( EOL TrackCommentLine )
 
 PopIndent
   "" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1442,9 +1442,13 @@ ClassBracedContent
     return stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
 
 NestedClassElements
-  PushIndent NestedClassElement*:elements PopIndent ->
-    return $skip unless elements#
-    return elements
+  PushIndent NestedClassElement*:elements TrailingNestedCommentLine*:trailing PopIndent ->
+    return $skip unless elements# or trailing#
+    // Same-indent comment-only trailing lines (issue #832) stay inside the
+    // class body's braces.  Inline trailing comments on the last element
+    // continue to escape — those typically annotate the surrounding class,
+    // not a member.
+    return trailing# ? [...elements, ...trailing] : elements
 
 NestedClassElement
   Nested ClassElement StatementDelimiter
@@ -3366,6 +3370,7 @@ NestedBlockStatements
       expressions,
       children,
       bare: true,
+      trailing: trailing?# ? trailing : undefined,
     }
 
 NestedBlockStatement

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1444,11 +1444,11 @@ ClassBracedContent
 NestedClassElements
   PushIndent NestedClassElement*:elements TrailingNestedCommentLine*:trailing PopIndent ->
     return $skip unless elements# or trailing#
-    // Same-indent comment-only trailing lines (issue #832) stay inside the
-    // class body's braces.  Inline trailing comments on the last element
-    // continue to escape — those typically annotate the surrounding class,
-    // not a member.
-    return trailing# ? [...elements, ...trailing] : elements
+    // Standalone same-or-deeper-indent comment-only trailing lines (#832)
+    // stay inside the class body's braces.  Inline trailing comments on
+    // the last element continue to escape — those typically annotate the
+    // surrounding class, not a member.
+    trailing# ? [...elements, ...trailing] : elements
 
 NestedClassElement
   Nested ClassElement StatementDelimiter
@@ -3354,23 +3354,23 @@ PostfixedSingleLineNoCommaStatements
     }
 
 NestedBlockStatements
-  PushIndent NestedBlockStatement*:statements TrailingNestedComments?:trailing PopIndent ->
-    return $skip unless statements# or trailing?#
+  PushIndent NestedBlockStatement*:statements TrailingNestedComments:trailing PopIndent ->
+    return $skip unless statements# or trailing#
 
     // Each element of statements is a list of same-line statements. Flatten.
-    expressions: StatementTuple[] := statements.flat()
+    expressions := statements.flat() as StatementTuple[]
     // Trailing same-indent comments (issue #832) live in children, NOT in
     // expressions, so downstream walkers (assignResults / insertReturn / etc.)
     // still see the last real statement as expressions.-1.
     children: ASTNode[] := [expressions]
-    children.push(trailing) if trailing?#
+    children.push(trailing) if trailing#
 
     return {
       type: "BlockStatement",
       expressions,
       children,
       bare: true,
-      trailing: trailing?# ? trailing : undefined,
+      trailing: trailing# ? trailing : undefined,
     }
 
 NestedBlockStatement
@@ -3380,25 +3380,27 @@ NestedBlockStatement
       ...statements.slice(1).map (s) => ["", ...s],
     ]
 
-# Captures trailing `// ...` comments at the end of an indented block: an
-# optional inline comment on the last statement's line, plus any number of
-# standalone same-indent comment lines. The lookahead `&EOL` keeps these from
-# eating into content that belongs to the surrounding block. (issue #832)
+# Trailing `// ...` comments at the end of an indented block: an optional
+# inline comment on the last statement's line, plus any number of same-or-
+# deeper-indent standalone comment lines.  Always succeeds (possibly with
+# zero entries) so the caller can simply check `trailing#`. (issue #832)
 TrailingNestedComments
   TrailingInlineComment?:inline TrailingNestedCommentLine*:lines ->
-    return $skip unless inline or lines?#
     out := []
     out.push(inline) if inline
-    out.push(...lines) if lines?#
+    out.push(...lines) if lines#
     return out
 
+# Only fires when there's actually a `//` — otherwise backtracks so EOS
+# captures any leading whitespace / `/* */` as it normally would.
 TrailingInlineComment
-  _?:ws SingleLineComment:c &EOL ->
+  _?:ws SingleLineComment:c ->
     return [ws, c]
 
+# Can't reuse `Nested` here because its `EOS` would consume the comment.
 TrailingNestedCommentLine
-  EOL:eol Indent:indent SingleLineComment:c &EOL ->
-    return $skip unless indent.level is state.currentIndent.level
+  EOL:eol Indent:indent SingleLineComment:c ->
+    return $skip unless indent.level >= state.currentIndent.level
     return [eol, indent, c]
 
 BlockStatementPart
@@ -5658,13 +5660,15 @@ CaseClause
   When CaseExpressionList:cases IgnoreColon InsertOpenBrace ( ThenClause / BareBlock ):block InsertBreak:b InsertNewline InsertIndent InsertCloseBrace ::WhenClause ->
     // If the block ends with a `// ...` comment (issue #832), prefix the
     // inserted `;break;` with a newline so it isn't swallowed by the comment.
+    // Copy $0 rather than mutating in place — Hera may cache the match.
+    children .= $0
     if hasTrailingComment block
-      bIdx := $0.indexOf b
+      bIdx := children.indexOf b
       b = { ...b, token: "\n" + b.token }
-      $0[bIdx] = b
+      children = [...children.slice(0, bIdx), b, ...children.slice(bIdx + 1)]
     return {
       type: "WhenClause",
-      children: $0,
+      children,
       cases,
       block,
       break: b,

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -59,12 +59,10 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
 function braceBlock(block: BlockStatement): void
   if block.bare and not block.root
     block.children.unshift " {"
-    // Trailing `//` comments end at EOL, so put `}` on a new line to keep it
-    // from being consumed by the comment. (#832)
-    if hasTrailingComment block.children
-      block.children.push "\n}"
-    else
-      block.children.push "}"
+    // Trailing `//` comments end at EOL, so slip a newline in before the
+    // close brace to keep it from being consumed by the comment. (#832)
+    block.children.push "\n" if hasTrailingComment block.children
+    block.children.push "}"
     { implicitlyReturned } := block
     block.bare = block.implicitlyReturned = false
     if implicitlyReturned
@@ -73,11 +71,8 @@ function braceBlock(block: BlockStatement): void
 /** Undo any bracing done by braceBlock */
 function unbraceBlock(block: BlockStatement): void
   return if block.bare
-  // " {" gets transformed into "{" in ThinArrowFunction.
-  // braceBlock emits "\n}" instead of "}" when the block ends with a
-  // trailing comment (#832), so accept both shapes.
-  /* c8 ignore next -- defensive: "\n}" only comes from NestedBlockStatements blocks, while unbraceBlock is only reached for SingleLineStatements blocks (unwrapObject path); paths don't currently overlap */
-  if block.children[0] is like " {", "{" and block.children.-1 is like "}", "\n}"
+  // " {" gets transformed into "{" in ThinArrowFunction
+  if block.children[0] is like " {", "{" and block.children.-1 is "}"
     block.children.shift()
     block.children.pop()
     block.bare = true

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -73,8 +73,11 @@ function braceBlock(block: BlockStatement): void
 /** Undo any bracing done by braceBlock */
 function unbraceBlock(block: BlockStatement): void
   return if block.bare
-  // " {" gets transformed into "{" in ThinArrowFunction
-  if block.children[0] is like " {", "{" and block.children.-1 is "}"
+  // " {" gets transformed into "{" in ThinArrowFunction.
+  // braceBlock emits "\n}" instead of "}" when the block ends with a
+  // trailing comment (#832), so accept both shapes.
+  /* c8 ignore next -- defensive: "\n}" only comes from NestedBlockStatements blocks, while unbraceBlock is only reached for SingleLineStatements blocks (unwrapObject path); paths don't currently overlap */
+  if block.children[0] is like " {", "{" and block.children.-1 is like "}", "\n}"
     block.children.shift()
     block.children.pop()
     block.bare = true

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -10,6 +10,7 @@ import type {
 } from ./types.civet
 
 import {
+  hasTrailingComment
   isToken
   replaceNode
   startsWith
@@ -58,7 +59,12 @@ function blockWithPrefix(prefixStatements: StatementTuple[] | undefined, block: 
 function braceBlock(block: BlockStatement): void
   if block.bare and not block.root
     block.children.unshift " {"
-    block.children.push "}"
+    // Trailing `//` comments end at EOL, so put `}` on a new line to keep it
+    // from being consumed by the comment. (#832)
+    if hasTrailingComment block.children
+      block.children.push "\n}"
+    else
+      block.children.push "}"
     { implicitlyReturned } := block
     block.bare = block.implicitlyReturned = false
     if implicitlyReturned

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -551,9 +551,11 @@ function insertReturn(node: ASTNode): void
       // Then try to add implicit return
       insertReturn node.block
       unless isExit node.block
-        comment := hasTrailingComment node.block.expressions
+        // Trailing same-indent `//` comments now live in `block.children`
+        // (#832) rather than `expressions`, so check there.
+        comment := node.block.trailing?# or hasTrailingComment node.block.expressions
         node.block.expressions.push [
-          comment ? node.block.expressions.-1.0 or "\n" : ""
+          comment ? node.block.expressions.-1?[0] or "\n" : ""
           wrapWithReturn undefined, node, not comment
         ]
       return

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -400,6 +400,12 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
     children.push ":void 0"
   children.push closeParen
 
+  // Trailing `//` comments captured inside the then/else blocks (#832) get
+  // dropped when those blocks collapse to ternary operands; hoist them out
+  // after the close paren so they survive the conversion.
+  children.push b.trailing if b.trailing?#
+  children.push e.block.trailing if e?.block.trailing?#
+
   makeNode {
     type: "IfExpression"
     children

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -740,6 +740,7 @@ export type BlockStatement = ASTParent &
   root?: boolean  // is this the global root block for the program?
   topLevelAwait?: boolean // for root block, is there top-level `await`? (before any IIFE wrapping)
   topLevelYield?: boolean // for root block, is there top-level `yield`? (before any IIFE wrapping)
+  trailing?: ASTNode[]  // trailing same-indent `//` comments (#832); also present in children
 
 export type ImportDeclaration = ASTParent &
   type: "ImportDeclaration"

--- a/test/class.civet
+++ b/test/class.civet
@@ -28,6 +28,19 @@ describe "class", ->
     }
   """
 
+  // Comment-only class body should keep the comment inside the braces.
+  // (issue #832 follow-up)
+  testCase """
+    comment-only body stays inside (#832)
+    ---
+    class Foo
+      // foo
+    ---
+    class Foo {
+      // foo
+    }
+  """
+
   testCase """
     braced empty statement
     ---

--- a/test/if.civet
+++ b/test/if.civet
@@ -134,10 +134,12 @@ describe "if", ->
     else
       // no
     ---
-    if (x) {}
+    if (x) {
       // yes
-    else {}
+    }
+    else {
       // no
+    }
   """
 
   testCase """
@@ -148,8 +150,9 @@ describe "if", ->
     else
       console.log 'no'
     ---
-    if (x) {}
+    if (x) {
       // yes
+    }
     else {
       console.log('no')
     }

--- a/test/if.civet
+++ b/test/if.civet
@@ -841,6 +841,32 @@ describe "if", ->
         "b")
     """
 
+    // Trailing `// ...` in an if-expression body must survive the ternary
+    // conversion (issue #832 follow-up).
+    testCase """
+      if expression with trailing comment in body
+      ---
+      z = if x
+        x // foo
+      ---
+      z = (x?
+        x:void 0) // foo
+    """
+
+    testCase """
+      if expression with trailing comment in else body
+      ---
+      z = if x
+        x
+      else
+        y // foo
+      ---
+      z = (x?
+        x
+      :
+        y) // foo
+    """
+
     testCase """
       if expression on new line
       ---

--- a/test/if.civet
+++ b/test/if.civet
@@ -158,6 +158,23 @@ describe "if", ->
     }
   """
 
+  // Comment at a shallower indent should stay outside the block — exercises
+  // the indent-mismatch reject in TrailingNestedCommentLine (issue #832).
+  testCase """
+    outer-level comment after indented block
+    ---
+    if a
+      stmt
+    // outer comment
+    foo
+    ---
+    if (a) {
+      stmt
+    }
+    // outer comment
+    foo
+  """
+
   testCase """
     nested
     ---

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -261,8 +261,8 @@ describe "braced JSX attributes", ->
     } />
     ---
     <div x={() => {
-      return alert('hi')
-    } // comment
+      return alert('hi') // comment
+    }
     } />
   """
 
@@ -289,8 +289,8 @@ describe "braced JSX attributes", ->
     ---
     <div x={() => {
       return alert('hi')
-    }
       // comment
+    }
     } />
   """
 

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1675,7 +1675,9 @@ describe "switch", ->
             foo()
       ---
       () => {
-        if(Array.isArray(x) && x.length >= 1) {const [_] = x;return}
+        if(Array.isArray(x) && x.length >= 1) {const [_] = x;return
+            // nothing
+      }
       else  {
             return foo()
           }
@@ -1726,7 +1728,9 @@ describe "switch", ->
       ---
       () => {
         const results=[];for (const x of y) {
-          if(Array.isArray(x) && x.length >= 1) {const [_] = x;results.push(void 0);}
+          if(Array.isArray(x) && x.length >= 1) {const [_] = x;results.push(void 0);
+              // nothing
+      }
       else  {
               results.push(foo())
             }
@@ -2038,7 +2042,8 @@ describe "switch", ->
         }
         case c: {
           console.log('c')
-          \n  } // fall through
+           // fall through
+        }
         case d: {
           console.log('d')
           \n  }

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -638,6 +638,34 @@ describe "switch", ->
     }
   """
 
+  // Exercises the `block.trailing?#` branch of WhenClause's implicit return
+  // (issue #832): a semicolon-terminated statement followed by a standalone
+  // trailing `// ...` line.
+  testCase """
+    standalone trailing comment after semi-ended when body
+    ---
+    =>
+      switch x
+        when 'a'
+          a;
+          // trailing
+        else
+          b
+    ---
+    () => {
+      switch(x) {
+        case 'a': {
+          a;
+          return
+          // trailing
+        }
+        default: {
+          return b
+        }
+      }
+    }
+  """
+
   // #1118
   testCase """
     break after pattern matching statement

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -638,6 +638,72 @@ describe "switch", ->
     }
   """
 
+  // Trailing comments in `when` bodies stay inside the case block,
+  // matching the try/catch behavior in test/try.civet. (issue #832)
+  testCase """
+    comment-only when body stays inside (#832)
+    ---
+    switch x
+      when 1
+        // todo
+      when 2
+        console.log y
+    ---
+    switch(x) {
+      case 1: {
+        // todo
+    ;break;
+      }
+      case 2: {
+        console.log(y);break;
+      }
+    }
+  """
+
+  testCase """
+    trailing inline comment on last statement of when (#832)
+    ---
+    switch x
+      when 1
+        stmt1() //comment 1
+        stmt2() //comment 2
+      when 2
+        console.log y
+    ---
+    switch(x) {
+      case 1: {
+        stmt1() //comment 1
+        stmt2() //comment 2
+    ;break;
+      }
+      case 2: {
+        console.log(y);break;
+      }
+    }
+  """
+
+  testCase """
+    trailing comment line after last statement of when (#832)
+    ---
+    switch x
+      when 1
+        stmt()
+        // trailing inside when
+      when 2
+        console.log y
+    ---
+    switch(x) {
+      case 1: {
+        stmt()
+        // trailing inside when
+    ;break;
+      }
+      case 2: {
+        console.log(y);break;
+      }
+    }
+  """
+
   // Exercises the `block.trailing?#` branch of WhenClause's implicit return
   // (issue #832): a semicolon-terminated statement followed by a standalone
   // trailing `// ...` line.

--- a/test/try.civet
+++ b/test/try.civet
@@ -151,6 +151,59 @@ describe "try", ->
     finally {}
   """
 
+  // https://github.com/DanielXMoore/Civet/issues/832
+  testCase """
+    comment-only catch body stays inside (#832)
+    ---
+    try
+      something
+    catch
+      // ESLint please don't say it's an empty block
+    ---
+    try {
+      something
+    }
+    catch {
+      // ESLint please don't say it's an empty block
+    }
+  """
+
+  testCase """
+    trailing inline comment on last statement of try (#832)
+    ---
+    try
+      stmt1() //comment 1
+      stmt2() //comment 2
+    catch
+      //comment 3
+    ---
+    try {
+      stmt1() //comment 1
+      stmt2() //comment 2
+    }
+    catch {
+      //comment 3
+    }
+  """
+
+  testCase """
+    trailing comment line after last statement of catch (#832)
+    ---
+    try
+      x()
+    catch
+      y()
+      // trailing inside catch
+    ---
+    try {
+      x()
+    }
+    catch {
+      y()
+      // trailing inside catch
+    }
+  """
+
   testCase """
     catch with then
     ---


### PR DESCRIPTION
Fixes #832.

## Summary
- A trailing `//` comment as the last line of an indented block was being escaped out past the closing brace; the same was true for comment-only block bodies and trailing inline comments on the last statement.
- Cause: `EOS` in the next outer `Nested` greedily swallows trailing comment lines, so the block's expressions ended before the comment.

## Approach
- Add a `TrailingNestedComments?` slot to `NestedBlockStatements` (plus helpers `TrailingInlineComment` and `TrailingNestedCommentLine`) so the indented block captures its own trailing comments before the outer block can see them.
- Add a `PushIndent` fallback (`TrackCommentLine`) so a comment-only body still pushes an indent.
- Put the captured comments in `block.children`, NOT `block.expressions`. Downstream AST walkers (assignResults, insertReturn, pattern-matching's continue-switch check) keep seeing the last real statement at `expressions.-1`, so they need no per-walker skip logic.
- `braceBlock` (block.civet) checks `hasTrailingComment block.children` and uses `\n}` so the brace doesn't get consumed by a trailing comment.
- `WhenClause` prefixes the inserted `;break;` with `\n` when the body ends with a comment, for the same reason.

## Test plan
- [x] `pnpm test:grep "832"` — three new red→green tests in `test/try.civet`
- [x] `pnpm test` — full suite, only pre-existing failures (5× CLI --typecheck baseline + 1× unplugin timeout)
- [x] `pnpm test:self` — passes the same with the rebuilt parser
- [x] `pnpm typecheck` — 0 regressions, net -1 vs main

🤖 Generated with [Claude Code](https://claude.com/claude-code)