### PR TITLE
coverage: exclude sibling git worktrees from the gate

### DIFF
--- a/scripts/coverage-check.civet
+++ b/scripts/coverage-check.civet
@@ -72,6 +72,10 @@ try
     '--extension', '.ts'
     '--include', '**/source/ts-service/**'
     '--exclude', '**/node_modules/**'
+    // Same rationale as coverage-merge.civet: keep sibling worktree copies and
+    // the vendored zed grammar out of the on-demand ts-service report.
+    '--exclude', '**/.claude/**'
+    '--exclude', '**/lsp/zed/grammars/**'
   ], { cwd: root, stdio: ['ignore', 'ignore', 'inherit'] }
 catch
   console.error `Coverage gate failed: c8 could not build the ts-service report (see c8 output above).`

--- a/scripts/coverage-merge.civet
+++ b/scripts/coverage-merge.civet
@@ -90,6 +90,10 @@ execFileSync process.execPath, [
   '--exclude', '**/lsp/server/source/browser.civet'
   '--exclude', '**/integration/**'
   '--exclude', '**/lsp/zed/grammars/**'
+  // Sibling git worktrees under .claude/worktrees/** are full repo copies;
+  // their source/** matches the includes above and pollutes the local total
+  // (CI's clean checkout has no .claude/). Exclude so the gate reflects reality.
+  '--exclude', '**/.claude/**'
   // ts-service is gated separately from root coverage only (see
   // scripts/coverage-check.civet). Three different compilations of the
   // same source — standalone .civet load + dist/ts-service/index.{js,mjs}


### PR DESCRIPTION
## Cause

The merged-report and on-demand ts-service `c8 report` invocations use `--include '**/source/**'` (and `**/lsp/*/source/**`). The leading `**/` also matches `.claude/worktrees/*/source/**` — git worktrees are full repo copies. With temp profiles that reference them, **168 duplicate, near-0%-coverage files** get pulled into the local total, dragging `coverage:check` far below 100%. CI's clean checkout has no `.claude/`, so this only bites locally (and made the local gate effectively unusable for judging real coverage).

## Fix

Add `--exclude '**/.claude/**'` to the merge (`scripts/coverage-merge.civet`) and the ts-service report (`scripts/coverage-check.civet`), plus `**/lsp/zed/grammars/**` to the latter so it matches the merge's existing exclude.

After: merged report drops from 224 → 56 files (0 worktree, 0 zed), and `coverage:check` passes locally (`100% statements / branches / functions / lines`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)