### PR TITLE
Trailing binary ops and pipelines in braced object literals and globs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  CI_TYPECHECK_MAX_ERRORS: 931
+  CI_TYPECHECK_MAX_ERRORS: 803
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  CI_TYPECHECK_MAX_ERRORS: 802
+  CI_TYPECHECK_MAX_ERRORS: 803
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   API_TOKEN: ${{ secrets.API_TOKEN }}
-  CI_TYPECHECK_MAX_ERRORS: 803
+  CI_TYPECHECK_MAX_ERRORS: 802
 
 jobs:
   build:

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -155,14 +155,17 @@ obj :=
 ### Braced Literals
 
 With braces, the `{x}` shorthand generalizes to any
-sequence of member accesses and/or calls and/or unary operators:
+sequence of member accesses and/or calls and/or unary operators
+and/or trailing binary operators:
 
 <Playground>
 another := {person.name, obj?.c?.x}
 computed := {foo(), bar()}
 named := {lookup[x+y]}
-cast := {value as T}
 bool := {!!available}
+cast := {value as T}
+fallback := {person.name ?? "Anonymous"}
+pipeline := {value |> String}
 </Playground>
 
 To avoid the trailing `}` in a braced object literal, you can use `{}`
@@ -215,6 +218,8 @@ point = data.{x,y}
 point.{x,y} = data
 point3D = { point.{x,y}, z: 0 }
 complex := obj.{x:a, b.c()?.y}
+fallback := obj.{x ?? 0, y ?? 0}
+pipeline := obj.{x |> String, y |> String}
 merged := data.{...global, ...user}
 data.{a, b, ...rest} = result
 </Playground>

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8559,7 +8559,7 @@ TypeDeclaration
       type: "Declaration",
       ts: true,
       children: $0,
-      names: "names" in d ? d.names ?? [] : [],
+      names: "names" in d ? d.names : [],
     }
   ( Export _? )?:export_ ( Declare _? )?:declare TypeDeclarationRest:t ->
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -86,6 +86,7 @@ import type {
   AssignmentExpression,
   ASTNode,
   ASTRef,
+  BinaryOpRHS,
   Binding,
   BindingRestElement,
   BlockStatement,
@@ -731,7 +732,7 @@ BinaryOpNotDedented
   !NewlineBinaryOpAllowed _? -> $2
   NewlineBinaryOpAllowed ( NestedBinaryOpAllowed / !Nested ) NotDedented -> $2
 
-BinaryOpRHS
+BinaryOpRHS ::BinaryOpRHS
   BinaryOpNotDedented:ws1 IsLike:op _?:ws2 PatternExpressionList:patterns ->
     return [ ws1, op, ws2, patterns ]
   # Snug binary ops a+b
@@ -4156,7 +4157,8 @@ PropertyDefinition
   # NOTE: Added `{x.y?.z()}` shorthand for `{z: x.y?.z()}`
   # NOTE: this needs to be at the bottom to prevent shadowing NamedProperty
   # NOTE: Prevent `.x` from expanding to `x: $ => $.x`
-  _?:ws !( EOS / "." ) UnaryOp*:pre CallExpression:value UnaryPostfix?:post ::unknown ->
+  # NOTE: Also allow unary prefix and/or unary/binary/pipeline postfix
+  _?:ws !( EOS / "." ) UnaryOp*:pre CallExpression:value UnaryPostfix?:post BinaryOpRHS*:rhs PipelineExpressionBodySameLine:pipeline ::ASTNode ->
     unless pre# or post
       switch value!.type
         // `{identifier}` remains `{identifier}`, the one shorthand JS supports
@@ -4217,7 +4219,7 @@ PropertyDefinition
     if name[0] is "#" then name = name.slice(1)
 
     // { y? } → { ...((y != null) && {y}) }
-    if not pre# and post?.token is "?" and value!.type is "Identifier"
+    if not (pre# or rhs# or pipeline#) and post?.token is "?" and value!.type is "Identifier"
       dots := { $loc, token: "..." }
       paren := parenthesizeExpression({ children: ["(", value, " != null) && {", name, "}"] })
       return {
@@ -4228,12 +4230,20 @@ PropertyDefinition
         value: paren,
       }
 
+    propValue: ASTNode .= processUnaryExpression pre, value, post
+    if rhs#
+      propValue = processBinaryOpExpression [propValue, rhs] 
+    if pipeline#
+      propValue =
+        type: "PipelineExpression"
+        children: [[], propValue, pipeline]
+
     return {
       type: "Property",
-      children: [ws, name, ": ", processUnaryExpression(pre, value, post)],
+      children: [ws, name, ": ", propValue],
       name,
       names: [],
-      value,
+      value: propValue,
       implicitName: true,
     }
   # NOTE: basic identifiers are now part of the rule above

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -84,8 +84,10 @@ import type {
   ArrayBindingPattern,
   ArrowFunction,
   AssignmentExpression,
+  ASTError,
   ASTNode,
   ASTRef,
+  BinaryOp,
   BinaryOpRHS,
   Binding,
   BindingRestElement,
@@ -97,31 +99,49 @@ import type {
   ComptimeStatement,
   Condition,
   Declaration,
+  DeclarationKind,
   DebuggerStatement,
   DefaultClause,
   DoStatement,
   ElseClause,
   EmptyCondition,
   EmptyStatement,
+  EnumDeclaration,
   ExpressionNode,
+  ForReduction,
+  ForControlDeclaration,
+  ForStatementControl,
   ForStatement,
+  FromClause,
   FunctionExpression,
   FunctionParameter,
   FunctionRestParameter,
   Identifier,
   IfStatement,
+  InterfaceDeclaration,
   ImportDeclaration,
+  ImportClause,
   Index,
   IterationExpression,
   IterationFamily,
   IterationStatement,
   Label,
   LabelledStatement,
+  LexicalDeclaration,
+  MethodDefinition,
+  MethodSignature,
+  MultiMethodDefinition,
   NamedBindingPattern,
   NamedImportElement,
   NamespaceDeclaration,
   NonNullAssertion,
   ObjectBindingPattern,
+  ObjectProperty,
+  OperatorBehavior,
+  OperatorDeclaration,
+  OperatorImportClause,
+  OperatorImportSpecifier,
+  OperatorSignature,
   Parameter,
   ParenthesizedExpression,
   PatternClause,
@@ -138,14 +158,20 @@ import type {
   ThisType,
   ThrowStatement,
   TryStatement,
+  ThisAssignments,
+  TypeDeclaration,
   TypeArgument,
+  TypeArgumentList,
   TypeFunction,
   TypeNode,
+  TypeTuple,
+  VoidType,
   WhenClause,
   WithClause,
   Yield,
   YieldExpression,
 } from "./parser/types.civet"
+
 /**
  * Globals
  */
@@ -257,7 +283,11 @@ Object.defineProperties(state, {
   },
 })
 
-function setOperatorBehavior(name: string, behavior: unknown)
+/**
+ * Register an operator. Undefined behavior means "blessed as an operator, with
+ * default precedence/associativity."
+ */
+function setOperatorBehavior(name: string, behavior: OperatorBehavior?)
   existing := state.operators.get(name)
   if existing and behavior // merge behaviors
     state.operators.set(name, {...existing, ...behavior})
@@ -749,10 +779,10 @@ BinaryOpRHS ::BinaryOpRHS
     // > operator needs to have space on both sides (or neither)
     return $skip if op[1].token is ">" and op[0].length is 0
     // NOTE: Flatten NotDedentedBinaryOp into whitespace and operator
-    return [...op, ...rhs]
+    return [...op, ...rhs] as BinaryOpRHS
   !NewlineBinaryOpAllowed SingleLineBinaryOpRHS -> $2
 
-IsLike
+IsLike ::BinaryOp
   Is _? ( OmittedNegation _? )?:negated Like ->
     return {
       type: "PatternTest",
@@ -770,7 +800,7 @@ WRHS
     return wrhs
   ( ( EOS __ ) / _ ) RHS
 
-SingleLineBinaryOpRHS
+SingleLineBinaryOpRHS ::BinaryOpRHS
   # NOTE: It's named single line but that's only for the operator, the RHS can be after a newline
   # This is to maintain compatibility with CoffeeScript conditions
   _?:ws1 BinaryOp:op ( ( EOS __ ) / _ ):ws2 RHS:rhs ->
@@ -2891,7 +2921,7 @@ FunctionExpression
     fn := makeAmpersandFunction({
       ref: refA,
       body: processBinaryOpExpression([refA, [
-        [ws1, op, ws2, rhs] // BinaryOpRHS
+        [ws1, op, ws2, rhs] satisfies BinaryOpRHS
       ]])
     })
     return {
@@ -2916,7 +2946,7 @@ FunctionExpression
     }
 
 # NOTE: Dynamic infix operators
-OperatorDeclaration
+OperatorDeclaration ::OperatorDeclaration
   # `operator {x, y} := ...` declaration while blessing
   Operator:op OperatorBehavior?:behavior _:w LexicalDeclaration:decl ->
     decl.names.forEach((name: string) => setOperatorBehavior(name, behavior))
@@ -2937,21 +2967,24 @@ OperatorDeclaration
   # `operator id` alone blesses `id` as an operator
   Operator:op _:w1 Identifier:id OperatorBehavior?:behavior ( CommaDelimiter _? Identifier OperatorBehavior? )*:ids ->
     children := []
+    names := [id.name]
     setOperatorBehavior(id.name, behavior)
     children.push(behavior.error) if behavior?.error
     ids.forEach [, , id2, behavior2] =>
+      names.push(id2.name)
       setOperatorBehavior(id2.name, behavior2)
       children.push(behavior2.error) if behavior2?.error
 
     return {
       id,
+      names,
       children,
     }
 
 # NOTE: Like FunctionSignature, but no async or star or @,
 # and parameters are required (to be useful).
 OperatorSignature
-  ( Async _ )?:async Operator:op ( _ Function )?:func ( _? Star )?:generator _:w1 Identifier:id OperatorBehavior?:behavior _?:w2 NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ::FunctionSignature ->
+  ( Async _ )?:async Operator:op ( _ Function )?:func ( _? Star )?:generator _:w1 Identifier:id OperatorBehavior?:behavior _?:w2 NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ::OperatorSignature ->
     async = [] unless async
     generator = [] unless generator
     // Add "function" (if not already one) to replace "operator"
@@ -2976,16 +3009,16 @@ OperatorSignature
       behavior,
     }
 
-OperatorBehavior
+OperatorBehavior ::OperatorBehavior
   OperatorPrecedence OperatorAssociativity? ->
     return { ...$1, ...$2 }
   OperatorAssociativity OperatorPrecedence? ->
     return { ...$1, ...$2 }
 
-OperatorPrecedence
+OperatorPrecedence ::OperatorBehavior
   # inspired by https://docs.raku.org/language/functions#Precedence
   _? ( "tighter" / "looser" / "same" ):mod NonIdContinue _? ( Identifier / ( OpenParen BinaryOp CloseParen ) ):op ->
-    let prec, error
+    let prec: number, error: ASTError?
     if op.type is "Identifier"
       if state.operators.has(op.name)
         prec = state.operators.get(op.name).prec
@@ -2995,7 +3028,6 @@ OperatorPrecedence
           type: "Error",
           message: `Precedence refers to unknown operator ${op.name}`,
         }
-
     else
       prec = getPrecedence((op as any)[1])
 
@@ -3009,7 +3041,7 @@ OperatorPrecedence
 
     return { prec, error }
 
-OperatorAssociativity
+OperatorAssociativity ::OperatorBehavior
   # inspired by https://docs.raku.org/language/functions#Associativity
   _? ( "left" / "right" / "non" / "relational" / "arguments" ):assoc NonIdContinue ->
     if assoc is "relational"
@@ -4135,10 +4167,11 @@ PropertyDefinition
       implicitName: true,
     }
 
-  _?:ws MethodDefinition:def ::unknown ->
+  _?:ws MethodDefinition:def ::MethodDefinition | MultiMethodDefinition ->
     // Add commas between multiple method definitions (from globs)
     if def.type is "MultiMethodDefinition"
       return {
+        ...def,
         children: def.children.flatMap((c: any, i: number) => i ? [",", c] : [c])
       }
     // NOTE: Forbidding EmptyBlock in MethodDefinition to allow `foo()`
@@ -4158,7 +4191,7 @@ PropertyDefinition
   # NOTE: this needs to be at the bottom to prevent shadowing NamedProperty
   # NOTE: Prevent `.x` from expanding to `x: $ => $.x`
   # NOTE: Also allow unary prefix and/or unary/binary/pipeline postfix
-  _?:ws !( EOS / "." ) UnaryOp*:pre CallExpression:value UnaryPostfix?:post BinaryOpRHS*:rhs PipelineExpressionBodySameLine:pipeline ::ASTNode ->
+  _?:ws !( EOS / "." ) UnaryOp*:pre CallExpression:value UnaryPostfix?:post BinaryOpRHS*:rhs PipelineExpressionBodySameLine:pipeline ::Identifier | ObjectProperty | ObjectProperty[] ->
     unless pre# or post
       switch value!.type
         // `{identifier}` remains `{identifier}`, the one shorthand JS supports
@@ -4232,7 +4265,7 @@ PropertyDefinition
 
     propValue: ASTNode .= processUnaryExpression pre, value, post
     if rhs#
-      propValue = processBinaryOpExpression [propValue, rhs] 
+      propValue = processBinaryOpExpression [propValue, rhs]
     if pipeline#
       propValue =
         type: "PipelineExpression"
@@ -4356,7 +4389,7 @@ Decorators
     return $0
 
 # https://262.ecma-international.org/#prod-MethodDefinition
-MethodDefinition
+MethodDefinition ::MethodDefinition | MultiMethodDefinition
   Abstract __ MethodSignature:signature ->
     return {
       type: "MethodDefinition",
@@ -4480,7 +4513,7 @@ MethodModifier
       children: [ async, generator ],
     }
 
-MethodSignature
+MethodSignature ::MethodSignature
   ConstructorShorthand NonEmptyParameters:parameters ->
     return {
       type: "MethodSignature",
@@ -5326,59 +5359,61 @@ ForClause
       generator,
     }
 
-ForStatementControlWithWhen
+ForStatementControlWithWhen ::ForStatementControl
   ForStatementControlWithReduction:control WhenCondition?:condition ->
     return control unless condition
-    expressions := [["", {
+    expressions: StatementTuple[] := [["", {
       type: "ContinueStatement",
       children: ["continue"]
     }]]
-    block := {
+    block: BlockStatement := {
       type: "BlockStatement",
       expressions,
       children: [expressions],
       bare: true,
     }
+    blockPrefix: StatementTuple[] := [...control.blockPrefix ?? [],
+      ["", {
+        type: "IfStatement",
+        then: block,
+        children: ["if (!", makeLeftHandSideExpression(trimFirstSpace(condition)), ") ", block],
+        // & placeholders in the condition came from outside the for-body,
+        // so they should lift past it (otherwise `continue` ends up trapped
+        // inside an arrow function — issue #1788).
+        implicitLift: true,
+      }, ";"]
+    ]
     return {
       ...control,
-      blockPrefix: [...control.blockPrefix ?? [],
-        ["", {
-          type: "IfStatement",
-          then: block,
-          children: ["if (!", makeLeftHandSideExpression(trimFirstSpace(condition)), ") ", block],
-          // & placeholders in the condition came from outside the for-body,
-          // so they should lift past it (otherwise `continue` ends up trapped
-          // inside an arrow function — issue #1788).
-          implicitLift: true,
-        }, ";"]
-      ],
+      blockPrefix,
     }
 
-ForStatementControlWithReduction
+ForStatementControlWithReduction ::ForStatementControl
   # Try without reduction first, to allow sum/count/etc as variables
   ForStatementControl
   ForReduction:reduction ForStatementControl:control ->
     return { ...control, reduction }
 
-ForReduction
-  ( "some" / "every" / "count" / "first" / "sum" / "product" / "min" / "max" / "join" / "concat" ):subtype NonIdContinue __:ws ->
+ForReduction ::ForReduction
+  # Split so Hera's generated $C calls stay within typed overloads.
+  ( ( "some" / "every" / "count" / "first" / "sum" ) / ( "product" / "min" / "max" / "join" / "concat" ) ):subtype NonIdContinue __:ws ->
     return {
       type: "ForReduction",
       subtype,
       children: [ ws ],
     }
 
-ForStatementControl
+ForStatementControl ::ForStatementControl
   !CoffeeForLoopsEnabled ForStatementParameters -> $2
   CoffeeForLoopsEnabled CoffeeForStatementParameters -> $2
 
 WhenCondition
   __ When ExpressionWithObjectApplicationForbidden:exp -> exp
 
-CoffeeForStatementParameters
+CoffeeForStatementParameters ::ForStatementControl
   # NOTE: Coffee for loops can't have parens
   ( Await __ )? InsertOpenParen:open CoffeeForDeclaration:declaration CoffeeForIndex?:index __ ( In / Of / From ):kind ExpressionWithObjectApplicationForbidden:exp ( _? By ExpressionWithObjectApplicationForbidden )?:step InsertCloseParen:close ->
-    blockPrefix := []
+    blockPrefix: StatementTuple[] := []
     exp = trimFirstSpace(exp)
     declaration = trimFirstSpace(declaration)
 
@@ -5488,7 +5523,7 @@ CoffeeForStatementParameters
         type: "Declaration"
         children: forHeadChildren
         names: []
-      }
+      } satisfies ForControlDeclaration
 
       return {
         declaration: forHead,
@@ -5532,15 +5567,15 @@ CoffeeForDeclaration
       names: binding.names,
     }
 
-ForStatementParameters
+ForStatementParameters ::ForStatementControl
   # https://262.ecma-international.org/#prod-ForStatement
-  OpenParen __ ( LexicalDeclaration / VariableStatement / CommaExpression? ):declaration __ Semicolon CommaExpression? Semicolon CommaExpression? __ CloseParen ->
+  OpenParen __ ForStatementDeclaration:declaration __ Semicolon CommaExpression? Semicolon CommaExpression? __ CloseParen ->
     return {
       declaration,
       children: $0,
     }
   # NOTE: Added optional parens
-  InsertOpenParen __ ( LexicalDeclaration / VariableStatement / CommaExpression? ):declaration __ Semicolon CommaExpression? Semicolon (!EOS ExpressionWithIndentedApplicationForbidden)? InsertCloseParen ->
+  InsertOpenParen __ ForStatementDeclaration:declaration __ Semicolon CommaExpression? Semicolon (!EOS ExpressionWithIndentedApplicationForbidden)? InsertCloseParen ->
     increment := $8?[1]
     return {
       declaration,
@@ -5565,7 +5600,12 @@ ForStatementParameters
     return processForInOf($0)
   ForRangeParameters
 
-ForRangeParameters
+ForStatementDeclaration ::ASTNode
+  LexicalDeclaration
+  VariableStatement
+  CommaExpression?
+
+ForRangeParameters ::ForStatementControl
   # NOTE: CoffeeScript-style `for [start..end] by step` without declaration
   ( Await __ )? OpenParen:open OpenBracket RangeExpression:exp CloseBracket ( __ By ExpressionWithObjectApplicationForbidden )?:step CloseParen:close ->
     return forRange(open, null, exp, step, close)
@@ -6344,8 +6384,13 @@ ImportDeclaration ::ImportDeclaration
       pos: from[0]!.$loc.pos-1,
       length: from[0]!.$loc#+1,
     }
-    children := [i, t, imports, w, from]
-    return { type: "ImportDeclaration", ts: !!t, children, imports, from }
+    return {
+      type: "ImportDeclaration",
+      ts: !!t,
+      children: [i, t, imports, w, from],
+      imports,
+      from,
+    }
   # NOTE: from ... import ... reverse syntax
   FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws Operator OperatorBehavior?:behavior SameLineOrIndentedFurther:ows OperatorNamedImports:imports ->
     errors := []
@@ -6375,7 +6420,7 @@ ImpliedImport
     return { $loc, token: "import " }
 
 # https://262.ecma-international.org/#prod-ImportClause
-ImportClause
+ImportClause ::ImportClause
   ImportedBinding:binding ( __ Comma __ ( NameSpaceImport / NamedImports ) )?:rest ->
     if rest
       // Spread to forward NamedImports/NameSpaceImport optional fields.
@@ -6398,7 +6443,7 @@ ImportClause
   NamedImports
 
 # https://262.ecma-international.org/#prod-NameSpaceImport
-NameSpaceImport
+NameSpaceImport ::ImportClause
   Star:star ImportAsToken __ ImportedBinding:binding ->
     return {
       type: "Declaration",
@@ -6409,7 +6454,7 @@ NameSpaceImport
     }
 
 # https://262.ecma-international.org/#prod-NamedImports
-NamedImports
+NamedImports ::ImportClause
   OpenBrace ( NamedImportRest / TypeAndImportSpecifier )*:items ( __ Comma )? __ CloseBrace ->
     // Rest can appear anywhere; reorder moves it to the tail.
     reordered := (reorderBindingRestProperty items).children as (NamedImportElement | { type: "Error", message: string })[]
@@ -6441,7 +6486,7 @@ NamedImportRest
       delim,
     }
 
-OperatorNamedImports
+OperatorNamedImports ::OperatorImportClause
   OpenBrace OperatorImportSpecifier*:specifiers __ CloseBrace ->
     names := specifiers.flatMap(({binding}) => binding.names)
 
@@ -6468,7 +6513,7 @@ DynamicImportContents
   Star
 
 # https://262.ecma-international.org/#prod-FromClause
-FromClause
+FromClause ::FromClause
   # NOTE: Robust parsing with missing module for better LSP completions
   From SameLineOrIndentedFurther ( ModuleSpecifier / UnclosedSingleLineStringLiteral )?:module ->
     module ??= [
@@ -6547,7 +6592,7 @@ ImportSpecifier
       children: [ws, binding, delim],
     }
 
-OperatorImportSpecifier
+OperatorImportSpecifier ::OperatorImportSpecifier
   __ ModuleExportName OperatorBehavior?:behavior ImportAsToken __ ImportedBinding:binding ObjectPropertyDelimiter ->
     return {
       binding,
@@ -6622,8 +6667,8 @@ UnquotedSpecifier
     return { $loc, token: `"${spec}"` }
 
 # https://262.ecma-international.org/#prod-ImportedBinding
-ImportedBinding
-  BindingIdentifier
+ImportedBinding ::Identifier
+  __:ws Identifier:id -> prepend(ws, id)
 
 # https://262.ecma-international.org/#prod-ExportDeclaration
 ExportDeclaration
@@ -6643,21 +6688,23 @@ ExportDeclaration
   # NOTE: Avoid matching `f := ->`, leaving that for the next rule.
   Decorators? Export __ Default __ !FunctionDeclaration ( LexicalDeclaration / VariableStatement / TypeAliasDeclaration / NamespaceDeclaration / EnumDeclaration / OperatorDeclaration ):declaration ->
     let id, error
-    if declaration.id
-      id = declaration.id
-    else
-      assert(declaration.names, "Could not find name of declaration in export default")
-      if declaration.names# !== 1
+    if declaration.type is "Declaration"
+      names := declaration.names
+      if names# !== 1
         error = {
           type: "Error",
-          message: `export default with ${declaration.names#} variable declaration (should be 1)`
+          message: `export default with ${names#} variable declaration (should be 1)`
         }
-      id = declaration.names[0]
+      id = names[0]
+    else
+      id = declaration.id
+    ts := declaration.type is "TypeDeclaration" or
+      declaration.type is "NamespaceDeclaration"
     return [
       declaration,
-      { children: [";"], ts: declaration.ts },
+      { children: [";"], ts },
       error ??
-      { type: "ExportDeclaration", declaration: id, ts: declaration.ts,
+      { type: "ExportDeclaration", declaration: id, ts,
         children: [ ...$0.slice(0, -2), id ] }
     ]
   # NOTE: This covers all forms that can be directly export defaulted in TS.
@@ -6665,12 +6712,12 @@ ExportDeclaration
   Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration / MaybeNestedPostfixedExpressionOrCommaLoop ):declaration ->
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
   Export __ ExportFromClause:exports __ FromClause ->
-    return { type: "ExportDeclaration", ts: exports.ts, children: $0 }
+    return { type: "ExportDeclaration", ts: "ts" in exports and exports.ts, children: $0 }
   # NOTE: from ... export ... reverse syntax
   FromClause:from __:fws Export:e __:ews ExportFromClause:exports ->
     return {
       type: "ExportDeclaration",
-      ts: exports.ts,
+      ts: "ts" in exports and exports.ts,
       children: [ e, ews, exports, " ", from, trimFirstSpace(fws) ],
     }
   # NOTE: Declaration and VariableStatement should come before NamedExports
@@ -6778,19 +6825,20 @@ HoistableDeclaration
   FunctionDeclaration
 
 # https://262.ecma-international.org/#prod-LexicalDeclaration
-LexicalDeclaration
+LexicalDeclaration ::LexicalDeclaration
   # NOTE: Eliminated left recursion
   LetOrConst:decl LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
-    bindings := [binding].concat(tail.map(([,,,b]) => b))
+    bindings: Binding[] := [binding as Binding].concat(tail.map(([,,,b]) => b as Binding))
+    thisAssignments: ThisAssignments := bindings.flatMap((b) => b.thisAssignments)
 
     return {
       type: "Declaration",
-      children: $0,
+      children: $0 as Children,
       names: bindings.flatMap((b) => b.names),
       bindings,
-      decl,
+      decl: decl as DeclarationKind,
       splices: bindings.flatMap((b) => b.splices),
-      thisAssignments: bindings.flatMap((b) => b.thisAssignments),
+      thisAssignments,
     }
   # NOTE: Added const/let shorthands
   # NOTE: Using Expression to allow for If/SwitchExpressions
@@ -6852,7 +6900,7 @@ Initializer
   }
 
 # https://262.ecma-international.org/#prod-VariableStatement
-VariableStatement
+VariableStatement ::Declaration
   Var __ VariableDeclarationList ->
     return {
       ...$3,
@@ -8394,22 +8442,23 @@ JSXChildExpression
   # NOTE: Added lexical declaration, which gets hoisted,
   # converted into an assignment, and voided to avoid rendering.
   Whitespace? LexicalDeclaration:d ->
+    decl := d!
     // Add refs from thisAssignments to list of names
-    names .= d.names.concat(
-      d.thisAssignments.map((a: any) => a[1][1])
+    names .= decl.names.concat(
+      decl.thisAssignments!.map((a: any) => a[1][1])
     )
     // Remove duplicate names
     names.sort()
     names = names.filter((name: string, i: number) => i is 0 or name !== names[i-1])
     d = {
-      ...d,
+      ...decl,
       hoistDec: {
         type: "Declaration",
         children: [
           "let ",
           names.map((n: string, i: number) => i is 0 ? [n] : [",", n]).flat()
         ],
-      },
+      } as ASTNode,
       children: (d.children as any[]).slice(1),  // drop LetOrConst
     }
     if d.thisAssignments?#
@@ -8508,7 +8557,7 @@ TypeDeclaration
       type: "Declaration",
       ts: true,
       children: $0,
-      names: d.names ?? [],
+      names: "names" in d ? d.names ?? [] : [],
     }
   ( Export _? )?:export_ ( Declare _? )?:declare TypeDeclarationRest:t ->
     return {
@@ -8526,7 +8575,7 @@ TypeDeclarationRest
   NamespaceDeclaration
   FunctionSignature
 
-TypeAliasDeclaration
+TypeAliasDeclaration ::TypeDeclaration
   # TODO: ( __ Type ) can be refined further to check for consistently nested binary ops, etc.
   TypeKeyword _? IdentifierName:id TypeParameters? OptionalEquals ( MaybeNestedType / ( __ Type ) ) ->
     return {
@@ -8544,7 +8593,7 @@ TypeAliasDeclaration
       ts: true,
     }
 
-InterfaceDeclaration
+InterfaceDeclaration ::InterfaceDeclaration
   Interface _? IdentifierName:id TypeParameters? InterfaceExtendsClause? InterfaceOrEmptyBlock ->
     return {
       type: "InterfaceDeclaration",
@@ -8691,10 +8740,10 @@ NestedDeclareElement
 # NOTE: Variation on TypeDeclaration where Declare already applied.
 DeclareElement ::ASTNode
   Decorators? Export __ Default __ ( Identifier / ClassSignature / InterfaceDeclaration ):declaration
-  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
-  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 }
+  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 } as ASTNode
+  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 } as ASTNode
 
-EnumDeclaration
+EnumDeclaration ::EnumDeclaration
   ( Const _ )?:_isConst Enum _? IdentifierName:id EnumBlock:block ->
     ts := {
       ts: true,
@@ -8884,8 +8933,8 @@ MaybeNestedTypeUnary
     return $2
   NotDedented TypeUnary
 
-ReturnTypeSuffix
-  _? QuestionMark?:optional _? Colon ReturnType:t ::ASTNode ->
+ReturnTypeSuffix ::ReturnTypeAnnotation
+  _? QuestionMark?:optional _? Colon ReturnType:t ->
     return {
       ...t,
       optional,
@@ -8895,29 +8944,30 @@ ReturnTypeSuffix
 ReturnType
   ( __ "asserts" NonIdContinue )?:asserts ForbidIndentedApplication TypePredicate?:t RestoreIndentedApplication ::ReturnTypeAnnotation ->
     return $skip unless t
+    returnType: TypeNode .= t
     if asserts
-      t = {
+      returnType = {
         type: "TypeAsserts",
         t,
         children: [asserts[0], asserts[1], t],
         ts: true,
-      }
+      } satisfies TypeNode
     return {
       type: "ReturnTypeAnnotation",
-      children: [t],
-      t,
+      children: [returnType],
+      t: returnType,
       ts: true,
     }
 
-TypePredicate
+TypePredicate ::TypeNode
   MaybeNestedType:lhs ( __ Is Type )?:rhs ->
     return lhs unless rhs
     return {
       type: "TypePredicate",
-      lhs,
-      rhs: rhs[3],
-      children: [lhs, ...rhs],
-    }
+      lhs: lhs as ASTNode,
+      rhs: rhs[3] as ASTNode,
+      children: [lhs as ASTNode, ...rhs as ASTNode[]],
+    } as TypeNode
 
 Type
   TypeWithPostfix
@@ -8949,7 +8999,7 @@ TypeUnary
       suffix,
       t,
       // omit empty prefix for trimming space
-      children: prefix# ? $0 : [t, suffix],
+      children: (prefix# ? $0 : [t, suffix]) as Children,
     }
 
 TypeUnarySuffix
@@ -9093,12 +9143,12 @@ TypeElementList ::ASTNode[]
       append(first, delim)
     ].concat(
       rest.map(([_, e], i) =>
-        nextDelim := rest[i+1] and [rest[i+1][0][0], rest[i+1][0][1]]
+        nextDelim := rest[i+1] ? [rest[i+1][0][0], rest[i+1][0][1]] : undefined
         append(e, nextDelim)
       )
     )
 
-TypeElement
+TypeElement ::ASTNode
   # NOTE: Allow for postfix splat like CoffeeScript
   # NOTE: Match named form first, to avoid matching `foo: bar,` as Type
   # and then DotDotDot from next entry.
@@ -9166,7 +9216,7 @@ NestedTypeBulletedTuple
 
 # NOTE: Bulleted tuple intended for beginning of lines,
 # when leading indentation has already been consumed.
-TypeBulletedTuple
+TypeBulletedTuple ::TypeNode
   InsertOpenBracket:open ( TypeBullet NestedTypeBullet* )?:content InsertCloseBracket:close ->
     return $skip unless content
     content = [
@@ -9184,6 +9234,7 @@ TypeBulletedTuple
 
     return {
       type: "TypeTuple",
+      ts: true,
       children: [open, ...content!, close],
     }
 
@@ -9215,8 +9266,8 @@ TypeConditional ::ASTNode
   _? /(?=if|unless)/ TypeIfThenElse ->
     return prepend($1, expressionizeTypeIf($3))
   TypeCondition NotDedented QuestionMark __ Type __ Colon __ Type ->
-    return [ $1, $2, $3, $4, $9, $6, $7, $8, $5 ] if $1.negated
-    return $0
+    return [ $1, $2, $3, $4, $9, $6, $7, $8, $5 ] as ASTNode if $1.negated
+    return $0 as ASTNode
   TypeBinary
 
 TypeCondition
@@ -9318,7 +9369,7 @@ TypeFunction
       }
     // Implicit void return type
     if "token" in returnType and returnType.$loc and returnType.token is ""
-      t := {
+      t: VoidType := {
         type: "VoidType",
         $loc: returnType.$loc,
         token: "void",
@@ -9351,13 +9402,13 @@ TypeFunctionArrow
 
 TypeArguments
   OpenAngleBracket:open ( __ TypeArgumentDelimited )+:args __:ws CloseAngleBracket:close ::TypeArguments ->
-    args = args.flatMap(([ws, [arg, delim]]) => [prepend(ws, arg), delim])
-    args.pop() // remove last delimiter
+    flatArgs := args.flatMap(([ws, [arg, delim]]) => [prepend(ws, arg), delim]) as TypeArgumentList
+    flatArgs.pop() // remove last delimiter
     return {
       type: "TypeArguments",
       ts: true,
-      args,
-      children: [ open, args, ws, close ],
+      args: flatArgs,
+      children: [ open, flatArgs, ws, close ],
     }
 
 ImplicitTypeArguments
@@ -9890,7 +9941,7 @@ Reset
             if behavior and typeof behavior is not "object"
               throw new Error("operators configuration object must have string or object values")
 
-            setOperatorBehavior(name, behavior)
+            setOperatorBehavior(name, behavior as OperatorBehavior?)
 
         return
       }
@@ -9908,7 +9959,7 @@ Init
         Object.assign(config, directive.config)
 
     if config.strict
-      $0 = [...$0, '"use strict";\n']
+      return [...$0, '"use strict";\n']
     return $0
 
 Prologue

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4144,6 +4144,7 @@ PropertyDefinition
         name: id,
         names: id.names,
         value,
+        flagToggle: toggle,
       }
 
     // `{ 😊 }` → `{ "😊": u$1F60A$ }`. PropertyName already rewrote `id`'s
@@ -4192,7 +4193,7 @@ PropertyDefinition
   # NOTE: Prevent `.x` from expanding to `x: $ => $.x`
   # NOTE: Also allow unary prefix and/or unary/binary/pipeline postfix
   _?:ws !( EOS / "." ) UnaryOp*:pre CallExpression:value UnaryPostfix?:post BinaryOpRHS*:rhs PipelineExpressionBodySameLine:pipeline ::Identifier | ObjectProperty | ObjectProperty[] ->
-    unless pre# or post
+    unless pre# or post or rhs# or pipeline#
       switch value!.type
         // `{identifier}` remains `{identifier}`, the one shorthand JS supports
         case "Identifier":
@@ -4278,6 +4279,7 @@ PropertyDefinition
       names: [],
       value: propValue,
       implicitName: true,
+      callExpression: value,
     }
   # NOTE: basic identifiers are now part of the rule above
   #_?:ws IdentifierReference:id ->

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -197,7 +197,7 @@ function createVarDecs(block: BlockStatement, scopes: any, pushVar?: any): void
 
   const blockNodes = new Set(gatherNodes(statements, (s) => s.type is "BlockStatement"))
   // Remove function blocks and for statements, they get handled separately because they have additional parameter scopes and lexical scopes to add
-  fnNodes.forEach(({ block }) => blockNodes.delete(block))
+  fnNodes.forEach(({ block }) => blockNodes.delete(block) if block)
   forNodes.forEach(({ block }) => blockNodes.delete(block))
 
   // recurse into nested blocks
@@ -212,6 +212,7 @@ function createVarDecs(block: BlockStatement, scopes: any, pushVar?: any): void
 
   // recurse into nested functions
   fnNodes.forEach ({ block, parameters }) =>
+    return unless block
     scopes.push(new Set(parameters.names))
     createVarDecs(block, scopes)
     scopes.pop()

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -10,13 +10,15 @@ import type {
   Declaration
   ExpressionNode
   IfStatement
-  ImportClauseNode
+  ImportClause
   ImportDeclaration
   Initializer
   IterationStatement
+  LexicalDeclaration
   ParenthesizedExpression
   StatementTuple
   SwitchStatement
+  ThisAssignments
   TypeSuffix
   WithClause
   Whitespace
@@ -82,7 +84,7 @@ import {
   processCallMemberExpression
 } from ./lib.civet
 
-function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], typeSuffix: TypeSuffix?, ws: WSNode, assign: ASTLeaf, e: ASTNode)
+function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"], typeSuffix: TypeSuffix?, ws: WSNode, assign: ASTLeaf, e: ASTNode): LexicalDeclaration
   // Adjust position to space before assignment to make TypeScript remapping happier
   decl = {
     ...decl,
@@ -94,7 +96,7 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
   [splices, assignments] .= gatherBindingCode pattern
 
   splices = splices.map (s) => [", ", s]
-  thisAssignments := assignments.map (a) => ["", a, ";"] as const
+  thisAssignments: ThisAssignments := assignments.map (a) => ["", a, ";"]
 
   typeSuffix ??= pattern.typeSuffix if "typeSuffix" in pattern
   initializer := makeNode
@@ -113,7 +115,7 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
 
   children := [decl, binding]
 
-  makeNode {
+  makeNode<LexicalDeclaration> {
     type: "Declaration"
     pattern.names
     decl
@@ -515,7 +517,7 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
 
   // Operator-import clauses share `type: "Declaration"` but never carry
   // type-only specifiers, so they fall through the all-type check harmlessly.
-  i := imports as ImportClauseNode
+  i := imports as ImportClause
   // Standalone NamedImports: no default, no namespace — drop the whole decl.
   if not i.binding and not i.star
     specs := i.specifiers
@@ -526,7 +528,7 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
   // builds the clause as `[binding, ...rest]` with the named clause last, so
   // drop only the trailing `, { type S }` by wrapping `rest` in a ts:true node.
   children := imports.children!
-  namedSpecs := (children.at(-1)! as ImportClauseNode).specifiers
+  namedSpecs := (children.at(-1)! as ImportClause).specifiers
   return decl unless namedSpecs?.length and namedSpecs.every .ts
 
   [binding, ...rest] := children
@@ -540,10 +542,10 @@ function markAllTypeImports(decl: ImportDeclaration): ImportDeclaration
 // since a const-destructure can't bind types.
 function processStaticImport(decl: ImportDeclaration)
   { imports, from, children } := decl
-  // `"rest" in imports` narrows the union — only ImportClauseNode declares it.
+  // `"rest" in imports` narrows the union — only ImportClause declares it.
   return markAllTypeImports decl unless imports and "rest" in imports
 
-  namedImports := (imports.binding ? imports.children!.at(-1)! : imports) as ImportClauseNode
+  namedImports := (imports.binding ? imports.children!.at(-1)! : imports) as ImportClause
   allSpecs := namedImports.specifiers!
   // Rewrite only when native ESM can't express the shape: rest or pattern bindings.
   return markAllTypeImports decl unless namedImports.rest or allSpecs.some (s) => s.pattern

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -4,10 +4,14 @@ import type {
   ASTNodeObject
   ASTLeaf
   ASTError
+  Binding
   Children
+  ForControlDeclaration
   ForDeclaration
+  ForStatementControl
   RangeDots
   RangeExpression
+  StatementTuple
   Whitespace
 } from ./types.civet
 
@@ -157,7 +161,7 @@ function forRange(
   range: RangeExpression
   stepExp: ASTNode
   close: ASTLeaf
-)
+): ForStatementControl
   { start, end, left, right, increasing } .= range
 
   counterRef := makeRef("i")
@@ -219,7 +223,8 @@ function forRange(
       . " + "
       . stepRef
 
-  let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign, blockPrefix
+  let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign
+  let blockPrefix: StatementTuple[]?
   let names: string[] = forDeclaration?.names ?? []
   if forDeclaration?
     if forDeclaration.type is "AssignmentExpression" // Coffee-style for loop
@@ -281,7 +286,7 @@ function processForInOf($0: [
   exp: ASTNodeObject
   step: [Whitespace, ASTLeaf, ASTNode]
   close: ASTLeaf
-])
+]): ForStatementControl
   [awaits, eachOwn, open, declaration, declaration2, ws, inOf, exp, step, close] .= $0
   // Hera 0.9.0: `&ForInOfDeclaration` assertion now yields `true` in the eachOwn slot.
   eachOwn = undefined if eachOwn <? "boolean"
@@ -307,7 +312,8 @@ function processForInOf($0: [
     throw new Error("for..of/in cannot use 'by' except with range literals")
 
   let eachOwnError: ASTError?
-  let hoistDec, blockPrefix: ASTNode[] = []
+  let hoistDec: ASTNode?
+  blockPrefix: StatementTuple[] := []
 
   // for each item[, index] of array
   if eachOwn and eachOwn[0].token is "each"
@@ -339,11 +345,12 @@ function processForInOf($0: [
       }, ";"]
 
       eachDeclaration := declaration
-      declaration =
+      declaration = {
         type: "Declaration"
         children: ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", trimFirstSpace(expRef), ".length"]
         decl: "let"
         names: []
+      } satisfies ForControlDeclaration
 
       condition := [counterRef, " < ", lenRef, "; "]
       children := [open, declaration, "; ", condition, counterRef, increment, close]
@@ -377,11 +384,11 @@ function processForInOf($0: [
     inOf.token is "in" and declaration2 and pattern.type is not "Identifier"
   )
     itemRef := makeRef if inOf.token is "in" then "key" else "item"
-    blockPrefix.push ["", {
+    blockPrefix.push(["", {
       type: "Declaration"
       children: [declaration, " = ", itemRef]
       names: declaration!.names
-    }, ";"]
+    } satisfies ForControlDeclaration, ";"])
     declaration =
       type: "ForDeclaration"
       binding: {
@@ -389,8 +396,11 @@ function processForInOf($0: [
         pattern: itemRef
         children: [ itemRef ]
         names: []
-      }
+        splices: []
+        thisAssignments: []
+      } as unknown as Binding
       children: ["const ", itemRef]
+      decl: "const"
       names: []
     unless pattern.type is "Identifier"
       pattern = itemRef
@@ -413,24 +423,25 @@ function processForInOf($0: [
         children: ["let ", counterRef, " = 0"]
         decl: "let"
         names: []
-      }
-      blockPrefix.push ["", {
+      } satisfies ForControlDeclaration
+      blockPrefix.push(["", {
         type: "Declaration"
         children: [trimFirstSpace(ws2), decl2, " = ", counterRef, "++"]
         names: decl2!.names
         decl: decl2!.decl
-      }, ";"]
+      } satisfies ForControlDeclaration, ";"])
 
     // grammar guarantees inOf.token is "of" or "in" only
     when "in" // for key, value in object
       // First, wrap object in ref if complex expression
       expRef := maybeRef exp
       unless expRef is exp
-        hoistDec =
+        hoistDec = {
           type: "Declaration"
           children: ["let ", expRef]
           names: []
           decl: "let"
+        } satisfies ForControlDeclaration
         exp =
           type: "AssignmentExpression"
           children: [" ", expRef, " =", exp]

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -233,6 +233,7 @@ function processReturn(f: FunctionNode, implicitReturns: boolean): void
  */
 function processReturnValue(func: FunctionNode)
   { block } := func
+  return false unless block
   values := gatherRecursiveWithinFunction block, .type is "ReturnValue"
   return false unless values#
 
@@ -1481,7 +1482,7 @@ function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
     expression = {
       ...expression
       parameters: newParameters
-      children: expression.children.map & is parameters ? newParameters : &
+      children: expression.children.map(& is parameters ? newParameters : &) as Children
     }
 
   type: "CallExpression"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -744,9 +744,6 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         [value, suppressPrefix] =
           handleThisPrivateShorthands(value) as [typeof value, boolean]
 
-        // Not yet needed:
-        [name, value] = [value, name] if glob.reversed
-
         unless suppressPrefix // Don't prefix @ shorthand
           if value is like {type: "StringLiteral"}, {type: "Literal", subtype: "StringLiteral"}
             expression := trimFirstSpace(value)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -84,6 +84,7 @@ import {
   inplaceInsertTrimmingSpace
   inplacePrepend
   insertTrimmingSpace
+  isASTNodeObject
   isComma
   isEmptyBareBlock
   isFunction
@@ -680,7 +681,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
     if glob?.type is "PropertyGlob"
       prefix .= children[...i]
       parts: ObjectProperty[] := []
-      let ref
+      let ref: ASTRef?
       // add ref to ensure object base evaluated only once
       if needsRef(prefix) and glob.object.properties# > 1
         // unwrap unnecessary parentheses in ref assignment
@@ -703,17 +704,34 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
           continue
         suppressPrefix .= false
         name .= if part.type is "Property" then part.name
-        rawValue := part.value ?? name
-        unless rawValue?.type and (
-          rawValue.type is in ["CallExpression", "MemberExpression", "Identifier", "StringLiteral", "ComputedPropertyName"] or
-          rawValue.type is "Literal" and rawValue.subtype is "StringLiteral"
+        rawValue .= part.value ?? name
+        callExpression .= if part.type is "Property" then part.callExpression
+        // Reinterpret LiveScript flag shorthand in globs as unary prefix
+        // shorthand, e.g. `obj.{!x}` → `{x: !obj.x}`.
+        if part.type is "Property" and part.flagToggle
+          flagName := part.name
+          flagNameLoc := (flagName as any).$loc
+          toggle := {
+            $loc: flagNameLoc
+            token: part.flagToggle
+          } as UnaryOpSymbolLeaf
+          rawValue =
+            type: "UnaryExpression"
+            children: [[toggle], flagName, undefined]
+            pre: [toggle]
+            expression: flagName
+          callExpression = flagName
+        callExpression ??= rawValue
+        unless callExpression?.type and (
+          callExpression.type is in ["CallExpression", "MemberExpression", "Identifier", "StringLiteral", "ComputedPropertyName"] or
+          callExpression.type is "Literal" and callExpression.subtype is "StringLiteral"
         )
           parts.push
             type: "Error"
             message: `Glob pattern must have call or member expression value, found ${JSON.stringify(rawValue)}`
           continue
-        value: ASTNodeObject | Children .= rawValue
-        wValue := getTrimmingSpace part.value
+
+        value: ASTNodeObject | Children .= callExpression
 
         // Capture private-field shorthand info before handleThisPrivateShorthands
         // strips the synthetic `this.` wrapper. Used in processAssignments to
@@ -757,7 +775,18 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
           if ref?
             prefix = [ ref ]
             prefixDot = [ ...prefix, glob.dot ]
-        if wValue
+
+        unless rawValue is callExpression
+          // The glob prefix was applied to an inner call expression; replace
+          // that original target inside any unary/binary/pipeline wrapper.
+          replaceNodes rawValue, (& is callExpression), (node, parent) =>
+            if isASTNodeObject parent
+              for key, child in parent as any
+                if child is node
+                  (parent as any)[key] = value
+            value
+          value = rawValue as ASTNodeObject
+        if wValue := getTrimmingSpace part.value
           if Array.isArray(value)
             value.unshift wValue
           else

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1937,6 +1937,7 @@ function processCoffeeClasses(statements: StatementTuple[]): void
           signature
           children: [ ...signature.children, block ]
         expressions.unshift [indent, construct]
+      /* c8 ignore next -- existing constructors are only selected when they have blocks, and synthesized constructors always get makeEmptyBlock(). */
       throw new Error("Expected constructor block for autobind") unless construct.block
       index := findSuperCall construct.block
       construct.block.expressions.splice index+1, 0,

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -744,6 +744,10 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         [value, suppressPrefix] =
           handleThisPrivateShorthands(value) as [typeof value, boolean]
 
+        // Synthetic dynamic import declarations use reversed globs to map
+        // module-side property names to local binding names.
+        [name, value] = [value, name] if glob.reversed
+
         unless suppressPrefix // Don't prefix @ shorthand
           if value is like {type: "StringLiteral"}, {type: "Literal", subtype: "StringLiteral"}
             expression := trimFirstSpace(value)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -8,7 +8,6 @@
 
 import type {
   AccessStart
-  ASTError
   ASTLeaf
   ASTNode
   ASTNodeObject
@@ -32,7 +31,6 @@ import type {
   CoffeeClassPrototype
   ExpressionNode
   ForStatement
-  FunctionSignature
   IfStatement
   Index
   Initializer
@@ -41,16 +39,16 @@ import type {
   Label
   LabelledStatement
   Literal
-  LiteralContentNode
   MemberExpression
   MethodDefinition
+  MethodSignature
   NormalCatchParameter
   ObjectExpression
+  ObjectProperty
   ParametersNode
   ParenthesizedExpression
   Placeholder
   Property
-  SpreadProperty
   StatementTuple
   SwitchStatement
   TypeArgument
@@ -681,7 +679,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
   for each glob, i of children
     if glob?.type is "PropertyGlob"
       prefix .= children[...i]
-      parts := []
+      parts: ObjectProperty[] := []
       let ref
       // add ref to ensure object base evaluated only once
       if needsRef(prefix) and glob.object.properties# > 1
@@ -698,60 +696,72 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         if part.type is "Error"
           parts.push part
           continue
-        if part.type is "MethodDefinition"
+        if part.type is "MethodDefinition" or part.type is "MultiMethodDefinition"
           parts.push
             type: "Error"
             message: "Glob pattern cannot have method definition"
           continue
-        if part.value and part.value.type is not in ["CallExpression", "MemberExpression", "Identifier", "StringLiteral", "ComputedPropertyName"] as (string?)[]
+        suppressPrefix .= false
+        name .= if part.type is "Property" then part.name
+        rawValue := part.value ?? name
+        unless rawValue?.type and (
+          rawValue.type is in ["CallExpression", "MemberExpression", "Identifier", "StringLiteral", "ComputedPropertyName"] or
+          rawValue.type is "Literal" and rawValue.subtype is "StringLiteral"
+        )
           parts.push
             type: "Error"
-            message: `Glob pattern must have call or member expression value, found ${JSON.stringify(part.value)}`
+            message: `Glob pattern must have call or member expression value, found ${JSON.stringify(rawValue)}`
           continue
-
-        suppressPrefix .= false
-        name .= part.name
-        value .= part.value ?? name
+        value: ASTNodeObject | Children .= rawValue
         wValue := getTrimmingSpace part.value
 
         // Capture private-field shorthand info before handleThisPrivateShorthands
         // strips the synthetic `this.` wrapper. Used in processAssignments to
         // polyfill `obj.{#x} = src` as `obj.#x = src.#x` since JS destructuring
         // can't target private fields.
-        privateField .= undefined as string?
-        if value?.privateShorthand
+        let privateField: string?
+        if value.type is "MemberExpression" and value.privateShorthand
           privateField = value.privateId?.name
 
-        [value, suppressPrefix] = handleThisPrivateShorthands value
+        [value, suppressPrefix] =
+          handleThisPrivateShorthands(value) as [typeof value, boolean]
 
         // Not yet needed:
         [name, value] = [value, name] if glob.reversed
 
         unless suppressPrefix // Don't prefix @ shorthand
-          if value.type is "StringLiteral"
+          if value is like {type: "StringLiteral"}, {type: "Literal", subtype: "StringLiteral"}
+            expression := trimFirstSpace(value)
             value = [ ...prefix,
-              type: "Index"
-              children: [ "[", trimFirstSpace(value), "]" ]
-            ]
+              makeNode {
+                type: "Index"
+                expression
+                children: [ "[", expression, "]" ]
+              }
+            ] as Children
           else if value.type is "ComputedPropertyName"
             value = [ ...prefix,
               type: "Index"
               children: [ trimFirstSpace value ]
-            ]
+            ] as Children
           else if value.type is "Identifier" and value.unicode?
             // Unicode identifier: dot access of mangled `u$…$` is the wrong
             // property — use bracket access with the source name.
             value = [ ...prefix,
               type: "Index"
               children: [ "[", propertyKey(value), "]" ]
-            ]
+            ] as Children
           else
-            value = [ ...prefixDot, trimFirstSpace value ]
+            value = [ ...prefixDot, trimFirstSpace value ] as Children
           // Switch from refAssignment to ref
           if ref?
             prefix = [ ref ]
             prefixDot = [ ...prefix, glob.dot ]
-        if (wValue) value.unshift wValue
+        if wValue
+          if Array.isArray(value)
+            value.unshift wValue
+          else
+            value = [wValue, value] as Children
         if part.type is "SpreadProperty"
           parts.push {
             type: part.type
@@ -766,7 +776,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
         else
           parts.push {
             type: part.type
-            name
+            name! // Property always has name
             value
             privateField
             delim: part.delim
@@ -783,6 +793,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
           }
       object: ObjectExpression :=
         type: "ObjectExpression"
+        names: glob.object.names
         children: [
           glob.object.children.0 // {
           ...parts
@@ -1000,7 +1011,13 @@ function convertFunctionToMethod(id: any, exp: any)
     ...exp,
     type: "MethodDefinition",
     name: id.name,
-    signature: { ...exp.signature, id, name: id.name },
+    signature: {
+      ...exp.signature
+      type: "MethodSignature"
+      id
+      id.name
+      exp.parameters
+    },
     children
   }
 
@@ -1012,7 +1029,13 @@ function convertArrowFunctionToMethod(id: any, exp: any)
     ...exp,
     type: "MethodDefinition",
     name: id.name,
-    signature: { ...exp.signature, id, name: id.name },
+    signature: {
+      ...exp.signature
+      type: "MethodSignature"
+      id
+      id.name
+      exp.parameters
+    },
     block,
     children,
     autoBind: true
@@ -1062,7 +1085,7 @@ function convertObjectToJSXAttributes(obj: ObjectExpression)
   parts := [] // JSX attributes
   rest := []  // parts that need to be in {...rest} form
   for part, i of obj.properties
-    if part.usesRef
+    if "usesRef" in part and part.usesRef
       rest.push part
       continue
     if (i > 0) parts.push(' ')
@@ -1139,6 +1162,7 @@ function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType
       }
       name
       returnType
+      parameters
     }
     block
     parameters
@@ -1347,7 +1371,7 @@ function processAssignments(statements: ASTNode): void
     // Expand to comma-separated direct assignments: `(obj.#x = src.#x, obj.#y = src.#y)`.
     if $1.length is 1
       [, soleLhs, , soleOp] := $1[0]
-      isPrivateGlobProp := (p: Property | SpreadProperty | MethodDefinition | ASTError): p is Property =>
+      isPrivateGlobProp := (p: ObjectProperty): p is Property =>
         p?.type is "Property" and !!p.privateField
       if soleOp.token is "=" and soleLhs.type is "ObjectExpression" and
          soleLhs.properties?.some(isPrivateGlobProp) and
@@ -1868,9 +1892,10 @@ function processCoffeeClasses(statements: StatementTuple[]): void
           children: [parametersList]
           parameters: parametersList
           names: []
-        signature: FunctionSignature := {}
+        signature: MethodSignature := {}
           type: "MethodSignature"
           children: [ "constructor(", parameters, ")" ]
+          name: "constructor"
           parameters
           modifier: {}
           returnType: undefined
@@ -1883,6 +1908,7 @@ function processCoffeeClasses(statements: StatementTuple[]): void
           signature
           children: [ ...signature.children, block ]
         expressions.unshift [indent, construct]
+      throw new Error("Expected constructor block for autobind") unless construct.block
       index := findSuperCall construct.block
       construct.block.expressions.splice index+1, 0,
         ...for each [, a] of autoBinds

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -509,6 +509,7 @@ function aggregateDuplicateBindings(bindings: ASTNode)
       ]
       names: []
       bindings: [] // avoid implicit return of any bindings
+      decl: "const"
 
   return declarations
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1194,7 +1194,11 @@ export type Property = ASTParent &
   value: ASTNode
   delim?: ASTNode // attached when inside a comma-delimited property list
   implicitName?: boolean
+  /** When we wrap a property in unary/binary/pipeline shorthand, track inner CallExpression */
+  callExpression?: ASTNode
   usesRef?: boolean
+  /** LiveScript flag shorthand marker, e.g. `{+x}`, `{!x}`, `{-x}`. */
+  flagToggle?: "+" | "!" | "-"
   // Source name when the value is a `#privateField` shorthand inside a
   // PropertyGlob; consumed by processAssignments to polyfill the assignment
   // (`obj.{#x} = src` → `obj.#x = src.#x`) since JS destructuring cannot

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -701,6 +701,11 @@ export type PropertyGlob = ASTParent &
   type: "PropertyGlob"
   dot: ASTNode
   object: ObjectExpression
+  /**
+   * Dynamic import declarations reverse object glob output so
+   * `import { source as local }` becomes `{local: namespace.source}`.
+   */
+  reversed?: boolean?
 
 export type Call = ASTParent &
   type: "Call"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -22,18 +22,23 @@ export type StatementNode =
   | Declaration
   | DoStatement
   | EmptyStatement
+  | EnumDeclaration
   | ExportDeclaration
   | ExpressionNode
+  | ForControlDeclaration
   | ForStatement
   | IfStatement
+  | InterfaceDeclaration
   | ImportDeclaration
   | IterationStatement
   | LabelledStatement
+  | NamespaceDeclaration
   | PatternMatchingStatement
   | ReturnStatement
   | SwitchStatement
   | ThrowStatement
   | TryStatement
+  | TypeDeclaration
 
 /**
 * Nodes that represent expressions.
@@ -109,13 +114,16 @@ export type OtherNode =
   | ForDeclaration
   | FunctionRestParameter
   | ImportAssertion
-  | ImportClauseNode
-  | OperatorImportClauseNode
+  | ImportClause
+  | OperatorImportClause
   | Index
   | Initializer
   | Keyword
   | Label
+  | LiteralContent
+  | MethodSignature
   | ModuleSpecifier
+  | MultiMethodDefinition
   | NamedBindingPattern
   | NonNullAssertion
   | NormalCatchParameter
@@ -127,9 +135,11 @@ export type OtherNode =
   | PinProperty
   | Placeholder
   | PostRestBindingElements
+  | Property
   | PropertyAccess
   | PropertyBind
   | PropertyGlob
+  | SpreadProperty
   | RangeExpression
   | ReturnTypeAnnotation
   | ReturnValue
@@ -224,7 +234,7 @@ export type ASTLeaf =
   children?: never
 
 export type ASTLeafWithType<T extends string> =
-  Exclude<ASTLeaf, "type"> & { type: T }
+  Omit<ASTLeaf, "type"> & { type: T }
 
 export type CommentNode =
   type: "Comment"
@@ -382,6 +392,8 @@ export type AssignmentExpressionLHS = [undefined, NonNullable<ASTNode>, [WSNode,
 
 export type MemberExpression = ASTParent &
   type: "MemberExpression"
+  privateShorthand?: boolean
+  privateId?: Identifier
 
 export type CallExpression = ASTParent &
   type: "CallExpression"
@@ -505,6 +517,7 @@ export type IfStatement = ASTParent &
   negated: boolean?
   then: BlockStatement
   else: ElseClause?
+  implicitLift?: boolean
 
 export type ElseClause = ASTObject &
   type: "ElseClause"
@@ -573,10 +586,10 @@ export type DoStatement = ASTParent &
 
 export type ForStatement = ASTParent &
   type: "ForStatement"
-  declaration: (Declaration | ForDeclaration)?
+  declaration: (Declaration | ForDeclaration | ForControlDeclaration)?
   /** Original declaration that got rewritten by `for each`
   (used for implicit body) */
-  eachDeclaration?: (Declaration | ForDeclaration)?
+  eachDeclaration?: (Declaration | ForDeclaration | ForControlDeclaration)?
   block: BlockStatement
   hoistDec: ASTNode
   /** From grammar `( _? Star )?`: optional [whitespace, Star] tuple. */
@@ -586,13 +599,28 @@ export type ForStatement = ASTParent &
   reduction?: ForReduction
   object?: boolean
 
+export type ForStatementControl = ASTParent &
+  declaration?: ASTNode | null
+  eachDeclaration?: ASTNode
+  blockPrefix?: StatementTuple[]?
+  hoistDec?: ASTNode
+  reduction?: ForReduction
+
+export type ForControlDeclaration = ASTParent &
+  type: "Declaration"
+  names: string[]
+  bindings?: undefined
+  decl?: DeclarationKind
+  implicitLift?: boolean
+
 export type ForDeclaration = ASTParent &
   type: "ForDeclaration"
   names: string[]
   binding: Binding
   decl: "let" | "const" | "var"
+  own?: boolean
 
-export type ForReduction
+export type ForReduction = ASTParent &
   type: "ForReduction"
   subtype: "some" | "every" | "count" | "first" | "sum" | "product" | "min" | "max" | "join" | "concat"
 
@@ -673,6 +701,7 @@ export type PropertyGlob = ASTParent &
   type: "PropertyGlob"
   dot: ASTNode
   object: ObjectExpression
+  reversed?: boolean?
 
 export type Call = ASTParent &
   type: "Call"
@@ -747,10 +776,12 @@ export type BlockStatement = ASTParent &
 export type ImportDeclaration = ASTParent &
   type: "ImportDeclaration"
   ts?: boolean
-  imports?: ImportClauseNode | OperatorImportClauseNode
-  from?: ASTNode
+  imports?: ImportClause | OperatorImportClause
+  from?: FromClause
   /** Set only for bare side-effect imports (`import "./mod"`). */
   module?: ModuleSpecifier
+
+export type FromClause = Children & [Keyword, ASTNode, ...ASTNode[]]
 
 /** Element inside `import {…}` — a specifier or `...rest`. */
 export type NamedImportElement =
@@ -765,12 +796,21 @@ export type NamedImportElement =
         ts?: boolean
       } )
 
+/** Precedence/associativity metadata for custom operators. */
+export type OperatorAssoc = "left" | "right" | "non" | "arguments"
+
+export type OperatorBehavior
+  prec?: number
+  assoc?: OperatorAssoc
+  relational?: boolean
+  error?: ASTError?
+
 /** Element inside `import operator {…}`. */
 export type OperatorImportSpecifier =
   ASTParent &
-    binding: ASTNodeObject & { names: string[] }
+    binding: Identifier
     /** Per-specifier precedence/associativity; falls back to cluster's. */
-    behavior?: ASTNodeObject
+    behavior?: OperatorBehavior?
 
 // Import clauses share `type: "Declaration"` with the statement-level
 // Declaration, so `gatherRecursive(…, .type is "Declaration")` walkers probe
@@ -781,7 +821,7 @@ type DeclarationProbe =
   decl?: undefined
 
 /** Clause between `import` and `from` (default, namespace, named, or combos). */
-export type ImportClauseNode = ASTParent & DeclarationProbe &
+export type ImportClause = ASTParent & DeclarationProbe &
   type: "Declaration"
   names: string[]
   binding?: ASTNodeObject & { names: string[] }
@@ -789,8 +829,8 @@ export type ImportClauseNode = ASTParent & DeclarationProbe &
   specifiers?: Extract<NamedImportElement, { type?: undefined }>[]
   rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
 
-/** Clause for `import operator {…}` — separate specifier shape from ImportClauseNode. */
-export type OperatorImportClauseNode = ASTParent & DeclarationProbe &
+/** Clause for `import operator {…}` — separate specifier shape from ImportClause. */
+export type OperatorImportClause = ASTParent & DeclarationProbe &
   type: "Declaration"
   names: string[]
   specifiers: OperatorImportSpecifier[]
@@ -809,6 +849,33 @@ export type NamespaceDeclaration = ASTParent &
   id: Identifier
   ts: true
 
+export type TypeDeclaration = ASTParent &
+  type: "TypeDeclaration"
+  id: Identifier
+  ts: true
+
+export type InterfaceDeclaration = ASTParent &
+  type: "InterfaceDeclaration"
+  id: Identifier
+  ts: true
+
+export type EnumDeclaration = ASTParent &
+  type: "EnumDeclaration"
+  id: Identifier
+
+export type OperatorFunctionDeclaration = FunctionExpression &
+  operator: true
+
+export type OperatorIdentifierDeclaration = ASTParent &
+  type?: undefined
+  id: Identifier
+  names: string[]
+
+export type OperatorDeclaration =
+  | LexicalDeclaration
+  | OperatorFunctionDeclaration
+  | OperatorIdentifierDeclaration
+
 export type Star =
   type: "Star"
   $loc: Loc
@@ -826,16 +893,23 @@ export type ImportAssertion = ASTParent &
   keyword: "with" | "assert"
   object: ASTNode
 
+export type DeclarationKind = "let" | "const" | "var" | Keyword | ASTLeaf
+
 export type Declaration = ASTParent &
   type: "Declaration"
   names: string[]
   bindings: Binding[]
-  decl: "let" | "const" | "var"
-  splices?: unknown
+  decl: DeclarationKind
+  splices?: unknown[]
   thisAssignments?: ThisAssignments
   // Should placeholders in contents be lifted above the parent block,
   // because they actual came from code outside the block?
   implicitLift?: boolean
+
+export type LexicalDeclaration = Declaration &
+  splices: unknown[]
+  thisAssignments: ThisAssignments
+  hoistDec?: ASTNode
 
 export type Binding = ASTParent &
   type: "Binding"
@@ -844,7 +918,7 @@ export type Binding = ASTParent &
   typeSuffix?: TypeSuffix?
   initializer?: Initializer?
   splices: unknown[]
-  thisAssignments: unknown[]
+  thisAssignments: ThisAssignments
 
 /**
 * `let x = expression` / `{x = default}` / etc.  Children are a 3-tuple
@@ -1038,7 +1112,7 @@ export type Whitespace = (ASTLeaf | ASTString | CommentNode)[]?
 
 export type Delimiter = ASTLeaf | ASTString | Delimiter[]
 
-type PropertyName =
+export type PropertyName =
   Literal | ComputedPropertyName | Identifier
 
 export type ComputedPropertyName =
@@ -1101,27 +1175,31 @@ export type ObjectBindingPattern =
 export type ObjectExpression = ASTParent &
   type: "ObjectExpression"
   names: string[]
-  properties: (Property | SpreadProperty | MethodDefinition | ASTError)[]
+  properties: ObjectProperty[]
+
+export type ObjectProperty = Property | SpreadProperty | MethodDefinition | MultiMethodDefinition | ASTError
 
 export type SpreadProperty = ASTParent &
   type: "SpreadProperty"
   names: string[]
   dots: ASTNode
-  value?: ASTNode
+  value: NonNullable<ASTNode>
   delim?: ASTNode // attached when inside a comma-delimited property list
+  usesRef?: boolean
 
 export type Property = ASTParent &
   type: "Property"
-  name: string
+  name: NonNullable<ASTNode>
   names: string[]
   value: ASTNode
+  delim?: ASTNode // attached when inside a comma-delimited property list
   implicitName?: boolean
   usesRef?: boolean
   // Source name when the value is a `#privateField` shorthand inside a
   // PropertyGlob; consumed by processAssignments to polyfill the assignment
   // (`obj.{#x} = src` → `obj.#x = src.#x`) since JS destructuring cannot
   // target private fields.
-  privateField?: string
+  privateField?: string?
 
 export type ArrayExpression = ASTParent &
   type: "ArrayExpression"
@@ -1176,14 +1254,19 @@ export type PipelineExpression =
 
 export type MethodDefinition = ASTParent &
   type: "MethodDefinition"
-  name: string
-  async?: ASTNode[]
-  generator?: ASTNode[]
+  name: NonNullable<ASTNode>
+  async?: ASTNode[]?
+  generator?: ASTNode[]?
   signature: FunctionSignature
-  block: BlockStatement
+  block?: BlockStatement
   parameters: ParametersNode
-  autoBind?: boolean // CoffeeScript => bound methods
+  autoBind?: boolean? // CoffeeScript => bound methods
   delim?: ASTNode // attached when inside a comma-delimited property list
+  abstract?: boolean?
+  ts?: boolean
+
+export type MultiMethodDefinition = ASTParent &
+  type: "MultiMethodDefinition"
 
 export type ArrowFunction = ASTParent &
   type: "ArrowFunction"
@@ -1202,16 +1285,29 @@ export type ArrowFunction = ASTParent &
 export type FunctionSignature = ASTParent &
   type: "MethodSignature" | "FunctionSignature"
   /** undefined means anonymous (e.g. arrow function) */
-  name?: string?
+  name?: ASTNode
   id?: Identifier?
+  async?: ASTNode[]?
+  generator?: ASTNode[]?
   modifier: MethodModifier
-  returnType: ReturnTypeAnnotation?
+  optional?: ASTNode?
+  returnType?: ReturnTypeAnnotation?
   parameters: ParametersNode
+  block?: BlockStatement | null
   /**
   Force implicit return for this function for IIFE
   (overriding "civet -implicitReturns")
   */
-  implicitReturn?: boolean
+  implicitReturn?: boolean?
+
+export type OperatorSignature = FunctionSignature &
+  type: "FunctionSignature"
+  id: Identifier
+  behavior?: OperatorBehavior?
+
+export type MethodSignature = FunctionSignature &
+  type: "MethodSignature"
+  name: NonNullable<ASTNode>
 
 export type TypeSuffix = ASTParent &
   type: "TypeSuffix"
@@ -1342,15 +1438,11 @@ export type CoffeeClassPublic = ASTParent &
 export type Literal =
   type: "Literal"
   subtype: "NullLiteral" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral" | "RegularExpressionLiteral"
-  children: Children & LiteralContentNode[]
+  children: Children & (LiteralContent | ASTLeaf | string)[]
   parent?: Parent
   raw: string
 
-export type LiteralContentNode =
-  | ASTLeaf
-  | ASTLeafWithType "BooleanLiteral" | "NullLiteral" | "NumericLiteral" | "StringLiteral"
-  | string
-
+export type LiteralContent = ASTLeafWithType "BooleanLiteral" | "NullLiteral" | "NumericLiteral" | "StringLiteral"
 export type BooleanLiteral = ASTLeafWithType "BooleanLiteral"
 export type NullLiteral = ASTLeafWithType "NullLiteral"
 export type NumericLiteral = ASTLeafWithType "NumericLiteral"
@@ -1394,6 +1486,7 @@ export type TypeNode =
   | TypeParenthesized
   | TypeAsserts
   | TypePredicate
+  | VoidType
 
 export type TypeIdentifier = ASTParent &
   type: "TypeIdentifier"
@@ -1404,7 +1497,9 @@ export type TypeArguments = ASTParent &
   type: "TypeArguments"
   ts: true
   // Should alternate: argument, delimiter, argument, delimiter, ..., argument
-  args: (TypeArgument | Delimiter)[]
+  args: TypeArgumentList
+
+export type TypeArgumentList = (TypeArgument | Delimiter)[]
 
 export type TypeArgument = ASTObject &
   type: "TypeArgument"
@@ -1422,11 +1517,11 @@ export type TypeUnary = ASTParent &
 export type TypeTuple = ASTParent &
   type: "TypeTuple"
   ts: true
-  elements: ASTNode[]
+  elements?: ASTNode[]
 
 export type TypeElement = ASTParent &
   type: "TypeElement"
-  name?: string
+  name?: ASTNode
   t: TypeNode
 
 export type TypeFunction = ASTParent &
@@ -1448,6 +1543,7 @@ export type TypeTypeof = ASTParent &
 
 export type TypeAsserts = ASTParent &
   type: "TypeAsserts"
+  ts: true
   t: TypeNode
 
 export type TypePredicate = ASTParent &
@@ -1459,14 +1555,13 @@ export type VoidType = ASTLeafWithType "VoidType"
 
 export type TypeLiteralNode = ASTLeaf | ASTString | VoidType
 
-export type ThisAssignments = ([string, ASTRef] | AssignmentExpression)[]
+export type ThisAssignment =
+  | [string, ASTRef]
+  | [ASTNode, ASTNode, ASTNode, ASTRef]
+  | AssignmentExpression
+  | [IndentNode, ThisAssignment, StatementDelimiter?]
+export type ThisAssignments = ThisAssignment[]
 
 export type WithClause = ASTParent &
   type: "WithClause"
   targets: [WSNode, ExpressionNode][]
-
-export type OperatorBehavior
-  prec?: number
-  assoc?: "left" | "right" | "non" | "relational" | "arguments"
-  relational?: boolean
-  error?: ASTError

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -701,7 +701,6 @@ export type PropertyGlob = ASTParent &
   type: "PropertyGlob"
   dot: ASTNode
   object: ObjectExpression
-  reversed?: boolean?
 
 export type Call = ASTParent &
   type: "Call"

--- a/source/parser/unary.civet
+++ b/source/parser/unary.civet
@@ -1,5 +1,6 @@
 import type {
   ArrayExpression
+  Children
   ASTLeaf
   ASTNode
   Existence
@@ -179,7 +180,7 @@ function processUnaryNestedExpression(pre: UnaryOpElement[], args: ArrayExpressi
                   {
                     ...arg
                     expression
-                    children: children.map & is exp ? expression : &
+                    children: children.map(& is exp ? expression : &) as Children
                   }
                 else
                   arg

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -361,7 +361,7 @@ function prepend(prefix: ASTNode, node: ASTNode): ASTNode
   else if isParent node
     {
       ...node
-      children: [prefix, ...node.children]
+      children: [prefix, ...node.children as Children]
     } as typeof node
   // Mirrors `append`: can't glom into a leaf, so wrap as an array.
   else
@@ -376,7 +376,7 @@ function append(node: ASTNode, suffix: ASTNode): ASTNode
   else if isParent node
     {
       ...node
-      children: [...node.children, suffix]
+      children: [...node.children as Children, suffix]
     } as typeof node
   else
     [node, suffix]

--- a/test/compat/auto-var.civet
+++ b/test/compat/auto-var.civet
@@ -1,4 +1,6 @@
 {testCase} from ../helper.civet
+assert from assert
+{createVarDecs} from ../../source/parser/auto-dec.civet
 
 describe "auto-var", ->
   testCase """
@@ -418,6 +420,43 @@ describe "auto-var", ->
       return c = 2
     }
   """
+
+  it "skips function nodes without blocks", ->
+    block := {
+      type: "BlockStatement"
+      bare: false
+      expressions: [
+        ["", {
+          type: "FunctionExpression"
+          children: []
+          block: null
+          parameters: {names: []}
+        }, undefined]
+        ["", {
+          type: "FunctionExpression"
+          children: []
+          block: {
+            type: "BlockStatement"
+            bare: false
+            expressions: []
+            children: []
+          }
+          parameters: {names: []}
+        }, undefined]
+        ["", {
+          type: "AssignmentExpression"
+          children: []
+          names: ["x"]
+        }, undefined]
+      ]
+      children: []
+    } as any
+
+    createVarDecs block, []
+
+    assert.equal block.expressions[0][1].type, "Declaration"
+    assert.equal block.expressions[1][1].type, "FunctionExpression"
+    assert.equal block.expressions[2][1].type, "FunctionExpression"
 
   testCase """
     nested blocks

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -671,6 +671,22 @@ describe "JSX object literal shorthand", ->
   """
 
   testCase """
+    object glob with unary prefix and suffixes
+    ---
+    <Component {props.{not disabled, count + 1, name |> String}} />
+    ---
+    <Component disabled={!props.disabled} count={props.count + 1} name={String(props.name)} />
+  """
+
+  testCase """
+    inline object glob with unary prefix and suffixes
+    ---
+    <Component props.{not disabled, count + 1, name |> String} />
+    ---
+    <Component disabled={!props.disabled} count={props.count + 1} name={String(props.name)} />
+  """
+
+  testCase """
     named property
     ---
     <Component {props[key]} />

--- a/test/object.civet
+++ b/test/object.civet
@@ -1,4 +1,6 @@
 {testCase, throws, wrapper} from ./helper.civet
+assert from assert
+{processCallMemberExpression} from ../source/parser/lib.civet
 
 describe "object", ->
   testCase """
@@ -1606,6 +1608,14 @@ describe "object", ->
     """
 
     testCase """
+      renamed this shorthand with value spacing
+      ---
+      obj.{b:  @c}
+      ---
+      ({b:   this.c})
+    """
+
+    testCase """
       this shorthand
       ---
       x.{@a, @a.b, @a.x(), @a.x().y}
@@ -1635,6 +1645,44 @@ describe "object", ->
       ---
       ({"hello world":x["hello world"], [`template string`]:x[`template string`], [a+b]:x[a+b]})
     """
+
+    it "processes literal string subtype glob values", ->
+      literal := {
+        type: "Literal"
+        subtype: "StringLiteral"
+        children: [{type: "StringLiteral", token: '"hello"'}]
+        raw: '"hello"'
+      } as any
+      result := processCallMemberExpression {
+        type: "MemberExpression"
+        children: [
+          {
+            type: "Identifier"
+            name: "obj"
+            names: ["obj"]
+            children: [{token: "obj"}]
+          }
+          {
+            type: "PropertyGlob"
+            dot: {token: "."}
+            object: {
+              type: "ObjectExpression"
+              names: []
+              children: [{token: "{"}, {token: "}"}]
+              properties: [{
+                type: "Property"
+                name: literal
+                value: literal
+                children: [undefined, literal, undefined, ":", literal, undefined]
+                names: []
+              }]
+            }
+          }
+        ]
+      } as any
+
+      assert.equal result.type, "ObjectExpression"
+      assert.equal result.properties[0].value[1].type, "Index"
 
     testCase """
       assignment

--- a/test/object.civet
+++ b/test/object.civet
@@ -1,4 +1,5 @@
 {testCase, throws, wrapper} from ./helper.civet
+import type {ObjectExpression, Property} from ../source/parser/types.civet
 assert from assert
 {processCallMemberExpression} from ../source/parser/lib.civet
 
@@ -1681,8 +1682,13 @@ describe "object", ->
         ]
       } as any
 
-      assert.equal result.type, "ObjectExpression"
-      assert.equal result.properties[0].value[1].type, "Index"
+      assert.equal result?.type, "ObjectExpression"
+      object := result as ObjectExpression
+      assert.equal object.properties[0].type, "Property"
+      property := object.properties[0] as Property
+      assert Array.isArray(property.value), "property value should be prefixed member access"
+      value := property.value as any[]
+      assert.equal value[1].type, "Index"
 
     testCase """
       assignment

--- a/test/object.civet
+++ b/test/object.civet
@@ -1653,6 +1653,102 @@ describe "object", ->
     """
 
     testCase """
+      not
+      ---
+      obj.{not b}
+      ---
+      ({b:!obj.b})
+    """
+
+    testCase """
+      bang
+      ---
+      obj.{!b}
+      ---
+      ({b:!obj.b})
+    """
+
+    testCase """
+      negative
+      ---
+      obj.{-b}
+      ---
+      ({b:-obj.b})
+    """
+
+    testCase """
+      positive
+      ---
+      obj.{+b}
+      ---
+      ({b:+obj.b})
+    """
+
+    testCase """
+      unary prefix with binary suffix
+      ---
+      obj.{!b or c}
+      ---
+      ({b:!obj.b || c})
+    """
+
+    testCase """
+      positive prefix with binary suffix
+      ---
+      obj.{+b or c}
+      ---
+      ({b:+obj.b || c})
+    """
+
+    testCase """
+      as T
+      ---
+      obj.{b as T}
+      ---
+      ({b:obj.b as T})
+    """
+
+    testCase """
+      binary operator
+      ---
+      obj.{b + 1}
+      ---
+      ({b:obj.b + 1})
+    """
+
+    testCase """
+      nullish coalescing
+      ---
+      obj.{b ?? fallback}
+      ---
+      ({b:obj.b ?? fallback})
+    """
+
+    testCase """
+      pipeline
+      ---
+      obj.{b |> String}
+      ---
+      ({b:String(obj.b)})
+    """
+
+    testCase """
+      unary, type cast, and pipeline
+      ---
+      a.{not b, c as T, d |> String}
+      ---
+      ({b:!a.b, c:a.c as T, d:String(a.d)})
+    """
+
+    testCase """
+      unary, type cast, and pipeline inside braced object literals
+      ---
+      {a.{not b, c as T, d |> String}}
+      ---
+      ({b:!a.b, c:a.c as T, d:String(a.d)})
+    """
+
+    testCase """
       ...spread assignment
       ---
       obj.{a, b, ...rest} = x
@@ -1736,28 +1832,6 @@ describe "object", ->
       obj.{a, b=5}
       ---
       ParseError
-    """
-
-    throws """
-      no + flags
-      ---
-      obj.{+x}
-      ---
-      ParseErrors: unknown:1:6 Glob pattern must have call or member expression value, found "true"
-    """
-    throws """
-      no - flags
-      ---
-      obj.{-x}
-      ---
-      ParseErrors: unknown:1:6 Glob pattern must have call or member expression value, found "false"
-    """
-    throws """
-      no ! flags
-      ---
-      obj.{!x}
-      ---
-      ParseErrors: unknown:1:6 Glob pattern must have call or member expression value, found "false"
     """
 
     throws """

--- a/test/object.civet
+++ b/test/object.civet
@@ -1410,6 +1410,30 @@ describe "object", ->
     """
 
     testCase """
+      not member call
+      ---
+      boolified := {not x.y()}
+      ---
+      const boolified = {y: !x.y()}
+    """
+
+    testCase """
+      bang member call
+      ---
+      boolified := {!x.y()}
+      ---
+      const boolified = {y: !x.y()}
+    """
+
+    testCase """
+      negative member call
+      ---
+      negated := {-x.y()}
+      ---
+      const negated = {y: -x.y()}
+    """
+
+    testCase """
       as T
       ---
       cast := {x as T}
@@ -1423,6 +1447,30 @@ describe "object", ->
       cast := {x() as T}
       ---
       const cast = {x: x() as T}
+    """
+
+    testCase """
+      member call as T
+      ---
+      cast := {x.y() as T}
+      ---
+      const cast = {y: x.y() as T}
+    """
+
+    testCase """
+      member call nullish coalescing
+      ---
+      value := {x.y() ?? fallback}
+      ---
+      const value = {y: x.y() ?? fallback}
+    """
+
+    testCase """
+      member call pipeline
+      ---
+      value := {x.y() |> String}
+      ---
+      const value = {y: String(x.y())}
     """
 
     testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -370,12 +370,12 @@ describe "object", ->
     ParseError
   """
 
-  throws """
-    doesn't allow comparisons inside
+  testCase """
+    allows comparisons inside shorthand
     ---
     obj = {x<=y}
     ---
-    ParseError
+    obj = {x: x<=y}
   """
 
   testCase """

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -2193,7 +2193,7 @@ describe "switch", ->
     ---
     let ref;switch(direction) {
       case Direction.Up: {
-        { ref = location.y - 1 };break;
+        ref = ({ y: location.y - 1 });break;
       }
     };const nextLocation =ref
   """

--- a/test/types/js.civet
+++ b/test/types/js.civet
@@ -121,6 +121,24 @@ describe "Types", ->
     """
 
     testCase.js """
+      adds empty blocks to method signatures
+      ---
+      class A
+        show(): string
+        show(s: string): string
+        bar()
+          @show()
+      ---
+      class A {
+        
+        show(s){}
+        bar() {
+          return this.show()
+        }
+      }
+    """
+
+    testCase.js """
       omits import type
       ---
       import type {S, T} from "foo"


### PR DESCRIPTION
- Extend braced object literal shorthand to support trailing binary operators, such as nullish coalescing, and pipelines after call/member shorthand. (Unary operators before and after were already supported.)
  - In particular, I've been wanting `{obj.prop ?? fallback}` which now works.
  - `{obj.prop |> String}` should also be helpful.
  - https://github.com/DanielXMoore/Civet/issues/1637#issuecomment-2525106724 also suggested this, with `{ location.y - 1 }`
- Extend object globs with the same unary prefix, type cast, binary suffix, and pipeline support. (None of these were working before.)
  - In particular, `x{+y}` is no longer treated as `x{y: true}`, which failed (and ditto for other flag notation); it gets rewritten into `{y: +x.y}`
- Track inner shorthand call expressions so glob prefixing rewrites the target expression inside unary/binary/pipeline wrappers.
- Parser/type cleanup for the new AST metadata and related parser nodes, reducing type errors by 79.
  - This is what took most of my time: to not introduce new type errors, I went down the rabbit hole of annotating the grammar with types and fixing a bunch of things.
- Update reference docs with braced literal and glob examples.
- Add regression and coverage tests for the new shorthand/glob behavior.

<details>
<summary>typecheck:diff - 79 fixed type errors</summary>

```
Fixed (80):
  source/parser.hera
    2922:20 TS2769 Argument of type '{ type: string; message: string; }' is not assignable to parameter of type 'ASTNode'.
    2923:39 TS2769 Argument of type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...' is not assignable to parameter of type 'ASTNodeObject' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    2948:6 TS2749 'FunctionSignature' refers to a value, but is being used as a type here. Did you mean 'typeof FunctionSignature'?
    2948:6 TS2749 'FunctionSignature' refers to a value, but is being used as a type here. Did you mean 'typeof FunctionSignature'?
    2948:6 TS2749 'FunctionSignature' refers to a value, but is being used as a type here. Did you mean 'typeof FunctionSignature'?
    2976:6 TS2749 'FunctionSignature' refers to a value, but is being used as a type here. Did you mean 'typeof FunctionSignature'?
    4100:12 TS2352 Conversion of type 'ASTNodeObject' to type 'SpreadProperty | Property' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
    4145:29 TS2339 Property 'block' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "abstract" | "abstract "; ts: boolean; }, "" | (CommentNode | { $loc: Loc; token: any; })[], { type: string; ... 4 more ...; parameters: ParametersNode; } | { ...; }]; ... 6 more ...; ts: boolean; } | { ...; } | Unwrap<...>'.
    4145:47 TS2339 Property 'block' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "abstract" | "abstract "; ts: boolean; }, "" | (CommentNode | { $loc: Loc; token: any; })[], { type: string; ... 4 more ...; parameters: ParametersNode; } | { ...; }]; ... 6 more ...; ts: boolean; } | { ...; } | Unwrap<...>'.
    4372:24 TS2339 Property 'async' does not exist on type '{ type: string; children: [{ $loc: Loc; token: string; }, ParametersNode]; name: string; modifier: {}; returnType: undefined; parameters: ParametersNode; } | { type: string; children: any[]; async: any; generator: any; name: any; optional: { ...; } | undefined; modifier: { ...; } | { ...; }; returnType: ASTNode; par...'.
    4373:28 TS2339 Property 'generator' does not exist on type '{ type: string; children: [{ $loc: Loc; token: string; }, ParametersNode]; name: string; modifier: {}; returnType: undefined; parameters: ParametersNode; } | { type: string; children: any[]; async: any; generator: any; name: any; optional: { ...; } | undefined; modifier: { ...; } | { ...; }; returnType: ASTNode; par...'.
    4500:23 TS2339 Property 'async' does not exist on type '{ modifier: { async: boolean; generator: boolean; get: boolean; set: boolean; }; children: ((string | { $loc: Loc; token: any; } | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[] | { ...; } | undefined)[]; } | { ...; }'.
    4501:27 TS2339 Property 'generator' does not exist on type '{ modifier: { async: boolean; generator: boolean; get: boolean; set: boolean; }; children: ((string | { $loc: Loc; token: any; } | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[] | { ...; } | undefined)[]; } | { ...; }'.
    5178:37 TS7056 The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
    5286:6 TS7056 The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
    5293:36 TS2339 Property 'blockPrefix' does not exist on type '{ type: string; children: (string | Children | AwaitExpression | (ChainOp & { token?: never; relational?: never; }) | ASTError | ASTRef | ... 15 more ... | undefined)[]; block: null; generator: [...] | undefined; declaration: ASTString | ... 8 more ... | undefined; } | ... 14 more ... | { ...; }'.
    5299:6 TS7056 The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.
    5303:16 TS2339 Property 'reduction' does not exist on type '{ declaration: ASTString | Children | (string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | { type: string; children: (CommentNode | ... 135 more ... | undefined)[]; } | ... 5 more ... | undefined; children: ("" | ... 18 more ... | undefined)[]; } | ... ...'.
    5334:32 TS2339 Property 'blockPrefix' does not exist on type 'Unwrap<MaybeResult<{ declaration: ASTString | Children | (string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | { type: string; children: (CommentNode | ... 135 more ... | undefined)[]; } | ... 5 more ... | undefined; children: [...]; } | ... 6 more ... |...'.
    5351:37 TS2554 Expected 0-9 arguments, but got 10.
    5431:44 TS2339 Property 'names' does not exist on type '{ children: any[]; type: "Comment"; $loc: Loc; token: string; parent?: (ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; ... 9 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 123 more ... | undefined; } | ... 129 more ... | { ...; }'.
    5809:24 TS2769 Argument of type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "finally"; }, BlockStatement]; block: BlockStatement; }' is not assignable to parameter of type 'ASTNodeObject'.
    6290:40 TS2339 Property 'name' does not exist on type 'ASTNodeObject'.
    6295:21 TS2322 Type '{ type: string; message: string; }' is not assignable to type 'ASTNode'.
    6334:21 TS2339 Property '$loc' does not exist on type 'FlatArray<string | { $loc: Loc; token: any; } | [(string | { $loc: Loc; token: any; } | CommentNode)[], { $loc: Loc; token: any; }][] | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; }, 0 | ... 20 more ... | 20>[] | { ...; } | { ...; } | { ...; } | { ...; }'.
    6335:24 TS2339 Property '$loc' does not exist on type 'FlatArray<string | { $loc: Loc; token: any; } | [(string | { $loc: Loc; token: any; } | CommentNode)[], { $loc: Loc; token: any; }][] | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; }, 0 | ... 20 more ... | 20>[] | { ...; } | { ...; } | { ...; } | { ...; }'.
    6344:40 TS2339 Property 'name' does not exist on type 'ASTNodeObject'.
    6349:26 TS2322 Type '{ type: string; message: string; }' is not assignable to type 'ASTNode'.
    6396:22 TS2339 Property 'names' does not exist on type 'ASTNodeObject'.
    6436:56 TS2339 Property 'names' does not exist on type 'ASTNodeObject'.
    6524:16 TS2339 Property 'unicode' does not exist on type 'ASTNodeObject'.
    6658:53 TS2339 Property 'ts' does not exist on type '[{ readonly type: "Star"; readonly $loc: Loc; readonly token: "*"; }, ["" | (CommentNode | { $loc: Loc; token: any; })[], { type: "Keyword"; $loc: Loc; token: "as"; }, "" | (CommentNode | { ...; })[], any] | undefined] | Unwrap<...>'.
    6663:19 TS2339 Property 'ts' does not exist on type '[{ readonly type: "Star"; readonly $loc: Loc; readonly token: "*"; }, ["" | (CommentNode | { $loc: Loc; token: any; })[], { type: "Keyword"; $loc: Loc; token: "as"; }, "" | (CommentNode | { ...; })[], any] | undefined] | Unwrap<...>'.
    6750:10 TS2339 Property 'thisAssignments' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    6753:23 TS2488 Type 'Children | [ASTNode, NullCheckLeaf] | (ASTNode[] & { type?: undefined; } & { token?: undefined; } & { children?: undefined; } & [ASTString | ASTLeaf | ASTRef | Keyword]) | ... 15 more ... | undefined' must have a '[Symbol.iterator]()' method that returns an iterator.
    6753:40 TS2339 Property 'splices' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    6753:59 TS2339 Property 'thisAssignments' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    6755:10 TS2339 Property 'splices' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    6758:40 TS2339 Property 'splices' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    6828:22 TS2339 Property 'names' does not exist on type 'ASTNodeObject'.
    8388:16 TS2339 Property 'names' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8389:9 TS2339 Property 'thisAssignments' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8405:10 TS2339 Property 'thisAssignments' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8406:39 TS2339 Property 'splices' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8406:58 TS2339 Property 'thisAssignments' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8409:18 TS2339 Property 'thisAssignments' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8412:15 TS2339 Property 'splices' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8413:39 TS2339 Property 'splices' does not exist on type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "const" | "let"; }, { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: [...]; }; splices: unknown[][]; thisAssignments: (string | ... 1 more ... | [...])[][]; } | {...'.
    8476:22 TS2339 Property 'names' does not exist on type 'ASTNodeObject'.
    8501:16 TS2339 Property 'names' does not exist on type '{ type: string; children: ["" | (CommentNode | { $loc: Loc; token: any; })[], { type: "Keyword"; $loc: Loc; token: "const" | "let" | "var"; }, { type: string; children: [...]; names: any; }, [...][]]; ts: boolean; names: any; } | ... 4 more ... | [...]'.
    9041:6 TS2749 'TypeTuple' refers to a value, but is being used as a type here. Did you mean 'typeof TypeTuple'?
    9041:6 TS2749 'TypeTuple' refers to a value, but is being used as a type here. Did you mean 'typeof TypeTuple'?
    9041:6 TS2749 'TypeTuple' refers to a value, but is being used as a type here. Did you mean 'typeof TypeTuple'?
    9057:6 TS2749 'TypeTuple' refers to a value, but is being used as a type here. Did you mean 'typeof TypeTuple'?
    9083:14 TS2769 Argument of type '{ type: string; name: Identifier; t: TypeNode; children: ("" | Identifier | TypeNode | (CommentNode | { $loc: Loc; token: any; })[] | [...] | [...] | [...] | undefined)[]; } | [...] | { ...; }' is not assignable to parameter of type 'ASTNodeObject'.
    9087:16 TS2769 Argument of type '{ type: string; name: Identifier; t: TypeNode; children: ("" | Identifier | TypeNode | (CommentNode | { $loc: Loc; token: any; })[] | [...] | [...] | [...] | undefined)[]; } | [...] | { ...; }' is not assignable to parameter of type 'ASTNodeObject'.
    9209:5 TS2322 Type '[{ type: string; negated: any; children: [TypeIdentifier | TypeLiteral | TypeTypeof | TypeUnary | TypeTuple | ... 7 more ... | (TypeNode | ... 1 more ... | [...][])[], [...] | undefined, { ...; } | ... 2 more ... | { ...; }, ASTNode]; }, ... 7 more ..., TypeNode]' is not assignable to type 'ASTNode'.
    9320:20 TS2322 Type '{ type: string; $loc: Loc; token: string; }' is not assignable to type 'ASTNode'.
    9344:5 TS2322 Type '(TypeArgument | [(string | { $loc: Loc; token: any; } | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[] | undefined, { ...; }] | { ...; } | undefined)[]' is not assignable to type '["" | (CommentNode | { $loc: Loc; token: any; })[], [TypeArgument, [(string | { $loc: Loc; token: any; } | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[] | undefined, { ...; }] | { ...; } | undefined]][]'.
    9391:21 TS2345 Argument of type '(this: undefined, [comma, args]: [[FlatArray<string | { $loc: Loc; token: any; } | [(string | { $loc: Loc; token: any; } | CommentNode)[], { $loc: Loc; token: any; }][] | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; }, 0 | ... 20 more ... | 20>[], { ...; }], { ...; } | ... 1 more ...' is not assignable to parameter of type '(this: undefined, value: [[FlatArray<string | { $loc: Loc; token: any; } | [(string | { $loc: Loc; token: any; } | CommentNode)[], { $loc: Loc; token: any; }][] | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; }, 0 | ... 20 more ... | 20>[], { ...; }], { ...; } | ... 1 more ... | (T...'.
    9901:7 TS2322 Type '[[string, { $loc: Loc; token: any; }] | undefined, ({ type: string; children: never[]; config: any; } | [string, StringLiteral, string, [(string | { $loc: Loc; token: any; } | CommentNode)[], { ...; }][]] | [...] | [...])[], string]' is not assignable to type '[[string, { $loc: Loc; token: any; }] | undefined, ({ type: string; children: never[]; config: any; } | [string, StringLiteral, string, [(string | { $loc: Loc; token: any; } | CommentNode)[], { ...; }][]] | [...] | [...])[]]'.
  source/parser/binding.civet
    192:13 TS2322 Type '{ $loc: Loc; token: string; }' is not assignable to type 'string'.
    193:31 TS2322 Type 'string' is not assignable to type 'undefined'.
    194:13 TS2322 Type 'string' is not assignable to type 'undefined'.
    195:13 TS2322 Type 'ASTRef' is not assignable to type 'undefined'.
  source/parser/declaration.civet
    119:5 TS2322 Type 'ASTLeaf' is not assignable to type '"const" | "let" | "var" | undefined'.
  source/parser/for.civet
    389:9 TS2322 Type 'ASTRef' is not assignable to type 'Identifier | Literal | RegularExpressionLiteral | AtBinding | ArrayBindingPattern | NamedBindingPattern | ObjectBindingPattern | PinPattern | ReturnValue'.
  source/parser/lib.civet
    44:3 TS6196 'LiteralContentNode' is declared but never used.
    713:22 TS2551 Property 'name' does not exist on type 'SpreadProperty | Property'. Did you mean 'names'?
    728:47 TS2339 Property 'reversed' does not exist on type 'PropertyGlob'.
    772:25 TS2339 Property 'delim' does not exist on type 'Property'.
    780:20 TS2339 Property 'delim' does not exist on type 'Property'.
    789:11 TS2322 Type 'ASTNode | { type: string; message: string; } | { type: "SpreadProperty"; value: any; dots: ASTNode; delim: ASTNode; names: string[]; children: ASTNode[]; usesRef: boolean; } | { ...; }' is not assignable to type 'ASTNode'.
    791:9 TS2322 Type '(ASTError | { type: string; message: string; } | { type: "SpreadProperty"; value: any; dots: ASTNode; delim: ASTNode; names: string[]; children: ASTNode[]; usesRef: boolean; } | { ...; })[]' is not assignable to type '(MethodDefinition | ASTError | SpreadProperty | Property)[]'.
    1071:22 TS2339 Property 'type' does not exist on type 'string'.
    1140:7 TS2322 Type 'ASTNode' is not assignable to type 'string | undefined'.
    1475:27 TS2339 Property 'usesRef' does not exist on type 'CallExpression | MemberExpression | { children: (string | CommentNode | Children | BlockStatement | ... 128 more ... | undefined)[]; usesRef: boolean; parent?: (ASTObject & ... 3 more ... & object) | ... 123 more ... | undefined; type: "CallExpression"; implicit?: boolean; } | { ...; }'.
  source/parser/pattern-matching.civet
    334:7 TS2322 Type 'CommentNode | ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ... 127 more ... | UntypedNode' is not assignable to type '"const" | "let" | "var"'.
    503:22 TS2345 Argument of type '{ type: "Declaration"; children: (string | ASTRef | (string | ASTRef)[])[]; names: never[]; bindings: never[]; }' is not assignable to parameter of type 'ASTNode'.
```

</details>