### PR TITLE
feat: allow yield in fat-arrow functions (#2140)

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1233,6 +1233,70 @@ function findSuperCall(block: BlockStatement): number
   else
     -1
 
+/**
+ * Convert an arrow function whose body contains `yield` into a generator
+ * function expression, wrapped with `.bind(this)` so that `this` references
+ * inside the body still refer to the enclosing scope's `this` (matching the
+ * lexical-`this` semantics of the original arrow function).
+ *
+ * Issue #2140 / TC39 proposal for arrow generators.
+ *
+ *   => yield @x
+ *   ↓↓↓
+ *   (function*() { return (yield this.x) }).bind(this)
+ */
+function transformArrowFunctionWithYield(f: any): void
+  { block, parameters, returnType, async, signature } := f
+
+  // Preserve arrow's implicit-return semantics: if the body is a bare
+  // expression (`=> X`), insert an explicit return so the value still flows
+  // out as the generator's return value (matching TC39's proposal).
+  if block?.type is "BlockStatement" and block.implicitlyReturned
+    insertReturn block
+    block.implicitlyReturned = false
+
+  // Brace the block (it may have been bare for a single-expression body).
+  if block?.type is "BlockStatement" and block.bare and not block.root
+    block.children.unshift " {"
+    block.children.push "}"
+    block.bare = false
+
+  // Mark as generator and build new children using `function*` syntax
+  // instead of `=>`.
+  generator := ["*"]
+  signature.modifier ??= {}
+  signature.modifier.generator = true
+  signature.generator = generator
+  signature.children = [async, "function", generator, parameters, returnType]
+
+  f.type = "FunctionExpression"
+  f.generator = generator
+  f.children = [async, "function", generator, parameters, returnType, block]
+
+  // FunctionExpression at expression position needs parentheses (otherwise
+  // it would parse as a function declaration). If `this` is referenced
+  // lexically inside the original arrow body, additionally wrap with
+  // `.bind(this)` so the bound generator's `this` matches the enclosing
+  // scope (as the arrow promised).
+  // Capture the original parent BEFORE wrapping: makeLeftHandSideExpression
+  // invokes makeNode → updateParentPointers, which reassigns `f.parent` to
+  // the new ParenthesizedExpression. If we then asked replaceNode to use
+  // `f.parent`, we'd swap `f` for `newNode` inside `newNode` itself —
+  // producing a self-cycle.
+  originalParent := f.parent as ASTNodeObject?
+  lhs := makeLeftHandSideExpression f
+  newNode := if gatherRecursiveWithinFunction(block, (is like { token: "this" }))#
+    makeNode {
+      type: "CallExpression"
+      children: [lhs, ".bind(this)"]
+    }
+  else
+    lhs
+
+  if newNode !== f and originalParent?
+    replaceNode f, newNode, originalParent
+    updateParentPointers newNode, originalParent
+
 function processSignature(f: FunctionNode): void
   {block, signature} := f
 
@@ -1252,13 +1316,17 @@ function processSignature(f: FunctionNode): void
   if not f.generator?# and hasYield(block)
     if f.generator?
       addGenerator = true
+    else if f.type is "ArrowFunction"
+      // Allow `yield` inside `=>` arrow functions by transforming the arrow
+      // into a generator function expression bound to `this`.
+      transformArrowFunctionWithYield f
     else
       for each y of gatherRecursiveWithinFunction block, .type is "YieldExpression"
         i := y.children.findIndex (&: any).type is "Yield"
         // i+1 because after "yield" we have a consistent location in sourcemap
         y.children.splice i+1, 0,
           type: "Error"
-          message: `yield invalid in ${f.type is "ArrowFunction" ? "=> arrow function" : signature.modifier.get ? "getter" : signature.modifier.set ? "setter" : signature.name}` // name likely constructor
+          message: `yield invalid in ${signature.modifier.get ? "getter" : signature.modifier.set ? "setter" : signature.name}` // name likely constructor
 
   for each overload of [f, ...precedingOverloads f]
     if addAsync and overload.async? and not overload.async#

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -6,6 +6,7 @@ import type {
   ASTLeaf
   ASTNode
   ASTNodeObject
+  ASTNodeParent
   ASTRef
   AtBindingProperty
   Binding
@@ -1258,7 +1259,7 @@ function transformArrowFunctionWithYield(f: any): void
 
   // Capture parent before makeLeftHandSideExpression reassigns f.parent,
   // else replaceNode would swap f inside newNode itself (self-cycle).
-  originalParent := f.parent as ASTNodeObject?
+  originalParent := f.parent as ASTNodeParent?
   lhs := makeLeftHandSideExpression f
   newNode := if gatherRecursiveWithinFunction(block, (is like { token: "this" }))#
     makeNode {

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1233,36 +1233,19 @@ function findSuperCall(block: BlockStatement): number
   else
     -1
 
-/**
- * Convert an arrow function whose body contains `yield` into a generator
- * function expression, wrapped with `.bind(this)` so that `this` references
- * inside the body still refer to the enclosing scope's `this` (matching the
- * lexical-`this` semantics of the original arrow function).
- *
- * Issue #2140 / TC39 proposal for arrow generators.
- *
- *   => yield @x
- *   ↓↓↓
- *   (function*() { return (yield this.x) }).bind(this)
- */
+// `=> yield x` → `(function*() {return yield x})`, `.bind(this)` if uses `this`
 function transformArrowFunctionWithYield(f: any): void
   { block, parameters, returnType, async, signature } := f
 
-  // Preserve arrow's implicit-return semantics: if the body is a bare
-  // expression (`=> X`), insert an explicit return so the value still flows
-  // out as the generator's return value (matching TC39's proposal).
   if block?.type is "BlockStatement" and block.implicitlyReturned
     insertReturn block
     block.implicitlyReturned = false
 
-  // Brace the block (it may have been bare for a single-expression body).
   if block?.type is "BlockStatement" and block.bare and not block.root
     block.children.unshift " {"
     block.children.push "}"
     block.bare = false
 
-  // Mark as generator and build new children using `function*` syntax
-  // instead of `=>`.
   generator := ["*"]
   signature.modifier ??= {}
   signature.modifier.generator = true
@@ -1273,16 +1256,8 @@ function transformArrowFunctionWithYield(f: any): void
   f.generator = generator
   f.children = [async, "function", generator, parameters, returnType, block]
 
-  // FunctionExpression at expression position needs parentheses (otherwise
-  // it would parse as a function declaration). If `this` is referenced
-  // lexically inside the original arrow body, additionally wrap with
-  // `.bind(this)` so the bound generator's `this` matches the enclosing
-  // scope (as the arrow promised).
-  // Capture the original parent BEFORE wrapping: makeLeftHandSideExpression
-  // invokes makeNode → updateParentPointers, which reassigns `f.parent` to
-  // the new ParenthesizedExpression. If we then asked replaceNode to use
-  // `f.parent`, we'd swap `f` for `newNode` inside `newNode` itself —
-  // producing a self-cycle.
+  // Capture parent before makeLeftHandSideExpression reassigns f.parent,
+  // else replaceNode would swap f inside newNode itself (self-cycle).
   originalParent := f.parent as ASTNodeObject?
   lhs := makeLeftHandSideExpression f
   newNode := if gatherRecursiveWithinFunction(block, (is like { token: "this" }))#
@@ -1317,8 +1292,6 @@ function processSignature(f: FunctionNode): void
     if f.generator?
       addGenerator = true
     else if f.type is "ArrowFunction"
-      // Allow `yield` inside `=>` arrow functions by transforming the arrow
-      // into a generator function expression bound to `this`.
       transformArrowFunctionWithYield f
     else
       for each y of gatherRecursiveWithinFunction block, .type is "YieldExpression"

--- a/test/function.civet
+++ b/test/function.civet
@@ -283,31 +283,33 @@ describe "function", ->
       })
     """
 
-    throws """
-      yield forbidden within thick arrow
+    testCase """
+      yield within thick arrow becomes bound generator
       ---
       => yield 5
       ---
-      ParseErrors: unknown:1:9 yield invalid in => arrow function
+      (function*() {return  yield 5})
     """
 
-    throws """
-      yield forbidden within thick arrow, inlineMap
-      ---
-      => yield 5
-      ---
-      ParseErrors: unknown:1:9 yield invalid in => arrow function
-    """, inlineMap: true
-
-    throws """
-      multiple forbidden yield
+    testCase """
+      multiple yields in thick arrow
       ---
       =>
         yield 1
         yield 2
       ---
-      ParseErrors: unknown:2:8 yield invalid in => arrow function
-      unknown:3:8 yield invalid in => arrow function
+      (function*() {
+        yield 1
+        yield 2
+      })
+    """
+
+    testCase """
+      thick arrow generator preserves lexical this via .bind(this)
+      ---
+      => yield @x
+      ---
+      (function*() {return  yield this.x}).bind(this)
     """
 
     testCase """

--- a/test/infra/worker-pool.civet
+++ b/test/infra/worker-pool.civet
@@ -151,7 +151,12 @@ describe "WorkerPool", ->
     @timeout 10000
     pool = new WorkerPool 1
     errors: unknown[] := []
-    await pool.run "compile", "=> yield 5", { errors }
+    src := """
+      class Foo
+        get prop()
+          yield 5
+    """
+    await pool.run "compile", src, { errors }
     assert errors.length > 0, "errors should be populated by worker"
 
   it "terminates worker after job if thread count was reduced while busy", ->

--- a/test/integration.civet
+++ b/test/integration.civet
@@ -44,7 +44,11 @@ describe "integration", ->
 
   it "should return errors via option", ->
     errors: ParseError[] .= []
-    await civetCompile '=> yield 5', {errors}
+    await civetCompile '''
+      class Foo
+        get prop()
+          yield 5
+    ''', {errors}
     assert.equal errors#, 1
 
   it "should build with esbuild plugin and have the correct source map info", ->

--- a/test/yield.civet
+++ b/test/yield.civet
@@ -41,3 +41,87 @@ describe "yield expression", ->
       1+2
     )
   """
+
+describe "yield in arrow function (#2140)", ->
+  testCase """
+    simple thick arrow with yield
+    ---
+    => yield 5
+    ---
+    (function*() {return  yield 5})
+  """
+
+  testCase """
+    thick arrow with yield and this
+    ---
+    => yield @
+    ---
+    (function*() {return  yield this}).bind(this)
+  """
+
+  testCase """
+    thick arrow with yield and @-property
+    ---
+    => yield @x
+    ---
+    (function*() {return  yield this.x}).bind(this)
+  """
+
+  testCase """
+    thick arrow with parameter and yield
+    ---
+    (x) => yield x
+    ---
+    (function*(x) {return  yield x})
+  """
+
+  testCase """
+    thick arrow with multiple yields
+    ---
+    =>
+      yield 1
+      yield 2
+    ---
+    (function*() {
+      yield 1
+      yield 2
+    })
+  """
+
+  testCase """
+    assigned thick arrow generator
+    ---
+    gen := => yield @x
+    ---
+    const gen =(function*() {return  yield this.x}).bind(this)
+  """
+
+  testCase """
+    async thick arrow with yield becomes async generator
+    ---
+    async => yield 42
+    ---
+    (async function*() {return  yield 42})
+  """
+
+  testCase """
+    yield* in thick arrow
+    ---
+    => yield* arr
+    ---
+    (function*() {return  yield* arr})
+  """
+
+  testCase """
+    yield in arrow inside class method preserves this
+    ---
+    class Foo
+      method()
+        gen := => yield @x
+    ---
+    class Foo {
+      method() {
+        const gen =(function*() {return  yield this.x}).bind(this);return gen
+      }
+    }
+  """


### PR DESCRIPTION
Closes #2140.

## Summary

Allows `yield` inside `=>` arrow functions by compiling to a generator function expression bound to the enclosing `this`:

```civet
=> yield @x
###
(function*() {return  yield this.x}).bind(this)
```

When the arrow body doesn't reference `this`, the `.bind(this)` wrapper is omitted.

Implements the feature @edemaine sketched in #2140, matching CoffeeScript 1's `=> yield @` behavior.

## Test plan

- [x] Full test suite passes (4293 passing)
- [x] New tests in `test/yield.civet` cover simple, @-property, parameters, multi-yield, assignment, async, yield*, and class-method cases
- [x] Existing "yield forbidden in arrow" tests updated to expect the new compiled output

🤖 Generated with [Claude Code](https://claude.ai/code)