### PR TITLE
LSP: pull-model diagnostics (`textDocument/diagnostic`)

### DIFF
--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -163,3 +163,4 @@ hx --health civet
 ## Tooling
 
 - [YavaScript](https://github.com/suchipi/yavascript) is a standalone script runner supporting Civet (no Node required)
+- [mcp-language-server](https://github.com/STRd6/mcp-language-server) exposes `civet-lsp` to AI agents over the Model Context Protocol (diagnostics, hover, go-to-definition, references, edits)

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -1330,8 +1330,9 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     scheduleExecuteQueue()
 
   /**
-   * Diagnostics for an already-staged document. `undefined` means "not ready"
-   * (push callers skip rather than clear); `[]` means "no problems".
+   * Diagnostics for an already-staged document. Returns `[]` when there's
+   * nothing to report — either a clean source or no transpiler meta yet
+   * (e.g. an empty file with no snapshot).
    */
   function computeDiagnosticsForDoc(document: TextDocument, service: ResolvedService): Diagnostic[]
     logger.log("Computing diagnostics for doc: " + document.uri)

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -18,6 +18,10 @@
   type SymbolInformation
   TextEdit
   SemanticTokensRequest
+  DocumentDiagnosticRequest
+  DocumentDiagnosticReportKind
+  type DocumentDiagnosticParams
+  type DocumentDiagnosticReport
   FileChangeType
   type Connection
   type SignatureHelp
@@ -299,6 +303,11 @@ export function startServer(connection: Connection, dependencies: ServerDependen
             tokenTypes: semanticTokenTypes as! string[]
             tokenModifiers: semanticTokenModifiers as! string[]
           full: true
+        // Pull-model diagnostics (LSP 3.17). interFileDependencies: our
+        // results can change when other files do (cross-file TS types).
+        diagnosticProvider:
+          interFileDependencies: true
+          workspaceDiagnostics: false
 
       }
     }
@@ -1320,11 +1329,12 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     changeQueue.add(document)
     scheduleExecuteQueue()
 
-  // Both callers (executeQueue and updateProjectDiagnostics) pass a service
-  // explicitly after staging the document, so `service` is always provided and
-  // the doc is already staged when we arrive here.
-  function updateDiagnosticsForDoc(document: TextDocument, service: ResolvedService)
-    logger.log("Updating diagnostics for doc: " + document.uri)
+  /**
+   * Diagnostics for an already-staged document. `undefined` means "not ready"
+   * (push callers skip rather than clear); `[]` means "no problems".
+   */
+  function computeDiagnosticsForDoc(document: TextDocument, service: ResolvedService): Diagnostic[]
+    logger.log("Computing diagnostics for doc: " + document.uri)
     sourcePath := documentToSourcePath(document)
     assert sourcePath
 
@@ -1370,20 +1380,16 @@ export function startServer(connection: Connection, dependencies: ServerDependen
 
     // Non-transpiled
     if sourcePath.match tsSuffix
-      diagnostics := getTypeScriptDiagnostics(sourcePath, document)
+      return getTypeScriptDiagnostics(sourcePath, document)
 
-      return connection.sendDiagnostics {
-        uri: document.uri
-        version: document.version
-        diagnostics
-      }
-
-    // Transpiled file
+    // Transpiled file. No meta/transpiledDoc yet (e.g. an empty source that
+    // hasn't produced a snapshot) means there's nothing to report.
     meta := service.host.getMeta(sourcePath)
-    return logger.log `no meta for ${sourcePath}` unless meta
+    transpiledDoc := meta?.transpiledDoc
+    unless transpiledDoc
+      return []
 
-    { sourcemapLines, transpiledDoc, parseErrors, fatal } := meta
-    return logger.log `no transpiledDoc for ${sourcePath}` unless transpiledDoc
+    { sourcemapLines, parseErrors, fatal } := meta!
 
     transpiledPath := documentToSourcePath(transpiledDoc)
     diagnostics: Diagnostic[] := []
@@ -1397,13 +1403,15 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     unless fatal
       diagnostics.push(...getTypeScriptDiagnostics(transpiledPath, transpiledDoc, sourcemapLines))
 
+    return diagnostics
+
+  /** Compute and push diagnostics via `textDocument/publishDiagnostics`. */
+  function updateDiagnosticsForDoc(document: TextDocument, service: ResolvedService)
     connection.sendDiagnostics {
       uri: document.uri
       version: document.version
-      diagnostics
+      diagnostics: computeDiagnosticsForDoc(document, service)
     }
-
-    return
 
   // Using a cancellation token we prevent parallel executions of scheduleUpdateDiagnostics
   let runningDiagnosticsUpdate: { isCanceled: boolean } | undefined
@@ -1608,6 +1616,23 @@ export function startServer(connection: Connection, dependencies: ServerDependen
       tsConfigPath := path.join projectPath, 'tsconfig.json'
       await doReloadServiceForProject(projPath, tsConfigPath)
     return true
+
+  /**
+   * Pull-model diagnostics (LSP 3.17): computed against the current document
+   * at request time, so an edit shows on the next pull with no push race.
+   * Empty report when the doc isn't open (no content to analyze).
+   */
+  connection.onRequest DocumentDiagnosticRequest.type, (params: DocumentDiagnosticParams): Promise<DocumentDiagnosticReport> =>
+    document := documents.get params.textDocument.uri
+    return { kind: DocumentDiagnosticReportKind.Full, items: [] } unless document
+
+    sourcePath := documentToSourcePath params.textDocument
+    assert sourcePath
+    service := await ensureServiceForSourcePath sourcePath
+    await updating params.textDocument
+
+    items := computeDiagnosticsForDoc(document, service)
+    { kind: DocumentDiagnosticReportKind.Full, items }
 
   // Semantic tokens: use TypeScript's semantic classifications, remapped via sourcemap
   connection.onRequest SemanticTokensRequest.type, (params) =>

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -70,6 +70,13 @@ describe "LSP features (shared project server)", ->
   after ->
     await client.stop() if client
 
+  it "advertises pull-model diagnostics in its capabilities", ->
+    provider := init.capabilities.diagnosticProvider
+    assert provider, "expected a diagnosticProvider capability"
+    assert.equal provider.interFileDependencies, true,
+      "Civet's cross-file TS types mean diagnostics depend on other files"
+    assert.equal provider.workspaceDiagnostics, false
+
   it "hover returns just the signature when no documentation exists", ->
     // Exercises the `documentation ?? ""` branch at server.civet line 272
     // when Previewer.plain returns an empty string for an undocumented symbol.

--- a/lsp/server/test/lsp-protocol.test.civet
+++ b/lsp/server/test/lsp-protocol.test.civet
@@ -122,6 +122,72 @@ describe "LSP protocol", ->
       (p) => p.uri is liveUri
     assert diagnostics, "server should continue producing diagnostics after no-op events"
 
+  it "answers textDocument/diagnostic pull requests with a full report", ->
+    pullPath := path.join(projectRoot, "proto-pull.civet")
+    uri := docUri pullPath
+
+    client.notify "textDocument/didOpen", {
+      textDocument: {
+        uri
+        languageId: "civet"
+        version: 1
+        text: 'x: number := "not a number"'
+      }
+    }
+
+    report := await client.request "textDocument/diagnostic", {
+      textDocument: { uri }
+    }
+
+    assert.equal report.kind, "full", "expected a full document diagnostic report"
+    assert report.items.some((d: any) => d.severity is 1),
+      `expected a TypeScript error in the pull report, got ${JSON.stringify report.items}`
+
+  it "returns an empty report for an empty document (no transpiler meta yet)", ->
+    // An empty .civet source produces no snapshot/meta, so computeDiagnostics
+    // hits the `no transpiledDoc` guard. Exercises that branch for real.
+    uri := docUri path.join(projectRoot, "proto-empty.civet")
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text: '' }
+    }
+    report := await client.request "textDocument/diagnostic", {
+      textDocument: { uri }
+    }
+    assert.equal report.kind, "full"
+    assert.equal report.items.length, 0
+
+  it "returns an empty full report when pulling on an unopened document", ->
+    // No didOpen: the server has no content to analyze, so it answers with a
+    // valid (empty) full report rather than erroring.
+    uri := docUri path.join(projectRoot, "proto-pull-unopened.civet")
+    report := await client.request "textDocument/diagnostic", {
+      textDocument: { uri }
+    }
+    assert.equal report.kind, "full"
+    assert.equal report.items.length, 0
+
+  it "reflects edits synchronously via textDocument/diagnostic (pull)", ->
+    // The core fix: a pull request recomputes against the current document
+    // state at request time, so an edit is reflected on the very next pull
+    // without racing the debounced push pipeline.
+    pullPath := path.join(projectRoot, "proto-pull-edit.civet")
+    uri := docUri pullPath
+
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text: 'x := 1' }
+    }
+    clean := await client.request "textDocument/diagnostic", { textDocument: { uri } }
+    assert.equal clean.items.filter((d: any) => d.severity is 1).length, 0,
+      `expected no errors for clean text, got ${JSON.stringify clean.items}`
+
+    client.notify "textDocument/didChange", {
+      textDocument: { uri, version: 2 }
+      contentChanges: [{ text: 'x: number := "nope"' }]
+    }
+    errored := await client.request "textDocument/diagnostic", { textDocument: { uri } }
+    assert errored.items.some((d: any) => d.severity is 1),
+      "expected the pull to reflect the edit's type error immediately"
+
   // Runs last: attaches a persistent `on` handler for publishDiagnostics that
   // only filters on its own (proto-race) uri, so even if the handler stays
   // installed past this test it's inert for later suites.


### PR DESCRIPTION
## Cause

The Civet LSP only *pushes* diagnostics (`publishDiagnostics`). Clients that prefer the LSP 3.17 **pull model** — notably the `mcp-language-server` bridge used for agent workflows — get no `diagnosticProvider`, so they fall back to a cache of the last push. That cache lags the debounced push pipeline (and isn't republished for unopened consumer files), which is why MCP diagnostics didn't refresh on edits.

## Approach

- Advertise a `diagnosticProvider` capability (`interFileDependencies: true` — our results depend on other files via cross-file TS types).
- Handle `textDocument/diagnostic` by computing against the **current** document at request time, so an edit is reflected on the very next pull with no push race. Push still coexists for live editors (VS Code).
- Extract `computeDiagnosticsForDoc`, shared by the push path and the pull handler.

Tests cover the full report, synchronous edit reflection, the unopened-document case, and an empty-document case (which exercises the no-snapshot guard for real rather than relying on it being unreachable).

Bridge-side counterpart: STRd6/mcp-language-server#1 consumes the pull results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)