### PR TITLE
Grammar cleanup; `////`+ is a comment; fix empty heregex

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
     "@danielx/civet": "0.11.6",
-    "@danielx/hera": "0.9.7",
+    "@danielx/hera": "0.9.8",
     "@types/assert": "^1.5.6",
     "@types/babel__core": "7.20.5",
     "@types/mocha": "^10.0.8",
@@ -153,7 +153,7 @@
     "vscode-languageserver-textdocument": "^1.0.8"
   },
   "peerDependencies": {
-    "@danielx/hera": "^0.9.7",
+    "@danielx/hera": "^0.9.8",
     "typescript": ">=4.5",
     "yaml": "^2.4.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 0.11.6
         version: 0.11.6(typescript@6.0.2)(yaml@2.8.3)
       '@danielx/hera':
-        specifier: 0.9.7
-        version: 0.9.7
+        specifier: 0.9.8
+        version: 0.9.8
       '@types/assert':
         specifier: ^1.5.6
         version: 1.5.11
@@ -865,8 +865,8 @@ packages:
     resolution: {integrity: sha512-0bjwD05ZIGZ0w6Jcw06+eOU7a7P52YtLqjIXynLFftg4iV1DYCoDrd4qHp4DT+/nbTvOeX5RV88ldoZfD3X5sQ==}
     hasBin: true
 
-  '@danielx/hera@0.9.7':
-    resolution: {integrity: sha512-+rByMEvr/6UvmHde3T9ZA9kMfRg15yjJD7dlF/6WcgbbqmJUGiVCFzpIMdc+jaWM8GEQT8Uuj6gP08u6j1KTeg==}
+  '@danielx/hera@0.9.8':
+    resolution: {integrity: sha512-BRuRnQzNBdMmPhbxb1FbL3Aw2vXEV6nvMxL2ttwQkUE2G+Vrh33WbfbqsV9Ul3fFW5s0VvpYRFXFRyw1dhx1TQ==}
     hasBin: true
 
   '@discoveryjs/json-ext@0.5.7':
@@ -7407,7 +7407,7 @@ snapshots:
 
   '@danielx/hera@0.8.20': {}
 
-  '@danielx/hera@0.9.7': {}
+  '@danielx/hera@0.9.8': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6999,13 +6999,22 @@ HeregexLiteral
         children,
       }
 
+    source := body.map((part) => part.token).join("")
+    if not source#
+      children := [open, {...open, token: "(?:)"}, close]
+      children.push flags if flags#
+      return {
+        type: "RegularExpressionLiteral",
+        children,
+      }
+
     return {
       type: "RegularExpressionLiteral",
       children: $0,
     }
 
 HeregexBody
-  !TripleSlash HeregexPart* -> $2
+  !"/" HeregexPart* -> $2
 
 HeregexPart
   RegularExpressionClass
@@ -7137,8 +7146,8 @@ SingleLineComment
   CoffeeCommentEnabled CoffeeSingleLineComment
 
 JSSingleLineComment
-  # JS Comments are two slashes not followed by a third (because that is a heregex)
-  /\/\/(?!\/)[^\r\n]*/ ->
+  # Two or four+ slashes are comments; three slashes are heregexes/directives.
+  /\/\/(?!\/(?!\/))[^\r\n]*/ ->
     return { type: "Comment", $loc, token: $0 } as const
 
 # https://262.ecma-international.org/#prod-MultiLineComment

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6999,9 +6999,13 @@ HeregexLiteral
         children,
       }
 
-    source := body.map((part) => part.token).join("")
+    source := body.map(.token).join("")
     if not source#
-      children: Children := [open, {...open, token: "(?:)"}, close]
+      pos := open.$loc.pos + open.$loc#
+      empty :=
+        token: "(?:)"
+        $loc: { pos, length: close.$loc.pos - pos }
+      children: Children := [open, empty, close]
       children.push flags if flags#
       return {
         type: "RegularExpressionLiteral",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -685,16 +685,16 @@ WPostfixedArgumentPart
   _? PostfixedArgumentPart ->
     return prepend($1, $2)
 
-ArgumentPart
+ArgumentPart ::Argument
   # NOTE: Allow leading or trailing dots for argument splats like CoffeeScript
-  DotDotDot:spread Expression:expression ::Argument ->
+  DotDotDot:spread Expression:expression ->
     return {
       type: "Argument",
       children: $0,
       expression,
       spread,
     }
-  Expression:expression DotDotDot?:spread ::Argument ->
+  Expression:expression DotDotDot?:spread ->
     return {
       type: "Argument",
       children: spread ? [ spread, expression ] : [ expression ],
@@ -702,16 +702,16 @@ ArgumentPart
       spread,
     }
 
-PostfixedArgumentPart
+PostfixedArgumentPart ::Argument
   # NOTE: Allow leading or trailing dots for argument splats like CoffeeScript
-  DotDotDot:spread PostfixedExpression:expression ::Argument ->
+  DotDotDot:spread PostfixedExpression:expression ->
     return {
       type: "Argument",
       children: $0,
       expression,
       spread,
     }
-  PostfixedExpression:expression DotDotDot?:spread ::Argument ->
+  PostfixedExpression:expression DotDotDot?:spread ->
     return {
       type: "Argument",
       children: spread ? [ spread, expression ] : [ expression ],
@@ -780,15 +780,15 @@ RHS
     return exp
 
 # https://262.ecma-international.org/#prod-UnaryExpression
-UnaryExpression
+UnaryExpression ::ASTNode
   # NOTE: Added nested/array case, for e.g. indented await argument
-  IndentedApplicationAllowed UnaryOp+:pre ( ArrayLiteral / NestedArgumentList ):args !CallExpressionRest UnaryPostfix?:post ::ASTNode ->
+  IndentedApplicationAllowed UnaryOp+:pre ( ArrayLiteral / NestedArgumentList ):args !CallExpressionRest UnaryPostfix?:post ->
     return processUnaryNestedExpression(pre, args, post) ?? $skip
 
   # NOTE: Merged AwaitExpression with UnaryOp
   # https://262.ecma-international.org/#prod-AwaitExpression
   # NOTE: Eliminated left recursion
-  UnaryOp*:pre UnaryBody:exp UnaryPostfix?:post ::ASTNode ->
+  UnaryOp*:pre UnaryBody:exp UnaryPostfix?:post ->
     return processUnaryExpression(pre, exp, post)
 
 UnaryWithoutParenthesizedAssignment
@@ -865,16 +865,16 @@ NWTypePostfix
     return { ts: true, children: $0 }
 
 # https://262.ecma-international.org/#prod-UpdateExpression
-UpdateExpression
+UpdateExpression ::ASTNode
   # NOTE: Not allowing whitespace between prefix and postfix increment operators and operand
   # This is especially important for ++ to work as binary concat operator
-  UpdateExpressionSymbol:symbol !Whitespace UnaryWithoutParenthesizedAssignment:assigned ::ASTNode ->
+  UpdateExpressionSymbol:symbol !Whitespace UnaryWithoutParenthesizedAssignment:assigned ->
     return {
       type: "UpdateExpression",
       assigned,
       children: [symbol, assigned],
     }
-  LeftHandSideExpression ( UpdateExpressionSymbol /(?!\p{ID_Start}|[_$0-9(\[{])/ )? ::ASTNode ->
+  LeftHandSideExpression ( UpdateExpressionSymbol /(?!\p{ID_Start}|[_$0-9(\[{])/ )? ->
     return $1 unless $2
     return {
       type: "UpdateExpression",
@@ -1133,11 +1133,11 @@ PipelineExpressionBody
 PipelineExpressionBodySameLine
   ( _? Pipe __ PipelineTailItem )*
 
-PipelineHeadItem
+PipelineHeadItem ::ASTNode
   # Needed to avoid left recursion
-  NonPipelineExpression ::ASTNode
+  NonPipelineExpression
   # Allow a pipeline to be part of first step if within parenthesis
-  OptimizedParenthesizedExpression ::ASTNode
+  OptimizedParenthesizedExpression
 
 PipelineTailItem
   ( AwaitOp / Return / Throw ) !AccessStart !MaybeParenNestedExpression ::ASTNode -> $1
@@ -1159,39 +1159,39 @@ PipelineTailItem
     return $2
 
 # https://262.ecma-international.org/#prod-PrimaryExpression
-PrimaryExpression
-  ObjectLiteral ::ASTNode ->
+PrimaryExpression ::ASTNode
+  ObjectLiteral ->
     return $1
   # NOTE: ObjectLiteral needs to be before ArrayLiteral to support `[x]: y`
-  ArrayLiteral ::ASTNode ->
+  ArrayLiteral ->
     return $1
-  ThisLiteral ::ASTNode ->
+  ThisLiteral ->
     return $1
-  TemplateLiteral ::ASTNode ->
+  TemplateLiteral ->
     return $1
   # NOTE: TemplateLiteral must be before Literal, so that CoffeeScript
   # interpolated strings get checked first before StringLiteral.
-  Literal ::ASTNode ->
+  Literal ->
     return $1
   # NOTE: Must be before IdentiferExpression so `async function ...` isn't parsed as `async(function ...)`
-  FunctionExpression ::ASTNode ->
+  FunctionExpression ->
     return $1
   # NOTE: Must be below ObjectLiteral for inline objects `a: 1, b: 2` to not be shadowed by matching the first identifier
-  IdentifierReference ::ASTNode ->
+  IdentifierReference ->
     return $1
-  ClassExpression ::ASTNode ->
+  ClassExpression ->
     return $1
-  RegularExpressionLiteral ::ASTNode ->
+  RegularExpressionLiteral ->
     return $1
-  OptimizedParenthesizedExpression ::ASTNode ->
+  OptimizedParenthesizedExpression ->
     return $1
-  Placeholder ::ASTNode ->
+  Placeholder ->
     return $1
-  SymbolLiteral ::ASTNode ->
+  SymbolLiteral ->
     return $1
   # https://facebook.github.io/jsx/#sec-jsx-PrimaryExpression
   # NOTE: Modified to parse multiple JSXElement/JSXFragments as one fragment
-  JSXImplicitFragment ::ASTNode ->
+  JSXImplicitFragment ->
     return $1
 
 OptimizedParenthesizedExpression
@@ -1307,10 +1307,10 @@ ExtendsClause
 
 # with for mixin shorthand
 # class A extends B with C, D -> class A extends D(C(B))
-WithClause
+WithClause ::WithClause
   # Nested form where C, D appear on separate lines, indented
   # Also allows for arbitrary expressions
-  NotDedented With PushIndent ( Nested Expression _? Comma? )*:targets PopIndent ::WithClause ->
+  NotDedented With PushIndent ( Nested Expression _? Comma? )*:targets PopIndent ->
     return $skip unless targets#
     targets = targets.map(($) => $.slice(0, -1)) // strip Comma?
     return {
@@ -1318,7 +1318,7 @@ WithClause
       children: $0,
       targets,
     }
-  NotDedented With NotDedented:ws ExtendsTarget:t ( _? Comma NotDedented ExtendsTarget )*:rest ::WithClause ->
+  NotDedented With NotDedented:ws ExtendsTarget:t ( _? Comma NotDedented ExtendsTarget )*:rest ->
     return {
       type: "WithClause",
       children: $0,
@@ -1971,15 +1971,15 @@ SliceParameters
       children,
     }
 
-AccessStart
-  PropertyAccessModifier?:modifier Dot:dot ![.\s] ::AccessStart ->
+AccessStart ::AccessStart
+  PropertyAccessModifier?:modifier Dot:dot ![.\s] ->
     return {
       type: "AccessStart",
       children: modifier ? [modifier, dot] : [dot],
       optional: modifier?.token === "?",
     }
   # NOTE: ?x -> ?.x, !x -> !.x shorthand
-  PropertyAccessModifier:modifier InsertDot:dot ![.\s] ::AccessStart ->
+  PropertyAccessModifier:modifier InsertDot:dot ![.\s] ->
     return {
       type: "AccessStart",
       children: [modifier, dot],
@@ -2378,34 +2378,34 @@ NWBindingIdentifier
   ReturnValue ->
     return { children: [$1], names: [] }
 
-AtIdentifierRef
-  ReservedWord:r ::ASTRef ->
+AtIdentifierRef ::ASTRef
+  ReservedWord:r ->
     return makeRef(`_${r}`, r)
-  IdentifierName:id ::ASTRef ->
+  IdentifierName:id ->
     ref := makeRef(id.name)
     // Propagate so the binding side can emit `this["X"]` matching `@X`.
     if id.unicode then ref.unicode = id.unicode
     return ref
 
-PinPattern
+PinPattern ::PinPattern
   # Forbid ImplicitObjectLiterals such as `x: y` in pinned pattern,
   # to allow for typed arguments of the form `(^x: T) =>`
   # and because comparing to object literals isn't generally helpful
-  Caret IdentifierName:expression &Colon ::PinPattern ->
+  Caret IdentifierName:expression &Colon ->
     return {
       type: "PinPattern",
       children: [expression],
       expression: expression as Identifier,
       typeSuffix: typeSuffixForExpression(expression),
     }
-  Caret SingleLineExpressionWithIndentedApplicationForbidden:expression ::PinPattern ->
+  Caret SingleLineExpressionWithIndentedApplicationForbidden:expression ->
     return {
       type: "PinPattern",
       children: [expression],
       expression,
       typeSuffix: typeSuffixForExpression(expression),
     }
-  ActualMemberExpression:expression ::PinPattern ->
+  ActualMemberExpression:expression ->
     return {
       type: "PinPattern",
       children: [expression],
@@ -2413,7 +2413,7 @@ PinPattern
       typeSuffix: typeSuffixForExpression(expression),
     }
   # Handle unary numeric in switch patterns
-  ([+-] NumericLiteral):expression ::PinPattern ->
+  ([+-] NumericLiteral):expression ->
     return {
       type: "PinPattern",
       children: [expression],
@@ -2421,7 +2421,7 @@ PinPattern
       typeSuffix: typeSuffixForExpression(expression as ASTNode),
     }
   # Handle undefined in switch patterns
-  Undefined:expression ::PinPattern ->
+  Undefined:expression ->
     return {
       type: "PinPattern",
       children: [expression],
@@ -2710,8 +2710,8 @@ BindingElement
     }
 
 # https://262.ecma-international.org/#prod-BindingRestElement
-BindingRestElement
-  _?:ws DotDotDot:dots ( BindingPattern / BindingIdentifier / EmptyBindingPattern ):binding BindingTypeSuffix?:typeSuffix ::BindingRestElement ->
+BindingRestElement ::BindingRestElement
+  _?:ws DotDotDot:dots ( BindingPattern / BindingIdentifier / EmptyBindingPattern ):binding BindingTypeSuffix?:typeSuffix ->
     return {
       type: "BindingRestElement",
       children: [ws, dots, binding],
@@ -2723,7 +2723,7 @@ BindingRestElement
       rest: true,
     }
 
-  _?:ws ( BindingPattern / BindingIdentifier ):binding DotDotDot:dots ::BindingRestElement ->
+  _?:ws ( BindingPattern / BindingIdentifier ):binding DotDotDot:dots ->
     return {
       type: "BindingRestElement",
       children: [...(ws || []), dots, binding],
@@ -3051,9 +3051,9 @@ ThinArrow
   "->" / "→" ->
     return { $loc, token: "->" }
 
-ExplicitBlock
+ExplicitBlock ::BlockStatement
   # Allow single-line block only when the block starts on the same line
-  _?:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / SingleLineStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ::BlockStatement ->
+  _?:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / SingleLineStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ->
     /* c8 ignore next -- structurally unreachable: EmptyBracedContent catches empty/ws-only, valid content matches one of the alts, invalid content blocks CloseBrace. $skip kept as state-safety belt inside AllowAll/RestoreAll. */
     return $skip unless block
     return {
@@ -3063,7 +3063,7 @@ ExplicitBlock
     } as BlockStatement
   # For backward compatibility with JavaScript, allow open brace to start on
   # the next line, as long as it's followed by a newline or close brace
-  IndentedAtLeast:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ::BlockStatement ->
+  IndentedAtLeast:ws1 OpenBrace:open AllowAll ( NestedBlockStatements / EmptyBracedContent )?:block RestoreAll __:ws2 CloseBrace:close ->
     /* c8 ignore next -- structurally unreachable: same logic as the single-line alt above. $skip kept as state-safety belt inside AllowAll/RestoreAll. */
     return $skip unless block
     return {
@@ -3094,16 +3094,16 @@ ImplicitNestedBlock
     } as BlockStatement
 
 # NOTE: This is the body of if/else/for/when etc.
-Block
+Block ::BlockStatement
   # NOTE: Added indentation based implied braces
-  ImplicitNestedBlock ::BlockStatement
+  ImplicitNestedBlock
   # NOTE: Explicit block after implicit block so that a properly indented `{}`
   # gets treated like an object literal, not an empty block.
-  ExplicitBlock ::BlockStatement
+  ExplicitBlock
 
-  ThenClause ::BlockStatement
+  ThenClause
   # NOTE: !EOS prevents capturing a following unindented Statement
-  _?:ws !EOS DeclarationOrStatement:s ::BlockStatement ->
+  _?:ws !EOS DeclarationOrStatement:s ->
     expressions: StatementTuple[] := [[ws, s]]
     return {
       type: "BlockStatement",
@@ -3121,15 +3121,15 @@ BareNestedBlock
 # NOTE: This is the body of a case, where no braces are necessary.
 # Essentially `Block` but with ImplicitNestedBlock replaced by BareNestedBlock,
 # and allowing EmptyBareBlock.
-BareBlock
-  BareNestedBlock ::BlockStatement
+BareBlock ::BlockStatement
+  BareNestedBlock
   # NOTE: Explicit block after implicit block so that a properly indented `{}`
   # gets treated like an object literal, not an empty block.
-  ExplicitBlock ::BlockStatement
+  ExplicitBlock
 
-  ThenClause ::BlockStatement
+  ThenClause
   # NOTE: !EOS prevents capturing a following unindented Statement
-  _?:ws !EOS Statement:s SemicolonDelimiter?:semi ::BlockStatement ->
+  _?:ws !EOS Statement:s SemicolonDelimiter?:semi ->
     expressions: StatementTuple[] := [[ws, s, semi]]
     return {
       type: "BlockStatement",
@@ -3137,18 +3137,18 @@ BareBlock
       children: [expressions],
       bare: true,
     }
-  EmptyBareBlock ::BlockStatement
+  EmptyBareBlock
 
 ThenClause
   Then ThenBlock -> $2
 
 # `then` can be followed by nested block (unlike CoffeeScript)
 # or same-line statements separated by `;`, or empty
-ThenBlock
+ThenBlock ::BlockStatement
   NoBlock EmptyBlock -> $2
-  ImplicitNestedBlock ::BlockStatement
-  ObjectSingleLineStatements ::BlockStatement
-  SingleLineStatements ::BlockStatement
+  ImplicitNestedBlock
+  ObjectSingleLineStatements
+  SingleLineStatements
 
 BracedThenClause
   &Then InsertOpenBrace:open ThenClause:exp InsertCloseBrace:close ::BlockStatement ->
@@ -3160,17 +3160,17 @@ BracedThenClause
     }
 
 # A block that must include braces (function body, try/catch/finally)
-BracedOrEmptyBlock
-  BracedBlock ::BlockStatement
-  EmptyBlock ::BlockStatement
+BracedOrEmptyBlock ::BlockStatement
+  BracedBlock
+  EmptyBlock
 
-NoCommaBracedOrEmptyBlock
-  NoCommaBracedBlock ::BlockStatement
-  EmptyBlock ::BlockStatement
+NoCommaBracedOrEmptyBlock ::BlockStatement
+  NoCommaBracedBlock
+  EmptyBlock
 
-NoPostfixBracedOrEmptyBlock
-  NoPostfixBracedBlock ::BlockStatement
-  EmptyBlock ::BlockStatement
+NoPostfixBracedOrEmptyBlock ::BlockStatement
+  NoPostfixBracedBlock
+  EmptyBlock
 
 EmptyBlock
   # Implied empty block
@@ -3192,9 +3192,9 @@ BlockOrEmptyStatement
 
 # NOTE: We allow if/else bodies to be empty, in which case they get a {} body
 # (`;` would also make sense, but TypeScript doesn't allow them.)
-BlockOrEmpty
-  ObjectSingleLineStatements ::BlockStatement
-  Block ::BlockStatement
+BlockOrEmpty ::BlockStatement
+  ObjectSingleLineStatements
+  Block
   NoBlock EmptyBlock -> $2
 
 EmptyStatementBareBlock
@@ -3269,14 +3269,14 @@ NoCommaBracedBlock
       children: [o, s.children, ws, c],
     }
 
-NonSingleBracedBlock
+NonSingleBracedBlock ::BlockStatement
   !EOS ExplicitBlock !TrailingOperator -> $2
 
   # NOTE: Added indentation based implied braces
-  ImplicitNestedBlock ::BlockStatement
+  ImplicitNestedBlock
 
   # Immediate nested array/object literal
-  InsertOpenBrace:o ( NestedBulletedArray / NestedImplicitObjectLiteral ):s InsertCloseBrace:c ::BlockStatement ->
+  InsertOpenBrace:o ( NestedBulletedArray / NestedImplicitObjectLiteral ):s InsertCloseBrace:c ->
     expressions := [["", s]]
     return {
       type: "BlockStatement",
@@ -3682,9 +3682,9 @@ ElementListWithIndentedApplicationForbidden
 
 # https://262.ecma-international.org/#prod-ElementList
 # NOTE: Modified and simplified from the spec
-ElementList
-  BulletedArray ::ASTNode[] -> [$1]
-  SingleLineElementList ::ASTNode[]
+ElementList ::ASTNode[]
+  BulletedArray -> [$1]
+  SingleLineElementList
 
 SingleLineElementList
   # NOTE: Forbid EOS to prevent eating indentation in Expression
@@ -4862,21 +4862,21 @@ AwaitOp
     }
 
 # https://262.ecma-international.org/#prod-ModuleItem
-ModuleItem
-  IsBare ImportDeclaration:decl ::ASTNode -> processStaticImport(decl)
-  IsBare ExportDeclaration ::ASTNode -> $2
-  StatementListItem ::ASTNode
+ModuleItem ::ASTNode
+  IsBare ImportDeclaration:decl -> processStaticImport(decl)
+  IsBare ExportDeclaration -> $2
+  StatementListItem
 
 # https://262.ecma-international.org/#prod-StatementListItem
-StatementListItem
+StatementListItem ::ASTNode
   Declaration ::Declaration
   # NOTE: Allow bulleted array literals as top-level statements.
-  BulletedArrayWithTrailing:array ::ASTNode
+  BulletedArrayWithTrailing:array
   # NOTE: Allow multi-line implicit object literals as top-level statements.
-  ImplicitObjectLiteral ::ASTNode ->
+  ImplicitObjectLiteral ->
     return makeLeftHandSideExpression($1)
   # NOTE: Added postfix conditionals/loops
-  PostfixedStatement ::ASTNode
+  PostfixedStatement
 
 PostfixedStatement
   Statement:statement ( _? PostfixStatement )?:post ->
@@ -4893,14 +4893,14 @@ PostfixedNoCommaStatement
     return addPostfixStatement(statement, ...post) if post
     return statement
 
-PostfixedExpression
+PostfixedExpression ::ASTNode
   # Loops allow spreads before the postfix
-  AssignmentExpressionSpread:expression _?:ws !IfClause PostfixStatement:post ::ASTNode ->
+  AssignmentExpressionSpread:expression _?:ws !IfClause PostfixStatement:post ->
     return attachPostfixStatementAsExpression(expression, [ws, post])
   # Ifs just allow expressions
-  Expression:expression ( _? PostfixStatement ):post ::ASTNode ->
+  Expression:expression ( _? PostfixStatement ):post ->
     return attachPostfixStatementAsExpression(expression, post)
-  Expression ::ASTNode
+  Expression
 
 # Outside contexts where commas are too important (e.g. parameters/arguments),
 # postfixed loops can have comma expressions and spreads to accumulate multiple
@@ -4909,9 +4909,9 @@ CommaLoop
   CommaExpressionSpread:expression _?:ws !IfClause PostfixStatement:post ->
     return attachPostfixStatementAsExpression(expression, [ws, post])
 
-PostfixedExpressionOrCommaLoop
-  CommaLoop ::ASTNode
-  PostfixedExpression ::ASTNode
+PostfixedExpressionOrCommaLoop ::ASTNode
+  CommaLoop
+  PostfixedExpression
 
 # Expression with postfixes *or* comma operators (mixing seems ambiguous)
 # Note that postfixed loops do allow commas though, for accumulating multiple
@@ -5024,21 +5024,21 @@ Label
 # but should not have colon in output
 # Colon is required if the identifier is a Civet keyword,
 # except for iteration keywords which refer to containing anonymous loop
-LabelIdentifier
-  Colon IdentifierName:id ::Label ->
+LabelIdentifier ::Label
+  Colon IdentifierName:id ->
     return {
       type: "Label",
       name: id.name,
       children: [id],
     }
-  /(?:loop|while|until|for|do)(?!\p{ID_Continue})/ ::Label ->
+  /(?:loop|while|until|for|do)(?!\p{ID_Continue})/ ->
     return {
       type: "Label",
       special: $0,
       name: "", // to be filled in
       children: []
     }
-  Identifier:id ::Label ->
+  Identifier:id ->
     return {
       type: "Label",
       name: id.name,
@@ -5050,9 +5050,9 @@ LabelledItem
   FunctionDeclaration
 
 # https://262.ecma-international.org/#prod-IfStatement
-IfStatement
+IfStatement ::IfStatement
   # NOTE: Allow indentation in condition when there's an explicit `then` clause
-  ( If / Unless ):kind _?:ws BoundedCondition:condition ThenClause:block ElseClause?:e ::IfStatement ->
+  ( If / Unless ):kind _?:ws BoundedCondition:condition ThenClause:block ElseClause?:e ->
     if kind.negated
       kind = { ...kind, token: "if" }
       condition = negateCondition(condition, kind.$loc)
@@ -5068,7 +5068,7 @@ IfStatement
       else: e,
     }
   # NOTE: Block isn't Statement so we can handle implied braces by nesting
-  IfClause:clause BlockOrEmpty:block ElseClause?:e ::IfStatement ->
+  IfClause:clause BlockOrEmpty:block ElseClause?:e ->
     // Ensure semicolon separating single line from `else`
     if block.bare and e
       block = bracedBlock(block)
@@ -5579,8 +5579,8 @@ EmptyCondition
     }
 
 # https://262.ecma-international.org/#prod-CaseBlock
-CaseBlock
-  ( Nested / _ )? OpenBrace NestedCaseClauses:clauses __ CloseBrace ::CaseBlock ->
+CaseBlock ::CaseBlock
+  ( Nested / _ )? OpenBrace NestedCaseClauses:clauses __ CloseBrace ->
     return {
       type: "CaseBlock",
       clauses: clauses,
@@ -5588,7 +5588,7 @@ CaseBlock
     }
 
   # NOTE: Added optional braces with nesting
-  InsertOpenBrace NestedCaseClauses:clauses InsertNewline InsertIndent InsertCloseBrace ::CaseBlock ->
+  InsertOpenBrace NestedCaseClauses:clauses InsertNewline InsertIndent InsertCloseBrace ->
     return {
       type: "CaseBlock",
       clauses: clauses,
@@ -5768,15 +5768,15 @@ CatchParameter
     }
 
 # An expression with explicit or implied parentheses, for use in if/while/switch
-Condition
-  OpenParen:open _?:ws DeclarationCondition:expression CloseParen:close ::Condition ->
+Condition ::Condition
+  OpenParen:open _?:ws DeclarationCondition:expression CloseParen:close ->
     return {
       type: "ParenthesizedExpression",
       children: [open, ws, expression, close],
       expression,
     }
-  ParenthesizedExpression !TrailingOperator ::Condition -> $1
-  InsertOpenParen:open DeclarationCondition:expression InsertCloseParen:close ::Condition ->
+  ParenthesizedExpression !TrailingOperator -> $1
+  InsertOpenParen:open DeclarationCondition:expression InsertCloseParen:close ->
     return {
       type: "ParenthesizedExpression",
       children: [open, expression, close],
@@ -5784,7 +5784,7 @@ Condition
     }
 
   # NOTE: Indented condition allows for further nested function application
-  PushIndent InsertOpenParen:open ( Nested PostfixedExpression )?:expression InsertCloseParen:close PopIndent ::Condition ->
+  PushIndent InsertOpenParen:open ( Nested PostfixedExpression )?:expression InsertCloseParen:close PopIndent ->
     return $skip unless expression
     return {
       type: "ParenthesizedExpression",
@@ -5794,7 +5794,7 @@ Condition
   # NOTE: Added paren-less condition
   # NOTE: Unindented condition forbids nested function application
   # to avoid ambiguity with 'then' clause
-  InsertOpenParen:open ExpressionWithObjectApplicationForbidden:expression InsertCloseParen:close ::Condition ->
+  InsertOpenParen:open ExpressionWithObjectApplicationForbidden:expression InsertCloseParen:close ->
     // Don't double wrap parenthesized expressions
     return expression if expression.type is "ParenthesizedExpression"
     expression = trimFirstSpace(expression)
@@ -6167,15 +6167,15 @@ NestedPostfixedExpressionNoTrailing
     return $skip unless expression
     return expression
 
-MaybeNestedExpression
+MaybeNestedExpression ::unknown
   # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
   # the second case, where they get checked by PrimaryExpression,
   # which then allows for trailing binary operators etc.
-  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested Expression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ::unknown ->
+  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested Expression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
     return $skip unless expression
     return expression unless trailing
     return [ expression, trailing ]
-  ForbidImplicitFragment Expression?:expression RestoreImplicitFragment ::unknown ->
+  ForbidImplicitFragment Expression?:expression RestoreImplicitFragment ->
     return $skip unless expression
     return expression
 
@@ -6197,10 +6197,10 @@ MaybeParenNestedExpression
     return [space, open, exp, trailing, newline, indent, close]
 
 # https://262.ecma-international.org/#prod-ImportDeclaration
-ImportDeclaration
+ImportDeclaration ::ImportDeclaration
   # NOTE: TypeScript's CommonJS import syntax
   # https://www.typescriptlang.org/docs/handbook/modules/reference.html#export--and-import--require
-  Import _ Identifier _? Equals __ "require" NonIdContinue Arguments ::ImportDeclaration ->
+  Import _ Identifier _? Equals __ "require" NonIdContinue Arguments ->
     // Replace `import` with `const` in JS output
     imp := [
       { ...$1, ts: true },
@@ -6210,7 +6210,7 @@ ImportDeclaration
       type: "ImportDeclaration",
       children: [imp, $0.slice(1)],
     }
-  ( ( Import SameLineOrIndentedFurther ) / ImpliedImport ):i Operator OperatorBehavior?:behavior SameLineOrIndentedFurther:ws1 OperatorNamedImports:imports SameLineOrIndentedFurther:ws2 FromClause:from ::ImportDeclaration ->
+  ( ( Import SameLineOrIndentedFurther ) / ImpliedImport ):i Operator OperatorBehavior?:behavior SameLineOrIndentedFurther:ws1 OperatorNamedImports:imports SameLineOrIndentedFurther:ws2 FromClause:from ->
     errors := []
     errors.push(behavior.error) if behavior?.error
     imports.specifiers.forEach (spec) =>
@@ -6224,7 +6224,7 @@ ImportDeclaration
       imports,
       from,
     }
-  Import SameLineOrIndentedFurther ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports __ FromClause:from ::ImportDeclaration ->
+  Import SameLineOrIndentedFurther ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports __ FromClause:from ->
     return {
       type: "ImportDeclaration",
       children: $0,
@@ -6235,9 +6235,9 @@ ImportDeclaration
   # &/\s/ assertion: ModuleSpecifier's UnquotedSpecifier can otherwise eat
   # the `(` of `import("foo")` or the `.` of `import.meta` as a one-char
   # specifier, masking the dynamic-import / member-access parse paths.
-  Import:i &/\s/ SameLineOrIndentedFurther:ws ModuleSpecifier:module ::ImportDeclaration -> { type: "ImportDeclaration", children: [i, ws, module], module }
+  Import:i &/\s/ SameLineOrIndentedFurther:ws ModuleSpecifier:module -> { type: "ImportDeclaration", children: [i, ws, module], module }
   # NOTE: Robust parsing for better LSP completions
-  Import:i _?:ws UnclosedSingleLineStringLiteral?:unclosed &EOS ::ImportDeclaration ->
+  Import:i _?:ws UnclosedSingleLineStringLiteral?:unclosed &EOS ->
     return {
       type: "ImportDeclaration",
       children: [
@@ -6254,7 +6254,7 @@ ImportDeclaration
   # NOTE: Added import shorthand
   # NOTE: Not adding $loc to source map here yet because it will point to the start of the identifier
   # the proper place may be to use the From location
-  ImpliedImport:i ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports SameLineOrIndentedFurther:w FromClause:from ::ImportDeclaration ->
+  ImpliedImport:i ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports SameLineOrIndentedFurther:w FromClause:from ->
     // Map implied import location to `from`
     // The pos and length adjustment better match how tsc outputs to include the space before `from` with the `from` token
     i.$loc = {
@@ -6264,7 +6264,7 @@ ImportDeclaration
     children := [i, t, imports, w, from]
     return { type: "ImportDeclaration", ts: !!t, children, imports, from }
   # NOTE: from ... import ... reverse syntax
-  FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws Operator OperatorBehavior?:behavior SameLineOrIndentedFurther:ows OperatorNamedImports:imports ::ImportDeclaration ->
+  FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws Operator OperatorBehavior?:behavior SameLineOrIndentedFurther:ows OperatorNamedImports:imports ->
     errors := []
     errors.push(behavior.error) if behavior?.error
     imports.specifiers.forEach (spec) =>
@@ -6278,7 +6278,7 @@ ImportDeclaration
       imports,
       from,
     }
-  FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports ::ImportDeclaration ->
+  FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports ->
     return {
       type: "ImportDeclaration",
       children: [ i, iws, t, imports, fws, from ],
@@ -6854,15 +6854,15 @@ DecimalIntegerLiteral
 # NOTE: This includes unprocessed double-quoted strings.  If you might want to
 # accept a template literal in the form of a CoffeeScript double-quoted string
 # interpolation, be sure to check TemplateLiteral before StringLiteral.
-StringLiteral
-  DoubleQuote DoubleStringCharacters:str DoubleQuote ::StringLiteral ->
+StringLiteral ::StringLiteral
+  DoubleQuote DoubleStringCharacters:str DoubleQuote ->
     return {
       type: "StringLiteral",
       $loc,
       token: `"${modifyString(str.token)}"`,
     } as const
 
-  SingleQuote SingleStringCharacters:str SingleQuote ::StringLiteral ->
+  SingleQuote SingleStringCharacters:str SingleQuote ->
     return {
       type: "StringLiteral",
       $loc,
@@ -7692,11 +7692,11 @@ _JSXTag
   JSXComment
 
 # https://facebook.github.io/jsx/#prod-JSXElement
-JSXElement
-  JSXSelfClosingElement ::ASTNode
+JSXElement ::ASTNode
+  JSXSelfClosingElement
   # NOTE: In default JSX mode, JSX children must be properly indented,
   # and closing tags are optional (but still allowed).
-  !CoffeeJSXEnabled PushJSXOpeningElement:open JSXMixedChildren?:children JSXOptionalClosingElement:close PopJSXStack ::ASTNode ->
+  !CoffeeJSXEnabled PushJSXOpeningElement:open JSXMixedChildren?:children JSXOptionalClosingElement:close PopJSXStack ->
     /* c8 ignore next -- JSXMixedChildren always returns an object; $skip kept as a defensive guard against future grammar edits that could change that */
     return $skip unless children
     let parts
@@ -7715,7 +7715,7 @@ JSXElement
     return { type: "JSXElement", children: parts, tag: open[1] }
   # NOTE: In CoffeeScript JSX mode, JSX children do not need to be properly
   # indented, but tags must be explicitly closed.
-  CoffeeJSXEnabled JSXOpeningElement:open JSXChildren? Whitespace? JSXClosingElement:close ::ASTNode ->
+  CoffeeJSXEnabled JSXOpeningElement:open JSXChildren? Whitespace? JSXClosingElement:close ->
     $0 = $0.slice(1)
     // Check that tags match
     return $skip if open[1] !== close[2]
@@ -7751,10 +7751,10 @@ JSXClosingElement
   "</" Whitespace? JSXElementName Whitespace? ">"
 
 # https://facebook.github.io/jsx/#prod-JSXFragment
-JSXFragment
+JSXFragment ::ASTNode
   # NOTE: In default JSX mode, JSX children must be properly indented,
   # and closing tags are optional (but still allowed).
-  !CoffeeJSXEnabled PushJSXOpeningFragment:open JSXMixedChildren?:children JSXOptionalClosingFragment:close PopJSXStack ::ASTNode ->
+  !CoffeeJSXEnabled PushJSXOpeningFragment:open JSXMixedChildren?:children JSXOptionalClosingFragment:close PopJSXStack ->
     /* c8 ignore next -- JSXMixedChildren always returns an object; $skip kept as a defensive guard against future grammar edits that could change that */
     return $skip unless children
     $0 = $0.slice(1)
@@ -7768,7 +7768,7 @@ JSXFragment
     return { type: "JSXFragment", children: parts, jsxChildren: children.jsxChildren }
   # NOTE: In CoffeeScript JSX mode, JSX children do not need to be properly
   # indented, but tags must be explicitly closed.
-  CoffeeJSXEnabled "<>" JSXChildren?:children Whitespace? JSXClosingFragment ::ASTNode ->
+  CoffeeJSXEnabled "<>" JSXChildren?:children Whitespace? JSXClosingFragment ->
     $0 = $0.slice(1)
     return {
       type: "JSXFragment",
@@ -8588,10 +8588,10 @@ NestedDeclareElement
   Nested DeclareElement InterfacePropertyDelimiter
 
 # NOTE: Variation on TypeDeclaration where Declare already applied.
-DeclareElement
-  Decorators? Export __ Default __ ( Identifier / ClassSignature / InterfaceDeclaration ):declaration ::ASTNode
-  Decorators? ( Export _? )? TypeLexicalDeclaration ::ASTNode -> { ts: true, children: $0 }
-  ( Export _? )? TypeDeclarationRest ::ASTNode -> { ts: true, children: $0 }
+DeclareElement ::ASTNode
+  Decorators? Export __ Default __ ( Identifier / ClassSignature / InterfaceDeclaration ):declaration
+  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
+  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 }
 
 EnumDeclaration
   ( Const _ )?:_isConst Enum _? IdentifierName:id EnumBlock:block ->
@@ -8983,9 +8983,9 @@ TypeElementListWithIndentedApplicationForbidden
     return $2 if $2
     return $skip
 
-TypeElementList
-  TypeBulletedTuple ::ASTNode[] -> [$1]
-  !EOS TypeElement:first ( ( _? Comma !EOS ) TypeElement )*:rest ::ASTNode[] ->
+TypeElementList ::ASTNode[]
+  TypeBulletedTuple -> [$1]
+  !EOS TypeElement:first ( ( _? Comma !EOS ) TypeElement )*:rest ->
     return [first] unless rest#
     delim := [rest[0][0][0], rest[0][0][1]]
     return [
@@ -9110,13 +9110,13 @@ TypeWithPostfix
     return prepend(postfix[0],
       expressionizeTypeIf([ ...postfix[1], $1, undefined ]))
 
-TypeConditional
-  _? /(?=if|unless)/ TypeIfThenElse ::ASTNode ->
+TypeConditional ::ASTNode
+  _? /(?=if|unless)/ TypeIfThenElse ->
     return prepend($1, expressionizeTypeIf($3))
-  TypeCondition NotDedented QuestionMark __ Type __ Colon __ Type ::ASTNode ->
+  TypeCondition NotDedented QuestionMark __ Type __ Colon __ Type ->
     return [ $1, $2, $3, $4, $9, $6, $7, $8, $5 ] if $1.negated
     return $0
-  TypeBinary ::ASTNode
+  TypeBinary
 
 TypeCondition
   # NOTE: Type after `extends` needs to forbid TypePostfix,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7001,7 +7001,7 @@ HeregexLiteral
 
     source := body.map((part) => part.token).join("")
     if not source#
-      children := [open, {...open, token: "(?:)"}, close]
+      children: Children := [open, {...open, token: "(?:)"}, close]
       children.push flags if flags#
       return {
         type: "RegularExpressionLiteral",
@@ -7017,7 +7017,7 @@ HeregexBody
   !"/" HeregexPart*:body -> body
 
 ```
-heregexEscapes := {
+heregexEscapes: Record<string, string> := {
   "\n": "\\n",
   "\r": "\\r",
   "\u2028": "\\u2028",
@@ -7035,7 +7035,7 @@ HeregexPart
   CoffeeInterpolationEnabled CoffeeStringSubstitution -> { type: "Substitution", children: $2 }
   TemplateSubstitution -> { type: "Substitution", children: $1 }
 
-  "\\" .:escape -> { $loc, token: heregexEscapes[escape] ?? "\\" + escape }
+  $( /\\./ ):escape -> { $loc, token: heregexEscapes[escape[1]] ?? escape }
 
   HeregexComment -> { $loc, token: "" }
   # NOTE: CoffeeScript strips out all unescaped whitespace chars
@@ -9252,7 +9252,7 @@ TypeFunction
         message: "abstract function types must be constructors (abstract new)",
       }
     // Implicit void return type
-    if returnType.$loc and returnType.token is ""
+    if "token" in returnType and returnType.$loc and returnType.token is ""
       t := {
         type: "VoidType",
         $loc: returnType.$loc,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6982,7 +6982,7 @@ HeregexLiteral
           ? e
           : {
             ...e,
-            token: e.token.replace(/`|\\|\$/g, "\\$&"),
+            token: e.token.replace(/[`\\$]/g, "\\$&"),
           }
         ),
         "`"
@@ -7014,7 +7014,20 @@ HeregexLiteral
     }
 
 HeregexBody
-  !"/" HeregexPart* -> $2
+  !"/" HeregexPart*:body -> body
+
+```
+heregexEscapes := {
+  "\n": "\\n",
+  "\r": "\\r",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+  "\t": "\\t",
+  "\v": "\\v",
+  "\f": "\\f",
+  " ": " ",
+}
+```
 
 HeregexPart
   RegularExpressionClass
@@ -7022,32 +7035,19 @@ HeregexPart
   CoffeeInterpolationEnabled CoffeeStringSubstitution -> { type: "Substitution", children: $2 }
   TemplateSubstitution -> { type: "Substitution", children: $1 }
 
-  /(?:\\.)/ ->
-    token .= $0
-    switch $0[1]
-      case "\n":
-        token = "\\n"; break
-      case "\r":
-        token = "\\r"; break
-      case " ":
-        token =   " "; break
-    return { $loc, token }
+  "\\" .:escape -> { $loc, token: heregexEscapes[escape] ?? "\\" + escape }
 
-  HeregexComment ->
-    return { $loc, token: "" }
+  HeregexComment -> { $loc, token: "" }
   # NOTE: CoffeeScript strips out all unescaped whitespace chars
   # but Python doesn't strip out whitespace inside character classes
   # or inside '(?' groups and assertions
   # TODO: this behavior should be toggled by a coffeeCompat directive
-  /[\s]+/ ->
-    return { $loc, token: "" }
+  /[\s]+/ -> { $loc, token: "" }
   # Escape forward slashes (that aren't part of a triple slash)
-  /\/(?!\/\/)/ ->
-    return { $loc, token: "\\/" }
+  /\/(?!\/\/)/ -> { $loc, token: "\\/" }
   # Don't swallow up # and $ which might be interpolations,
   # but handle them as single characters if they're not
-  /[^[\/\s#$\\]+|[#$]/ ->
-    return { $loc, token: $0 }
+  /[^[\/\s#$\\]+|[#$]/ -> { $loc, token: $0 }
 
 HeregexComment
   # NOTE: CoffeeScript doesn't treat JS comments as regex comments

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -298,6 +298,9 @@ export function parseProgram(input: string, options?: { filename?: string, parse
       filename = initialConfig = sync = null
       return root
 
+unicodeEscapePattern := String.raw`\\u\{0*(?:[\dA-Fa-f]{1,5}|10[\dA-Fa-f]{4})\}|\\u[\dA-Fa-f]{4}`
+nonAsciiIdentifierPattern := String.raw`[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶]`
+
 const wellKnownSymbols = [
   "asyncIterator",
   "hasInstance",
@@ -3473,7 +3476,13 @@ SymbolElement
 # JS-valid form.
 Identifier
   # perf: assertion to exit early
-  /(?=\p{ID_Start}|[_$\\]|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ !ReservedWord IdentifierName:id -> id
+  ///
+    (?=
+      \p{ID_Start}
+      | [_$\\]
+      | ${const nonAsciiIdentifierPattern}
+    )
+  /// !ReservedWord IdentifierName:id -> id
 
 # https://262.ecma-international.org/#prod-IdentifierName
 # Two sequential char-class groups (start, then continue*). Each alternates
@@ -3481,7 +3490,20 @@ Identifier
 # / `\u{X+}` escapes capped at 0x10FFFF, and non-ASCII non-id codepoints
 # not claimed by Civet operators (the long inline exclusion list).
 IdentifierName
-  /(?:\p{ID_Start}|[_$]|\\u\{0*(?:[\dA-Fa-f]{1,5}|10[\dA-Fa-f]{4})\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])(?:\p{ID_Continue}|[\u200C\u200D$]|\\u\{0*(?:[\dA-Fa-f]{1,5}|10[\dA-Fa-f]{4})\}|\\u[\dA-Fa-f]{4}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])*/ ::Identifier ->
+  ///
+    (?:
+      \p{ID_Start}
+      | [_$]
+      | ${const unicodeEscapePattern}
+      | ${const nonAsciiIdentifierPattern}
+    )
+    (?:
+      \p{ID_Continue}
+      | [\u200C\u200D$]
+      | ${const unicodeEscapePattern}
+      | ${const nonAsciiIdentifierPattern}
+    )*
+  /// ::Identifier ->
     { name, token } := escapeIdentifier($0)
     return {
       type: "Identifier",
@@ -7214,7 +7236,12 @@ SemicolonDelimiter
     }
 
 NonIdContinue
-  /(?!\p{ID_Continue}|[^\u0000-\u007F\p{ID_Continue}\s÷—‖’•‥…⁇→⇒∈∉∋∌≔≠≡≢≣≤≥≪≫⋙▷⧺⩵⩶])/ -> undefined
+  ///
+    (?!
+      \p{ID_Continue}
+      | ${const nonAsciiIdentifierPattern}
+    )
+  /// -> undefined
 
 Loc
   "" ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4664,7 +4664,7 @@ BinaryOpSymbol
     }
   # NOTE: %/ and %% must be above %
   # NOTE: // must be above /
-  "/"
+  "/" !"/" -> $1
   "%"
   "++" / "⧺" ->
     return {

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -204,6 +204,50 @@ describe "regexp", ->
       /\\r/
     """
 
+    tab := "\t"
+    lineSeparator := "\u2028"
+    paragraphSeparator := "\u2029"
+
+    testCase ```
+      escaped tab
+      ---
+      ;
+      ///\\${tab}///
+      ---
+      ;
+      /\\t/
+    ```
+
+    testCase ```
+      escaped line separator
+      ---
+      ;
+      ///\\${lineSeparator}///
+      ---
+      ;
+      /\\u2028/
+    ```
+
+    testCase ```
+      escaped paragraph separator
+      ---
+      ;
+      ///\\${paragraphSeparator}///
+      ---
+      ;
+      /\\u2029/
+    ```
+
+    testCase ```
+      strips unescaped whitespace
+      ---
+      ;
+      ///a${tab}b${lineSeparator}c${paragraphSeparator}d///
+      ---
+      ;
+      /abcd/
+    ```
+
     testCase """
       space in character class
       ---

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -131,6 +131,40 @@ describe "regexp", ->
     """
 
     testCase """
+      empty
+      ---
+      ;
+      /// ///
+      ---
+      ;
+      /(?:)/
+    """
+
+    testCase """
+      empty with flags
+      ---
+      ;
+      /// ///g
+      ---
+      ;
+      /(?:)/g
+    """
+
+    testCase """
+      four or more slashes are comments
+      ---
+      ;
+      ////
+      /////
+      //////
+      ---
+      ;
+      ////
+      /////
+      //////
+    """
+
+    testCase """
       escapes single slashes
       ---
       ;

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -111,6 +111,20 @@ describe "regexp", ->
     """
 
     testCase """
+      /// not treated as division
+      ---
+      ;
+      ///x///
+      ///y///
+      ///z///
+      ---
+      ;
+      /x/;
+      /y/;
+      /z/
+    """
+
+    testCase """
       escapes
       ---
       ;
@@ -211,52 +225,20 @@ describe "regexp", ->
     paragraphSeparator := "\u2029"
 
     testCase ```
-      escaped tab
+      escaped whitespace
       ---
       ;
       ///\\${tab}///
-      ---
-      ;
-      /\\t/
-    ```
-
-    testCase ```
-      escaped vertical tab
-      ---
-      ;
       ///\\${verticalTab}///
-      ---
-      ;
-      /\\v/
-    ```
-
-    testCase ```
-      escaped form feed
-      ---
-      ;
       ///\\${formFeed}///
-      ---
-      ;
-      /\\f/
-    ```
-
-    testCase ```
-      escaped line separator
-      ---
-      ;
       ///\\${lineSeparator}///
-      ---
-      ;
-      /\\u2028/
-    ```
-
-    testCase ```
-      escaped paragraph separator
-      ---
-      ;
       ///\\${paragraphSeparator}///
       ---
       ;
+      /\\t/;
+      /\\v/;
+      /\\f/;
+      /\\u2028/;
       /\\u2029/
     ```
 

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -205,6 +205,8 @@ describe "regexp", ->
     """
 
     tab := "\t"
+    verticalTab := "\v"
+    formFeed := "\f"
     lineSeparator := "\u2028"
     paragraphSeparator := "\u2029"
 
@@ -216,6 +218,26 @@ describe "regexp", ->
       ---
       ;
       /\\t/
+    ```
+
+    testCase ```
+      escaped vertical tab
+      ---
+      ;
+      ///\\${verticalTab}///
+      ---
+      ;
+      /\\v/
+    ```
+
+    testCase ```
+      escaped form feed
+      ---
+      ;
+      ///\\${formFeed}///
+      ---
+      ;
+      /\\f/
     ```
 
     testCase ```


### PR DESCRIPTION
This PR updates Civet’s Hera dependency to 0.9.8 and applies the parser grammar cleanups enabled by the newer Hera syntax. It also ports over some of the heregex cleanup done in Hera 0.9.8, including fixing empties (`/// ///` for example) and changing 4+ `/`s into a comment.

- Bump `@danielx/hera` from `0.9.7` to `0.9.8`.
- Factor out repeated `::Type` annotations up to the rule level in `source/parser.hera`.
- Use Hera `///...///` regex syntax to make Civet’s long identifier regexes more readable.
- Extract shared identifier regex fragments for Unicode escapes and non-ASCII identifier/operator handling.
- Fixes empty heregex output so `/// ///` compiles to `/(?:)/` instead of invalid `//`, like CoffeeScript and Hera.
- Treats `////` and longer slash runs as comments while preserving exactly `///` for heregexes/directives. I think this is useful because I so presumably others like writing `/////////////////////` as a separator in files. And in the current state, `//////` (empty regex) and `/////` (heregex opening followed by the start of a comment) are extremely confusing and hard to read.
- Cleans up Civet’s heregex grammar implementation using a shared escape table and simpler rule actions, modeled after how I cleaned up the grammar in Hera.
- Adds tests for empty heregexes, slash-run comments, escaped tab/line/paragraph separators, and unescaped whitespace stripping.

## Addendum

- Fixed a parser ambiguity where consecutive heregex literals could be misread as binary division plus a `//` comment. For example, after parsing `///x///`, the next `///y///` could previously be split as `/` followed by `//y///`, so every other heregex was treated as a comment.
- Binary division now rejects a following `/`, preserving `///...///` for heregex parsing while keeping `//` and `////`+ comment behavior intact.
