### PR TITLE
LSP: grammar-level folding and selection ranges for `.hera`

### DIFF
--- a/lsp/server/source/lib/hera-analyzer.civet
+++ b/lsp/server/source/lib/hera-analyzer.civet
@@ -10,9 +10,13 @@
   type CompletionItem
   CompletionItemKind
   type DocumentSymbol
+  type FoldingRange
+  FoldingRangeKind
   type Hover
   type Location
   MarkupKind
+  type Range
+  type SelectionRange
   SymbolKind
 } from vscode-languageserver
 
@@ -208,6 +212,46 @@ export function getHoverFor(doc: TextDocument, pos: Position): Hover?
 /** The cached outline for `doc`. */
 export function getDocumentSymbols(doc: TextDocument): DocumentSymbol[]?
   symbolsCache.get doc.uri
+
+/** One fold per grammar rule (name line → last body line) from the cached
+    rule symbols, so folds stay in grammar coordinates — unlike the TS-outline
+    path, which folds the transpiled parser and remaps out of range. */
+export function getFoldingRanges(doc: TextDocument): FoldingRange[]?
+  syms := symbolsCache.get doc.uri
+  return undefined unless syms
+  folds: FoldingRange[] := []
+  for sym of syms
+    startLine := sym.range.start.line
+    { line: endLine, character: endChar } := sym.range.end
+    // Range end is exclusive: char 0 ⇒ content ends on the previous line (next
+    // rule's header / trailing blank); non-zero ⇒ on range.end.line itself
+    // (last rule, no trailing newline).
+    lastLine := endChar is 0 ? endLine - 1 : endLine
+    /* c8 ignore next -- defensive: a parsed rule spans >= 2 lines, so this never trips */
+    continue unless lastLine > startLine
+    folds.push { startLine, endLine: lastLine, kind: FoldingRangeKind.Region }
+  folds
+
+/** Whether `pos` is inside `range` (start-inclusive, end-exclusive), by offset. */
+function rangeContains(doc: TextDocument, range: Range, pos: Position): boolean
+  offset := doc.offsetAt pos
+  offset >= doc.offsetAt(range.start) and offset < doc.offsetAt(range.end)
+
+/** Grammar-level selection for `pos`: widen terminal → rule → file from the
+    cached rule symbols.  Undefined when `pos` is in no rule, so the caller can
+    fall back. */
+export function getSelectionRange(doc: TextDocument, pos: Position): SelectionRange?
+  syms := symbolsCache.get doc.uri
+  return undefined unless syms
+  rule := syms.find (s) => rangeContains doc, s.range, pos
+  return undefined unless rule
+  fileSel: SelectionRange :=
+    range:
+      start: { line: 0, character: 0 }
+      end: doc.positionAt doc.getText()#
+  ruleSel: SelectionRange := { range: rule.range, parent: fileSel }
+  child := rule.children?.find (c) => rangeContains doc, c.range, pos
+  child ? { range: child.range, parent: ruleSel } : ruleSel
 
 /** Rule-name completions; each carries `{ hera, uri }` so resolveHeraCompletion
     can attach rule-body docs lazily. */

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -62,8 +62,10 @@
   getCompletionsFor as heraCompletionsFor
   getDeclarationFor as heraDeclarationFor
   getDocumentSymbols as heraDocumentSymbols
+  getFoldingRanges as heraFoldingRanges
   getHoverFor as heraHoverFor
   getReferencesFor as heraReferencesFor
+  getSelectionRange as heraSelectionRange
   isAtGrammarLevel as isHeraGrammarLevel
   parseHeraDocument
   resolveHeraCompletion
@@ -1163,6 +1165,16 @@ export function startServer(connection: Connection, dependencies: ServerDependen
   connection.onFoldingRanges ({ textDocument }) =>
     sourcePath := documentToSourcePath(textDocument)
     assert sourcePath
+
+    // .hera folds wrap grammar rules; the transpiled path folds the generated
+    // parser and remaps out of the source's coordinate space.
+    if textDocument.uri.endsWith('.hera')
+      doc := documents.get(textDocument.uri)
+      if doc
+        await updating(textDocument)
+        if folds := heraFoldingRanges(doc)
+          return folds
+
     service := await ensureServiceForSourcePath(sourcePath)
     await updating(textDocument)
 
@@ -1202,6 +1214,17 @@ export function startServer(connection: Connection, dependencies: ServerDependen
   connection.onSelectionRanges ({ textDocument, positions }) =>
     sourcePath := documentToSourcePath(textDocument)
     assert sourcePath
+
+    // .hera selections widen terminal → rule → file in grammar coordinates.
+    // Gate on the grammar having parsed; fall back per out-of-rule position.
+    if textDocument.uri.endsWith('.hera')
+      doc := documents.get(textDocument.uri)
+      if doc
+        await updating(textDocument)
+        if heraDocumentSymbols(doc)
+          return positions.map (pos) =>
+            heraSelectionRange(doc, pos) ?? { range: { start: pos, end: pos } }
+
     service := await ensureServiceForSourcePath(sourcePath)
     await updating(textDocument)
 

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -10,7 +10,7 @@
 
 { spawnLspServer, docUri, type LspClient } from ./lsp-harness.civet
 { getCanonicalFileName } from ../source/lib/util.civet
-{ isAtGrammarLevel, parseHeraDocument, getHoverFor } from ../source/lib/hera-analyzer.civet
+{ isAtGrammarLevel, parseHeraDocument, getHoverFor, getFoldingRanges as heraFoldingRanges, getSelectionRange as heraSelectionRange } from ../source/lib/hera-analyzer.civet
 { TextDocument } from vscode-languageserver-textdocument
 { URI } from vscode-uri
 path from node:path
@@ -1474,6 +1474,61 @@ describe "LSP features (shared project server)", ->
       // swallows it (keeping prior caches) and diagnostics still publish.
       await openHera "hera-broken.hera", "@@@@@\n"
 
+    it "folding ranges wrap each grammar rule and stay in source bounds", ->
+      // No trailing newline so the last rule's body sits *on* range.end.line
+      // (non-zero end character) — exercises both arms of the end-line clamp.
+      foldText := "Start\n  A B\n\nA\n  \"a\"\n\nB\n  \"b\""
+      uri := await openHera "hera-fold.hera", foldText
+      lineCount := foldText.split('\n')#
+
+      folds := await client.request "textDocument/foldingRange", {
+        textDocument: { uri }
+      }
+      assert Array.isArray(folds), "expected folding array, got " + JSON.stringify(folds)
+      // One fold per rule (Start, A, B), each spanning >= 1 line and — the
+      // regression guard — never past the document's last line.
+      assert.equal folds.length, 3, "expected one fold per rule, got " + JSON.stringify(folds)
+      for f of folds as any[]
+        assert f.startLine < f.endLine, "fold must span >= 1 line: " + JSON.stringify(f)
+        assert f.endLine < lineCount, `fold endLine ${f.endLine} exceeds source line count ${lineCount}`
+      starts := (folds as any[]).map (f) => f.startLine
+      assert.deepEqual starts, [0, 3, 6], "folds should start at each rule's name line"
+      // B is the last rule with content on its final line (no trailing blank).
+      bFold := (folds as any[]).find (f) => f.startLine is 6
+      assert.equal bFold.endLine, 7, "last rule's fold should reach its body line"
+
+    it "selection ranges widen terminal → rule → file", ->
+      uri := await openHera "hera-sel.hera"
+
+      result := await client.request "textDocument/selectionRange", {
+        textDocument: { uri }
+        positions: [
+          { line: 4, character: 11 }  // inside the `Name` reference in Greeting
+          { line: 6, character: 2 }   // on the `Name` rule's own name
+          { line: 99, character: 0 }  // past EOF — outside every rule
+        ]
+      }
+      assert Array.isArray(result) and result.length is 3, "expected 3 selection entries, got " + JSON.stringify(result)
+
+      // Terminal click: innermost = the token, then its rule (Greeting, line 3),
+      // then the whole file (line 0).
+      term := result[0]
+      assert.equal term.range.start.line, 4, "innermost should be the clicked terminal"
+      assert.equal term.parent.range.start.line, 3, "parent should be the Greeting rule"
+      assert.equal term.parent.parent.range.start.line, 0, "outer should be the whole file"
+      assert not term.parent.parent.parent, "file is the outermost range"
+
+      // Rule-name click: no enclosing terminal, so widen straight to rule → file.
+      ruleSel := result[1]
+      assert.equal ruleSel.range.start.line, 6, "should select the Name rule"
+      assert.equal ruleSel.parent.range.start.line, 0, "parent should be the whole file"
+      assert not ruleSel.parent.parent, "rule's parent is the file"
+
+      // Outside every rule: server falls back to a degenerate range at the position.
+      fallback := result[2]
+      assert.equal fallback.range.start.line, fallback.range.end.line, "fallback collapses to a point"
+      assert not fallback.parent, "fallback has no parent"
+
 // Tests below each need their own workspace / tsconfig / initialize, so they
 // spawn a dedicated server per test.  Keep this set small.
 describe "LSP features (isolated workspaces)", ->
@@ -1748,3 +1803,11 @@ describe "parseHeraDocument", ->
     doc := TextDocument.create("file:///no-hera.hera", "hera", 1, "Rule\n  \"x\"\n")
     parseHeraDocument doc, undefined
     assert.equal getHoverFor(doc, { line: 0, character: 0 }), undefined
+
+  it "folding and selection ranges return undefined without a symbol cache", ->
+    // No parse ran for this uri, so the analyzer has no rule spans and must
+    // signal "no answer" (undefined) so the caller falls through to the TS
+    // service instead of fabricating ranges.
+    doc := TextDocument.create("file:///unparsed.hera", "hera", 1, "Rule\n  \"x\"\n")
+    assert.equal heraFoldingRanges(doc), undefined
+    assert.equal heraSelectionRange(doc, { line: 1, character: 2 }), undefined

--- a/lsp/vscode/CHANGELOG.md
+++ b/lsp/vscode/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Civet VS Code Extension Changelog
 
+## Unreleased
+* LSP: grammar-level folding and selection ranges for `.hera`, fixing folds that landed in the transpiled parser's coordinates (past the source's last line)
+
 ## 0.3.38 (2026-05-29)
 * LSP: Hera-aware grammar-level features for `.hera` — go-to-definition, references, outline, completions, and hover for grammar rules [[#2127](https://github.com/DanielXMoore/Civet/pull/2127)]
 * Syntax highlighting for `.hera` grammar files (handler bodies highlighted as Civet)


### PR DESCRIPTION
`textDocument/foldingRange` on a `.hera` file returned fold ranges in the **transpiled parser's** coordinate space — for a 10-line grammar the server returned folds like `L1-25, L27-43, L48-51, L76-79`, lines that don't exist in the source. `textDocument/selectionRange` had the same gap.

## Cause

`onFoldingRanges` and `onSelectionRanges` had no `.hera` branch, so they took the generic transpiled path: TS outlining / smart-selection on the *generated parser*, then `remapPosition` back through the composed Hera→Civet→TS sourcemap. For synthetic parser regions that remap lands at arbitrary positions, which can exceed the source line count. Every other position/range handler (`onHover`, `onDefinition`, `onDocumentSymbol`, …) already special-cases `.hera`.

## Approach

Add `getFoldingRanges` / `getSelectionRange` to the Hera analyzer, backed by the already-cached rule symbols (no re-parse). Both server handlers now short-circuit for `.hera` using the same `uri.endsWith('.hera')` model as `onDocumentSymbol`:

- **Folding** — one fold per rule, name line → last body line. End line is derived from the symbol range's exclusive end (char 0 ⇒ `endLine - 1`; non-zero ⇒ `endLine`, covering a last rule with no trailing newline).
- **Selection** — widens terminal → rule → file in grammar coordinates; falls back to a degenerate range per position outside any rule, keeping the response 1:1 with `positions`.

Tests assert the regression guard (every fold's `endLine` stays within the document), both end-line arms, the selection chain, and the no-symbol-cache fall-through.