### PR TITLE
Don't indent next line after keyword inside an Object

### DIFF
--- a/lsp/vscode/syntaxes/civet-configuration.json
+++ b/lsp/vscode/syntaxes/civet-configuration.json
@@ -28,7 +28,7 @@
     ["`", "`"]
   ],
   "indentationRules": {
-    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\\b(?!.*\\bthen\\b).*$)",
+    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\\b(?!.*\\bthen\\b)(?!\\s*:).*$)",
     "decreaseIndentPattern": "^\\s*(?:else\\b|catch\\b|finally\\b|when\\b|case\\b|[)\\]}])"
   }
 }


### PR DESCRIPTION
This will prevent unnecessary indent on new line when creating an Object with keys that are keyword
```js
qwe :=
    asd: 1
    class: 2| // <- cursor here, press enter
        | // <-- cursor after pressing enter with old indentation rules, shouldn't be indent here
```

this works in sublime, please test in vscode