### PR TITLE
Fix module resolution: TypeScript `paths`, old TS `resolveModuleNames`

### DIFF
--- a/source/ts-service/host.civet
+++ b/source/ts-service/host.civet
@@ -11,7 +11,6 @@
 path from node:path
 
 ts from typescript
-{ isExternalModuleNameRelative } := ts
 { type CompilerHost, type CompilerOptions, type IScriptSnapshot, type LanguageServiceHost } from typescript
 
 {
@@ -31,10 +30,6 @@ ts from typescript
 { mogrifyPackageJsonImports } from ./config.civet
 { resolveTranspiledModuleName } from ./resolve.civet
 assert from node:assert
-
-// ts doesn't have this key in the type
-interface ResolvedModuleWithFailedLookupLocations extends ts.ResolvedModuleWithFailedLookupLocations
-  failedLookupLocations: string[]
 
 export interface Host extends LanguageServiceHost
   /** Per-file metadata (sourcemap, parse errors, …) for a transpiled source. */
@@ -137,98 +132,20 @@ export function TSHost(
      * synthetic `<src>.<target>` so subsequent `getScriptSnapshot` calls
      * hit the transpiler.
      */
-    resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, _redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, _containingSourceFile?: ts.SourceFile)
-      moduleNames.map (name) =>
-        // Try to resolve the module using the standard TypeScript logic
-        { resolvedModule } := ts.resolveModuleName(name, containingFile, compilerOptions, self, resolutionCache) as ResolvedModuleWithFailedLookupLocations
-        return resolvedModule if resolvedModule
-
-        // get the transpiler for the extension
-        extension := getExtensionFromPath(name)
-        transpiler .= transpilers.get(extension)
-        if transpiler or !extension
-          exists := transpiler ? pathExists : baseDirectoryExists
-          resolvedModule := (resolved: string) =>
-            // Assumes exists(resolved) is true
-            // Directories don't yet have a transpiler chosen; try to find one
-            // via implicit index file.
-            // TODO: Only when state.features & NodeResolutionFeatures.EsmMode
-            // TODO: Read package.json as in loadNodeModuleFromDirectoryWorker
-            unless transpiler
-              for [_, t] of transpilers
-                index := path.join(resolved, "index" + t.extension)
-                if pathExists(index)
-                  transpiler = t
-                  resolved = index
-                  break
-
-              return unless transpiler
-            // Now pathExists(resolved) should be true
-            { target } := transpiler
-            return {
-              resolvedFileName: resolved + target
-              extension: target
-              isExternalLibraryImport: false
-            }
-
-          // Mimic tryResolve from
-          // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts
-          // tryLoadModuleUsingOptionalResolutionSettings.
-          // `baseUrl` is @deprecated in TS 5.0+ but TS still reads it first as
-          // the paths base, so we mirror that behavior for legacy tsconfigs.
-          { paths, pathsBasePath } := compilationSettings
-          baseUrl := (compilationSettings as { baseUrl?: string }).baseUrl
-          unless isExternalModuleNameRelative(name) // absolute
-            // tryLoadModuleUsingPathsIfEligible
-            if paths
-              // tryLoadModuleUsingPaths.  parseJsonConfigFileContent always
-              // assigns options.pathsBasePath the tsconfig's directory when
-              // `paths` is set, so baseUrl ?? pathsBasePath suffices.  See
-              // https://github.com/microsoft/TypeScript/blob/bbef6a7a31cff1d0d9f94b082996334baca74caa/src/compiler/utilities.ts#L6317-L6320
-              pathsBase := baseUrl ?? pathsBasePath as string
-              // TODO: more closely follow tryParsePatterns from
-              // https://github.com/microsoft/TypeScript/blob/bbef6a7a31cff1d0d9f94b082996334baca74caa/src/compiler/utilities.ts#L9743-L9745
-              best .= ''
-              bestPrefix .= ''
-              for [pattern, replacements] of Object.entries(paths)
-                if pattern.endsWith("*")
-                  prefix := pattern.slice(0, -1)
-                  if name.startsWith(prefix)
-                    for replacement of replacements
-                      resolved := path.resolve
-                        pathsBase
-                        replacement.replace('*', name.slice(prefix.length))
-
-                      if exists(resolved) and prefix.length > bestPrefix.length
-                        best = resolved
-                        bestPrefix = prefix
-
-                else if name is pattern
-                  for replacement of replacements
-                    resolved := path.resolve(pathsBase, replacement)
-                    if exists(resolved) and pattern.length > bestPrefix.length
-                      best = resolved
-                      bestPrefix = pattern
-
-              return resolvedModule(best) if best
-
-            // tryLoadModuleUsingBaseUrl
-            if baseUrl
-              /* c8 ignore next 2 -- only fires for tsconfigs with `baseUrl`; test fixtures don't set it */
-              resolved := path.resolve(baseUrl, name)
-              return resolvedModule(resolved) if exists(resolved)
-
-          else // relative
-            // TODO: tryLoadModuleUsingRootDirs
-
-          // This backup resolver is really just for relative paths.
-          // TODO: Implement absolute case from tryResolve
-          // https://github.com/microsoft/TypeScript/blob/cf33fd0cde22905effce371bb02484a9f2009023/src/compiler/moduleNameResolver.ts#L3221
-          resolved := path.resolve path.dirname(containingFile), name
-          return resolvedModule(resolved) if exists(resolved)
-          // TODO: add to resolution cache?
-
-        return undefined
+    resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, containingSourceFile?: ts.SourceFile)
+      moduleNames.map (name, index) =>
+        resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, compilerOptions
+        resolveTranspiledModuleName({
+          name
+          containingFile
+          compilerOptions
+          resolutionMode
+          transpilers
+          resolveTypeScript: =>
+            ts.resolveModuleName name, containingFile, compilerOptions, self, resolutionCache, redirectedReference, resolutionMode
+          fileExists: pathExists
+          directoryExists: baseDirectoryExists
+        }).resolvedModule
 
     resolveModuleNameLiterals(literals: readonly any[], containingFile: string, redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, containingSourceFile?: ts.SourceFile)
       literals.map (literal, index) =>

--- a/source/ts-service/host.civet
+++ b/source/ts-service/host.civet
@@ -92,7 +92,6 @@ export function TSHost(
 
   baseReadFile := baseHost@readFile
   baseFileExists := baseHost@fileExists
-  /* c8 ignore next -- modern TS hosts provide directoryExists; fallback supports older/custom hosts. */
   baseDirectoryExists := baseHost.directoryExists?.bind(baseHost) ?? => false
 
   let self: Host

--- a/source/ts-service/resolve.civet
+++ b/source/ts-service/resolve.civet
@@ -132,7 +132,7 @@ export function resolveTranspiledModuleName({
 
           for replacement of replacements
             target := if starIndex >= 0
-              replacement.replace "*", matched
+              replacement.replace "*", => matched
             else
               replacement
             bestCandidates.push path.resolve pathsBase, target

--- a/source/ts-service/resolve.civet
+++ b/source/ts-service/resolve.civet
@@ -8,6 +8,7 @@ path from node:path
 
 ts from typescript
 { type Transpiler } from ./types.civet
+{ getExtensionFromPath } from ./path.civet
 
 export interface ResolveTranspiledModuleOptions
   name: string
@@ -29,64 +30,129 @@ export function resolveTranspiledModuleName({
   fileExists
   directoryExists
 }: ResolveTranspiledModuleOptions): ts.ResolvedModuleWithFailedLookupLocations
-  // 1. Check for explicit transpiled extensions.
-  for [ext, t] of transpilers
-    if name.endsWith ext
-      resolved := path.resolve path.dirname(containingFile), name
-      if fileExists resolved
-        return
-          resolvedModule:
-            resolvedFileName: resolved + t.target
-            extension: t.target
-            isExternalLibraryImport: false
+  resolvedModule := (sourcePath: string, transpiler: Transpiler): ts.ResolvedModuleFull =>
+    resolvedFileName: sourcePath + transpiler.target
+    extension: transpiler.target
+    isExternalLibraryImport: false
 
-  // 2. Try regular TypeScript resolution.
+  // Try regular TypeScript resolution first. This preserves TS's own `paths`,
+  // `package.json#imports`, and package-resolution behavior when the target is
+  // already a TS/JS file or a mogrified `.civet.tsx` package import.
   tsResolved := resolveTypeScript()
   return tsResolved if tsResolved.resolvedModule
 
-  // TypeScript resolution should suffice for package imports like `node:fs`.
-  // Don't try implicit extensions or directory imports.
-  return tsResolved unless ts.isExternalModuleNameRelative name
-
-  // Node16/NodeNext ESM resolution intentionally rejects extensionless
-  // relative imports and directory `import`s, while CommonJS/`require`
-  // mode still permits them.  Respect TS's per-specifier mode so Civet
-  // does not make `import "./dep"` work where `import "./dep.ts"` or an
-  // explicit index path would be required.
-  // getEmitModuleResolutionKind is exported at runtime but omitted from
-  // typescript.d.ts, so declare just that member at the call site.
   moduleResolution := (ts as typeof ts & {
     getEmitModuleResolutionKind: (compilerOptions: ts.CompilerOptions) => ts.ModuleResolutionKind
   }).getEmitModuleResolutionKind compilerOptions
-  return tsResolved if resolutionMode is ts.ModuleKind.ESNext and (
-    moduleResolution is ts.ModuleResolutionKind.Node16 or
-    moduleResolution is ts.ModuleResolutionKind.NodeNext
+  isRelative := ts.isExternalModuleNameRelative name
+  // Node16/NodeNext ESM resolution intentionally rejects extensionless
+  // relative imports and directory `import`s, while CommonJS/`require` mode
+  // still permits them.  Respect TS's per-specifier mode so Civet does not
+  // make `import "./dep"` work where `import "./dep.ts"` or an explicit index
+  // path would be required.
+  allowImplicitExtension .= isRelative and not (
+    resolutionMode is ts.ModuleKind.ESNext and (
+      moduleResolution is ts.ModuleResolutionKind.Node16 or
+      moduleResolution is ts.ModuleResolutionKind.NodeNext
+    )
   )
+  allowDirectoryIndex .= (not isRelative or allowImplicitExtension) and
+    moduleResolution is not ts.ModuleResolutionKind.Classic
 
-  // 3. Check for implicit transpiled extensions.
-  resolved := path.resolve path.dirname(containingFile), name
-  for [ext, t] of transpilers
-    sourcePath := resolved + ext
+  // Resolve a concrete source path to its synthetic TS sibling.  Explicit
+  // extensions are always allowed; implicit extensions and directory indexes
+  // are controlled by the closure flags above so the paths and relative-import
+  // phases can apply different fallback rules without extra parameters.
+  tryResolveSource := (sourcePath: string): ts.ResolvedModuleFull? =>
+    // Explicit transpiler extension, e.g. "./dep.civet" or a paths target
+    // "src/dep.civet". This is valid even in Node16/NodeNext ESM mode because
+    // the import already names the source extension.
     if fileExists sourcePath
-      return
-        resolvedModule:
-          resolvedFileName: sourcePath + t.target
-          extension: t.target
-          isExternalLibraryImport: false
+      candidateExtension := getExtensionFromPath sourcePath
+      if candidateTranspiler := transpilers.get candidateExtension
+        return resolvedModule sourcePath, candidateTranspiler
 
-  // 4. Check for directory imports of index files.
-  // Classic resolution checks files but not directory indexes; node-style
-  // and bundler resolutions support `./dir` -> `./dir/index.*`.
-  return tsResolved if moduleResolution is ts.ModuleResolutionKind.Classic
-  if directoryExists resolved
-    for [_, t] of transpilers
-      index := path.join resolved, "index" + t.extension
-      if fileExists index
-        return
-          resolvedModule:
-            resolvedFileName: index + t.target
-            extension: t.target
-            isExternalLibraryImport: false
+    // Implicit source extensions are a relative-import fallback: "./dep" can
+    // resolve to "./dep.civet" when the active module-resolution mode allows
+    // extensionless relative imports.  The paths-alias pass keeps this off so
+    // aliases do not gain bare-file probing behavior.
+    if allowImplicitExtension
+      for [ext, t] of transpilers
+        candidate := sourcePath + ext
+        if fileExists candidate
+          return resolvedModule candidate, t
 
-  // 5. Return TypeScript's failure information.
+    // Directory imports mirror node-style resolution, e.g. "./dir" or a paths
+    // alias target "src/dir" resolving to "src/dir/index.civet". Classic TS
+    // resolution checks files only, so keep that old guard here.
+    if allowDirectoryIndex and directoryExists sourcePath
+      for [_, t] of transpilers
+        index := path.join sourcePath, "index" + t.extension
+        if fileExists index
+          return resolvedModule index, t
+    return
+
+  unless isRelative
+    if paths := compilerOptions.paths
+      // parseJsonConfigFileContent sets pathsBasePath when `paths` is present.
+      // If baseUrl is also set, TS still treats it as the paths base even
+      // though standalone baseUrl probing is deprecated and intentionally not
+      // recreated below.
+      if pathsBase := compilerOptions.baseUrl ?? (
+        compilerOptions as ts.CompilerOptions & { pathsBasePath?: string }
+      ).pathsBasePath
+        // Mimic the important part of TS's paths matching: only the best
+        // (longest-prefix) pattern contributes replacements, and replacement
+        // order is preserved.  We only use this after TS's own resolver failed,
+        // so this is a Civet-target fallback, not a full replacement for TS.
+        bestPrefixLength .= -1
+        bestCandidates: string[] .= []
+
+        for [pattern, replacements] of Object.entries paths
+          starIndex := pattern.indexOf "*"
+          let matched: string?
+          let prefixLength: number
+          if starIndex >= 0
+            prefix := pattern[<starIndex]
+            suffix := pattern[>starIndex]
+            if name.startsWith(prefix) and name.endsWith(suffix) and name# >= prefix# + suffix#
+              matched = name[prefix# ..< name# - suffix#]
+              prefixLength = prefix#
+            else
+              continue
+          else
+            continue unless name is pattern
+            matched = ""
+            prefixLength = pattern#
+
+          continue if prefixLength < bestPrefixLength
+          if prefixLength > bestPrefixLength
+            bestPrefixLength = prefixLength
+            bestCandidates = []
+
+          for replacement of replacements
+            target := if starIndex >= 0
+              replacement.replace "*", matched
+            else
+              replacement
+            bestCandidates.push path.resolve pathsBase, target
+
+        // Paths aliases can point at explicit `.civet` files or at directories
+        // with `index.civet`, but not at bare files that need implicit
+        // ".civet" suffix probing.
+        for candidate of bestCandidates
+          if resolved := tryResolveSource candidate
+            return resolvedModule: resolved
+
+  // For package/bare specifiers, TypeScript resolution should either succeed
+  // via the host's synthetic `.civet.tsx` fileExists hook or provide the right
+  // failure details.  Do not apply relative-style implicit extension or
+  // directory probing to unresolved packages.
+  return tsResolved unless isRelative
+
+  relativeSourcePath := path.resolve path.dirname(containingFile), name
+  resolved := tryResolveSource relativeSourcePath
+  return resolvedModule: resolved if resolved
+
+  // Return TypeScript's failure information.
   tsResolved

--- a/source/ts-service/service.civet
+++ b/source/ts-service/service.civet
@@ -189,7 +189,8 @@ export function createBaseHost(options: ts.CompilerOptions, system: ts.System): 
     getNewLine()
       system.newLine
     directoryExists(path: string)
-      system.directoryExists?(path) ?? false
+      return false unless system.directoryExists?
+      system.directoryExists path
     readDirectory(path: string, extensions?: readonly string[], excludes?: readonly string[], includes?: readonly string[], depth?: number)
       system.readDirectory(path, extensions, excludes, includes, depth)
     realpath(path: string)

--- a/source/ts-service/typecheck.civet
+++ b/source/ts-service/typecheck.civet
@@ -167,6 +167,24 @@ export function makeIncrementalTypecheckProgram(
         directoryExists: origDirectoryExists
       }
 
+  // TypeScript <5 uses this older hook instead of resolveModuleNameLiterals.
+  // Keep it on the same resolver so TS 4.x typecheckers see extensionless
+  // imports such as `./dep` -> `./dep.civet`.
+  baseHost.resolveModuleNames = (moduleNames: string[], containingFile: string, _reusedNames, redirectedReference, opts: ts.CompilerOptions, containingSourceFile?: ts.SourceFile) =>
+    moduleNames.map (name, index) =>
+      resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, opts
+      resolveTranspiledModuleName({
+        name
+        containingFile
+        compilerOptions: opts
+        resolutionMode
+        transpilers
+        resolveTypeScript: =>
+          ts.resolveModuleName name, containingFile, opts, baseHost, undefined, redirectedReference, resolutionMode
+        fileExists: origFileExists
+        directoryExists: origDirectoryExists
+      }).resolvedModule
+
   // ts.createIncrementalProgram reads any prior tsbuildinfo via the
   // host's readFile (driven by compilerOptions.tsBuildInfoFile) — no
   // explicit oldProgram parameter, the API picks it up internally.

--- a/test/infra/ts-service-config.civet
+++ b/test/infra/ts-service-config.civet
@@ -232,6 +232,33 @@ describe "resolveTranspiledModuleName fallback branches", ->
     finally
       fs.rmSync tmpDir, { recursive: true, force: true }
 
+  it "treats paths wildcard matches as literal replacement text", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-paths-dollar-'
+    try
+      srcDir := path.join tmpDir, 'src'
+      fs.mkdirSync srcDir
+      fs.writeFileSync path.join(srcDir, 'dep$&name.civet'), "export n: number := 1\n"
+
+      resolved := resolveTranspiledModuleName({
+        name: '@special/dep$&name'
+        containingFile: path.join tmpDir, 'index.ts'
+        compilerOptions:
+          moduleResolution: ts.ModuleResolutionKind.Node10
+          baseUrl: tmpDir
+          paths:
+            '@special/*': ['src/*.civet']
+        transpilers: makeCivetTranspiler()
+        resolveTypeScript: => failure
+        fileExists: fs.existsSync
+        directoryExists
+      })
+
+      resolvedFile := resolved.resolvedModule?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('src/dep$&name.civet.tsx'),
+        `expected literal wildcard replacement, got ${resolved.resolvedModule?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
 describe "ts-service legacy module resolver", ->
   it "resolveModuleNames resolves extensionless imports to .civet siblings", ->
     tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-legacy-'

--- a/test/infra/ts-service-config.civet
+++ b/test/infra/ts-service-config.civet
@@ -4,9 +4,13 @@ assert from assert
 * as fs from node:fs
 * as os from node:os
 * as path from node:path
+ts from typescript
 
 { buildTranspilers, parseTsConfigForCivet } from "../../source/ts-service/config.civet"
+{ resolveTranspiledModuleName } from "../../source/ts-service/resolve.civet"
+{ createBaseHost } from "../../source/ts-service/service.civet"
 {
+  TSHost
   TSService
   createInMemoryDocFactory
   makeCivetPlugin
@@ -85,6 +89,146 @@ describe "parseTsConfigForCivet missing-tsconfig fallback", ->
       // empty-include arm was taken (otherwise this would be empty).
       assert parsed.fileNames.some(.endsWith 'plain.ts'),
         `expected plain.ts in default walk; got ${parsed.fileNames.join(', ')}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+describe "createBaseHost", ->
+  it "returns false when a custom System does not provide directoryExists", ->
+    system := {
+      ...ts.sys
+      directoryExists: undefined
+    } as unknown as ts.System
+    host := createBaseHost {}, system
+    assert.equal host.directoryExists!("missing"), false
+
+describe "TSHost", ->
+  it "accepts a base host without directoryExists", ->
+    baseHost := {
+      readFile: (_fileName: string) => undefined
+      fileExists: (_fileName: string) => false
+      getDefaultLibFileName: (_options: ts.CompilerOptions) => "lib.d.ts"
+    } as ts.CompilerHost
+    host := TSHost(
+      { rootDir: os.tmpdir() }
+      []
+      baseHost
+      makeCivetTranspiler()
+      createInMemoryDocFactory()
+    )
+    assert.equal host.fileExists(path.join(os.tmpdir(), 'missing.civet.tsx')), false
+
+describe "resolveTranspiledModuleName fallback branches", ->
+  failure := {
+    resolvedModule: undefined
+    failedLookupLocations: []
+  } as ts.ResolvedModuleWithFailedLookupLocations
+
+  directoryExists := (p: string) =>
+    fs.existsSync(p) and fs.statSync(p).isDirectory()
+
+  it "returns TypeScript failure details for unresolved relative imports", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-missing-relative-'
+    try
+      resolved := resolveTranspiledModuleName({
+        name: './missing'
+        containingFile: path.join tmpDir, 'index.ts'
+        compilerOptions:
+          moduleResolution: ts.ModuleResolutionKind.Node10
+        transpilers: makeCivetTranspiler()
+        resolveTypeScript: => failure
+        fileExists: fs.existsSync
+        directoryExists
+      })
+      assert.equal resolved, failure
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  nodeEsmModes: {
+    label: string
+    moduleResolution: ts.ModuleResolutionKind
+    moduleKind: ts.ModuleKind
+  }[] := [
+    { label: 'Node16', moduleResolution: ts.ModuleResolutionKind.Node16, moduleKind: ts.ModuleKind.Node16 }
+    { label: 'NodeNext', moduleResolution: ts.ModuleResolutionKind.NodeNext, moduleKind: ts.ModuleKind.NodeNext }
+  ]
+  for { label, moduleResolution, moduleKind } of nodeEsmModes
+    it `does not probe implicit extensions in ${label} ESM mode`, ->
+      tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-esm-extensionless-'
+      try
+        fs.writeFileSync path.join(tmpDir, 'dep.civet'), "export n: number := 1\n"
+
+        resolved := resolveTranspiledModuleName({
+          name: './dep'
+          containingFile: path.join tmpDir, 'index.ts'
+          compilerOptions:
+            module: moduleKind
+            moduleResolution: moduleResolution
+          resolutionMode: ts.ModuleKind.ESNext
+          transpilers: makeCivetTranspiler()
+          resolveTypeScript: => failure
+          fileExists: fs.existsSync
+          directoryExists
+        })
+        assert.equal resolved, failure
+      finally
+        fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "returns TypeScript failure details for unresolved bare imports", ->
+    resolved := resolveTranspiledModuleName({
+      name: 'missing-package'
+      containingFile: path.join os.tmpdir(), 'index.ts'
+      compilerOptions:
+        moduleResolution: ts.ModuleResolutionKind.Node10
+      transpilers: makeCivetTranspiler()
+      resolveTypeScript: => failure
+      fileExists: fs.existsSync
+      directoryExists
+    })
+    assert.equal resolved, failure
+
+  it "skips paths mappings when TypeScript did not provide a paths base", ->
+    resolved := resolveTranspiledModuleName({
+      name: '@/dep.civet'
+      containingFile: path.join os.tmpdir(), 'index.ts'
+      compilerOptions:
+        moduleResolution: ts.ModuleResolutionKind.Node10
+        paths:
+          '@/*': ['src/*']
+      transpilers: makeCivetTranspiler()
+      resolveTypeScript: => failure
+      fileExists: fs.existsSync
+      directoryExists
+    })
+    assert.equal resolved, failure
+
+  it "uses the best paths pattern and preserves replacement order", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-paths-branches-'
+    try
+      srcDir := path.join tmpDir, 'src'
+      fs.mkdirSync srcDir
+      exactPath := path.join srcDir, 'exact.civet'
+      fs.writeFileSync exactPath, "export n: number := 1\n"
+
+      resolved := resolveTranspiledModuleName({
+        name: '@long/dep'
+        containingFile: path.join tmpDir, 'index.ts'
+        compilerOptions:
+          moduleResolution: ts.ModuleResolutionKind.Node10
+          baseUrl: tmpDir
+          paths:
+            'nomatch/*': ['nope/*']
+            'other': ['src/other.civet']
+            '@long/dep': ['src/missing.civet', 'src/exact.civet']
+            '@long/*': ['src/star-missing/*']
+        transpilers: makeCivetTranspiler()
+        resolveTypeScript: => failure
+        fileExists: fs.existsSync
+        directoryExists
+      })
+
+      resolvedFile := resolved.resolvedModule?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('src/exact.civet.tsx'),
+        `expected exact paths replacement to resolve, got ${resolved.resolvedModule?.resolvedFileName}`
     finally
       fs.rmSync tmpDir, { recursive: true, force: true }
 

--- a/test/infra/ts-service-config.civet
+++ b/test/infra/ts-service-config.civet
@@ -97,17 +97,21 @@ describe "createBaseHost", ->
     system := {
       ...ts.sys
       directoryExists: (_path: string) => true
+      realpath: (_path: string) => "real"
     } as unknown as ts.System
     host := createBaseHost {}, system
     assert.equal host.directoryExists!("present"), true
+    assert.equal host.realpath!("present"), "real"
 
   it "returns false when custom System directoryExists is absent", ->
     system := {
       ...ts.sys
       directoryExists: undefined
+      realpath: undefined
     } as unknown as ts.System
     host := createBaseHost {}, system
     assert.equal host.directoryExists!("missing"), false
+    assert.equal host.realpath!("missing"), "missing"
 
 describe "TSHost", ->
   it "accepts a base host without directoryExists", ->

--- a/test/infra/ts-service-config.civet
+++ b/test/infra/ts-service-config.civet
@@ -93,7 +93,15 @@ describe "parseTsConfigForCivet missing-tsconfig fallback", ->
       fs.rmSync tmpDir, { recursive: true, force: true }
 
 describe "createBaseHost", ->
-  it "returns false when a custom System does not provide directoryExists", ->
+  it "delegates custom System directoryExists when present", ->
+    system := {
+      ...ts.sys
+      directoryExists: (_path: string) => true
+    } as unknown as ts.System
+    host := createBaseHost {}, system
+    assert.equal host.directoryExists!("present"), true
+
+  it "returns false when custom System directoryExists is absent", ->
     system := {
       ...ts.sys
       directoryExists: undefined

--- a/test/infra/ts-service-config.civet
+++ b/test/infra/ts-service-config.civet
@@ -6,6 +6,12 @@ assert from assert
 * as path from node:path
 
 { buildTranspilers, parseTsConfigForCivet } from "../../source/ts-service/config.civet"
+{
+  TSService
+  createInMemoryDocFactory
+  makeCivetPlugin
+  makeIncrementalTypecheckProgram
+} from "../../source/ts-service/index.civet"
 { type Plugin } from "../../source/ts-service/types.civet"
 
 makeCivetTranspiler := () =>
@@ -57,7 +63,7 @@ describe "parseTsConfigForCivet missing-tsconfig fallback", ->
       assert parsed.fileNames.some(.endsWith 'b.civet.tsx'),
         `expected b.civet in fallback scope; got ${parsed.fileNames.join(', ')}`
 
-      // The stray .ts file is NOT included — that's the whole point of the
+      // The stray .ts file is NOT included - that's the whole point of the
       // narrowed fallback (issue #240: huge JS/TS trees OOM the service).
       assert not parsed.fileNames.some(.endsWith 'stray.ts'),
         `expected stray.ts to be excluded from fallback scope; got ${parsed.fileNames.join(', ')}`
@@ -75,9 +81,234 @@ describe "parseTsConfigForCivet missing-tsconfig fallback", ->
       emptyTranspilers := buildTranspilers ([] as Plugin[])
       parsed := parseTsConfigForCivet tmpDir, emptyTranspilers
       assert.equal parsed.configFound, false
-      // With no transpilers, the .ts walk is still active — confirms the
+      // With no transpilers, the .ts walk is still active - confirms the
       // empty-include arm was taken (otherwise this would be empty).
       assert parsed.fileNames.some(.endsWith 'plain.ts'),
         `expected plain.ts in default walk; got ${parsed.fileNames.join(', ')}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+describe "ts-service legacy module resolver", ->
+  it "resolveModuleNames resolves extensionless imports to .civet siblings", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-legacy-'
+    try
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","strict":true},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from './dep'\nconst x: number = n\n"
+      fs.writeFileSync path.join(tmpDir, 'dep.civet'), "export const n: number := 1\n"
+
+      service := TSService tmpDir, {
+        plugins: [makeCivetPlugin()]
+        docFactory: createInMemoryDocFactory()
+      }
+      resolved := service.host.resolveModuleNames!(
+        ['./dep']
+        indexPath
+        undefined
+        undefined
+        service.host.getCompilationSettings()
+        undefined
+      )
+      assert resolved[0]?.resolvedFileName.endsWith('dep.civet.tsx'),
+        `expected ./dep to resolve to dep.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "resolveModuleNames resolves tsconfig paths aliases to explicit .civet files", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-paths-'
+    try
+      srcDir := path.join tmpDir, 'src'
+      fs.mkdirSync srcDir
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","strict":true,"baseUrl":".","paths":{"@/*":["src/*"]}},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from '@/dep.civet'\nconst x: number = n\n"
+      fs.writeFileSync path.join(srcDir, 'dep.civet'), "export const n: number := 1\n"
+
+      service := TSService tmpDir, {
+        plugins: [makeCivetPlugin()]
+        docFactory: createInMemoryDocFactory()
+      }
+      resolved := service.host.resolveModuleNames!(
+        ['@/dep.civet']
+        indexPath
+        undefined
+        undefined
+        service.host.getCompilationSettings()
+        undefined
+      )
+      resolvedFile := resolved[0]?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('src/dep.civet.tsx'),
+        `expected @/dep.civet to resolve to src/dep.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "resolveModuleNames resolves tsconfig paths aliases to .civet index files", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-paths-index-'
+    try
+      depDir := path.join tmpDir, 'src', 'dep'
+      fs.mkdirSync depDir, { recursive: true }
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","strict":true,"baseUrl":".","paths":{"@/*":["src/*"]}},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from '@/dep'\nconst x: number = n\n"
+      fs.writeFileSync path.join(depDir, 'index.civet'), "export const n: number := 1\n"
+
+      service := TSService tmpDir, {
+        plugins: [makeCivetPlugin()]
+        docFactory: createInMemoryDocFactory()
+      }
+      resolved := service.host.resolveModuleNames!(
+        ['@/dep']
+        indexPath
+        undefined
+        undefined
+        service.host.getCompilationSettings()
+        undefined
+      )
+      resolvedFile := resolved[0]?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('src/dep/index.civet.tsx'),
+        `expected @/dep to resolve to src/dep/index.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "resolveModuleNames resolves explicit .civet files from packages", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-package-'
+    try
+      pkgDir := path.join tmpDir, 'node_modules', 'pkg'
+      fs.mkdirSync pkgDir, { recursive: true }
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","moduleResolution":"node","strict":true},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from 'pkg/dep.civet'\nconst x: number = n\n"
+      fs.writeFileSync path.join(pkgDir, 'package.json'), '{"name":"pkg","version":"1.0.0"}'
+      fs.writeFileSync path.join(pkgDir, 'dep.civet'), "export const n: number := 1\n"
+
+      service := TSService tmpDir, {
+        plugins: [makeCivetPlugin()]
+        docFactory: createInMemoryDocFactory()
+      }
+      resolved := service.host.resolveModuleNames!(
+        ['pkg/dep.civet']
+        indexPath
+        undefined
+        undefined
+        service.host.getCompilationSettings()
+        undefined
+      )
+      resolvedFile := resolved[0]?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('node_modules/pkg/dep.civet.tsx'),
+        `expected pkg/dep.civet to resolve to node_modules/pkg/dep.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "incremental resolveModuleNames resolves extensionless imports to .civet siblings", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-incremental-'
+    try
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","strict":true},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from './dep'\nconst x: number = n\n"
+      fs.writeFileSync path.join(tmpDir, 'dep.civet'), "export const n: number := 1\n"
+
+      { host, builder } := makeIncrementalTypecheckProgram tmpDir, {
+        plugins: [makeCivetPlugin()]
+      }
+      resolved := host.resolveModuleNames!(
+        ['./dep']
+        indexPath
+        undefined
+        undefined
+        builder.getProgram().getCompilerOptions()
+        undefined
+      )
+      assert resolved[0]?.resolvedFileName.endsWith('dep.civet.tsx'),
+        `expected ./dep to resolve to dep.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "incremental resolveModuleNames resolves tsconfig paths aliases to explicit .civet files", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-paths-incremental-'
+    try
+      srcDir := path.join tmpDir, 'src'
+      fs.mkdirSync srcDir
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","strict":true,"baseUrl":".","paths":{"@/*":["src/*"]}},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from '@/dep.civet'\nconst x: number = n\n"
+      fs.writeFileSync path.join(srcDir, 'dep.civet'), "export const n: number := 1\n"
+
+      { host, builder } := makeIncrementalTypecheckProgram tmpDir, {
+        plugins: [makeCivetPlugin()]
+      }
+      resolved := host.resolveModuleNames!(
+        ['@/dep.civet']
+        indexPath
+        undefined
+        undefined
+        builder.getProgram().getCompilerOptions()
+        undefined
+      )
+      resolvedFile := resolved[0]?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('src/dep.civet.tsx'),
+        `expected @/dep.civet to resolve to src/dep.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "incremental resolveModuleNames resolves tsconfig paths aliases to .civet index files", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-paths-index-incremental-'
+    try
+      depDir := path.join tmpDir, 'src', 'dep'
+      fs.mkdirSync depDir, { recursive: true }
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","strict":true,"baseUrl":".","paths":{"@/*":["src/*"]}},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from '@/dep'\nconst x: number = n\n"
+      fs.writeFileSync path.join(depDir, 'index.civet'), "export const n: number := 1\n"
+
+      { host, builder } := makeIncrementalTypecheckProgram tmpDir, {
+        plugins: [makeCivetPlugin()]
+      }
+      resolved := host.resolveModuleNames!(
+        ['@/dep']
+        indexPath
+        undefined
+        undefined
+        builder.getProgram().getCompilerOptions()
+        undefined
+      )
+      resolvedFile := resolved[0]?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('src/dep/index.civet.tsx'),
+        `expected @/dep to resolve to src/dep/index.civet.tsx, got ${resolved[0]?.resolvedFileName}`
+    finally
+      fs.rmSync tmpDir, { recursive: true, force: true }
+
+  it "incremental resolveModuleNames resolves explicit .civet files from packages", ->
+    tmpDir := fs.mkdtempSync path.join os.tmpdir(), 'civet-resolve-package-incremental-'
+    try
+      pkgDir := path.join tmpDir, 'node_modules', 'pkg'
+      fs.mkdirSync pkgDir, { recursive: true }
+      indexPath := path.join tmpDir, 'index.ts'
+      fs.writeFileSync path.join(tmpDir, 'tsconfig.json'),
+        '{"compilerOptions":{"target":"es2020","module":"commonjs","moduleResolution":"node","strict":true},"files":["index.ts"]}'
+      fs.writeFileSync indexPath, "import { n } from 'pkg/dep.civet'\nconst x: number = n\n"
+      fs.writeFileSync path.join(pkgDir, 'package.json'), '{"name":"pkg","version":"1.0.0"}'
+      fs.writeFileSync path.join(pkgDir, 'dep.civet'), "export const n: number := 1\n"
+
+      { host, builder } := makeIncrementalTypecheckProgram tmpDir, {
+        plugins: [makeCivetPlugin()]
+      }
+      resolved := host.resolveModuleNames!(
+        ['pkg/dep.civet']
+        indexPath
+        undefined
+        undefined
+        builder.getProgram().getCompilerOptions()
+        undefined
+      )
+      resolvedFile := resolved[0]?.resolvedFileName.replace(/\\/g, '/')
+      assert resolvedFile?.endsWith('node_modules/pkg/dep.civet.tsx'),
+        `expected pkg/dep.civet to resolve to node_modules/pkg/dep.civet.tsx, got ${resolved[0]?.resolvedFileName}`
     finally
       fs.rmSync tmpDir, { recursive: true, force: true }


### PR DESCRIPTION
Follow-up to #2123. That PR factored Civet-aware module resolution into a shared resolver and fixed relative implicit extension / directory resolution during typechecking. This PR extends that shared path to cover two gaps:

- TypeScript 4.x / older host APIs that still call `resolveModuleNames` instead of `resolveModuleNameLiterals`. Replace that with the shared resolver.
- `tsconfig` `paths` aliases that point at Civet source files or Civet index files. This was implemented in old `resolveModuleNames` (I'm having flashbacks to when I implemented it years ago) but needed porting to new shared resolver.

## Details

- Reuses `resolveTranspiledModuleName` from both language-service and incremental typecheck hosts.
- Adds the legacy `resolveModuleNames` hook for incremental typechecking.
- Adds `paths` alias fallback support for:
  - explicit Civet targets, like `@/dep.civet`
  - directory index targets, like `@/dep` -> `src/dep/index.civet`
- Preserves Node16/NodeNext ESM behavior by not making extensionless relative imports work when TypeScript would reject them.
- Adds resolver coverage for TSService and incremental typecheck paths, including package imports like `pkg/dep.civet`.

This PR fixes `typecheck: true` on https://github.com/vendethiel/civet-unplugin-import-typecheck which uses old TS.