### PR TITLE
Improve `if..else` comment placement, avoid eating punctuation

### DIFF
--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -243,12 +243,12 @@ function insertSemicolon(statements: StatementTuple[]): void
     if i < l - 1
       if needsPrecedingSemicolon(statements[i + 1][1])
         delim := s[2]
+        semicolon := hasTrailingComment(s[1]) ? "\n;" : ";"
         if !delim
-          s[2] = ";"
+          s[2] = semicolon
         // If delim is an object assume it already has a semicolon
-        // TODO: trailing comments might violate this assumption
         else if typeof delim is "string" and !delim.match(/;/)
-          s[2] = `;${delim}`
+          s[2] = `${semicolon}${delim}`
 
 function needsPrecedingSemicolon(exp: ASTNode)
   return false unless exp

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -393,46 +393,31 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
     "?"
     expressionizedBlock
   ]
+  // Trailing `//` comments captured inside the then/else blocks (#832) get
+  // dropped when those blocks collapse to ternary operands; preserve them next
+  // to the operand they came from so following generated syntax stays live.
+  if b.trailing?#
+    children.push b.trailing
   if e
     e2 := expressionizeBlock(e.block)
     unless e2
       return wrapIIFE([["", statement]])
 
     // Replace 'else' in e.children[1] with ':'. (e.children[0] is space before 'else')
-    children.push e.children[0], ":", e2, ...e.children[3..]
+    children.push e.children[0], ":", e2
+    if e.block.trailing?#
+      children.push e.block.trailing
+      children.push "\n"
+    children.push ...e.children[3..]
   else
+    children.push "\n" if b.trailing?#
     children.push ":void 0"
   children.push closeParen
-
-  // Trailing `//` comments captured inside the then/else blocks (#832) get
-  // dropped when those blocks collapse to ternary operands; hoist them out
-  // after the close paren so they survive the conversion. If an ancestor is
-  // followed by a comma delimiter, add a newline after the comment so the comma
-  // is not swallowed by `//`.
-  if b.trailing?# or e?.block.trailing?#
-    children.push b.trailing if b.trailing?#
-    children.push e.block.trailing if e?.block.trailing?#
-    children.push "\n" if hasFollowingComma statement
 
   makeNode {
     type: "IfExpression"
     children
   }
-
-function arrayHasFollowingComma(children: ASTNode[], child: ASTNode): boolean
-  for each candidate, i of children
-    return true if candidate is child and isComma children[i + 1]
-    return true if Array.isArray(candidate) and arrayHasFollowingComma candidate, child
-  false
-
-function hasFollowingComma(node: ASTNodeObject): boolean
-  let child: ASTNode = node
-  let { parent } = node
-  while parent
-    return true if arrayHasFollowingComma parent.children, child
-    child = parent
-    parent = parent.parent
-  false
 
 function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any])
   children := [

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -406,14 +406,33 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
 
   // Trailing `//` comments captured inside the then/else blocks (#832) get
   // dropped when those blocks collapse to ternary operands; hoist them out
-  // after the close paren so they survive the conversion.
-  children.push b.trailing if b.trailing?#
-  children.push e.block.trailing if e?.block.trailing?#
+  // after the close paren so they survive the conversion. If an ancestor is
+  // followed by a comma delimiter, add a newline after the comment so the comma
+  // is not swallowed by `//`.
+  if b.trailing?# or e?.block.trailing?#
+    children.push b.trailing if b.trailing?#
+    children.push e.block.trailing if e?.block.trailing?#
+    children.push "\n" if hasFollowingComma statement
 
   makeNode {
     type: "IfExpression"
     children
   }
+
+function arrayHasFollowingComma(children: ASTNode[], child: ASTNode): boolean
+  for each candidate, i of children
+    return true if candidate is child and isComma children[i + 1]
+    return true if Array.isArray(candidate) and arrayHasFollowingComma candidate, child
+  false
+
+function hasFollowingComma(node: ASTNodeObject): boolean
+  let child: ASTNode = node
+  let { parent } = node
+  while parent
+    return true if arrayHasFollowingComma parent.children, child
+    child = parent
+    parent = parent.parent
+  false
 
 function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any])
   children := [

--- a/test/call-expression.civet
+++ b/test/call-expression.civet
@@ -84,6 +84,23 @@ describe "call-expression", ->
       w)
   """
 
+  testCase """
+    conditional argument keeps line comment from swallowing delimiter
+    ---
+    f(
+      unless esm
+        1 // c
+      2
+    )
+    ---
+    f(
+      (!esm?
+        1:void 0) // c
+    ,
+      2
+    )
+  """
+
   describe "https://github.com/DanielXMoore/Civet/issues/197", ->
     testCase """
       leading . after plain identifier

--- a/test/call-expression.civet
+++ b/test/call-expression.civet
@@ -95,9 +95,30 @@ describe "call-expression", ->
     ---
     f(
       (!esm?
-        1:void 0) // c
-    ,
+        1 // c
+    :void 0),
       2
+    )
+  """
+
+  testCase """
+    conditional argument keeps else line comment from swallowing delimiter
+    ---
+    f(
+      if esm
+        1
+      else
+        2 // c
+      3
+    )
+    ---
+    f(
+      (esm?
+        1
+      :
+        2 // c
+    ),
+      3
     )
   """
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -882,7 +882,7 @@ describe "if", ->
     """
 
     // Trailing `// ...` in an if-expression body must survive the ternary
-    // conversion (issue #832 follow-up).
+    // conversion (issue #832 follow-up) without swallowing generated syntax.
     testCase """
       if expression with trailing comment in body
       ---
@@ -890,7 +890,8 @@ describe "if", ->
         x // foo
       ---
       z = (x?
-        x:void 0) // foo
+        x // foo
+      :void 0)
     """
 
     testCase """
@@ -904,7 +905,31 @@ describe "if", ->
       z = (x?
         x
       :
-        y) // foo
+        y // foo
+      )
+    """
+
+    testCase """
+      if expression with trailing comments in both bodies
+      ---
+      z = if x
+        x // then
+      else
+        y // else
+      ---
+      z = (x?
+        x // then
+      :
+        y // else
+      )
+    """
+
+    testCase """
+      if expression with inline trailing comment after else
+      ---
+      foo := if a then b else c // comment
+      ---
+      const foo = (a? b : c) // comment
     """
 
     testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -332,9 +332,29 @@ describe "object", ->
     ---
     build({
       define: (!esm?
-        ({"import.meta.url": '""'}):void 0) // avoid warning
-    ,
+        ({"import.meta.url": '""'}) // avoid warning
+    :void 0),
       dropLabels:(!esm? ['ESM_ONLY']:void 0),
+    })
+  """
+
+  testCase """
+    nested conditional property keeps else line comment from swallowing delimiter
+    ---
+    build
+      define: if esm
+        1
+      else
+        2 // c
+      next: 3
+    ---
+    build({
+      define: (esm?
+        1
+      :
+        2 // c
+    ),
+      next: 3,
     })
   """
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -323,6 +323,22 @@ describe "object", ->
   """
 
   testCase """
+    nested conditional property keeps line comment from swallowing delimiter
+    ---
+    build
+      define: unless esm
+        "import.meta.url": '""' // avoid warning
+      dropLabels: ['ESM_ONLY'] unless esm
+    ---
+    build({
+      define: (!esm?
+        ({"import.meta.url": '""'}):void 0) // avoid warning
+    ,
+      dropLabels:(!esm? ['ESM_ONLY']:void 0),
+    })
+  """
+
+  testCase """
     spread
     ---
     { ...x }

--- a/test/semicolon.civet
+++ b/test/semicolon.civet
@@ -1,4 +1,7 @@
 {testCase} from ./helper.civet
+{processBlocks} from ../source/parser/block.civet
+type {StatementTuple} from ../source/parser/types.civet
+assert from assert
 
 // https://github.com/DanielXMoore/Civet/issues/643
 describe "semicolon insertion", ->
@@ -93,3 +96,24 @@ describe "semicolon insertion", ->
     );
     (y)
   """
+
+  it "preserves line comment before inserted ASI semicolon", ->
+    statements: StatementTuple[] := [
+      ["", {
+        type: "IfExpression"
+        children: ["x", {
+          type: "Comment"
+          $loc: pos: 0, length: 4
+          token: "// c"
+        }]
+      }]
+      ["", {
+        type: "ParenthesizedExpression"
+        children: ["(", "y", ")"]
+        expression: "y"
+      }]
+    ]
+
+    processBlocks statements
+
+    assert.equal statements[0][2], "\n;"

--- a/test/semicolon.civet
+++ b/test/semicolon.civet
@@ -78,14 +78,18 @@ describe "semicolon insertion", ->
   """
 
   testCase """
-    line comment before ASI semicolon
+    else line comment before ASI semicolon
     ---
-    x = unless esm
-      1 // c
+    x = if esm
+      1
+    else
+      2 // c
     (y)
     ---
-    x = (!esm?
-      1:void 0) // c
-    ;
+    x = (esm?
+      1
+    :
+      2 // c
+    );
     (y)
   """

--- a/test/semicolon.civet
+++ b/test/semicolon.civet
@@ -76,3 +76,16 @@ describe "semicolon insertion", ->
     };
     ["cli", "config", "esbuild-plugin"].forEach(x)
   """
+
+  testCase """
+    line comment before ASI semicolon
+    ---
+    x = unless esm
+      1 // c
+    (y)
+    ---
+    x = (!esm?
+      1:void 0) // c
+    ;
+    (y)
+  """


### PR DESCRIPTION
Fix a regression introduced by PR #2120 while addressing issue #832. Trailing `//` comments from `if` expression branches could be moved to a position where they swallowed generated JavaScript syntax (as I feared but could not previously reproduce).

In fact, our own `esbuild.civet` script ran into this issue, where a comma got swallowed, preventing Civet from using the latest version of itself.

## Cause

PR #2120 preserved trailing comments from expressionized `if`/`unless` branches by hoisting them after the generated ternary. That kept the comment text from being dropped, but it meant output like this could be produced:

```js
define: (!esm?
  ({"import.meta.url": '""'}):void 0) // avoid warning
,
```

Because `//` comments run to the end of the line, the generated comma or semicolon could become part of the comment, producing invalid or incorrectly parsed output.

## Approach

I tried two approaches to fixing this.

The first approach (in the first commit) handled this after the fact: keep hoisting comments after the ternary, but detect when the containing expression is followed by a comma and insert a newline so the comma is not swallowed. It also made ASI insertion use `\n;` when the previous statement ends in a trailing comment (as hinted at by an existing comment).

That fixed the concrete delimiter/ASI failures, but the comma detection was reactive: it had to inspect ancestors and guess which following generated tokens were unsafe.

The second approach (in the second commit) fixes ternary conversion at the source. Instead of hoisting branch comments after the complete ternary, `expressionizeIfStatement` now keeps each trailing branch comment next to the operand it came from:

```js
(a?
  b // then
:
  c // else
)
```

Generated ternary syntax is emitted after the comment on the next line when needed, so commas, close parens, and semicolons after the completed expression remain live syntax. This is simpler, preserves then/else comments separately, and avoids special-case ancestor comma detection.

Admittedly it does worse at preserving the number of lines, but I think the safety is worth it.

The second approach doesn't technically need the handling of trailing comments during ASI, but I've left it in for safety.

## Tests

Added regression coverage for:

- trailing comments in then and else branches of expressionized `if`
- both branches having trailing comments
- inline `then/else` comments, which should not gain an extra newline
- object-property and call-argument delimiters after expressionized conditionals
- ASI after an else-branch trailing comment
