### PR TITLE
Drop type-only named imports entirely in JS mode

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -504,10 +504,9 @@ function dynamizeFromClause(from: any)
   ["(", ...from, ")"]
 
 // True iff `node` is a NamedImports Declaration whose specifiers all carry
-// a `type` modifier (so they vanish in JS mode) and has no `...rest`.
+// a `type` modifier (so they vanish in JS mode). Returns false on empty
+// specifiers so `import {} from "x"` survives as a side-effect import.
 function isAllTypeNamed(node: any): boolean
-  return false unless node?.specifiers
-  return false if node.rest
   specs := node.specifiers
   return false unless specs.length
   specs.every (s: any) => s.ts
@@ -528,16 +527,16 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
 
   // Default + named (e.g. `import D, { type S } from "foo"`): drop only the
   // trailing `, { type S }` by wrapping it in a ts:true node.
-  return decl unless i.binding and imports.children
-  namedIdx := imports.children.findIndex (c: any) =>
+  children := imports.children!
+  namedIdx := children.findIndex (c: any) =>
     c?.type is "Declaration" and c?.specifiers and c is not i.binding
-  return decl unless namedIdx > 0 and isAllTypeNamed imports.children[namedIdx]
+  return decl unless namedIdx > 0 and isAllTypeNamed children[namedIdx]
 
   // ImportClause assembles children as [binding, ...rest] where rest is the
   // 4-tuple [ws, ",", ws, named] — so the trailing slice is namedIdx-3..end.
-  tail := imports.children.slice(namedIdx - 3)
+  tail := children.slice(namedIdx - 3)
   newImportsChildren := [
-    ...imports.children.slice(0, namedIdx - 3)
+    ...children.slice(0, namedIdx - 3)
     { ts: true, children: tail }
   ]
   newImports := { ...imports, children: newImportsChildren }

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -503,18 +503,59 @@ function dynamizeFromClause(from: any)
     from.push ", {", assert.keyword, ":", assert.object, "}"
   ["(", ...from, ")"]
 
+// True iff `node` is a NamedImports Declaration whose specifiers all carry
+// a `type` modifier (so they vanish in JS mode) and has no `...rest`.
+function isAllTypeNamed(node: any): boolean
+  return false unless node?.specifiers
+  return false if node.rest
+  specs := node.specifiers
+  return false unless specs.length
+  specs.every (s: any) => s.ts
+
+// Drop the named-imports portion in JS mode when every specifier is
+// `type`-prefixed (otherwise per-spec stripping leaves `import {} from "x"`,
+// which is a runtime side-effect import esbuild faithfully preserves).
+function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
+  return decl if decl.ts
+  { imports } := decl
+  return decl unless imports
+
+  i := imports as any
+  // Standalone NamedImports: no default, no namespace — drop whole decl.
+  if not i.binding and not i.star
+    return { ...decl, ts: true } if isAllTypeNamed i
+    return decl
+
+  // Default + named (e.g. `import D, { type S } from "foo"`): drop only the
+  // trailing `, { type S }` by wrapping it in a ts:true node.
+  return decl unless i.binding and imports.children
+  namedIdx := imports.children.findIndex (c: any) =>
+    c?.type is "Declaration" and c?.specifiers and c is not i.binding
+  return decl unless namedIdx > 0 and isAllTypeNamed imports.children[namedIdx]
+
+  // ImportClause assembles children as [binding, ...rest] where rest is the
+  // 4-tuple [ws, ",", ws, named] — so the trailing slice is namedIdx-3..end.
+  tail := imports.children.slice(namedIdx - 3)
+  newImportsChildren := [
+    ...imports.children.slice(0, namedIdx - 3)
+    { ts: true, children: tail }
+  ]
+  newImports := { ...imports, children: newImportsChildren }
+  newDeclChildren := decl.children!.map (c: any) => c is imports ? newImports : c
+  return { ...decl, imports: newImports, children: newDeclChildren }
+
 // Rewrite `import {…rest|nested}` to namespace import + const destructure.
 // Per-spec `type` imports get pulled into a separate native `import {type X}`
 // since a const-destructure can't bind types.
 function processStaticImport(decl: ImportDeclaration)
   { imports, from, children } := decl
   // `"rest" in imports` narrows the union — only ImportClauseNode declares it.
-  return decl unless imports and "rest" in imports
+  return markAllTypeImports decl unless imports and "rest" in imports
 
   namedImports := (imports.binding ? imports.children!.at(-1)! : imports) as ImportClauseNode
   allSpecs := namedImports.specifiers!
   // Rewrite only when native ESM can't express the shape: rest or pattern bindings.
-  return decl unless namedImports.rest or allSpecs.some (s) => s.pattern
+  return markAllTypeImports decl unless namedImports.rest or allSpecs.some (s) => s.pattern
 
   ref := makeRef "imports"
   star := { type: "Star", token: "*" }

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -542,7 +542,7 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
     { ts: true, children: tail }
   ]
   newImports := { ...imports, children: newImportsChildren }
-  newDeclChildren := decl.children!.map (c) => c is imports ? newImports as! ASTNode : c
+  newDeclChildren := decl.children!.map (c) => c is imports ? newImports : c
   return { ...decl, imports: newImports, children: newDeclChildren }
 
 // Rewrite `import {…rest|nested}` to namespace import + const destructure.

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -503,28 +503,23 @@ function dynamizeFromClause(from: any)
     from.push ", {", assert.keyword, ":", assert.object, "}"
   ["(", ...from, ")"]
 
-// True iff `clause` is a NamedImports clause whose specifiers all carry
-// a `type` modifier (so they vanish in JS mode). Returns false on empty
-// specifiers so `import {} from "x"` survives as a side-effect import.
-function isAllTypeNamed(clause: ImportClauseNode): boolean
-  specs := clause.specifiers
-  return false unless specs?.length
-  specs.every .ts
-
 // Drop the named-imports portion in JS mode when every specifier is
 // `type`-prefixed (otherwise per-spec stripping leaves `import {} from "x"`,
 // which is a runtime side-effect import esbuild faithfully preserves).
+// A specifier-less clause (`{ specifiers.length is 0 }`) is *not* all-type:
+// `import {} from "x"` is itself an intentional side-effect import we keep.
 function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
   return decl if decl.ts
   { imports } := decl
   return decl unless imports
 
   // Operator-import clauses share `type: "Declaration"` but never carry
-  // type-only specifiers, so they fall through isAllTypeNamed harmlessly.
+  // type-only specifiers, so they fall through the all-type check harmlessly.
   i := imports as ImportClauseNode
-  // Standalone NamedImports: no default, no namespace — drop whole decl.
+  // Standalone NamedImports: no default, no namespace — drop the whole decl.
   if not i.binding and not i.star
-    return { ...decl, ts: true } if isAllTypeNamed i
+    specs := i.specifiers
+    return { ...decl, ts: true } if specs?.length and specs.every .ts
     return decl
 
   // Default + named (e.g. `import D, { type S } from "foo"`): drop only the
@@ -532,10 +527,13 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
   children := imports.children!
   namedIdx := children.findIndex (c) =>
     c?.type is "Declaration" and (c as ImportClauseNode).specifiers and c is not i.binding
-  return decl unless namedIdx > 0 and isAllTypeNamed(children[namedIdx] as ImportClauseNode)
-
   // ImportClause assembles children as [binding, ...rest] where rest is the
-  // 4-tuple [ws, ",", ws, named] — so the trailing slice is namedIdx-3..end.
+  // 4-tuple [ws, ",", ws, named]; bail unless that trailing `named` was found.
+  // index ≥ 3 also keeps the namedIdx-3 slice below non-negative.
+  return decl unless namedIdx >= 3
+  namedSpecs := (children[namedIdx] as ImportClauseNode).specifiers
+  return decl unless namedSpecs?.length and namedSpecs.every .ts
+
   tail := children.slice(namedIdx - 3)
   newImportsChildren := [
     ...children.slice(0, namedIdx - 3)

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -522,23 +522,15 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
     return { ...decl, ts: true } if specs?.length and specs.every .ts
     return decl
 
-  // Default + named (e.g. `import D, { type S } from "foo"`): drop only the
-  // trailing `, { type S }` by wrapping it in a ts:true node.
+  // Default + named (e.g. `import D, { type S } from "foo"`): ImportClause
+  // builds the clause as `[binding, ...rest]` with the named clause last, so
+  // drop only the trailing `, { type S }` by wrapping `rest` in a ts:true node.
   children := imports.children!
-  namedIdx := children.findIndex (c) =>
-    c?.type is "Declaration" and (c as ImportClauseNode).specifiers and c is not i.binding
-  // ImportClause assembles children as [binding, ...rest] where rest is the
-  // 4-tuple [ws, ",", ws, named]; bail unless that trailing `named` was found.
-  // index ≥ 3 also keeps the namedIdx-3 slice below non-negative.
-  return decl unless namedIdx >= 3
-  namedSpecs := (children[namedIdx] as ImportClauseNode).specifiers
+  namedSpecs := (children.at(-1)! as ImportClauseNode).specifiers
   return decl unless namedSpecs?.length and namedSpecs.every .ts
 
-  tail := children.slice(namedIdx - 3)
-  newImportsChildren := [
-    ...children.slice(0, namedIdx - 3)
-    { ts: true, children: tail }
-  ]
+  [binding, ...rest] := children
+  newImportsChildren := [binding, { ts: true, children: rest }]
   newImports := { ...imports, children: newImportsChildren }
   newDeclChildren := decl.children!.map (c) => c is imports ? newImports : c
   return { ...decl, imports: newImports, children: newDeclChildren }

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -503,13 +503,13 @@ function dynamizeFromClause(from: any)
     from.push ", {", assert.keyword, ":", assert.object, "}"
   ["(", ...from, ")"]
 
-// True iff `node` is a NamedImports Declaration whose specifiers all carry
+// True iff `clause` is a NamedImports clause whose specifiers all carry
 // a `type` modifier (so they vanish in JS mode). Returns false on empty
 // specifiers so `import {} from "x"` survives as a side-effect import.
-function isAllTypeNamed(node: any): boolean
-  specs := node.specifiers
-  return false unless specs.length
-  specs.every (s: any) => s.ts
+function isAllTypeNamed(clause: ImportClauseNode): boolean
+  specs := clause.specifiers
+  return false unless specs?.length
+  specs.every .ts
 
 // Drop the named-imports portion in JS mode when every specifier is
 // `type`-prefixed (otherwise per-spec stripping leaves `import {} from "x"`,
@@ -519,7 +519,9 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
   { imports } := decl
   return decl unless imports
 
-  i := imports as any
+  // Operator-import clauses share `type: "Declaration"` but never carry
+  // type-only specifiers, so they fall through isAllTypeNamed harmlessly.
+  i := imports as ImportClauseNode
   // Standalone NamedImports: no default, no namespace — drop whole decl.
   if not i.binding and not i.star
     return { ...decl, ts: true } if isAllTypeNamed i
@@ -528,9 +530,9 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
   // Default + named (e.g. `import D, { type S } from "foo"`): drop only the
   // trailing `, { type S }` by wrapping it in a ts:true node.
   children := imports.children!
-  namedIdx := children.findIndex (c: any) =>
-    c?.type is "Declaration" and c?.specifiers and c is not i.binding
-  return decl unless namedIdx > 0 and isAllTypeNamed children[namedIdx]
+  namedIdx := children.findIndex (c) =>
+    c?.type is "Declaration" and (c as ImportClauseNode).specifiers and c is not i.binding
+  return decl unless namedIdx > 0 and isAllTypeNamed(children[namedIdx] as ImportClauseNode)
 
   // ImportClause assembles children as [binding, ...rest] where rest is the
   // 4-tuple [ws, ",", ws, named] — so the trailing slice is namedIdx-3..end.
@@ -540,7 +542,7 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
     { ts: true, children: tail }
   ]
   newImports := { ...imports, children: newImportsChildren }
-  newDeclChildren := decl.children!.map (c: any) => c is imports ? newImports : c
+  newDeclChildren := decl.children!.map (c) => c is imports ? newImports as! ASTNode : c
   return { ...decl, imports: newImports, children: newDeclChildren }
 
 // Rewrite `import {…rest|nested}` to namespace import + const destructure.

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -2058,7 +2058,7 @@ function processRepl(root: BlockStatement, rootIIFE: ASTNode): void
     continue unless decl.names?# // skip 'let ref'
     if decl.parent is topBlock or decl.decl is "var"
       decl.children.shift() // remove const/let/var
-      if decl.bindings.0?.pattern?.type is "ObjectBindingPattern"
+      if decl.bindings!.0?.pattern?.type is "ObjectBindingPattern"
         // If first pattern is braced, need to wrap in parens
         decl.children.unshift "("
         decl.children.push ")"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -109,6 +109,8 @@ export type OtherNode =
   | ForDeclaration
   | FunctionRestParameter
   | ImportAssertion
+  | ImportClauseNode
+  | OperatorImportClauseNode
   | Index
   | Initializer
   | Keyword
@@ -769,8 +771,16 @@ export type OperatorImportSpecifier =
     /** Per-specifier precedence/associativity; falls back to cluster's. */
     behavior?: ASTNodeObject
 
+// Import clauses share `type: "Declaration"` with the statement-level
+// Declaration, so `gatherRecursive(…, .type is "Declaration")` walkers probe
+// `bindings`/`decl` on them.  Typed as undefined here to let that destructuring
+// succeed without adding real shape — an import clause never carries these.
+type DeclarationProbe =
+  bindings?: undefined
+  decl?: undefined
+
 /** Clause between `import` and `from` (default, namespace, named, or combos). */
-export type ImportClauseNode = ASTParent &
+export type ImportClauseNode = ASTParent & DeclarationProbe &
   type: "Declaration"
   names: string[]
   binding?: ASTNodeObject & { names: string[] }
@@ -779,7 +789,7 @@ export type ImportClauseNode = ASTParent &
   rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
 
 /** Clause for `import operator {…}` — separate specifier shape from ImportClauseNode. */
-export type OperatorImportClauseNode = ASTParent &
+export type OperatorImportClauseNode = ASTParent & DeclarationProbe &
   type: "Declaration"
   names: string[]
   specifiers: OperatorImportSpecifier[]

--- a/test/types/js.civet
+++ b/test/types/js.civet
@@ -150,6 +150,28 @@ describe "Types", ->
     """
 
     testCase.js """
+      omits import when all named are type
+      ---
+      import { type S, type T } from "foo"
+      ---
+    """
+
+    testCase.js """
+      omits import shorthand when all named are type
+      ---
+      { type S, type T } from "foo"
+      ---
+    """
+
+    testCase.js """
+      keeps default when all named are type
+      ---
+      import D, { type S, type T } from "foo"
+      ---
+      import D from "foo"
+    """
+
+    testCase.js """
       omits export some types
       ---
       var a, b, c, d

--- a/test/types/js.civet
+++ b/test/types/js.civet
@@ -172,6 +172,14 @@ describe "Types", ->
     """
 
     testCase.js """
+      preserves empty named import side-effect
+      ---
+      import {} from "foo"
+      ---
+      import {} from "foo"
+    """
+
+    testCase.js """
       omits export some types
       ---
       var a, b, c, d


### PR DESCRIPTION
## Summary

`import { type S, type T } from "foo"` in `--js` (strip-types) mode was emitting `import {} from "foo"` after per-specifier type stripping. esbuild faithfully preserves that as a runtime side-effect import — which broke the LSP browser worker's data-URL eval (and any other consumer that doesn't want a phantom side-effect import).

## Cause

`generate.civet` omits nodes marked `ts: true` in JS mode. Each `TypeAndImportSpecifier` already gets `ts: true`, so the inner specifiers vanished — but the surrounding `import { … } from "x"` framing has no such flag, leaving the empty wrapper.

## Fix

`markAllTypeImports` runs from the early-return paths of `processStaticImport`:

- Standalone NamedImports (no default / namespace binding) with all specifiers `type` → mark the entire `ImportDeclaration` `ts: true` so the whole statement is dropped in JS.
- Default + named (`import D, { type S } from "foo"`) → wrap just the trailing `, { type S }` portion in a `ts: true` node, leaving `import D from "foo"`.

TS mode output is unchanged in every case.

## Test plan

- [x] 3 new `testCase.js` cases in `test/types/js.civet` (standalone, shorthand, default+named)
- [x] Full suite: 4172 passing
- [x] `typecheck-diff` vs main: 0 regressions, 0 fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)