### PR TITLE
parser: `$loc` for postfix-conditional consequent braces

### DIFF
--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -199,9 +199,22 @@ function addPostfixStatement(statement: ASTNode, ws: ASTNode, post: IterationSta
     ["", statement]
   ]
 
+  // Give the synthetic opening brace the consequent's leading $loc. The
+  // generated `if (!c) { stmt }` is single-line, so without a located `{`
+  // the brace has no source mapping and collapses onto the condition —
+  // which makes branch-coverage tools (c8) attribute the consequent arm to
+  // the condition, hiding the gap. Falls back to a bare string when the
+  // statement has no located leaf.
+  located := gatherRecursive(statement, (n) => "$loc" in n).0
+  open: ASTNode :=
+    if located and "$loc" in located and located.$loc
+      { $loc: located.$loc, token: " { " }
+    else
+      " { "
+
   block := makeNode {
     type: "BlockStatement"
-    children: [" { ", expressions, " }"]
+    children: [open, expressions, " }"]
     expressions
     bare: false
   }

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -3,9 +3,35 @@ assert from assert
 
 { SourceMap, base64Encode, decodeVLQ } from ../source/sourcemap.civet
 { remapPosition } from ../source/ts-diagnostic.civet
+{ TraceMap, originalPositionFor } from @jridgewell/trace-mapping
 { transform } from esbuild
 
 describe "source map", ->
+  it "maps a postfix-conditional consequent's opening brace to the consequent", ->
+    // `return 1 unless y` compiles to a single-line `if (!y) { return 1 }`.
+    // The synthetic `{` must carry the consequent's source position; without
+    // it the brace has no mapping and branch-coverage tools (c8) attribute the
+    // never-taken arm to the condition, hiding the gap. Checked via
+    // originalPositionFor — the same lookup v8-to-istanbul/c8 use (the segment
+    // with the greatest generated column <= the query, no interpolation).
+    src := "f := (y) ->\n  return 1 unless y\n  2\n"
+    { code, sourceMap } := await compile src,
+      sourceMap: true
+      filename: "x.civet"
+    genLines := code.split "\n"
+    gl := genLines.findIndex (l) => l.includes "{ return"
+    assert gl >= 0, `expected an inline consequent block in:\n${code}`
+    braceCol := genLines[gl]!.indexOf "{"
+
+    tracer := new TraceMap sourceMap.json("x.tsx")
+    // trace-mapping: 1-based line, 0-based column.
+    pos := originalPositionFor tracer, { line: gl + 1, column: braceCol }
+    // The consequent `return 1` is at source line 2 (1-based), column 2.
+    assert.equal pos.line, 2,
+      `expected consequent brace to map to source line 2, got ${JSON.stringify pos}`
+    assert.equal pos.column, 2,
+      `expected consequent brace to map to the consequent at column 2, got ${JSON.stringify pos}`
+
   it "should parse from base64Encoded", ->
     src := """
       x := a + 3


### PR DESCRIPTION
## Cause

A postfix `stmt unless cond` (or `if`/`while`/`for`) compiles to a single-line `if (!cond) { stmt }`. The synthetic opening brace was a bare string with no `$loc`, so it produced no sourcemap entry. Branch-coverage tools (c8 / v8-to-istanbul, via `originalPositionFor`) resolve the consequent block's start to the nearest mapped position — which, with no brace mapping, is the condition. The never-taken arm gets attributed to the condition, silently **hiding untested branches** (e.g. a `return [] unless x` guard whose `x`-falsy arm no test exercises reads as covered).

## Approach

Give the synthetic `{` the consequent statement's leading `$loc` so the block maps to its own source position, distinct from the condition. Falls back to a bare string when the statement has no located leaf.

Generated output **text is unchanged** (only sourcemap metadata changes) — the full suite passes. New test asserts the brace maps to the consequent via `originalPositionFor`, the exact lookup c8 uses; it's red without the fix (the brace has no mapping at all).

Surfaced while investigating why an LSP guard's branch read as covered (DanielXMoore/Civet#2133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)