### PR TITLE
Allow semicolon-separated class members on one line

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3347,8 +3347,11 @@ NoBlock
 # This version allows same-line postfixes like `while cond`.
 BracedBlock
   NonSingleBracedBlock
-  # Nonempty one liner
-  InsertOpenBrace:o !EOS PostfixedSingleLineStatements:s InsertSpace:ws InsertCloseBrace:c ::BlockStatement ->
+  # Nonempty one liner.  A bare trailing `;` is an explicit empty body, as
+  # in `constructor(x);`.  But a `;` followed by more content on the line
+  # separates the (empty) one-liner from the next statement or class
+  # element (#1240) rather than starting the body with an empty statement.
+  !( _? Semicolon !( EOS / ClosingDelimiter ) ) InsertOpenBrace:o !EOS PostfixedSingleLineStatements:s InsertSpace:ws InsertCloseBrace:c ::BlockStatement ->
     return $skip unless s.children#
     return {
       type: "BlockStatement",
@@ -4472,7 +4475,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     }
   # NOTE: Not adding extra validation using PropertySetParameterList
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
-  MethodSignature:signature !(PropertyAccess / ExplicitPropertyGlob / UnaryPostfix / NonNullAssertion) MethodBody?:block ->
+  MethodSignature:signature !(PropertyAccess / ExplicitPropertyGlob / UnaryPostfix / NonNullAssertion) BracedBlock?:block ->
     return {
       type: "MethodDefinition",
       children: [signature, block],
@@ -4485,7 +4488,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     }
 
   # shorthand get method definition
-  GetOrSet:kind _?:ws ForbidIndentedApplication ( MemberBase CallExpressionRest* ReturnTypeSuffix? )?:content RestoreIndentedApplication MethodBody?:block ->
+  GetOrSet:kind _?:ws ForbidIndentedApplication ( MemberBase CallExpressionRest* ReturnTypeSuffix? )?:content RestoreIndentedApplication BracedBlock?:block ->
     return $skip unless content
     [ base, rest, returnType ] := content
     value := [ base, rest ]
@@ -4550,13 +4553,6 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     { name } := lastAccess
 
     return makeGetterMethod(name, ws, value, returnType, block, kind)
-
-# A bare trailing `;` is an explicit empty one-liner body, as in
-# `constructor(x);`.  But a `;` followed by more content on the line
-# separates this method from the next class element (#1240) rather than
-# starting this method's body with an empty statement.
-MethodBody
-  !( _? Semicolon !( EOS / ClosingDelimiter ) ) BracedBlock -> $2
 
 MethodModifier
   # NOTE: Merged get/set definitions

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1511,14 +1511,27 @@ ClassBracedContent
 NestedClassElements
   PushIndent NestedClassElement*:elements TrailingNestedCommentLine*:trailing PopIndent ->
     return $skip unless elements# or trailing#
+    // Each element of elements is a list of same-line class elements. Flatten.
+    expressions := elements.flat()
     // Standalone same-or-deeper-indent comment-only trailing lines (#832)
     // stay inside the class body's braces.  Inline trailing comments on
     // the last element continue to escape — those typically annotate the
     // surrounding class, not a member.
-    trailing# ? [...elements, ...trailing] : elements
+    trailing# ? [...expressions, ...trailing] : expressions
 
 NestedClassElement
-  Nested ClassElement StatementDelimiter
+  Nested:nested ClassElementPart+:elements ->
+    return [
+      [nested, ...elements[0]],
+      ...elements.slice(1).map((s) => ["", ...s]),
+    ]
+
+# based on BlockStatementPart
+ClassElementPart
+  # NOTE: !EOS forces semicolon after all but the last element on the line
+  !EOS _?:ws ClassElement:element StatementDelimiter:delimiter ->
+    element = prepend(ws, element) if ws
+    return [element, delimiter]
 
 # https://262.ecma-international.org/#prod-ClassElement
 ClassElement
@@ -4459,7 +4472,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     }
   # NOTE: Not adding extra validation using PropertySetParameterList
   # NOTE: If this node layout changes, be sure to update `convertMethodTOFunction`
-  MethodSignature:signature !(PropertyAccess / ExplicitPropertyGlob / UnaryPostfix / NonNullAssertion) BracedBlock?:block ->
+  MethodSignature:signature !(PropertyAccess / ExplicitPropertyGlob / UnaryPostfix / NonNullAssertion) MethodBody?:block ->
     return {
       type: "MethodDefinition",
       children: [signature, block],
@@ -4472,7 +4485,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     }
 
   # shorthand get method definition
-  GetOrSet:kind _?:ws ForbidIndentedApplication ( MemberBase CallExpressionRest* ReturnTypeSuffix? )?:content RestoreIndentedApplication BracedBlock?:block ->
+  GetOrSet:kind _?:ws ForbidIndentedApplication ( MemberBase CallExpressionRest* ReturnTypeSuffix? )?:content RestoreIndentedApplication MethodBody?:block ->
     return $skip unless content
     [ base, rest, returnType ] := content
     value := [ base, rest ]
@@ -4537,6 +4550,13 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     { name } := lastAccess
 
     return makeGetterMethod(name, ws, value, returnType, block, kind)
+
+# A bare trailing `;` is an explicit empty one-liner body, as in
+# `constructor(x);`.  But a `;` followed by more content on the line
+# separates this method from the next class element (#1240) rather than
+# starting this method's body with an empty statement.
+MethodBody
+  !( _? Semicolon !( EOS / ClosingDelimiter ) ) BracedBlock -> $2
 
 MethodModifier
   # NOTE: Merged get/set definitions

--- a/test/class.civet
+++ b/test/class.civet
@@ -1787,6 +1787,22 @@ describe "class", ->
       }
     """
 
+    // bodyless overload signatures stay bodyless; only the
+    // implementation gets `{}`
+    testCase """
+      method overload signatures on one line
+      ---
+      class A
+        f(x: string): void; f(x: number): void; f(x: unknown): void
+          return
+      ---
+      class A {
+        f(x: string): void; f(x: number): void; f(x: unknown): void {
+          return
+        }
+      }
+    """
+
   describe "mixin 'with' notation", ->
     testCase """
       with notation

--- a/test/class.civet
+++ b/test/class.civet
@@ -1704,6 +1704,76 @@ describe "class", ->
       }
     """
 
+  describe "semicolon-separated members", ->
+    // #1240
+    testCase """
+      get and set shorthand on one line
+      ---
+      class Dummy
+        #x: number
+        get #x; private set #x
+      ---
+      class Dummy {
+        #x: number
+        get x(){ return this.#x }; private set x(value){ this.#x = value }
+      }
+    """
+
+    testCase """
+      fields on one line
+      ---
+      class A
+        x = 1; y = 2
+      ---
+      class A {
+        x = 1; y = 2
+      }
+    """
+
+    testCase """
+      methods on one line
+      ---
+      class A
+        foo(); bar()
+      ---
+      class A {
+        foo(){}; bar(){}
+      }
+    """
+
+    testCase """
+      methods on one line in braced body
+      ---
+      class A { foo(); bar() }
+      ---
+      class A { foo(){}; bar(){} }
+    """
+
+    testCase """
+      get and set shorthand in multiline braced body
+      ---
+      class A {
+        #x = 1
+        get #x; set #x
+      }
+      ---
+      class A {
+        #x = 1
+        get x(){ return this.#x }; set x(value){ this.#x = value }
+      }
+    """
+
+    testCase """
+      leading inline comment
+      ---
+      class A
+        /* c */ x = 1; y = 2
+      ---
+      class A {
+        /* c */ x = 1; y = 2
+      }
+    """
+
   describe "mixin 'with' notation", ->
     testCase """
       with notation

--- a/test/class.civet
+++ b/test/class.civet
@@ -1774,6 +1774,19 @@ describe "class", ->
       }
     """
 
+    // `;` before a same-line member is a separator, not the explicit
+    // empty-body idiom (`constructor(x);` alone keeps `{; }`)
+    testCase """
+      empty-body idiom followed by member
+      ---
+      class A
+        constructor(x); bar()
+      ---
+      class A {
+        constructor(x){}; bar(){}
+      }
+    """
+
   describe "mixin 'with' notation", ->
     testCase """
       with notation

--- a/test/function.civet
+++ b/test/function.civet
@@ -2428,6 +2428,32 @@ describe "function", ->
       }
     """
 
+  describe "semicolon-separated declarations", ->
+    // #1240
+    testCase """
+      two function declarations on one line
+      ---
+      function f(); function g()
+      ---
+      function f(){}; function g(){}
+    """
+
+    testCase """
+      bare trailing semicolon is an explicit empty body
+      ---
+      function f();
+      ---
+      function f() {; }
+    """
+
+    testCase """
+      function declaration followed by call
+      ---
+      function f(); f()
+      ---
+      function f(){}; f()
+    """
+
   describe "return.value", ->
     testCase """
       return =

--- a/test/function.civet
+++ b/test/function.civet
@@ -2454,6 +2454,19 @@ describe "function", ->
       function f(){}; f()
     """
 
+    // bodyless overload signatures stay bodyless; only the
+    // implementation gets `{}`
+    testCase """
+      overload signatures on one line
+      ---
+      function f(x: string): void; function f(x: number): void; function f(x: unknown): void
+        return
+      ---
+      function f(x: string): void; function f(x: number): void; function f(x: unknown): void {
+        return
+      }
+    """
+
   describe "return.value", ->
     testCase """
       return =


### PR DESCRIPTION
Fixes #1240.

**Cause:** two interlocking grammar gaps.
1. An implicit one-liner body (`BracedBlock`'s single-line alternative) could start with `;`, so in `get #x; private set #x` the getter greedily swallowed `; private set #x` as body statements — miscompiling (`get x() {;set(this.#x)...}`) or failing to parse, depending on what followed. Same beyond classes: `function f(); function g()` compiled to `function f() {; function g(){};return g }`.
2. Indented class-body lines only allowed a single element per line (`NestedClassElement = Nested ClassElement StatementDelimiter`), so even without the swallowing, `x = 1; y = 2` couldn't parse.

**Approach:**
- `BracedBlock`'s one-liner alternative now refuses to start with `;` when more content follows on the line: a bare trailing `;` still gives the explicit empty body (`constructor(x);` → `{; }`, an existing tested idiom), but `;` followed by more content is left as a statement/class-element separator. This covers methods, get/set shorthand, function declarations, operator definitions, static blocks, and catch/finally one-liners. The `NoComma`/`NoPostfix` variants (arrow bodies, do/try/comptime) are left as-is.
- `NestedClassElement` now matches `ClassElementPart+` per line (mirroring `NestedBlockStatement`/`BlockStatementPart`), flattened in `NestedClassElements`.

Typecheck diff vs main: 0 regressions. Self-test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)