### PR TITLE
docs: coverage mechanics guide for agents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,12 @@ return defaults if value is null
 The `-- <why>` part is required so the next reader can judge whether the
 ignore should be replaced with a test.
 
+Before reasoning about *why* something is or isn't covered — branch vs
+statement coverage, single-line conditionals, or whether a compiler change
+moves coverage — read [`notes/coverage-mechanics.md`](notes/coverage-mechanics.md).
+Verify claims against c8 output (`coverage/coverage-final.json`), not sourcemap
+segments or `remapPosition`.
+
 ### "Works locally, fails on CI" coverage divergence
 
 GitHub Actions on `pull_request` builds the **merge of HEAD onto base**, not

--- a/notes/coverage-mechanics.md
+++ b/notes/coverage-mechanics.md
@@ -20,9 +20,11 @@ reporting the branch correctly all along.
 - The **register hook** (`build/register.js` → `build/cache-utils.js`) compiles
   `.civet`/`.hera` at test time with the package resolved from
   `./node_modules/@danielx/civet` — a pnpm symlink to the **installed previous
-  release**, NOT your `dist/` build. So a change to `source/parser/**` does
-  **not** affect the sourcemaps c8 sees for `source/**` in root coverage until
-  it's released and the dep is bumped.
+  release** of the compiler, NOT your `dist/` build. Coverage still measures
+  your **current source** (that's what gets compiled and run); what lags is the
+  *compiler*. So a change to how `source/parser/**` emits code or sourcemaps
+  won't affect the maps c8 sees for `source/**` in root coverage until that
+  change is released and the dep is bumped.
 - `lsp/server` is the exception: its build uses `../../dist/civet` (your build),
   so compiler changes *do* affect lsp/server coverage.
 - To run your **local** compiler through the register hook (e.g. to test a
@@ -55,7 +57,7 @@ A postfix `stmt unless cond` (also `if`/`while`/`for`) compiles to a single-line
 - Net for the 100% gate: an untested single-line consequent **passes**
   statement/line coverage but **fails** branch coverage. To satisfy the gate,
   either test the arm, or — for a genuinely unreachable defensive arm —
-  `/* c8 ignore … -- why */` it (see CLAUDE.md → Coverage).
+  `/* c8 ignore … -- why */` it (see CONTRIBUTING.md → Coverage).
 
 ## Verifying whether a *compiler* change affects coverage
 

--- a/notes/coverage-mechanics.md
+++ b/notes/coverage-mechanics.md
@@ -12,11 +12,8 @@ reporting the branch correctly all along.
   at 100% on statements / branches / functions / lines (see
   `scripts/coverage-check.civet`). It is a global sum, not per-file — a few
   uncovered lines anywhere fail it.
-- Locally the gate is polluted by `.claude/worktrees/**` and
-  `lsp/zed/grammars/**` copies (near-0% coverage) that don't exist in CI's clean
-  checkout. **Don't trust the local pass/fail.** To judge one file, read its
-  entry in `coverage/coverage-final.json` directly (per-file `s`/`b`/`f` hit
-  maps) rather than the aggregate result.
+- To judge a single file, read its entry in `coverage/coverage-final.json`
+  directly (per-file `s`/`b`/`f` hit maps) rather than the aggregate pass/fail.
 
 ## Which compiler compiles what (this is the subtle one)
 

--- a/notes/coverage-mechanics.md
+++ b/notes/coverage-mechanics.md
@@ -1,0 +1,78 @@
+# Coverage mechanics — how c8 actually sees Civet code
+
+Hard-won facts. Check these before claiming a coverage gap is (or isn't) real.
+The trap that motivated this doc: assuming a single-line conditional "hides" a
+branch from c8, "fixing" it in the compiler, and only later discovering c8 was
+reporting the branch correctly all along.
+
+## The gate
+
+- `pnpm coverage` runs all three suites (root + `lsp/server` + `lsp/vscode` e2e)
+  and merges to `coverage/`. `pnpm coverage:check` gates the **summed** totals
+  at 100% on statements / branches / functions / lines (see
+  `scripts/coverage-check.civet`). It is a global sum, not per-file — a few
+  uncovered lines anywhere fail it.
+- Locally the gate is polluted by `.claude/worktrees/**` and
+  `lsp/zed/grammars/**` copies (near-0% coverage) that don't exist in CI's clean
+  checkout. **Don't trust the local pass/fail.** To judge one file, read its
+  entry in `coverage/coverage-final.json` directly (per-file `s`/`b`/`f` hit
+  maps) rather than the aggregate result.
+
+## Which compiler compiles what (this is the subtle one)
+
+- The **register hook** (`build/register.js` → `build/cache-utils.js`) compiles
+  `.civet`/`.hera` at test time with the package resolved from
+  `./node_modules/@danielx/civet` — a pnpm symlink to the **installed previous
+  release**, NOT your `dist/` build. So a change to `source/parser/**` does
+  **not** affect the sourcemaps c8 sees for `source/**` in root coverage until
+  it's released and the dep is bumped.
+- `lsp/server` is the exception: its build uses `../../dist/civet` (your build),
+  so compiler changes *do* affect lsp/server coverage.
+- To run your **local** compiler through the register hook (e.g. to test a
+  compiler change against coverage): `CIVET_SOURCE=./dist/main.js`.
+
+## How c8 reads sourcemaps — and why `remapPosition` lies about it
+
+- c8 / v8-to-istanbul map generated positions to source with
+  `@jridgewell/trace-mapping`'s `originalPositionFor`: the mapping segment with
+  the **greatest generated column ≤ the query**, no interpolation.
+- Civet's own `remapPosition` (`source/ts-diagnostic.civet`) is **different** —
+  it interpolates and may pick the segment at/after the column. Do **not** use
+  it to predict what c8 will report. If you want to know where c8 lands a
+  position, use `originalPositionFor` (it's a devDependency).
+
+## Branch vs statement/line coverage for single-line conditionals
+
+A postfix `stmt unless cond` (also `if`/`while`/`for`) compiles to a single-line
+`if (!cond) { stmt }`.
+
+- **Branch coverage already works.** c8 reports the consequent arm as *missed*
+  when `cond` is never falsy. v8-to-istanbul derives the branch from the
+  consequent's inner statement, independent of the synthetic brace's `$loc`.
+  Adding a `$loc` to the generated `{` does **not** change c8 output (verified:
+  byte-identical `coverage-final.json` with and without).
+- **Statement/line coverage does *not* flag it.** The single-line consequent's
+  statement is attributed to the (covered) condition line, so it reads as hit
+  even when never executed. Writing the consequent on its **own line**
+  (multi-line block) makes that line show up as an uncovered statement.
+- Net for the 100% gate: an untested single-line consequent **passes**
+  statement/line coverage but **fails** branch coverage. To satisfy the gate,
+  either test the arm, or — for a genuinely unreachable defensive arm —
+  `/* c8 ignore … -- why */` it (see CLAUDE.md → Coverage).
+
+## Verifying whether a *compiler* change affects coverage
+
+Reason from c8 output, never from sourcemap segments alone. Compile the same
+fixture with the old and new `dist/civet` and diff the c8 result:
+
+```bash
+# 1. fixture with an untested arm
+printf 'export f := (y) ->\n  return 0 unless y\n  y * 2\n' > /tmp/g.civet
+# 2. compile + run under c8 with each compiler (or via the register hook with
+#    CIVET_SOURCE=./dist/main.js), then diff the per-file s/b/f maps in
+#    coverage-final.json. Identical maps ⇒ the change is coverage-neutral.
+```
+
+A synthetic-brace `$loc` is at most a sourcemap-*accuracy* improvement (helps
+`remapPosition`-based LSP features like hover at that column); it is **not** a
+coverage fix.


### PR DESCRIPTION
Adds `notes/coverage-mechanics.md` (linked from CONTRIBUTING.md → Coverage) documenting how c8 actually sees Civet code, to prevent the misdiagnosis that just happened in a session:

- Branch coverage of single-line conditionals already works; a synthetic brace's `$loc` does **not** change c8 output (verified byte-identical). The "hiding" people notice is *statement/line* coverage attributing a single-line consequent to the condition line — a different thing.
- The register hook compiles `.civet` with the **installed** `@danielx/civet`, not `dist/` (use `CIVET_SOURCE=./dist/main.js` to test a local compiler); `lsp/server` is the exception (uses `../../dist/civet`).
- c8 reads maps via `originalPositionFor` (greatest genCol ≤ query, no interpolation), which differs from Civet's interpolating `remapPosition` — don't use the latter to predict c8.
- To check whether a compiler change moves coverage, diff c8 output, not sourcemap segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)