### PR TITLE
Isolate CLI --typecheck tests from the project tsconfig

### DIFF
--- a/test/cli.civet
+++ b/test/cli.civet
@@ -831,13 +831,41 @@ describe "CLI --config", ->
 
 describe "CLI --typecheck", ->
   let tmpDir: string
+  let origCwd: string
   fileNum .= 0
   before ->
-    // Place tmp files inside the project so TypeScript's rootDir accepts them
-    tmpDir = path.join process.cwd(), "test", "infra", "tmp-cli-typecheck-" + Math.random().toString(36).substring(2, 15)
+    // Out-of-project tmpDir + a minimal tsconfig stub so the unplugin's
+    // ts.findConfigFile walk lands here, not on the project's tsconfig
+    // (which has include:["source", ...] and would pull source/** into
+    // scope — surfacing as 800+ TS diagnostics on any test that drives
+    // the TSService load path, e.g. --typecheck --js).
+    tmpDir = path.join tmpdir(), "civet-cli-typecheck-" + Math.random().toString(36).substring(2, 15)
     await mkdir tmpDir, { recursive: true }
+    // Explicit `files: [_placeholder.ts]` keeps the stub tsconfig valid
+    // (TS18003 fires only when neither files nor include matches anything)
+    // without pulling any sibling files in tmpDir into scope — `files`
+    // suppresses TS's default `**/*` discovery.  Each test passes its
+    // input file explicitly through the load() path.
+    await writeFile path.join(tmpDir, '_placeholder.ts'), 'export {}\n'
+    await writeFile path.join(tmpDir, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Bundler'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      files: ['_placeholder.ts']
+    })
   after ->
     await rm tmpDir, { recursive: true, force: true }
+  beforeEach ->
+    origCwd = process.cwd()
+    process.chdir tmpDir
+  afterEach ->
+    process.chdir origCwd
 
   function makeCivetTempFile(content: string): string
     filePath := path.join tmpDir, `input-${fileNum++}.civet`


### PR DESCRIPTION
## Cause
The `CLI --typecheck` describe block in `test/cli.civet` ran with cwd at the project root. The unplugin's `ts.findConfigFile(process.cwd(), …)` walk therefore lands on the project's own `tsconfig.json`, whose `include: ["source", "test/**/*.civet", "types"]` pulls `source/**` into the typecheck scope.

This surfaces as 800+ project TS diagnostics dumped through assertion messages on any test that drives the TSService load path — visible today via the `--typecheck --js` case (which routes through TSService rather than `ts: 'preserve'`).

## Approach
Move `tmpDir` to `os.tmpdir()` and seed it with a stub `tsconfig.json` + `_placeholder.ts`. `files: ['_placeholder.ts']` suppresses TS's default `**/*` discovery while satisfying TS18003, so the only files in scope are the placeholder plus whatever each test adds explicitly through the CLI's `load()` path.

`beforeEach`/`afterEach` chdir into `tmpDir` so the find-walk stays inside the stub. Per-test "isolated" tests still work — they capture `process.cwd()` (now `tmpDir`), chdir to their own subdir, and chdir back to `tmpDir`, after which `afterEach` restores the original cwd.