### PR TITLE
Fix postfix if/unless followed by ; emitting invalid JS

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6206,8 +6206,8 @@ MaybeNestedExpression ::unknown
 # (e.g. for `return` or `yield`)
 # This also doesn't allow initial __ (whereas MaybeNestedExpression does)
 MaybeParenNestedExpression
-  # Skip if there's a postfix if/etc.
-  &( _? PostfixStatement NoBlock ) -> ""
+  # Skip if there's a postfix if/etc., possibly followed by `;` (see #2131).
+  &( _? PostfixStatement ( NoBlock / ( _? Semicolon ) ) ) -> ""
   # Not nested case
   !EOS Expression -> $2
   # Avoid double wrapping nested array/object return value in parentheses.

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1343,11 +1343,19 @@ function skipImplicitArguments(args: ASTNode[]): boolean
     if arg0!.type is "StatementExpression"
       arg0 = arg0.statement
 
-    return (and)
-      arg0!.type is "IterationExpression"
-      arg0!.subtype !== "DoStatement"
-      !arg0!.async
-      isEmptyBareBlock arg0.block
+    if arg0!.type is "IterationExpression"
+      return (and)
+        arg0!.subtype !== "DoStatement"
+        !arg0!.async
+        isEmptyBareBlock arg0.block
+
+    // Postfix `if`/`unless` followed by `;` (empty body) should be treated
+    // as a postfix modifier, not as an implicit-call argument with an empty
+    // consequent. See #2131.
+    if arg0!.type is "IfStatement"
+      return (and)
+        !arg0!.else
+        isEmptyBareBlock arg0.then
 
   return false
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -637,6 +637,46 @@ describe "if", ->
   """
 
   testCase """
+    postfix if followed by semicolon (#2131)
+    ---
+    foo() if x;
+    ---
+    if (x) { foo() };
+  """
+
+  testCase """
+    postfix unless followed by semicolon (#2131)
+    ---
+    foo() unless x;
+    ---
+    if (!x) { foo() };
+  """
+
+  testCase """
+    return postfix unless followed by semicolon (#2131)
+    ---
+    return unless x;
+    ---
+    if (!x) { return };
+  """
+
+  testCase """
+    return postfix if followed by semicolon (#2131)
+    ---
+    return if x;
+    ---
+    if (x) { return };
+  """
+
+  testCase """
+    throw postfix unless followed by semicolon (#2131)
+    ---
+    throw err unless x;
+    ---
+    if (!x) { throw err };
+  """
+
+  testCase """
     postfix if with indented condition
     ---
     return if


### PR DESCRIPTION
Fixes #2131.

## Summary

Postfix `if`/`unless` followed by a trailing `;` was being misparsed as an implicit call with the if-expression as argument, producing invalid output like `foo()((x?():void 0));` for `foo() if x;`.

Two parser paths needed updating:

- `skipImplicitArguments` only recognized empty-body iteration expressions; teach it to also skip when the sole implicit argument is an `IfStatement` with an empty consequent and no else.
- `MaybeParenNestedExpression` (used for `return`/`throw`/`yield`) bailed out when followed by `PostfixStatement NoBlock`; extend the lookahead to also accept a trailing `;`.

## Test plan

- [x] `foo() if x;` → `if (x) { foo() };`
- [x] `foo() unless x;` → `if (!x) { foo() };`
- [x] `return unless x;` → `if (!x) { return };`
- [x] `throw err unless x;` → `if (!x) { throw err };`
- [x] All 4253 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)