### PR TITLE
Use `const` for generated single-assignment bindings

### DIFF
--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -8,6 +8,7 @@ import type {
   ASTNodeObject
   ASTNodeParent
   ASTRef
+  AssignmentExpression
   AtBindingProperty
   Binding
   BindingElement
@@ -277,11 +278,39 @@ function processReturnValue(func: FunctionNode)
         makeNode wrapTypeInApplication returnType.t, "Awaited"
         returnType
 
+  // If return.value is assigned exactly once, by a plain `=` assignment at the
+  // top level of the function body that precedes any other use, merge the
+  // declaration into that assignment as `const` so output satisfies eslint's
+  // prefer-const (#1487)
+  merged .= false
+  unless declaration
+    valueSet := new Set<ASTNode> values
+    let writeExp: AssignmentExpression?
+    writeCount .= 0
+    for each exp of gatherRecursiveAll block, .type is "AssignmentExpression"
+      for each [, lhs, , op] of exp.lhs ?? []
+        continue unless valueSet.has lhs
+        writeCount++
+        if exp.lhs# is 1 and op.token is "="
+          writeExp = exp
+    for each exp of gatherRecursiveAll block, .type is "UpdateExpression"
+      writeCount++ if valueSet.has exp.assigned
+    if writeCount is 1 and writeExp? and
+       block.expressions.some(([, s]) => s is writeExp) and
+       // No use of return.value (including bare `return`, which becomes
+       // `return ret`) may precede the write
+       gatherRecursiveWithinFunction(block, (n) =>
+         n.type is "ReturnValue" or (n.type is "ReturnStatement" and not n.expression)
+       )[0] is writeExp.lhs[0][1]
+      writeExp.children.unshift "const "
+      writeExp.lhs[0][1].children = [ref, returnType] if returnType
+      merged = true
+
   // Modify existing declaration, or add declaration of return.value after {
   if declaration
     unless declaration.typeSuffix?
       declaration.children![1] = declaration.typeSuffix = returnType
-  else
+  else if not merged
     block.expressions.unshift [
       getIndent block.expressions[0]
       makeNode

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -483,14 +483,15 @@ function isReassignedIn(names: string[], node: ASTNode): boolean
   .some (exp) =>
     targets :=
       if exp.type is "AssignmentExpression"
-        exp.lhs?.flatMap(([, lhs]) => assignedNamesOf lhs) ?? []
+        // Parse-time AssignmentExpressions always carry lhs; only ref
+        // assignments synthesized by later passes omit it
+        exp.lhs.flatMap ([, lhs]) => assignedNamesOf lhs as ASTNodeObject
       else
-        assignedNamesOf exp.assigned
+        assignedNamesOf exp.assigned as ASTNodeObject
     targets.some (name) => nameSet.has name
 
 /** Variable names a node rebinds when used as an assignment target. */
-function assignedNamesOf(node: ASTNode): string[]
-  return [] unless node? and node !<? "string" and not Array.isArray node
+function assignedNamesOf(node: ASTNodeObject): string[]
   if "names" in node and Array.isArray node.names then node.names else []
 
 function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[], ElseClause?, FinallyClause?])

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -12,6 +12,7 @@ import type {
   ASTNode
   ASTNodeObject
   ASTRef
+  AssignmentExpression
   BlockStatement
   BreakStatement
   Call
@@ -57,6 +58,7 @@ import type {
   TypeSuffix
   Loc
   UnaryOpSymbolLeaf
+  UpdateExpression
   WSNode
 } from ./types.civet
 
@@ -469,6 +471,28 @@ function handleThisPrivateShorthands(value: any): [any, any]
 
   return [value, value.thisShorthand]
 
+/**
+ * Do any of the given names get reassigned (via assignment or update
+ * expression) within the given subtree? Conservative: a write to a
+ * shadowing redeclaration of the same name also counts as a reassignment.
+ */
+function isReassignedIn(names: string[], node: ASTNode): boolean
+  nameSet := new Set names
+  gatherRecursiveAll node, (n): n is AssignmentExpression | UpdateExpression =>
+    n.type is like "AssignmentExpression", "UpdateExpression"
+  .some (exp) =>
+    targets :=
+      if exp.type is "AssignmentExpression"
+        exp.lhs?.flatMap(([, lhs]) => assignedNamesOf lhs) ?? []
+      else
+        assignedNamesOf exp.assigned
+    targets.some (name) => nameSet.has name
+
+/** Variable names a node rebinds when used as an assignment target. */
+function assignedNamesOf(node: ASTNode): string[]
+  return [] unless node? and node !<? "string" and not Array.isArray node
+  if "names" in node and Array.isArray node.names then node.names else []
+
 function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[], ElseClause?, FinallyClause?])
   [t, , b, cs, e, f] .= $0
 
@@ -500,6 +524,9 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
           assert.equal parameter.type, "CatchParameter",
             `Invalid catch parameter ${parameter.type}`
           { binding: pattern, typeSuffix } := parameter as NormalCatchParameter
+          // `catch` bindings are assignable, but use `const` when never
+          // reassigned so output satisfies eslint's prefer-const (#1487)
+          decl := if isReassignedIn pattern.names, clause.block then "let" else "const"
           initializer: Initializer :=
             type: "Initializer"
             expression: ref
@@ -516,10 +543,10 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
           }]
           clause.block.expressions.unshift ["", {
             type: "Declaration"
-            children: ["let", " ", bindings]
+            children: [decl, " ", bindings]
             bindings
             names: bindings[0].names
-            decl: "let"
+            decl
           }, ";"]
 
         type: "DefaultClause"

--- a/test/function.civet
+++ b/test/function.civet
@@ -2436,7 +2436,53 @@ describe "function", ->
         return = 5
       ---
       function f() {
+        const ret = 5
+        return ret
+      }
+    """
+
+    // #1487
+    testCase """
+      return = inside nested block stays let
+      ---
+      function f(x)
+        if x
+          return = 5
+      ---
+      function f(x) {
         let ret;
+        if (x) {
+          ret = 5
+        }
+        return ret
+      }
+    """
+
+    testCase """
+      bare return before return = stays let
+      ---
+      function f(x)
+        return if x
+        return = 5
+      ---
+      function f(x) {
+        let ret;
+        if (x) { return ret }
+        ret = 5
+        return ret
+      }
+    """
+
+    testCase """
+      return.value read before write stays let
+      ---
+      function f
+        console.log return.value
+        return = 5
+      ---
+      function f() {
+        let ret;
+        console.log(ret)
         ret = 5
         return ret
       }
@@ -2479,8 +2525,7 @@ describe "function", ->
         return.value = 5
       ---
       function f() {
-        let ret;
-        ret = 5
+        const ret = 5
         return ret
       }
     """
@@ -2510,9 +2555,8 @@ describe "function", ->
         return = ret
       ---
       function f(arg) {
-        let ret1;
         const ret = arg
-        ret1 = ret
+        const ret1 = ret
         return ret1
       }
     """
@@ -2584,8 +2628,7 @@ describe "function", ->
         return = 5
       ---
       function f(): number {
-        let ret: number;
-        ret = 5
+        const ret: number = 5
         return ret
       }
     """
@@ -2614,8 +2657,7 @@ describe "function", ->
         return = 5
       ---
       (): number => {
-        let ret: number;
-        ret = 5
+        const ret: number = 5
         return ret
       }
     """
@@ -2630,8 +2672,7 @@ describe "function", ->
       ---
       ({
         f(): number {
-          let ret: number;
-          ret = 5
+          const ret: number = 5
           return ret
         }
       })
@@ -2644,8 +2685,7 @@ describe "function", ->
         return = false
       ---
       function f(x): asserts x is number {
-        let ret;
-        ret = false
+        const ret = false
         return ret
       }
     """
@@ -2657,8 +2697,7 @@ describe "function", ->
         return = false
       ---
       function f(x): x is number {
-        let ret: boolean;
-        ret = false
+        const ret: boolean = false
         return ret
       }
     """
@@ -2671,8 +2710,7 @@ describe "function", ->
       ---
       type AutoPromise<T> = Promise<Awaited<T>>;
       async (): AutoPromise<number> => {
-        let ret:Awaited<AutoPromise<number>>;
-        ret = await 5
+        const ret:Awaited<AutoPromise<number>> = await 5
         return ret
       }
     """

--- a/test/function.civet
+++ b/test/function.civet
@@ -2504,6 +2504,61 @@ describe "function", ->
     """
 
     testCase """
+      return += as only write stays let
+      ---
+      function f
+        return += 5
+      ---
+      function f() {
+        let ret;
+        ret += 5
+        return ret
+      }
+    """
+
+    testCase """
+      chained return = stays let
+      ---
+      function f(x)
+        return = x = 5
+      ---
+      function f(x) {
+        let ret;
+        ret = x = 5
+        return ret
+      }
+    """
+
+    testCase """
+      synthesized ref assignment keeps return = const
+      ---
+      function f
+        return = 5
+        foo() ||> .bar = 1
+      ---
+      function f() {
+        const ret = 5
+        let ref;(ref = foo()).bar = 1;ref;return ret
+      }
+    """
+
+    testCase """
+      update of other variable keeps return = const
+      ---
+      function f
+        i .= 0
+        i++
+        return = i
+      ---
+      function f() {
+        let i = 0
+        i++
+        const ret = i
+        return ret
+      }
+    """
+
+    testCase """
       return++
       ---
       function f

--- a/test/try.civet
+++ b/test/try.civet
@@ -473,6 +473,73 @@ describe "try", ->
     """
 
     testCase """
+      property write on default binding stays const
+      ---
+      try
+        foo()
+      catch <? RangeError
+        console.log 'R...Error'
+      catch e
+        e.message = 'wrapped'
+        console.log 'other', e
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 instanceof RangeError) {
+        console.log('R...Error')
+      }
+      else  {const e = e1;
+        e.message = 'wrapped'
+        console.log('other', e)
+      }}
+    """
+
+    testCase """
+      pipe with member assignment keeps default binding const
+      ---
+      try
+        foo()
+      catch <? RangeError
+        console.log 'R...Error'
+      catch e
+        bar() ||> .baz = e
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 instanceof RangeError) {
+        console.log('R...Error')
+      }
+      else  {const e = e1;
+        let ref;(ref = bar()).baz = e;ref
+      }}
+    """
+
+    testCase """
+      assignment to other variable keeps default binding const
+      ---
+      try
+        foo()
+      catch <? RangeError
+        console.log 'R...Error'
+      catch e
+        other = 5
+        console.log 'other', e
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 instanceof RangeError) {
+        console.log('R...Error')
+      }
+      else  {const e = e1;
+        other = 5
+        console.log('other', e)
+      }}
+    """
+
+    testCase """
       without default case
       ---
       try

--- a/test/try.civet
+++ b/test/try.civet
@@ -420,7 +420,54 @@ describe "try", ->
       else if(typeof e1 === 'object' && e1 != null && 'message' in e1 && typeof e1.message === 'string' && /bad/.test(e1.message)) {const {message} = e1;
         console.log('bad', message)
       }
+      else  {const e = e1;
+        console.log('other', e)
+      }}
+    """
+
+    // #1487
+    testCase """
+      reassigned default binding stays let
+      ---
+      try
+        foo()
+      catch <? RangeError
+        console.log 'R...Error'
+      catch e
+        e = transform e
+        console.log 'other', e
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 instanceof RangeError) {
+        console.log('R...Error')
+      }
       else  {let e = e1;
+        e = transform(e)
+        console.log('other', e)
+      }}
+    """
+
+    testCase """
+      updated default binding stays let
+      ---
+      try
+        foo()
+      catch <? RangeError
+        console.log 'R...Error'
+      catch e
+        e++
+        console.log 'other', e
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 instanceof RangeError) {
+        console.log('R...Error')
+      }
+      else  {let e = e1;
+        e++
         console.log('other', e)
       }}
     """


### PR DESCRIPTION
Fixes #1487

eslint's `prefer-const` flagged two Civet-generated `let` declarations that are only ever assigned once, and `eslint-disable` comments can't reach them (eaten before a second `catch` clause; misplaced relative to the hoisted `let ret;`).

- **Pattern-matching catch default clause**: `catch e` now emits `const e = e1` when none of the bound names are reassigned in the clause body (new `isReassignedIn` reuses `processAssignments`' definition of assigned names, so property writes don't count and closure writes conservatively do).
- **`return =`**: when `return.value` has exactly one plain `=` write at the top level of the function body preceding any other use (including bare `return`), the hoisted `let ret;` is merged into that write as `const ret = …`, carrying the return-type annotation. Multiple writes, compound ops, nested writes, or earlier reads keep `let`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)