### PR TITLE
LSP: Don't indent after keyword property inside Object

### DIFF
--- a/lsp/vscode/e2e/indentation.test.civet
+++ b/lsp/vscode/e2e/indentation.test.civet
@@ -28,6 +28,14 @@ indentAfterEnter := async (content: string): Promise<number> =>
   newLineIndex := content.split('\n').length
   indentOf doc.lineAt(newLineIndex).text
 
+// Open a doc, type text at end, and return the line that follows the original
+// content.  Useful for decrease-indent cases that fire while typing the line.
+lineAfterTyping := async (content: string, text: string): Promise<string> =>
+  { doc } := await openCivetAtEnd content
+  await vscode.commands.executeCommand 'type', { text }
+  newLineIndex := content.split('\n').length
+  doc.lineAt(newLineIndex).text
+
 suite 'Auto-indent on Enter (issue #170)', =>
   test 'indents body after function declaration', async =>
     indent := await indentAfterEnter 'function foo()'
@@ -72,3 +80,7 @@ suite 'Auto-indent on Enter (issue #170)', =>
   test 'does NOT increase indent after a keyword object key', async =>
     indent := await indentAfterEnter 'qwe :=\n    asd: 1\n    class: 2'
     assert indent is 4, `expected object-key indent to stay at 4, got ${indent}`
+
+  test 'does NOT decrease indent while typing a keyword object key', async =>
+    line := await lineAfterTyping 'qwe :=\n    asd: 1', '\nelse: 2'
+    assert line is '    else: 2', `expected object-key line to stay indented, got ${JSON.stringify line}`

--- a/lsp/vscode/e2e/indentation.test.civet
+++ b/lsp/vscode/e2e/indentation.test.civet
@@ -68,3 +68,7 @@ suite 'Auto-indent on Enter (issue #170)', =>
   test 'does NOT indent after an inline-then conditional', async =>
     indent := await indentAfterEnter 'if cond then x else y'
     assert indent is 0, `expected no indent after inline-then, got ${indent}`
+
+  test 'does NOT increase indent after a keyword object key', async =>
+    indent := await indentAfterEnter 'qwe :=\n    asd: 1\n    class: 2'
+    assert indent is 4, `expected object-key indent to stay at 4, got ${indent}`

--- a/lsp/vscode/syntaxes/civet-configuration.json
+++ b/lsp/vscode/syntaxes/civet-configuration.json
@@ -29,6 +29,6 @@
   ],
   "indentationRules": {
     "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\\b(?!.*\\bthen\\b)(?!\\s*:).*$)",
-    "decreaseIndentPattern": "^\\s*(?:else\\b|catch\\b|finally\\b|when\\b|case\\b|[)\\]}])"
+    "decreaseIndentPattern": "^\\s*(?:(?:else|catch|finally|when|case)\\b(?!\\s*:)|[)\\]}])"
   }
 }

--- a/lsp/vscode/syntaxes/civet-configuration.json
+++ b/lsp/vscode/syntaxes/civet-configuration.json
@@ -28,7 +28,7 @@
     ["`", "`"]
   ],
   "indentationRules": {
-    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\\b(?!.*\\bthen\\b).*$)",
+    "increaseIndentPattern": "^(?:.*(?:[({\\[]|=>>|->>|=>|->|\\bdo\\b|\\btry\\b|\\belse\\b|\\bcatch\\b|\\bfinally\\b|\\bloop\\b|\\bthen\\b)\\s*$|\\s*(?:export\\s+|async\\s+|default\\s+){0,3}(?:if|unless|for|while|until|switch|class|interface|enum|function|namespace|module|when|case|else|catch|finally)\\b(?!.*\\bthen\\b)(?!\\s*:).*$)",
     "decreaseIndentPattern": "^\\s*(?:else\\b|catch\\b|finally\\b|when\\b|case\\b|[)\\]}])"
   }
 }


### PR DESCRIPTION
Replacing #2128, which prevents unnecessary indent on new line when creating an Object with keys that are keyword
```js
qwe :=
    asd: 1
    class: 2| // <- cursor here, press enter
        | // <-- cursor after pressing enter with old indentation rules, shouldn't be indent here
```

I added E2E test, and tested myself on VSCode.