### PR TITLE
Docs: Wrap top-level yield in a generator before Prettier in the playground

### DIFF
--- a/civet.dev/.vitepress/utils/compileCivet.ts
+++ b/civet.dev/.vitepress/utils/compileCivet.ts
@@ -6,15 +6,37 @@ export function compileCivet(
   parseOptions: any
 ) {
   // This SSR rendering code must be synchronous because of Markdown API
-  let tsCode = civetInstance.compile(code, { parseOptions, sync: true });
+  const ast = civetInstance.compile(code, {
+    parseOptions,
+    sync: true,
+    ast: true,
+  });
+  let tsCode = civetInstance.generate(ast, {});
   const tsRawCode = tsCode;
 
   if (prettierInstance) {
     try {
-      tsCode = prettierInstance.format(tsCode, {
+      // Prettier misparses top-level `yield` (it's not legal there), turning
+      // `yield [a, b]` into `yield[(a, b)]`. Work around by wrapping in a
+      // generator function, formatting, then stripping the wrapper.
+      // https://github.com/DanielXMoore/Civet/issues/1673
+      const wrapYield = ast?.topLevelYield;
+      const wrapped = wrapYield
+        ? `function*$civetYieldWrap(){\n${tsCode}\n}`
+        : tsCode;
+      let formatted = prettierInstance.format(wrapped, {
         parser: 'typescript',
         printWidth: 50,
       });
+      if (wrapYield) {
+        const match = formatted.match(
+          /^function\* \$civetYieldWrap\(\) \{\n([\s\S]*)\n\}\s*$/
+        );
+        if (match) {
+          formatted = match[1].replace(/^  /gm, '') + '\n';
+        }
+      }
+      tsCode = formatted;
     } catch (err) {
       console.info('Prettier error. Fallback to raw civet output', {
         tsCode,

--- a/civet.dev/.vitepress/utils/compileCivet.ts
+++ b/civet.dev/.vitepress/utils/compileCivet.ts
@@ -32,9 +32,9 @@ export function compileCivet(
         const match = formatted.match(
           /^function\* \$civetYieldWrap\(\) \{\n([\s\S]*)\n\}\s*$/
         );
-        if (match) {
-          formatted = match[1].replace(/^  /gm, '') + '\n';
-        }
+        // Fall back to raw output if Prettier reshaped the wrapper
+        // unexpectedly — better to ship unformatted than to leak the wrapper.
+        formatted = match ? match[1].replace(/^  /gm, '') + '\n' : tsCode;
       }
       tsCode = formatted;
     } catch (err) {

--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -102,11 +102,28 @@ onmessage = async (e) => {
   let formattedOutput;
   if (prettierOutput) {
     try {
-      tsCode = await prettier.format(tsCode, {
+      // Prettier misparses top-level `yield` (it's not legal there), turning
+      // `yield [a, b]` into `yield[(a, b)]`. Work around by wrapping in a
+      // generator function, formatting, then stripping the wrapper.
+      // https://github.com/DanielXMoore/Civet/issues/1673
+      const wrapYield = ast?.topLevelYield;
+      const wrapped = wrapYield
+        ? `function*$civetYieldWrap(){\n${tsCode}\n}`
+        : tsCode;
+      let formatted = await prettier.format(wrapped, {
         parser: 'typescript',
         plugins: prettierPlugins,
         printWidth: 50,
       });
+      if (wrapYield) {
+        const match = formatted.match(
+          /^function\* \$civetYieldWrap\(\) \{\n([\s\S]*)\n\}\s*$/
+        );
+        if (match) {
+          formatted = match[1].replace(/^  /gm, '') + '\n';
+        }
+      }
+      tsCode = formatted;
       formattedOutput = tsCode;
     } catch (err) {
       console.info('Prettier error. Fallback to raw civet output', {

--- a/civet.dev/public/playground.worker.js
+++ b/civet.dev/public/playground.worker.js
@@ -8,10 +8,11 @@ onmessage = async (e) => {
   const highlighter = await getHighlighter();
   const inputHtml = highlighter.codeToHtml(code, { lang: 'civet' });
 
-  let tsCode, ast, sourceMap
+  let tsCode, ast, sourceMap, topLevelYield
   let errors = []
   try {
     ast = await Civet.compile(code, { ast: true, parseOptions });
+    topLevelYield = ast.topLevelYield;
     sourceMap = new Civet.SourceMap(code);
     tsCode = Civet.generate(ast, { js: !tsOutput, errors, sourceMap });
     if (errors.length) {
@@ -106,8 +107,7 @@ onmessage = async (e) => {
       // `yield [a, b]` into `yield[(a, b)]`. Work around by wrapping in a
       // generator function, formatting, then stripping the wrapper.
       // https://github.com/DanielXMoore/Civet/issues/1673
-      const wrapYield = ast?.topLevelYield;
-      const wrapped = wrapYield
+      const wrapped = topLevelYield
         ? `function*$civetYieldWrap(){\n${tsCode}\n}`
         : tsCode;
       let formatted = await prettier.format(wrapped, {
@@ -115,13 +115,13 @@ onmessage = async (e) => {
         plugins: prettierPlugins,
         printWidth: 50,
       });
-      if (wrapYield) {
+      if (topLevelYield) {
         const match = formatted.match(
           /^function\* \$civetYieldWrap\(\) \{\n([\s\S]*)\n\}\s*$/
         );
-        if (match) {
-          formatted = match[1].replace(/^  /gm, '') + '\n';
-        }
+        // Fall back to raw output if Prettier reshaped the wrapper
+        // unexpectedly — better to ship unformatted than to leak the wrapper.
+        formatted = match ? match[1].replace(/^  /gm, '') + '\n' : tsCode;
       }
       tsCode = formatted;
       formattedOutput = tsCode;


### PR DESCRIPTION
Closes #1673.

Prettier misparses `yield` outside a generator (it isn't legal there), turning `yield [a, b]` into `yield[(a, b)]` and `yield await [foo, bar]` into `yield[(await foo, await bar)]`. The underlying upstream issue is [prettier/prettier#16167](https://github.com/prettier/prettier/issues/16167).

Both the in-browser playground worker and the SSR `<Playground>` code-block path now wrap the TS output in `function*\$civetYieldWrap(){…}` when `ast.topLevelYield` is set, format, and strip the wrapper (function header, trailing `}`, one indent level). Non-yield snippets bypass the wrap and format exactly as before.