### PR TITLE
Fix implicit extension and directory resolution when typechecking

### DIFF
--- a/source/ts-service/host.civet
+++ b/source/ts-service/host.civet
@@ -29,6 +29,7 @@ ts from typescript
   removeExtension
 } from ./path.civet
 { mogrifyPackageJsonImports } from ./config.civet
+{ resolveTranspiledModuleName } from ./resolve.civet
 assert from node:assert
 
 // ts doesn't have this key in the type
@@ -232,41 +233,15 @@ export function TSHost(
     resolveModuleNameLiterals(literals: readonly any[], containingFile: string, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions)
       literals.map (literal) =>
         name: string := literal.text
-        // 1. Check for explicit transpiled extensions.
-        for [ext, t] of transpilers
-          if name.endsWith ext
-            resolved := path.resolve path.dirname(containingFile), name
-            if pathExists resolved
-              return
-                resolvedModule:
-                  resolvedFileName: resolved + t.target
-                  extension: t.target
-                  isExternalLibraryImport: false
-        // 2. Try regular TypeScript resolution.
-        tsResolved := ts.resolveModuleName name, containingFile, compilerOptions, self, resolutionCache
-        return tsResolved if tsResolved.resolvedModule
-        // 3. Check for implicit transpiled extensions.
-        resolved := path.resolve path.dirname(containingFile), name
-        for [ext, t] of transpilers
-          sourcePath := resolved + ext
-          if pathExists sourcePath
-            return
-              resolvedModule:
-                resolvedFileName: sourcePath + t.target
-                extension: t.target
-                isExternalLibraryImport: false
-        // 4. Check for directory imports of index files.
-        if baseDirectoryExists resolved
-          for [_, t] of transpilers
-            index := path.join resolved, "index" + t.extension
-            if pathExists index
-              return
-                resolvedModule:
-                  resolvedFileName: index + t.target
-                  extension: t.target
-                  isExternalLibraryImport: false
-        // 5. Return TypeScript's failure information.
-        tsResolved
+        resolveTranspiledModuleName {
+          name
+          containingFile
+          transpilers
+          resolveTypeScript: =>
+            ts.resolveModuleName name, containingFile, compilerOptions, self, resolutionCache
+          fileExists: pathExists
+          directoryExists: baseDirectoryExists
+        }
 
     addOrUpdateDocument(doc: TranspiledDoc): void
       rawPath := path.normalize docFactory.uriToPath(doc.uri)

--- a/source/ts-service/host.civet
+++ b/source/ts-service/host.civet
@@ -230,15 +230,18 @@ export function TSHost(
 
         return undefined
 
-    resolveModuleNameLiterals(literals: readonly any[], containingFile: string, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions)
-      literals.map (literal) =>
+    resolveModuleNameLiterals(literals: readonly any[], containingFile: string, redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, containingSourceFile?: ts.SourceFile)
+      literals.map (literal, index) =>
         name: string := literal.text
+        resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, compilerOptions
         resolveTranspiledModuleName {
           name
           containingFile
+          compilerOptions
+          resolutionMode
           transpilers
           resolveTypeScript: =>
-            ts.resolveModuleName name, containingFile, compilerOptions, self, resolutionCache
+            ts.resolveModuleName name, containingFile, compilerOptions, self, resolutionCache, redirectedReference, resolutionMode
           fileExists: pathExists
           directoryExists: baseDirectoryExists
         }

--- a/source/ts-service/host.civet
+++ b/source/ts-service/host.civet
@@ -232,27 +232,41 @@ export function TSHost(
     resolveModuleNameLiterals(literals: readonly any[], containingFile: string, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions)
       literals.map (literal) =>
         name: string := literal.text
+        // 1. Check for explicit transpiled extensions.
         for [ext, t] of transpilers
           if name.endsWith ext
             resolved := path.resolve path.dirname(containingFile), name
-            if pathExists(resolved)
+            if pathExists resolved
               return
                 resolvedModule:
                   resolvedFileName: resolved + t.target
                   extension: t.target
                   isExternalLibraryImport: false
-        unless getExtensionFromPath(name)
-          resolved := path.resolve path.dirname(containingFile), name
-          if baseDirectoryExists(resolved)
-            for [_, t] of transpilers
-              index := path.join(resolved, "index" + t.extension)
-              if pathExists(index)
-                return
-                  resolvedModule:
-                    resolvedFileName: index + t.target
-                    extension: t.target
-                    isExternalLibraryImport: false
-        resolvedModule: ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache).resolvedModule
+        // 2. Try regular TypeScript resolution.
+        tsResolved := ts.resolveModuleName name, containingFile, compilerOptions, self, resolutionCache
+        return tsResolved if tsResolved.resolvedModule
+        // 3. Check for implicit transpiled extensions.
+        resolved := path.resolve path.dirname(containingFile), name
+        for [ext, t] of transpilers
+          sourcePath := resolved + ext
+          if pathExists sourcePath
+            return
+              resolvedModule:
+                resolvedFileName: sourcePath + t.target
+                extension: t.target
+                isExternalLibraryImport: false
+        // 4. Check for directory imports of index files.
+        if baseDirectoryExists resolved
+          for [_, t] of transpilers
+            index := path.join resolved, "index" + t.extension
+            if pathExists index
+              return
+                resolvedModule:
+                  resolvedFileName: index + t.target
+                  extension: t.target
+                  isExternalLibraryImport: false
+        // 5. Return TypeScript's failure information.
+        tsResolved
 
     addOrUpdateDocument(doc: TranspiledDoc): void
       rawPath := path.normalize docFactory.uriToPath(doc.uri)

--- a/source/ts-service/resolve.civet
+++ b/source/ts-service/resolve.civet
@@ -39,6 +39,7 @@ export function resolveTranspiledModuleName({
   // 2. Try regular TypeScript resolution.
   tsResolved := resolveTypeScript()
   return tsResolved if tsResolved.resolvedModule
+  return tsResolved unless ts.isExternalModuleNameRelative name
 
   // 3. Check for implicit transpiled extensions.
   resolved := path.resolve path.dirname(containingFile), name

--- a/source/ts-service/resolve.civet
+++ b/source/ts-service/resolve.civet
@@ -1,0 +1,66 @@
+/**
+ * Shared Civet-aware module resolution policy for TSService and the
+ * one-shot incremental typecheck host.  Host-specific callers provide the
+ * TypeScript resolver result plus file/directory existence callbacks.
+ */
+
+path from node:path
+
+ts from typescript
+{ type Transpiler } from ./types.civet
+
+export interface ResolveTranspiledModuleOptions
+  name: string
+  containingFile: string
+  transpilers: Map<string, Transpiler>
+  resolveTypeScript(): ts.ResolvedModuleWithFailedLookupLocations
+  fileExists(path: string): boolean
+  directoryExists(path: string): boolean
+
+export function resolveTranspiledModuleName({
+  name
+  containingFile
+  transpilers
+  resolveTypeScript
+  fileExists
+  directoryExists
+}: ResolveTranspiledModuleOptions): ts.ResolvedModuleWithFailedLookupLocations
+  // 1. Check for explicit transpiled extensions.
+  for [ext, t] of transpilers
+    if name.endsWith ext
+      resolved := path.resolve path.dirname(containingFile), name
+      if fileExists resolved
+        return
+          resolvedModule:
+            resolvedFileName: resolved + t.target
+            extension: t.target
+            isExternalLibraryImport: false
+
+  // 2. Try regular TypeScript resolution.
+  tsResolved := resolveTypeScript()
+  return tsResolved if tsResolved.resolvedModule
+
+  // 3. Check for implicit transpiled extensions.
+  resolved := path.resolve path.dirname(containingFile), name
+  for [ext, t] of transpilers
+    sourcePath := resolved + ext
+    if fileExists sourcePath
+      return
+        resolvedModule:
+          resolvedFileName: sourcePath + t.target
+          extension: t.target
+          isExternalLibraryImport: false
+
+  // 4. Check for directory imports of index files.
+  if directoryExists resolved
+    for [_, t] of transpilers
+      index := path.join resolved, "index" + t.extension
+      if fileExists index
+        return
+          resolvedModule:
+            resolvedFileName: index + t.target
+            extension: t.target
+            isExternalLibraryImport: false
+
+  // 5. Return TypeScript's failure information.
+  tsResolved

--- a/source/ts-service/resolve.civet
+++ b/source/ts-service/resolve.civet
@@ -12,6 +12,8 @@ ts from typescript
 export interface ResolveTranspiledModuleOptions
   name: string
   containingFile: string
+  compilerOptions: ts.CompilerOptions
+  resolutionMode?: ts.ResolutionMode
   transpilers: Map<string, Transpiler>
   resolveTypeScript(): ts.ResolvedModuleWithFailedLookupLocations
   fileExists(path: string): boolean
@@ -20,6 +22,8 @@ export interface ResolveTranspiledModuleOptions
 export function resolveTranspiledModuleName({
   name
   containingFile
+  compilerOptions
+  resolutionMode
   transpilers
   resolveTypeScript
   fileExists
@@ -39,7 +43,25 @@ export function resolveTranspiledModuleName({
   // 2. Try regular TypeScript resolution.
   tsResolved := resolveTypeScript()
   return tsResolved if tsResolved.resolvedModule
+
+  // TypeScript resolution should suffice for package imports like `node:fs`.
+  // Don't try implicit extensions or directory imports.
   return tsResolved unless ts.isExternalModuleNameRelative name
+
+  // Node16/NodeNext ESM resolution intentionally rejects extensionless
+  // relative imports and directory `import`s, while CommonJS/`require`
+  // mode still permits them.  Respect TS's per-specifier mode so Civet
+  // does not make `import "./dep"` work where `import "./dep.ts"` or an
+  // explicit index path would be required.
+  // getEmitModuleResolutionKind is exported at runtime but omitted from
+  // typescript.d.ts, so declare just that member at the call site.
+  moduleResolution := (ts as typeof ts & {
+    getEmitModuleResolutionKind: (compilerOptions: ts.CompilerOptions) => ts.ModuleResolutionKind
+  }).getEmitModuleResolutionKind compilerOptions
+  return tsResolved if resolutionMode is ts.ModuleKind.ESNext and (
+    moduleResolution is ts.ModuleResolutionKind.Node16 or
+    moduleResolution is ts.ModuleResolutionKind.NodeNext
+  )
 
   // 3. Check for implicit transpiled extensions.
   resolved := path.resolve path.dirname(containingFile), name
@@ -53,6 +75,9 @@ export function resolveTranspiledModuleName({
           isExternalLibraryImport: false
 
   // 4. Check for directory imports of index files.
+  // Classic resolution checks files but not directory indexes; node-style
+  // and bundler resolutions support `./dir` -> `./dir/index.*`.
+  return tsResolved if moduleResolution is ts.ModuleResolutionKind.Classic
   if directoryExists resolved
     for [_, t] of transpilers
       index := path.join resolved, "index" + t.extension

--- a/source/ts-service/typecheck.civet
+++ b/source/ts-service/typecheck.civet
@@ -25,6 +25,7 @@ ts from typescript
   mogrifyPackageJsonImports
   parseTsConfigForCivet
 } from ./config.civet
+{ resolveTranspiledModuleName } from ./resolve.civet
 
 export interface IncrementalTypecheckOptions
   /** Plugins providing transpilers for `.civet`, `.hera`, etc. */
@@ -59,7 +60,6 @@ export function makeIncrementalTypecheckProgram(
   options: IncrementalTypecheckOptions
 ): IncrementalTypecheckResult
   transpilers := buildTranspilers options.plugins
-  extraExtensions := Array.from transpilers.keys()
   parsed := parseTsConfigForCivet projectPath, transpilers, { tsConfig: options.tsConfig }
 
   compilerOptions: ts.CompilerOptions := {
@@ -154,43 +154,15 @@ export function makeIncrementalTypecheckProgram(
   baseHost.resolveModuleNameLiterals = (literals: readonly any[], containingFile: string, _redirected, opts: ts.CompilerOptions) =>
     literals.map (lit) =>
       name: string := lit.text
-      // 1. Check for explicit transpiled extensions.
-      for ext of extraExtensions
-        if name.endsWith ext
-          t := transpilers.get(ext)!
-          containingDir := path.dirname containingFile
-          resolved := path.resolve containingDir, name
-          if origFileExists resolved
-            return
-              resolvedModule:
-                resolvedFileName: resolved + t.target
-                extension: t.target
-                isExternalLibraryImport: false
-      // 2. Try regular TypeScript resolution.
-      tsResolved := ts.resolveModuleName(name, containingFile, opts, baseHost)
-      return tsResolved if tsResolved.resolvedModule
-      // 3. Check for implicit transpiled extensions.
-      resolved := path.resolve path.dirname(containingFile), name
-      for [ext, t] of transpilers
-        sourcePath := resolved + ext
-        if origFileExists sourcePath
-          return
-            resolvedModule:
-              resolvedFileName: sourcePath + t.target
-              extension: t.target
-              isExternalLibraryImport: false
-      // 4. Check for directory imports of index files.
-      if origDirectoryExists resolved
-        for [_, t] of transpilers
-          index := path.join resolved, "index" + t.extension
-          if origFileExists index
-            return
-              resolvedModule:
-                resolvedFileName: index + t.target
-                extension: t.target
-                isExternalLibraryImport: false
-      // 5. Return TypeScript's failure information.
-      tsResolved
+      resolveTranspiledModuleName {
+        name
+        containingFile
+        transpilers
+        resolveTypeScript: =>
+          ts.resolveModuleName(name, containingFile, opts, baseHost)
+        fileExists: origFileExists
+        directoryExists: origDirectoryExists
+      }
 
   // ts.createIncrementalProgram reads any prior tsbuildinfo via the
   // host's readFile (driven by compilerOptions.tsBuildInfoFile) — no

--- a/source/ts-service/typecheck.civet
+++ b/source/ts-service/typecheck.civet
@@ -151,15 +151,18 @@ export function makeIncrementalTypecheckProgram(
       return mogrifyPackageJsonImports contents, transpilers
     contents
 
-  baseHost.resolveModuleNameLiterals = (literals: readonly any[], containingFile: string, _redirected, opts: ts.CompilerOptions) =>
-    literals.map (lit) =>
+  baseHost.resolveModuleNameLiterals = (literals: readonly any[], containingFile: string, redirectedReference, opts: ts.CompilerOptions, containingSourceFile?: ts.SourceFile) =>
+    literals.map (lit, index) =>
       name: string := lit.text
+      resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, opts
       resolveTranspiledModuleName {
         name
         containingFile
+        compilerOptions: opts
+        resolutionMode
         transpilers
         resolveTypeScript: =>
-          ts.resolveModuleName(name, containingFile, opts, baseHost)
+          ts.resolveModuleName name, containingFile, opts, baseHost, undefined, redirectedReference, resolutionMode
         fileExists: origFileExists
         directoryExists: origDirectoryExists
       }

--- a/source/ts-service/typecheck.civet
+++ b/source/ts-service/typecheck.civet
@@ -127,6 +127,8 @@ export function makeIncrementalTypecheckProgram(
     sf
 
   origFileExists := baseHost.fileExists.bind baseHost
+  /* c8 ignore next -- modern TS hosts provide directoryExists; fallback supports older/custom hosts. */
+  origDirectoryExists := baseHost.directoryExists?.bind(baseHost) ?? => false
   // fileExists override: TS validates resolveModuleNameLiterals's outputs
   // (synthetic `.civet.tsx` paths) by asking the host whether they exist.
   // Without this override, TS would consult the bare filesystem, the
@@ -149,27 +151,46 @@ export function makeIncrementalTypecheckProgram(
       return mogrifyPackageJsonImports contents, transpilers
     contents
 
-  // Redirect `import './foo.civet'` to its `.civet.tsx` synthetic sibling;
-  // anything else falls through to ts.resolveModuleName.  ts.resolveModuleName
-  // returns `{ resolvedModule: ResolvedModuleFull | undefined }`, so we can
-  // pass the field through directly without an explicit if/else.
   baseHost.resolveModuleNameLiterals = (literals: readonly any[], containingFile: string, _redirected, opts: ts.CompilerOptions) =>
     literals.map (lit) =>
       name: string := lit.text
+      // 1. Check for explicit transpiled extensions.
       for ext of extraExtensions
         if name.endsWith ext
           t := transpilers.get(ext)!
           containingDir := path.dirname containingFile
           resolved := path.resolve containingDir, name
           if origFileExists resolved
-            return {
-              resolvedModule: {
+            return
+              resolvedModule:
                 resolvedFileName: resolved + t.target
                 extension: t.target
                 isExternalLibraryImport: false
-              }
-            }
-      { resolvedModule: ts.resolveModuleName(name, containingFile, opts, baseHost).resolvedModule }
+      // 2. Try regular TypeScript resolution.
+      tsResolved := ts.resolveModuleName(name, containingFile, opts, baseHost)
+      return tsResolved if tsResolved.resolvedModule
+      // 3. Check for implicit transpiled extensions.
+      resolved := path.resolve path.dirname(containingFile), name
+      for [ext, t] of transpilers
+        sourcePath := resolved + ext
+        if origFileExists sourcePath
+          return
+            resolvedModule:
+              resolvedFileName: sourcePath + t.target
+              extension: t.target
+              isExternalLibraryImport: false
+      // 4. Check for directory imports of index files.
+      if origDirectoryExists resolved
+        for [_, t] of transpilers
+          index := path.join resolved, "index" + t.extension
+          if origFileExists index
+            return
+              resolvedModule:
+                resolvedFileName: index + t.target
+                extension: t.target
+                isExternalLibraryImport: false
+      // 5. Return TypeScript's failure information.
+      tsResolved
 
   // ts.createIncrementalProgram reads any prior tsbuildinfo via the
   // host's readFile (driven by compilerOptions.tsBuildInfoFile) — no

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1076,6 +1076,159 @@ describe "CLI --typecheck", ->
     finally
       process.chdir cwd
 
+  it "incremental path resolves directory imports using default moduleResolution", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "directory-import-default-resolution-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'NodeNext'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src/dep'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep/index.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from './dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "type mismatch through default moduleResolution should fail typecheck; exit was: " + exitCode
+      assert not stdErr.includes("Cannot find module './dep'"),
+        "default moduleResolution must resolve dep/index.civet: " + stdErr.slice(0, 600)
+      assert stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'"),
+        "expected string->number mismatch through default moduleResolution, got: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
+  it "incremental path respects classic moduleResolution for directory imports", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "directory-import-classic-resolution-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Classic'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src/dep'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep/index.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from './dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "classic moduleResolution should fail directory import; exit was: " + exitCode
+      assert stdErr.includes("Cannot find module './dep'"),
+        "classic moduleResolution must not resolve dep/index.civet: " + stdErr.slice(0, 600)
+      assert not (stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'")),
+        "classic moduleResolution unexpectedly resolved dep/index.civet: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
+  it "incremental path respects Node ESM import mode for extensionless imports", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "extensionless-import-node-esm-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'package.json'), JSON.stringify({ type: "module" })
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'Node16'
+        moduleResolution: 'Node16'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from './dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "Node ESM extensionless import should fail typecheck; exit was: " + exitCode
+      assert stdErr.includes("TS2834") and stdErr.includes("need explicit file extensions"),
+        "Node ESM import mode must not resolve extensionless dep.civet: " + stdErr.slice(0, 600)
+      assert not (stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'")),
+        "Node ESM import mode unexpectedly resolved extensionless dep.civet: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
+  it "incremental path resolves Node require mode extensionless imports", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "extensionless-require-node-cjs-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'package.json'), JSON.stringify({ type: "module" })
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'Node16'
+        moduleResolution: 'Node16'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import dep = require('./dep')
+      const n: number = dep.foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "type mismatch through Node require mode should fail typecheck; exit was: " + exitCode
+      assert not stdErr.includes("Cannot find module './dep'"),
+        "Node require mode must resolve extensionless dep.civet: " + stdErr.slice(0, 600)
+      assert stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'"),
+        "expected string->number mismatch through Node require mode, got: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
   it "incremental path preserves TypeScript failure info for missing imports", :any ->
     @timeout 30000
     isolated := path.join tmpDir, "missing-import-incremental"

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1000,6 +1000,115 @@ describe "CLI --typecheck", ->
     finally
       process.chdir cwd
 
+  it "incremental path resolves extensionless imports to .civet siblings", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "extensionless-import-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Bundler'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from './dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "type mismatch through ./dep should fail typecheck; exit was: " + exitCode
+      assert not stdErr.includes("Cannot find module './dep'"),
+        "extensionless './dep' must resolve to dep.civet: " + stdErr.slice(0, 600)
+      assert stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'"),
+        "expected string->number mismatch through './dep', got: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
+  it "incremental path resolves directory imports to index.civet", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "directory-import-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Bundler'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src/dep'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep/index.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from './dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "type mismatch through ./dep/index.civet should fail typecheck; exit was: " + exitCode
+      assert not stdErr.includes("Cannot find module './dep'"),
+        "directory './dep' must resolve to dep/index.civet: " + stdErr.slice(0, 600)
+      assert stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'"),
+        "expected string->number mismatch through './dep/index.civet', got: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
+  it "incremental path preserves TypeScript failure info for missing imports", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "missing-import-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Bundler'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src'), { recursive: true }
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import './missing'
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "missing import should fail typecheck; exit was: " + exitCode
+      assert stdErr.includes("Cannot find module") and stdErr.includes("./missing"),
+        "expected missing import diagnostic, got: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
   it "incremental path surfaces isolatedDeclarations diagnostics (TS9007/TS9010)", :any ->
     @timeout 30000
     isolated := path.join tmpDir, "iso-decl-incremental"

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1109,6 +1109,82 @@ describe "CLI --typecheck", ->
     finally
       process.chdir cwd
 
+  it "incremental path does not resolve bare package names to sibling .civet files", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "bare-package-file-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Bundler'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from 'dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "missing bare package should fail typecheck; exit was: " + exitCode
+      assert stdErr.includes("Cannot find module 'dep'"),
+        "bare package 'dep' must not resolve to sibling dep.civet: " + stdErr.slice(0, 600)
+      assert not (stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'")),
+        "bare package 'dep' unexpectedly resolved to sibling dep.civet: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
+  it "incremental path does not resolve bare package names to sibling index.civet directories", :any ->
+    @timeout 30000
+    isolated := path.join tmpDir, "bare-package-directory-incremental"
+    await mkdir isolated, { recursive: true }
+    await writeFile path.join(isolated, 'tsconfig.json'), JSON.stringify({
+      compilerOptions: {
+        target: 'ES2022'
+        module: 'ESNext'
+        moduleResolution: 'Bundler'
+        jsx: 'preserve'
+        strict: true
+        skipLibCheck: true
+        noEmit: true
+      }
+      include: ['src']
+    })
+    await mkdir path.join(isolated, 'src/dep'), { recursive: true }
+    await writeFile path.join(isolated, 'src/dep/index.civet'),
+      "export foo: string := 'hello'\n"
+    await writeFile path.join(isolated, 'src/consumer.ts'), """
+      import { foo } from 'dep'
+      const n: number = foo
+    """
+
+    cwd := process.cwd()
+    process.chdir isolated
+    try
+      { exitCode, stdErr } := await captureProcess =>
+        await cli ['--typecheck', '--no-config']
+      assert exitCode? and exitCode > 0,
+        "missing bare package should fail typecheck; exit was: " + exitCode
+      assert stdErr.includes("Cannot find module 'dep'"),
+        "bare package 'dep' must not resolve to sibling dep/index.civet: " + stdErr.slice(0, 600)
+      assert not (stdErr.includes("'string' is not assignable to type 'number'") or stdErr.includes("Type 'string'")),
+        "bare package 'dep' unexpectedly resolved to sibling dep/index.civet: " + stdErr.slice(0, 600)
+    finally
+      process.chdir cwd
+
   it "incremental path surfaces isolatedDeclarations diagnostics (TS9007/TS9010)", :any ->
     @timeout 30000
     isolated := path.join tmpDir, "iso-decl-incremental"

--- a/test/infra/unplugin.civet
+++ b/test/infra/unplugin.civet
@@ -665,6 +665,56 @@ describe "unplugin: file system", ->
       assert not combined.includes("Cannot find module '#dep'"),
         `'#dep' did not resolve via package.json imports map: ${combined.slice(0, 600)}`
 
+    it "buildEnd(true) resolves extensionless imports to .civet siblings", ->
+      @timeout 30000
+
+      importDir := path.join tmpDir, `extensionless-import-${fileNum++}`
+      await mkdir importDir, recursive: true
+      await writeFile path.join(importDir, "dep.civet"), "export foo: string := 'hello'\n"
+      consumerPath := path.join importDir, "consumer.ts"
+      await writeFile consumerPath, """
+        import { foo } from './dep'
+        const n: number = foo
+      """
+
+      plugin := rawPlugin {
+        ts: 'tsc'
+        config: false
+        typecheck: true
+        tsConfig: {
+          rootDir: importDir
+          compilerOptions:
+            target: "es2020"
+            module: "esnext"
+            moduleResolution: "bundler"
+            strict: true
+            skipLibCheck: true
+            jsx: "preserve"
+          files: [ consumerPath ]
+        }
+      }, { framework: 'esbuild' }
+      ctx := { ...nullContext, ...plugin }
+      plugin.esbuild.config { outdir: testOutDir }
+
+      capturedErrors: string[] .= []
+      origError := console.error
+      console.error = (msg) => { capturedErrors.push msg }
+      let thrown: Error?
+      try
+        await plugin.buildStart.call ctx
+        await plugin.buildEnd.call ctx, true
+      catch e
+        thrown = e as Error
+      finally
+        console.error = origError
+
+      combined := capturedErrors.join "\n"
+      assert thrown, "expected buildEnd to throw on the resulting type mismatch"
+      assert combined.includes("'string' is not assignable to type 'number'") or combined.includes("Type 'string'"),
+        `expected string->number mismatch through './dep', got: ${combined.slice(0, 600)}`
+      assert not combined.includes("Cannot find module './dep'"),
+        `extensionless './dep' did not resolve to dep.civet: ${combined.slice(0, 600)}`
+
     it "buildEnd(true) typechecks tsConfig.files entries that load() never saw", ->
       @timeout 30000
 


### PR DESCRIPTION
@vendethiel reported that implicit extensions weren't resolving when typechecking.

This PR updates the Civet TS service and incremental `civet --typecheck` resolver so that unresolved imports are checked against registered transpiler extensions after normal TypeScript resolution fails. This makes Civet typechecking behave more like bundler resolution for `.civet` sources.

Effective improvements:

- Supports implicit Civet extensions, e.g. `import "./dep"` resolving to `./dep.civet`
- Supports directory imports (with implicit `index.civet`) containing dots — previously this was under a "no extension" guard for no apparent reason
- Adds directory import support in the incremental typecheck path, e.g. `import "./dep"` resolving to `./dep/index.civet` — previously this was only in the host path
- Preserves TypeScript’s failed resolution result when all resolution fails, keeping better failure metadata and diagnostics

While here, I factored out the resolver into a separate shared module between the incremental/host paths. We should probably factor out more in the future, to reduce duplication.