### PR TITLE
VSCode extension: Load project's Hera, fix Windows casing

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   "recommendations": [
-    "DanielX.hera"
+    "DanielX.civet"
   ]
 }

--- a/lsp/server/source/lib/typescript-service.civet
+++ b/lsp/server/source/lib/typescript-service.civet
@@ -121,9 +121,11 @@ function TSService(projectURL = "./", logger: Logger = console): Promise<Resolve
   // above).  Optional peer — absent when the workspace has no `.hera` files,
   // in which case grammar features no-op.
   let hera: HeraModule?
+  let heraVersion: string?
   try
     hera = projectRequire("@danielx/hera") as HeraModule
-    logger.info `LOADED PROJECT HERA ${(projectRequire("@danielx/hera/package.json") as { version: string }).version}`
+    heraVersion = (projectRequire("@danielx/hera/package.json") as { version: string }).version
+    logger.info `LOADED PROJECT HERA ${heraVersion}`
 
   civetConfig: CompileOptions .= {}
   try
@@ -152,6 +154,8 @@ function TSService(projectURL = "./", logger: Logger = console): Promise<Resolve
   // Hera support: same project Civet powers the second Hera→Civet→TS stage,
   // so .hera files participate in the same config + version negotiation.
   heraPlugin := makeHeraPlugin {
+    Hera: hera
+    HeraVersion: heraVersion
     Civet
     CivetVersion
     config: pluginConfig

--- a/lsp/server/test/service.civet
+++ b/lsp/server/test/service.civet
@@ -614,6 +614,46 @@ describe "ts service hera plugin", ->
     diagnostics := service.getSemanticDiagnostics(hPath + ".tsx")
     assert Array.isArray(diagnostics), 'getSemanticDiagnostics should return an array'
 
+  it "uses project-resolved Hera for the built-in hera plugin", async ->
+    tmpDir := mkdtempSync(path.join(tmpdir(), 'civet-lsp-project-hera-'))
+    try
+      writeFileSync path.join(tmpDir, 'tsconfig.json'), '{"compilerOptions":{"target":"es2020","module":"esnext"}}'
+
+      heraDir := path.join tmpDir, 'node_modules', '@danielx', 'hera'
+      mkdirSync heraDir, recursive: true
+      writeFileSync path.join(heraDir, 'package.json'), JSON.stringify {
+        name: '@danielx/hera'
+        version: '123.45.67'
+        main: 'index.cjs'
+      }
+      writeFileSync path.join(heraDir, 'index.cjs'), ```
+        module.exports = {
+          compile() {
+            return {
+              code: 'export default "project-hera-plugin-used"\\n',
+              sourceMap: { lines: [] }
+            };
+          },
+          parseTokens() {
+            throw new Error("grammar analyzer not needed for this test");
+          }
+        };
+      ```
+
+      heraPath := path.join tmpDir, 'sample.hera'
+      writeFileSync heraPath, "Rule\n  \"x\"\n"
+
+      service := await TSService(pathToFileURL(tmpDir + path.sep).href, nullLogger)
+      heraDoc := TextDocument.create(pathToFileURL(heraPath).href, "hera", 0, fs.readFileSync(heraPath, "utf8"))
+      service.host.addOrUpdateDocument(heraDoc)
+
+      meta := service.host.getMeta(heraPath)
+      assert meta?.transpiledDoc, 'expected transpiledDoc'
+      assert meta!.transpiledDoc!.getText().includes("project-hera-plugin-used"),
+        "expected built-in Hera plugin to use the project-resolved Hera module"
+    finally
+      rmSync(tmpDir, { recursive: true, force: true })
+
 
 describe "lsp/server browser TSService wrapper", ->
   // LSP-server-specific: createBrowserTSService and browserDefaultTsConfig

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
-    "@danielx/civet": "0.11.13",
+    "@danielx/civet": "0.11.12",
     "@danielx/hera": "0.9.8",
     "@types/assert": "^1.5.6",
     "@types/babel__core": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
-    "@danielx/civet": "0.11.6",
+    "@danielx/civet": "0.11.13",
     "@danielx/hera": "0.9.8",
     "@types/assert": "^1.5.6",
     "@types/babel__core": "7.20.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^7.29.2
         version: 7.29.2
       '@danielx/civet':
-        specifier: 0.11.13
-        version: 0.11.13(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)
+        specifier: 0.11.12
+        version: 0.11.12(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)
       '@danielx/hera':
         specifier: 0.9.8
         version: 0.9.8
@@ -851,8 +851,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@danielx/civet@0.11.13':
-    resolution: {integrity: sha512-3yWLCHFB0YU4dvNpPGIyRmbgbzDDbLvKeRawOeaZqdTAGtpMoCIHTurRhg3Ejhe6N76+9WSEkwlUxNZ0yduDsA==}
+  '@danielx/civet@0.11.12':
+    resolution: {integrity: sha512-bckxDYPKRE10Vmf0LAKPL2sXnNJwDyNRChsIno+93UvSbHxTXoAP+1nCn8hASkvadeI0QKEDVYhiumglr0JsBg==}
     engines: {node: '>=19 || ^18.6.0 || ^16.17.0'}
     hasBin: true
     peerDependencies:
@@ -7399,7 +7399,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@danielx/civet@0.11.13(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)':
+  '@danielx/civet@0.11.12(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       unplugin: 2.3.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^7.29.2
         version: 7.29.2
       '@danielx/civet':
-        specifier: 0.11.6
-        version: 0.11.6(typescript@6.0.2)(yaml@2.8.3)
+        specifier: 0.11.13
+        version: 0.11.13(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)
       '@danielx/hera':
         specifier: 0.9.8
         version: 0.9.8
@@ -851,14 +851,17 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@danielx/civet@0.11.6':
-    resolution: {integrity: sha512-KPCF4ngJsabPzEBdUxk7FcONwT+rP/yvwJChfDfzLXJYwCqvMRW2c7yQ31Ve6dAz2tSHya3NhTS1BDbmGInxMQ==}
+  '@danielx/civet@0.11.13':
+    resolution: {integrity: sha512-3yWLCHFB0YU4dvNpPGIyRmbgbzDDbLvKeRawOeaZqdTAGtpMoCIHTurRhg3Ejhe6N76+9WSEkwlUxNZ0yduDsA==}
     engines: {node: '>=19 || ^18.6.0 || ^16.17.0'}
     hasBin: true
     peerDependencies:
+      '@danielx/hera': ^0.9.8
       typescript: '>=4.5'
       yaml: ^2.4.5
     peerDependenciesMeta:
+      '@danielx/hera':
+        optional: true
       typescript:
         optional: true
       yaml:
@@ -7396,11 +7399,12 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@danielx/civet@0.11.6(typescript@6.0.2)(yaml@2.8.3)':
+  '@danielx/civet@0.11.13(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       unplugin: 2.3.11
     optionalDependencies:
+      '@danielx/hera': 0.9.8
       typescript: 6.0.2
       yaml: 2.8.3
 

--- a/source/ts-service/host.civet
+++ b/source/ts-service/host.civet
@@ -134,7 +134,7 @@ export function TSHost(
     resolveModuleNames(moduleNames: string[], containingFile: string, _reusedNames: string[] | undefined, redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, containingSourceFile?: ts.SourceFile)
       moduleNames.map (name, index) =>
         resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, compilerOptions
-        resolveTranspiledModuleName({
+        result := resolveTranspiledModuleName({
           name
           containingFile
           compilerOptions
@@ -145,12 +145,14 @@ export function TSHost(
           fileExists: pathExists
           directoryExists: baseDirectoryExists
         }).resolvedModule
+        result?.resolvedFileName = scriptFileNames.get(getCanonicalFileName(result.resolvedFileName)) ?? result.resolvedFileName
+        result
 
     resolveModuleNameLiterals(literals: readonly any[], containingFile: string, redirectedReference: ts.ResolvedProjectReference | undefined, compilerOptions: CompilerOptions, containingSourceFile?: ts.SourceFile)
       literals.map (literal, index) =>
         name: string := literal.text
         resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, compilerOptions
-        resolveTranspiledModuleName {
+        result := resolveTranspiledModuleName {
           name
           containingFile
           compilerOptions
@@ -161,6 +163,9 @@ export function TSHost(
           fileExists: pathExists
           directoryExists: baseDirectoryExists
         }
+        resolvedModule := result.resolvedModule
+        resolvedModule?.resolvedFileName = scriptFileNames.get(getCanonicalFileName(resolvedModule.resolvedFileName)) ?? resolvedModule.resolvedFileName
+        result
 
     addOrUpdateDocument(doc: TranspiledDoc): void
       rawPath := path.normalize docFactory.uriToPath(doc.uri)

--- a/source/ts-service/typecheck.civet
+++ b/source/ts-service/typecheck.civet
@@ -70,6 +70,9 @@ export function makeIncrementalTypecheckProgram(
 
   baseHost := ts.createIncrementalCompilerHost compilerOptions
   fileMetaData: Map<string, FileMeta> := new Map
+  rootFileNames: Map<string, string> := new Map
+  for fileName of parsed.fileNames
+    rootFileNames.set getCanonicalFileName(fileName), fileName
 
   hashText := (text: string): string =>
     /* c8 ignore next -- baseHost.createHash is always set on Node */
@@ -155,7 +158,7 @@ export function makeIncrementalTypecheckProgram(
     literals.map (lit, index) =>
       name: string := lit.text
       resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, opts
-      resolveTranspiledModuleName {
+      result := resolveTranspiledModuleName {
         name
         containingFile
         compilerOptions: opts
@@ -166,6 +169,9 @@ export function makeIncrementalTypecheckProgram(
         fileExists: origFileExists
         directoryExists: origDirectoryExists
       }
+      resolvedModule := result.resolvedModule
+      resolvedModule?.resolvedFileName = rootFileNames.get(getCanonicalFileName(resolvedModule.resolvedFileName)) ?? resolvedModule.resolvedFileName
+      result
 
   // TypeScript <5 uses this older hook instead of resolveModuleNameLiterals.
   // Keep it on the same resolver so TS 4.x typecheckers see extensionless
@@ -173,7 +179,7 @@ export function makeIncrementalTypecheckProgram(
   baseHost.resolveModuleNames = (moduleNames: string[], containingFile: string, _reusedNames, redirectedReference, opts: ts.CompilerOptions, containingSourceFile?: ts.SourceFile) =>
     moduleNames.map (name, index) =>
       resolutionMode := containingSourceFile and ts.getModeForResolutionAtIndex containingSourceFile, index, opts
-      resolveTranspiledModuleName({
+      result := resolveTranspiledModuleName({
         name
         containingFile
         compilerOptions: opts
@@ -184,6 +190,8 @@ export function makeIncrementalTypecheckProgram(
         fileExists: origFileExists
         directoryExists: origDirectoryExists
       }).resolvedModule
+      result?.resolvedFileName = rootFileNames.get(getCanonicalFileName(result.resolvedFileName)) ?? result.resolvedFileName
+      result
 
   // ts.createIncrementalProgram reads any prior tsbuildinfo via the
   // host's readFile (driven by compilerOptions.tsBuildInfoFile) — no

--- a/test/infra/ts-service-bundle.civet
+++ b/test/infra/ts-service-bundle.civet
@@ -19,7 +19,7 @@ ts from typescript
   makeIncrementalTypecheckProgram
 } from "../../source/ts-service/index.civet"
 { makeHeraPlugin } from "../../source/ts-service/plugins/hera.civet"
-{ mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs"
+{ existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs"
 { tmpdir } from "os"
 
 describe "ts-service plugin factories", ->
@@ -164,7 +164,7 @@ describe "makeIncrementalTypecheckProgram", ->
       consumerPath := path.join tmpDir, 'consumer.civet'
       writeFileSync consumerPath, "{ answer } from ./dep.civet\nconsole.log answer\n"
 
-      { builder } := makeIncrementalTypecheckProgram tmpDir, {
+      { builder, host } := makeIncrementalTypecheckProgram tmpDir, {
         plugins: [makeCivetPlugin()]
       }
       program := builder.getProgram()
@@ -176,6 +176,18 @@ describe "makeIncrementalTypecheckProgram", ->
       diagnostics := builder.getSemanticDiagnostics consumer
       assert.equal diagnostics.length, 0,
         `expected no diagnostics on the consumer, got: ${diagnostics.map(.messageText).join(' | ')}`
+
+      lowerConsumerPath := consumerPath.toLowerCase()
+      if existsSync lowerConsumerPath
+        resolved := host.resolveModuleNames!(
+          ['./dep.civet']
+          lowerConsumerPath + '.tsx'
+          undefined
+          undefined
+          program.getCompilerOptions()
+          undefined
+        )
+        assert.equal resolved[0]?.resolvedFileName, depTsx.fileName
     finally
       rmSync tmpDir, { recursive: true, force: true }
 

--- a/test/infra/ts-service-direct.civet
+++ b/test/infra/ts-service-direct.civet
@@ -286,21 +286,10 @@ describe "ts-service direct factory usage", ->
     assert.equal diagnostics.length, 0,
       `expected no diagnostics, got: ${messages.join(' | ')}`
 
-  it "preserves mixed-case script filenames on case-insensitive systems", ->
-    rootDir := virtualRoot 'civet-virtual-mixed-case'
-    libDir := path.join(rootDir, 'typescript', 'lib')
-    system := {
-      ...createVirtualSystem(rootDir, libDir)
-      useCaseSensitiveFileNames: false
-    }
-    service := SharedTSService rootDir, {
-      plugins: [makeCivetPlugin()]
-      docFactory: directDocFactory
-      logger: nullLogger
-      system
-      libDir
-      discoverProjectFiles: false
-      tsConfig:
+  it "normalizes imported root script casing on case-insensitive systems", ->
+    tmpDir := mkdtempSync path.join tmpdir(), 'CivetCase-'
+    try
+      writeFileSync path.join(tmpDir, 'tsconfig.json'), JSON.stringify
         compilerOptions:
           target: 'ES2020'
           module: 'ESNext'
@@ -308,23 +297,42 @@ describe "ts-service direct factory usage", ->
           strict: true
           jsx: 'preserve'
           noEmit: true
-          lib: ['ES2020']
+          forceConsistentCasingInFileNames: true
         include: ['**/*']
-    }
-    indexPath := path.join rootDir, 'Index.civet'
-    service.host.addOrUpdateDocument TextDocument.create(
-      URI.file(indexPath).toString()
-      'civet'
-      1
-      'export value := 1\n'
-    )
+      libPath := path.join tmpDir, 'lib.civet'
+      indexPath := path.join tmpDir, 'Index.hera'
+      writeFileSync libPath, 'export value := 1\n'
+      writeFileSync indexPath, """
+        ```
+        import { value } from "./lib.civet"
+        ```
+        Start ::number
+          "x" -> value
 
-    diagnostics := service.getSemanticDiagnostics directDocFactory.uriToPath(URI.file(indexPath).toString()) + '.tsx'
-    messages := diagnostics.map (d) => String d.messageText
-    assert !messages.some((message) => /case-insensitive/.test message),
-      `expected no mixed-case duplicate diagnostic, got: ${messages.join(' | ')}`
-    assert.equal diagnostics.length, 0,
-      `expected no diagnostics, got: ${messages.join(' | ')}`
+      """
+
+      service := SharedTSService tmpDir + path.sep, {
+        plugins: [makeCivetPlugin(), makeHeraPlugin()]
+        docFactory: directDocFactory
+        logger: nullLogger
+      }
+
+      indexUri := URI.file(indexPath.toLowerCase()).toString()
+      service.host.addOrUpdateDocument TextDocument.create(
+        indexUri
+        'hera'
+        1
+        fs.readFileSync(indexPath, 'utf8')
+      )
+
+      diagnostics := service.getSemanticDiagnostics directDocFactory.uriToPath(indexUri) + '.tsx'
+      messages := diagnostics.map (d) => ts.flattenDiagnosticMessageText(d.messageText, '\n')
+      assert !diagnostics.some((diagnostic) => diagnostic.code is 1261),
+        `expected no TS1261 casing diagnostic, got: ${messages.join(' | ')}`
+      assert !messages.some((message) => /differs from file name/.test message),
+        `expected no mixed-case duplicate diagnostic, got: ${messages.join(' | ')}`
+    finally
+      rmSync tmpDir, recursive: true, force: true
 
   it "addOrUpdateDocument stores non-transpilable docs in scriptFileNames", ->
     // .ts docs don't match any transpiler, so the host's addOrUpdateDocument


### PR DESCRIPTION
## Summary

- Use the workspace-installed `@danielx/hera` for the VS Code/LSP built-in Hera plugin, matching the existing project-local Civet resolution. Previously only global install worked (because it's not bundled).
- Preserve canonical root/script filename casing when resolving transpiled modules, avoiding TS1261 mixed-casing diagnostics on case-insensitive file systems (I'm looking at you, Windows).
- Update the workspace VS Code extension recommendation from the Hera extension to the Civet extension.
- Bumped Civet bootstrap version to 0.11.12 to support `x?.y =` notation. 0.11.13 is buggy; to be fixed in next PR.

## Tests

- Added LSP coverage for project-resolved Hera being used by the built-in `.hera` plugin.
- Added ts-service coverage for casing normalization in direct and bundled typecheck paths.