### PR TITLE
Object semantics for `:` in export specifiers; object-construction exports

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3203,7 +3203,11 @@ fs from fs/promises
 metadata from ./package.json with type: 'json'
 </Playground>
 
-### Import-Like Object Destructuring
+### Object-Destructuring Import
+
+Import braces act like object destructuring: the key is the name in the
+module and the value is the local binding (the dual of
+[Object-Constructing Export](#object-constructing-export)).
 
 <Playground>
 import {X: LocalX, Y: LocalY} from "./util"
@@ -3272,11 +3276,12 @@ export a, b, c from "./cool.js"
 export x = 3
 </Playground>
 
-### Export Renaming
+### Object-Constructing Export
 
-In export braces, `:` renames with object semantics: the key is the
-public (exported) name and the value is the local binding it refers to,
-mirroring `module.exports = {publicName: localValue}`.
+The dual of [Object-Destructuring Import](#object-destructuring-import):
+export braces act like constructing the module's interface object. `:`
+renames, where the key is the public (exported) name and the value is the
+local binding, mirroring `module.exports = {publicName: localValue}`.
 With `from`, the value is the name in the source module instead:
 
 <Playground>
@@ -3286,18 +3291,8 @@ export { type S: T }
 export { "string name": x }
 </Playground>
 
-::: info
-Imports and exports are duals: import braces act like *destructuring*
-(`import { s: t }` binds local `t` from the module's `s`), while export
-braces act like *constructing* the module's interface object.
-Either way, the key is the name in the module being imported from or
-exported, and the value is the local side.
-:::
-
-### Object-Construction Exports
-
-Extending the object analogy, a value in export braces can be an object
-literal built from local bindings, exported under the key's name:
+Extending the object analogy, a value can be an object literal built from
+local bindings, exported under the key's name:
 
 <Playground>
 export { a: {b, c} }

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -3272,6 +3272,51 @@ export a, b, c from "./cool.js"
 export x = 3
 </Playground>
 
+### Export Renaming
+
+In export braces, `:` renames with object semantics: the key is the
+public (exported) name and the value is the local binding it refers to,
+mirroring `module.exports = {publicName: localValue}`.
+With `from`, the value is the name in the source module instead:
+
+<Playground>
+export { s: t }
+export { s: t } from "./stuff"
+export { type S: T }
+export { "string name": x }
+</Playground>
+
+::: info
+Imports and exports are duals: import braces act like *destructuring*
+(`import { s: t }` binds local `t` from the module's `s`), while export
+braces act like *constructing* the module's interface object.
+Either way, the key is the name in the module being imported from or
+exported, and the value is the local side.
+:::
+
+### Object-Construction Exports
+
+Extending the object analogy, a value in export braces can be an object
+literal built from local bindings, exported under the key's name:
+
+<Playground>
+export { a: {b, c} }
+</Playground>
+
+With `from`, the values name exports of the source module,
+which get imported first (nesting works too):
+
+<Playground>
+export { a: {b, c} } from "./m"
+export { a: {b}, d } from "./m"
+export { a: {b: {c}} } from "./m"
+</Playground>
+
+::: info
+Constructed exports are built once at module load, so unlike plain
+re-exports they are snapshots rather than live bindings.
+:::
+
 ### Export Default Shorthand
 
 Most declarations can also be `export default`:

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6878,13 +6878,14 @@ NamedExports
     return [open, first, ...rest, close]
 
 # https://262.ecma-international.org/#prod-ExportSpecifier
+# ImportAsToken allows `:` as shorthand for `as` (#1092), matching imports.
 ExportSpecifier
-  __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:local ( __ As __ ModuleExportName )?:rename ObjectPropertyDelimiter:delim ->
+  __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:local ( ImportAsToken __ ModuleExportName )?:rename ObjectPropertyDelimiter:delim ->
     // Local stays mangled (JS variable ref); external side uses propertyKey
     // so the exported name is the user-visible source.
     children :=
       if rename
-        [ws1, ts, local, rename[0], rename[1], rename[2], propertyKey(rename[3]), delim]
+        [ws1, ts, local, rename[0], rename[1], propertyKey(rename[2]), delim]
       else if local.unicode
         [ws1, ts, local, " as ", propertyKey(local), delim]
       else

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2476,11 +2476,8 @@ NWBindingIdentifier
     return { children: [$1], names: [] }
 
 AtIdentifierRef ::ASTRef
-  # Explicit `_` prefix even for Civet-only reserved words (`is`, `loop`, ...)
-  # which are valid JS so makeRef leaves them bare; a bare binding could
-  # shadow helpers like `var is`.
-  ReservedWord:r ->
-    return makeRef(`_${r}`, r)
+  # `@is`, `@loop`, etc. fall through to IdentifierName; makeRef +
+  # populateRefs keep the binding valid and unshadowed (see #1092 discussion).
   IdentifierName:id ->
     ref := makeRef(id.name)
     // Propagate so the binding side can emit `this["X"]` matching `@X`.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -57,6 +57,8 @@ import {
   processAssignmentDeclaration,
   processBinaryOpExpression,
   processCallMemberExpression,
+  processConstructedExport,
+  processConstructedExportFrom,
   processCoffeeDo,
   processCoffeeInterpolation,
   processForInOf,
@@ -98,6 +100,7 @@ import type {
   CommentNode,
   ComptimeStatement,
   Condition,
+  ConstructedExportSpecifier,
   Declaration,
   DeclarationKind,
   DebuggerStatement,
@@ -133,6 +136,7 @@ import type {
   MultiMethodDefinition,
   NamedBindingPattern,
   NamedImportElement,
+  NamedExports,
   NamespaceDeclaration,
   NonNullAssertion,
   ObjectBindingPattern,
@@ -6818,18 +6822,26 @@ ExportDeclaration
   Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration / MaybeNestedPostfixedExpressionOrCommaLoop ):declaration ->
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
   Export __ ExportFromClause:exports __ FromClause ->
+    if desugared := processConstructedExportFrom($0, exports, $5)
+      return desugared
     return { type: "ExportDeclaration", ts: "ts" in exports and exports.ts, children: $0 }
   # NOTE: from ... export ... reverse syntax
   FromClause:from __:fws Export:e __:ews ExportFromClause:exports ->
+    children := [ e, ews, exports, " ", from, trimFirstSpace(fws) ]
+    if desugared := processConstructedExportFrom(children, exports, from)
+      return desugared
     return {
       type: "ExportDeclaration",
       ts: "ts" in exports and exports.ts,
-      children: [ e, ews, exports, " ", from, trimFirstSpace(fws) ],
+      children,
     }
   # NOTE: Declaration and VariableStatement should come before NamedExports
   # so that NamedExports doesn't grab function, async, type, var, etc.
   # NOTE: TS decorators come before `export` keyword but TC39 stage 3 decorators proposal come after
   Decorators?:dec Export __ ( Declaration / VariableStatement / TypeAndNamedExports / ExportVarDec ):declaration ->
+    // `export { a: {b, c} }` → `const a = {b, c}; export { a as a }` (#1092)
+    if desugared := processConstructedExport($0, declaration)
+      return desugared
     // `export 😊 := 3` → `const u$…$ = 3; export { u$…$ as "😊" }`
     // (JS forbids string-named exports inside `export const`).
     splitClause := buildExportSplitClause(declaration)
@@ -6872,26 +6884,50 @@ TypeAndNamedExports
 
 # https://262.ecma-international.org/#prod-NamedExports
 NamedExports
-  OpenBrace ExportSpecifier* (__ Comma )? __ CloseBrace
+  OpenBrace ExportSpecifier*:specifiers (__ Comma )? __ CloseBrace ::NamedExports ->
+    return {
+      type: "NamedExports"
+      children: $0
+      specifiers
+      constructed: specifiers.filter (s) => s?.type is "ConstructedExportSpecifier"
+    }
   # Unbraced version: export x, y
   InsertInlineOpenBrace:open ImplicitExportSpecifier:first ( ImplicitObjectPropertyDelimiter ImplicitExportSpecifier )*:rest InsertCloseBrace:close &( StatementDelimiter / ( __ From )) ->
     return [open, first, ...rest, close]
 
 # https://262.ecma-international.org/#prod-ExportSpecifier
-# ImportAsToken allows `:` as shorthand for `as` (#1092), matching imports.
 ExportSpecifier
-  __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:local ( ImportAsToken __ ModuleExportName )?:rename ObjectPropertyDelimiter:delim ->
+  __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:local ( __ As __ ModuleExportName )?:rename ObjectPropertyDelimiter:delim ->
     // Local stays mangled (JS variable ref); external side uses propertyKey
     // so the exported name is the user-visible source.
     children :=
       if rename
-        [ws1, ts, local, rename[0], rename[1], propertyKey(rename[2]), delim]
+        [ws1, ts, local, rename[0], rename[1], rename[2], propertyKey(rename[3]), delim]
       else if local.unicode
         [ws1, ts, local, " as ", propertyKey(local), delim]
       else
         [ws1, ts, local, delim]
     return children unless ts
     return { ts: true, children }
+  # `exported: local` — object semantics (#1092): the key is the public name,
+  # like `module.exports = { publicName: localValue }`.  With `from`, the
+  # value side is the name in the source module.
+  __:ws1 ( TypeKeyword __ )?:ts ModuleExportName:exported __:ws2 Colon __:ws3 ModuleExportName:local ObjectPropertyDelimiter:delim ->
+    children := [ws1, ts, ws2, trimFirstSpace(ws3), local, " as ", propertyKey(exported), delim]
+    return children unless ts
+    return { ts: true, children }
+  # `exported: {…}` — construct an object and export it under the key (#1092).
+  # Desugared at the ExportDeclaration level by processConstructedExport /
+  # processConstructedExportFrom; children stay empty until then.
+  __:ws1 ModuleExportName:exported __:ws2 Colon __:ws3 BracedObjectLiteral:value ObjectPropertyDelimiter:delim ::ConstructedExportSpecifier ->
+    return {
+      type: "ConstructedExportSpecifier"
+      exported
+      value
+      ws: ws1
+      delim
+      children: []
+    }
 
 ImplicitExportSpecifier
   !Default ModuleExportName:local ( __ As __ ModuleExportName )?:rename ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2476,6 +2476,9 @@ NWBindingIdentifier
     return { children: [$1], names: [] }
 
 AtIdentifierRef ::ASTRef
+  # Explicit `_` prefix even for Civet-only reserved words (`is`, `loop`, ...)
+  # which are valid JS so makeRef leaves them bare; a bare binding could
+  # shadow helpers like `var is`.
   ReservedWord:r ->
     return makeRef(`_${r}`, r)
   IdentifierName:id ->

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6923,12 +6923,17 @@ ExportSpecifier
   # `exported: {…}` — construct an object and export it under the key (#1092).
   # Desugared at the ExportDeclaration level by processConstructedExport /
   # processConstructedExportFrom; children stay empty until then.
-  __:ws1 ModuleExportName:exported __:ws2 Colon __:ws3 BracedObjectLiteral:value ObjectPropertyDelimiter:delim ::ConstructedExportSpecifier ->
+  # `!Colon` keeps `type` usable as the export name (`export { type: {b} }`);
+  # an actual TypeKeyword prefix parses so the type-only error is clear.
+  __:ws1 ( TypeKeyword __ !Colon )?:ts ModuleExportName:exported __:ws2 Colon __:ws3 BracedObjectLiteral:value ObjectPropertyDelimiter:delim ::ConstructedExportSpecifier ->
     return {
       type: "ConstructedExportSpecifier"
       exported
       value
+      ts: !!ts
       ws: ws1
+      ws2
+      ws3
       delim
       children: []
     }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -140,6 +140,7 @@ import type {
   NamespaceDeclaration,
   NonNullAssertion,
   ObjectBindingPattern,
+  ObjectExpression,
   ObjectProperty,
   OperatorBehavior,
   OperatorDeclaration,
@@ -3992,7 +3993,7 @@ ObjectLiteral
   NestedImplicitObjectLiteral
   InlineObjectLiteral
 
-BracedObjectLiteral
+BracedObjectLiteral ::ObjectExpression
   # NOTE: Added {} followed by properties
   OpenBrace:open CloseBrace:close ApplicationStart AllowAll ( NestedPropertyDefinitions / SingleLineObjectProperties )?:properties RestoreAll ->
     return $skip unless properties?#
@@ -6889,7 +6890,7 @@ NamedExports
       type: "NamedExports"
       children: $0
       specifiers
-      constructed: specifiers.filter (s) => s?.type is "ConstructedExportSpecifier"
+      constructed: specifiers.filter (s): s is ConstructedExportSpecifier => not Array.isArray(s) and s?.type is "ConstructedExportSpecifier"
     }
   # Unbraced version: export x, y
   InsertInlineOpenBrace:open ImplicitExportSpecifier:first ( ImplicitObjectPropertyDelimiter ImplicitExportSpecifier )*:rest InsertCloseBrace:close &( StatementDelimiter / ( __ From )) ->
@@ -10100,7 +10101,7 @@ Reset
 Init
   Shebang? Prologue:directives ->
     directives.forEach (directive) =>
-      if directive.type is "CivetPrologue"
+      if not Array.isArray(directive) and directive.type is "CivetPrologue"
         Object.assign(config, directive.config)
 
     if config.strict

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -813,6 +813,8 @@ function processConstructedExport(children: ASTNode[], declaration: ASTNode): AS
   constructed := gatherRecursive declaration, .type is "ConstructedExportSpecifier"
   return unless constructed#
   statements: ASTNode[] := []
+  // Error but don't short-circuit: the LSP renders this to TSX, so desugaring
+  // anyway gives tsserver real symbols. The Error node still flags it.
   if (declaration as! {ts?: boolean}).ts or constructed.some .ts
     statements.push {
       type: "Error"
@@ -836,6 +838,7 @@ function processConstructedExportFrom(children: ASTNode[], exports: ASTNode, fro
   constructed := gatherRecursive exports, .type is "ConstructedExportSpecifier"
   return unless constructed#
   statements: ASTNode[] := []
+  // Error but don't short-circuit (see processConstructedExport).
   if (exports as! {ts?: boolean}).ts or constructed.some .ts
     statements.push {
       type: "Error"

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -59,6 +59,7 @@ import {
   append
   assert
   convertOptionalType
+  getTrimmingSpace
   insertTrimmingSpace
   isExit
   isWhitespaceOrEmpty
@@ -808,11 +809,11 @@ function exportedName(exported: Identifier | StringLiteral): ASTNode
  * `const a = {b, c}; export { a as a }`.  Returns undefined when the export
  * declaration has no ConstructedExportSpecifier.
  */
-function processConstructedExport(children: ASTNode[], declaration: ASTNodeObject): ASTNode[] | undefined
+function processConstructedExport(children: ASTNode[], declaration: ASTNode): ASTNode[] | undefined
   constructed := gatherRecursive declaration, .type is "ConstructedExportSpecifier"
   return unless constructed#
   statements: ASTNode[] := []
-  if (declaration as {ts?: boolean}).ts
+  if (declaration as! {ts?: boolean}).ts
     statements.push {
       type: "Error"
       message: "Object-construction exports cannot be type-only"
@@ -831,11 +832,11 @@ function processConstructedExport(children: ASTNode[], declaration: ASTNodeObjec
  * export { a as a }`, keeping any simple specifiers as a static re-export.
  * Returns undefined when the clause has no ConstructedExportSpecifier.
  */
-function processConstructedExportFrom(children: ASTNode[], exports: ASTNodeObject, from: ASTNode): ASTNode[] | undefined
+function processConstructedExportFrom(children: ASTNode[], exports: ASTNode, from: ASTNode): ASTNode[] | undefined
   constructed := gatherRecursive exports, .type is "ConstructedExportSpecifier"
   return unless constructed#
   statements: ASTNode[] := []
-  if (exports as {ts?: boolean}).ts
+  if (exports as! {ts?: boolean}).ts
     statements.push {
       type: "Error"
       message: "Object-construction exports cannot be type-only"
@@ -880,9 +881,12 @@ function importizeConstructedValue(value: ObjectExpression, imports: Map<string,
         id := v as Identifier
         entry .= imports.get id.name
         unless entry
-          entry = [propertyKey(id), makeRef(id.name)]
+          // The value node may carry leading whitespace (`{b: c}`) — trim it
+          // for the import specifier, keep it in the object via the ref swap.
+          entry = [trimFirstSpace(propertyKey(id)), makeRef(id.name)]
           imports.set id.name, entry
         ref := entry[1]
+        refWithSpace := [getTrimmingSpace(id), ref]
         if prop.implicitName
           // `{b}` shorthand: keep the key; the value becomes the imported
           // ref.  Splice right after the name — a trailing delim may follow.
@@ -890,7 +894,7 @@ function importizeConstructedValue(value: ObjectExpression, imports: Map<string,
           expanded.splice expanded.indexOf(id) + 1, 0, ": ", ref
           prop.children = expanded as Children
         else
-          prop.children = prop.children.map((c) => c is id ? ref : c) as Children
+          prop.children = prop.children.map((c) => c is id ? refWithSpace : c) as Children
         prop.value = ref
       else
         statements.push {

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -2,21 +2,28 @@ import type {
   AccessStart
   ASTLeaf
   ASTNode
+  ASTNodeObject
   ASTNodeParent
   ASTRef
   AwaitExpression
   Binding
   BlockStatement
+  Children
+  ConstructedExportSpecifier
   Declaration
+  ExportDeclaration
   ExpressionNode
+  Identifier
   IfStatement
   ImportClause
   ImportDeclaration
   Initializer
   IterationStatement
   LexicalDeclaration
+  ObjectExpression
   ParenthesizedExpression
   StatementTuple
+  StringLiteral
   SwitchStatement
   ThisAssignments
   TypeSuffix
@@ -37,8 +44,11 @@ import {
 import {
   findAncestor
   findChildIndex
+  gatherRecursive
   gatherRecursiveAll
 } from ./traversal.civet
+
+import { propertyKey } from ./identifier.civet
 
 import {
   getPatternBlockPrefix
@@ -776,6 +786,118 @@ function convertWithClause(withClause: WithClause, extendsClause?: [ASTLeaf, WSN
   // Ensure at least one space after extends token
   return [ extendsToken, insertTrimmingSpace(ws, " "), wrapped ]
 
+// Base the ref on the public name so unconflicted output reads naturally
+// (`const a = {b, c}; export { a as a }`).
+function constructedExportRef(spec: ConstructedExportSpecifier): ASTRef
+  makeRef spec.exported.type is "Identifier" ? spec.exported.name : "ref"
+
+// Output node for the public name in `… as <name>` position.  Plain
+// identifiers emit their raw token so populateRefs doesn't count the public
+// name as a taken binding (which would needlessly bump the ref to `a1`);
+// unicode and string names emit quoted.
+function exportedName(exported: Identifier | StringLiteral): ASTNode
+  if exported.type is "Identifier"
+    return propertyKey(exported) if exported.unicode
+    return exported.children[0]
+  exported
+
+/**
+ * Object-construction exports (#1092): `export { a: {b, c} }` reads as an
+ * object literal defining the module interface — the key is the public name,
+ * the value an object built from local bindings.  Desugars to
+ * `const a = {b, c}; export { a as a }`.  Returns undefined when the export
+ * declaration has no ConstructedExportSpecifier.
+ */
+function processConstructedExport(children: ASTNode[], declaration: ASTNodeObject): ASTNode[] | undefined
+  constructed := gatherRecursive declaration, .type is "ConstructedExportSpecifier"
+  return unless constructed#
+  statements: ASTNode[] := []
+  if (declaration as {ts?: boolean}).ts
+    statements.push {
+      type: "Error"
+      message: "Object-construction exports cannot be type-only"
+    }
+  for each spec of constructed
+    ref := constructedExportRef spec
+    statements.push "const ", ref, " = ", spec.value, ";"
+    spec.children = [spec.ws, ref, " as ", exportedName(spec.exported), spec.delim] as Children
+  statements.push { type: "ExportDeclaration", children } as ExportDeclaration
+  statements
+
+/**
+ * `export { a: {b, c} } from "./m"` — construction from a module (#1092):
+ * leaf identifier values name exports of the source module.  Desugars to
+ * `import { b as b1, c as c1 } from "./m"; const a = {b: b1, c: c1};
+ * export { a as a }`, keeping any simple specifiers as a static re-export.
+ * Returns undefined when the clause has no ConstructedExportSpecifier.
+ */
+function processConstructedExportFrom(children: ASTNode[], exports: ASTNodeObject, from: ASTNode): ASTNode[] | undefined
+  constructed := gatherRecursive exports, .type is "ConstructedExportSpecifier"
+  return unless constructed#
+  statements: ASTNode[] := []
+  if (exports as {ts?: boolean}).ts
+    statements.push {
+      type: "Error"
+      message: "Object-construction exports cannot be type-only"
+    }
+  // Leaf identifier values inside the construction are names in the source
+  // module; rewrite them to refs and import them (deduped) under those refs.
+  imports := new Map<string, [ASTNode, ASTRef]>()
+  for each spec of constructed
+    importizeConstructedValue spec.value, imports, statements
+  importSpecs: ASTNode[] := []
+  for [source, ref] of imports.values()
+    importSpecs.push ", " if importSpecs#
+    importSpecs.push source, " as ", ref
+  statements.push "import { ", importSpecs, " } ", from, ";"
+  exportSpecs: ASTNode[] := []
+  for each spec of constructed
+    ref := constructedExportRef spec
+    statements.push "const ", ref, " = ", spec.value, ";"
+    exportSpecs.push ", " if exportSpecs#
+    exportSpecs.push ref, " as ", exportedName(spec.exported)
+  statements.push "export { ", exportSpecs, " }"
+  // Simple specifiers (if any) stay as a static re-export; the constructed
+  // specifiers have empty children so they vanish from `children`.
+  named := gatherRecursive(exports, .type is "NamedExports")[0]
+  if named.specifiers# > constructed#
+    statements.push ";", { type: "ExportDeclaration", children } as ExportDeclaration
+  statements
+
+function importizeConstructedValue(value: ObjectExpression, imports: Map<string, [ASTNode, ASTRef]>, statements: ASTNode[]): void
+  for each prop of value.properties
+    unless prop.type is "Property"
+      statements.push {
+        type: "Error"
+        message: `Unsupported ${prop.type} in object-construction export from a module`
+      }
+      continue
+    { value: v } := prop
+    switch (v as ASTNodeObject?)?.type
+      when "ObjectExpression"
+        importizeConstructedValue v as ObjectExpression, imports, statements
+      when "Identifier"
+        id := v as Identifier
+        entry .= imports.get id.name
+        unless entry
+          entry = [propertyKey(id), makeRef(id.name)]
+          imports.set id.name, entry
+        ref := entry[1]
+        if prop.implicitName
+          // `{b}` shorthand: keep the key; the value becomes the imported
+          // ref.  Splice right after the name — a trailing delim may follow.
+          expanded := [...prop.children]
+          expanded.splice expanded.indexOf(id) + 1, 0, ": ", ref
+          prop.children = expanded as Children
+        else
+          prop.children = prop.children.map((c) => c is id ? ref : c) as Children
+        prop.value = ref
+      else
+        statements.push {
+          type: "Error"
+          message: "Values in an object-construction export from a module must be identifiers or nested object literals"
+        }
+
 export {
   convertWithClause
   processStaticImport
@@ -783,6 +905,8 @@ export {
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
   processAssignmentDeclaration
+  processConstructedExport
+  processConstructedExportFrom
   processDeclarationConditions
   processDeclarations
 }

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -813,15 +813,15 @@ function processConstructedExport(children: ASTNode[], declaration: ASTNode): AS
   constructed := gatherRecursive declaration, .type is "ConstructedExportSpecifier"
   return unless constructed#
   statements: ASTNode[] := []
-  if (declaration as! {ts?: boolean}).ts
+  if (declaration as! {ts?: boolean}).ts or constructed.some .ts
     statements.push {
       type: "Error"
       message: "Object-construction exports cannot be type-only"
     }
   for each spec of constructed
     ref := constructedExportRef spec
-    statements.push "const ", ref, " = ", spec.value, ";"
-    spec.children = [spec.ws, ref, " as ", exportedName(spec.exported), spec.delim] as Children
+    statements.push "const ", ref, " = ", trimFirstSpace(spec.ws3), spec.value, ";"
+    spec.children = [spec.ws, trimFirstSpace(spec.ws2), ref, " as ", exportedName(spec.exported), spec.delim] as Children
   statements.push { type: "ExportDeclaration", children } as ExportDeclaration
   statements
 
@@ -836,7 +836,7 @@ function processConstructedExportFrom(children: ASTNode[], exports: ASTNode, fro
   constructed := gatherRecursive exports, .type is "ConstructedExportSpecifier"
   return unless constructed#
   statements: ASTNode[] := []
-  if (exports as! {ts?: boolean}).ts
+  if (exports as! {ts?: boolean}).ts or constructed.some .ts
     statements.push {
       type: "Error"
       message: "Object-construction exports cannot be type-only"
@@ -854,9 +854,9 @@ function processConstructedExportFrom(children: ASTNode[], exports: ASTNode, fro
   exportSpecs: ASTNode[] := []
   for each spec of constructed
     ref := constructedExportRef spec
-    statements.push "const ", ref, " = ", spec.value, ";"
+    statements.push "const ", ref, " = ", trimFirstSpace(spec.ws3), spec.value, ";"
     exportSpecs.push ", " if exportSpecs#
-    exportSpecs.push ref, " as ", exportedName(spec.exported)
+    exportSpecs.push trimFirstSpace(spec.ws), trimFirstSpace(spec.ws2), ref, " as ", exportedName(spec.exported)
   statements.push "export { ", exportSpecs, " }"
   // Simple specifiers (if any) stay as a static re-export; the constructed
   // specifiers have empty children so they vanish from `children`.

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -133,6 +133,8 @@ import {
   dynamizeImportDeclarationExpression
   prependStatementExpressionBlock
   processAssignmentDeclaration
+  processConstructedExport
+  processConstructedExportFrom
   processDeclarationConditions
   processDeclarations
 } from ./declaration.civet
@@ -2479,6 +2481,8 @@ export {
   processAssignmentDeclaration
   processBinaryOpExpression
   processCallMemberExpression
+  processConstructedExport
+  processConstructedExportFrom
   processCoffeeDo
   processCoffeeInterpolation
   processForInOf

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -34,6 +34,7 @@ import {
 } from ./util.civet
 
 import {
+  isReservedWord
   makeRef
   maybeRefAssignment
 } from ./ref.civet
@@ -61,10 +62,6 @@ import {
 import {
   getHelperRef
 } from ./helper.civet
-
-import {
-  ReservedWord
-} from ../parser.hera
 
 function processPatternTest(lhs: ASTNode, patterns: PatternExpression[]): ASTNode
   { ref, refAssignmentComma } := maybeRefAssignment lhs, "m"
@@ -480,12 +477,10 @@ function aggregateDuplicateBindings(bindings: ASTNode)
 
   propsGroupedByName.forEach (shared, key) =>
     return unless key
-    // NOTE: Allows pattern matching reserved word keys by binding to inaccessible refs
-    // HACK: using the parser's ReservedWord rule here
-    if ReservedWord({ fail() { } }, {
-      pos: 0,
-      input: key,
-    })
+    // NOTE: Allows pattern matching reserved word keys by binding to
+    // inaccessible refs; explicit `_` prefix because Civet-only reserved
+    // words (`is`, `loop`, ...) are valid JS so makeRef leaves them bare
+    if isReservedWord key
       for each p of shared
         aliasBinding p, makeRef(`_${key}`, key)
       // Don't push declarations for reserved words

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -16,7 +16,33 @@ import {
   makeNode
 } from ./util.civet
 
+import {
+  ReservedWord
+} from ../parser.hera
+
+/**
+ * Whether `name` is a Civet reserved word (in the current parse
+ * configuration, e.g. CoffeeScript compatibility flags), as defined by the
+ * parser's ReservedWord rule.  Civet-reserved names are inaccessible to user
+ * code even when they're valid JS identifiers (e.g. `is`, `loop`).
+ */
+function isReservedWord(name: string): boolean
+  Boolean ReservedWord({ expectation: "", fail: => }, {
+    pos: 0,
+    input: name,
+  })
+
+// Words that can't be `const`-bound in JS output: reserved words
+// (including strict-mode ones, since Civet assumes strict mode) plus
+// `eval`/`arguments` which strict mode forbids as binding targets.
+// Broader in places than the Civet ReservedWord rule, which lacks
+// `implements`, `package`, `eval`, and `arguments`.
+jsReservedWord := /^(?:arguments|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|typeof|var|void|while|with|yield)$/
+
 function makeRef(base = "ref", id = base): ASTRef
+  // JS reserved words can't resolve to themselves as bindings;
+  // prefix `_` so populateRefs always emits a valid identifier.
+  base = `_${base}` if jsReservedWord.test base
   return {
     type: "Ref"
     base
@@ -125,6 +151,7 @@ function populateRefs(statements: ASTNode): void
       ref.children = ref.names = [name as ASTString]
 
 export {
+  isReservedWord
   makeRef
   makeRefAssignment
   maybeRef

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -37,12 +37,12 @@ function isReservedWord(name: string): boolean
 // `eval`/`arguments` which strict mode forbids as binding targets.
 // Broader in places than the Civet ReservedWord rule, which lacks
 // `implements`, `package`, `eval`, and `arguments`.
-jsReservedWord := /^(?:arguments|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|eval|export|extends|false|finally|for|function|if|implements|import|in|instanceof|interface|let|new|null|package|private|protected|public|return|static|super|switch|this|throw|true|typeof|var|void|while|with|yield)$/
+jsReservedWords := new Set "arguments await break case catch class const continue debugger default delete do else enum eval export extends false finally for function if implements import in instanceof interface let new null package private protected public return static super switch this throw true typeof var void while with yield".split " "
 
 function makeRef(base = "ref", id = base): ASTRef
   // JS reserved words can't resolve to themselves as bindings;
   // prefix `_` so populateRefs always emits a valid identifier.
-  base = `_${base}` if jsReservedWord.test base
+  base = `_${base}` if jsReservedWords.has base
   return {
     type: "Ref"
     base

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -862,7 +862,13 @@ export type ConstructedExportSpecifier = ASTParent &
   type: "ConstructedExportSpecifier"
   exported: Identifier | StringLiteral
   value: ObjectExpression
+  /** Per-specifier `type` keyword; always an error for constructed exports */
+  ts: boolean
   ws: ASTNode
+  /** Whitespace/comments between the exported name and the colon */
+  ws2: ASTNode
+  /** Whitespace/comments between the colon and the value */
+  ws3: ASTNode
   delim: ASTNode
 
 /**

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -105,6 +105,7 @@ export type OtherNode =
   | CommentNode
   | ComputedPropertyName
   | ConditionFragment
+  | ConstructedExportSpecifier
   | DefaultClause
   | ElisionElement
   | ElseClause
@@ -125,6 +126,7 @@ export type OtherNode =
   | ModuleSpecifier
   | MultiMethodDefinition
   | NamedBindingPattern
+  | NamedExports
   | NonNullAssertion
   | NormalCatchParameter
   | ObjectBindingPattern
@@ -843,6 +845,25 @@ export type ExportDeclaration = ASTParent &
   type: "ExportDeclaration"
   ts?: boolean
   declaration?: ASTNode
+
+/** `export { … }` braced clause; specifiers may include construction (#1092). */
+export type NamedExports = ASTParent &
+  type: "NamedExports"
+  specifiers: (ASTNode | ConstructedExportSpecifier)[]
+  constructed: ConstructedExportSpecifier[]
+
+/**
+ * `export { name: {…} }` — object-construction export (#1092).  The key is
+ * the public name; the value object is built from local bindings (or source
+ * names with `from`).  `children` starts empty; processConstructedExport /
+ * processConstructedExportFrom rewrite the export at the declaration level.
+ */
+export type ConstructedExportSpecifier = ASTParent &
+  type: "ConstructedExportSpecifier"
+  exported: Identifier | StringLiteral
+  value: ObjectExpression
+  ws: ASTNode
+  delim: ASTNode
 
 /**
  * `namespace Foo { … }` (TS).  Always ts:true since namespaces don't exist

--- a/test/export.civet
+++ b/test/export.civet
@@ -382,6 +382,32 @@ describe "export", ->
     """
 
     testCase """
+      construction with reserved-word export name
+      ---
+      export { default: {b} }
+      ---
+      const _default = {b};export { _default as default }
+    """
+
+    testCase """
+      construction from module with reserved-word export name
+      ---
+      export { class: {b} } from "./m"
+      ---
+      import { b as b1 } from "./m";const _class = {b: b1};export { _class as class }
+    """
+
+    testCase """
+      construction with reserved-word export name and colliding local
+      ---
+      _default := 1
+      export { default: {b} }
+      ---
+      const _default = 1
+      const _default1 = {b};export { _default1 as default }
+    """
+
+    testCase """
       construction with unicode export name
       ---
       export { 😊: {b} }

--- a/test/export.civet
+++ b/test/export.civet
@@ -259,44 +259,151 @@ describe "export", ->
   """
 
   testCase """
-    colon rename shorthand with from
-    ---
-    export { s: t } from ./stuff
-    ---
-    export { s as t } from "./stuff"
-  """
-
-  testCase """
-    colon rename shorthand without from
+    colon rename: key is the exported name
     ---
     export { s: t }
     ---
-    export { s as t }
+    export { t as s }
   """
 
   testCase """
-    colon rename shorthand mixed with as
+    colon rename with from
+    ---
+    export { s: t } from ./stuff
+    ---
+    export { t as s } from "./stuff"
+  """
+
+  testCase """
+    colon rename mixed with as
     ---
     export { a: b, c as d, e } from ./stuff
     ---
-    export { a as b, c as d, e } from "./stuff"
+    export { b as a, c as d, e } from "./stuff"
   """
 
   testCase """
-    colon rename shorthand in from ... export
+    colon rename in from ... export
     ---
     from ./stuff export { s: t }
     ---
-    export { s as t } from "./stuff"
+    export { t as s } from "./stuff"
   """
 
   testCase """
-    nested destructuring from still dynamizes
+    colon rename with type specifier
     ---
-    export { a: {b, c} } from "./stuff"
+    export { type S: T }
     ---
-    export const {a:{b, c}} = await import ("./stuff")
+    export { type T as S }
   """
+
+  testCase """
+    colon rename to string name
+    ---
+    export { "😊": x }
+    ---
+    export { x as "😊" }
+  """
+
+  testCase """
+    colon in export destructuring stays destructuring (#1321)
+    ---
+    export { s: t } = obj
+    ---
+    export var { s: t } = obj
+  """
+
+  describe "object-construction exports", ->
+    testCase """
+      local construction
+      ---
+      export { a: {b, c} }
+      ---
+      const a = {b, c};export { a as a }
+    """
+
+    testCase """
+      local construction with colliding local
+      ---
+      a := 1
+      export { a: {b, c} }
+      ---
+      const a = 1
+      const a1 = {b, c};export { a1 as a }
+    """
+
+    testCase """
+      construction from module
+      ---
+      export { a: {b, c} } from "./m"
+      ---
+      import { b as b1, c as c1 } from "./m";const a = {b: b1, c: c1};export { a as a }
+    """
+
+    testCase """
+      construction mixed with simple specifiers
+      ---
+      export { a: {b}, d } from "./m"
+      ---
+      import { b as b1 } from "./m";const a = {b: b1};export { a as a };export { d } from "./m"
+    """
+
+    testCase """
+      nested construction from module
+      ---
+      export { a: {b: {c}} } from "./m"
+      ---
+      import { c as c1 } from "./m";const a = {b: {c: c1}};export { a as a }
+    """
+
+    testCase """
+      construction from module dedupes imports
+      ---
+      export { a: {b}, c: {b} } from "./m"
+      ---
+      import { b as b1 } from "./m";const a = {b: b1};const c = {b: b1};export { a as a, c as c }
+    """
+
+    testCase """
+      construction with string export name
+      ---
+      export { "two words": {b} }
+      ---
+      const ref = {b};export { ref as "two words" }
+    """
+
+    testCase """
+      construction in from ... export
+      ---
+      from "./m" export { a: {b} }
+      ---
+      import { b as b1 } from "./m";const a = {b: b1};export { a as a }
+    """
+
+    throws """
+      construction from module with expression value
+      ---
+      export { a: {b: c + 1} } from "./m"
+      ---
+      ParseErrors: unknown:1:1 Values in an object-construction export from a module must be identifiers or nested object literals
+    """
+
+    throws """
+      construction from module with spread
+      ---
+      export { a: {...b} } from "./m"
+      ---
+      ParseErrors: unknown:1:1 Unsupported SpreadProperty in object-construction export from a module
+    """
+
+    throws """
+      type-only construction
+      ---
+      export type { a: {b} } from "./m"
+      ---
+      ParseErrors: unknown:1:1 Object-construction exports cannot be type-only
+    """
 
   testCase """
     optional comma

--- a/test/export.civet
+++ b/test/export.civet
@@ -455,6 +455,54 @@ describe "export", ->
       ParseErrors: unknown:1:1 Object-construction exports cannot be type-only
     """
 
+    throws """
+      type-only constructed specifier
+      ---
+      export { type a: {b} }
+      ---
+      ParseErrors: unknown:1:1 Object-construction exports cannot be type-only
+    """
+
+    throws """
+      type-only constructed specifier from module
+      ---
+      export { type a: {b} } from "./m"
+      ---
+      ParseErrors: unknown:1:1 Object-construction exports cannot be type-only
+    """
+
+    testCase """
+      construction with key named type
+      ---
+      export { type: {b} }
+      ---
+      const type = {b};export { type as type }
+    """
+
+    testCase """
+      construction preserves comments
+      ---
+      export { a /*key*/ : /*v*/ {b} }
+      ---
+      const a = /*v*/ {b};export { /*key*/ a as a }
+    """
+
+    testCase """
+      construction from module preserves comments
+      ---
+      export { a /*key*/ : /*v*/ {b} } from "./m"
+      ---
+      import { b as b1 } from "./m";const a = /*v*/ {b: b1};export { /*key*/ a as a }
+    """
+
+    testCase """
+      construction from module with assertion
+      ---
+      export { a: {b} } from "./m" with type: "json"
+      ---
+      import { b as b1 } from "./m" with {type: "json"};const a = {b: b1};export { a as a }
+    """
+
   testCase """
     optional comma
     ---

--- a/test/export.civet
+++ b/test/export.civet
@@ -259,6 +259,46 @@ describe "export", ->
   """
 
   testCase """
+    colon rename shorthand with from
+    ---
+    export { s: t } from ./stuff
+    ---
+    export { s as t } from "./stuff"
+  """
+
+  testCase """
+    colon rename shorthand without from
+    ---
+    export { s: t }
+    ---
+    export { s as t }
+  """
+
+  testCase """
+    colon rename shorthand mixed with as
+    ---
+    export { a: b, c as d, e } from ./stuff
+    ---
+    export { a as b, c as d, e } from "./stuff"
+  """
+
+  testCase """
+    colon rename shorthand in from ... export
+    ---
+    from ./stuff export { s: t }
+    ---
+    export { s as t } from "./stuff"
+  """
+
+  testCase """
+    nested destructuring from still dynamizes
+    ---
+    export { a: {b, c} } from "./stuff"
+    ---
+    export const {a:{b, c}} = await import ("./stuff")
+  """
+
+  testCase """
     optional comma
     ---
     export {

--- a/test/export.civet
+++ b/test/export.civet
@@ -350,6 +350,14 @@ describe "export", ->
     """
 
     testCase """
+      construction with named identifier value
+      ---
+      export { a: {b: c} } from "./m"
+      ---
+      import { c as c1 } from "./m";const a = {b: c1};export { a as a }
+    """
+
+    testCase """
       nested construction from module
       ---
       export { a: {b: {c}} } from "./m"
@@ -371,6 +379,14 @@ describe "export", ->
       export { "two words": {b} }
       ---
       const ref = {b};export { ref as "two words" }
+    """
+
+    testCase """
+      construction with unicode export name
+      ---
+      export { 😊: {b} }
+      ---
+      const u$1F60A$ = {b};export { u$1F60A$ as "😊" }
     """
 
     testCase """
@@ -401,6 +417,14 @@ describe "export", ->
       type-only construction
       ---
       export type { a: {b} } from "./m"
+      ---
+      ParseErrors: unknown:1:1 Object-construction exports cannot be type-only
+    """
+
+    throws """
+      type-only local construction
+      ---
+      export type { a: {b} }
       ---
       ParseErrors: unknown:1:1 Object-construction exports cannot be type-only
     """

--- a/test/function.civet
+++ b/test/function.civet
@@ -429,6 +429,24 @@ describe "function", ->
     """
 
     testCase """
+      Civet-only keyword @ params (#1092)
+      ---
+      (@is, @loop) ->
+      ---
+      (function(is, loop) {this.is = is;this.loop = loop;})
+    """
+
+    testCase """
+      @is param does not shadow Object.is helper (#1092)
+      ---
+      "civet objectIs"
+      (@is) -> @is is 3
+      ---
+      var is: { <B, A extends B> (a: A, b: B): b is A, <A, B> (a: A, b: B): a is A & B } = Object.is as any;
+      (function(is1) { this.is = is1; return is(this.is, 3 as const) })
+    """
+
+    testCase """
       local reference
       ---
       (@a, @b) ->


### PR DESCRIPTION
Closes #1092

Per the discussion here and on the issue: in export braces, `:` follows **object semantics** — the key is the public (exported) name, the value is where it comes from, mirroring `module.exports = { publicName: localValue }`. Imports are unchanged (destructuring semantics: `import { s: t }` is still `s as t`). The unified reading: keys are always the module-interface names.

**Phase 1 — rename shorthand (inverted):**
```coffee
export { s: t }                    → export { t as s }
export { s: t } from "./m"         → export { t as s } from "./m"
export { type S: T }               → export { type T as S }
export { "😊": x }                 → export { x as "😊" }
```

**Phase 2 — object-construction exports:**
```coffee
export { a: {b, c} }
# → const a = {b, c};export { a as a }

export { a: {b, c} } from "./m"
# → import { b as b1, c as c1 } from "./m";const a = {b: b1, c: c1};export { a as a }

export { a: {b}, d } from "./m"   # simple specifiers stay static re-exports
# → import { b as b1 } from "./m";const a = {b: b1};export { a as a };export { d } from "./m"
```
With `from`, leaf identifier values name exports of the source module (deduped named imports under collision-safe refs); nesting works; import assertions carry over to the synthesized import. Values that aren't identifiers or nested object literals are compile errors, as are type-only construction exports.

This replaces the accidental (untested) dynamize behavior where `export { a: {b,c} } from "./m"` compiled to `export const {a:{b,c}} = await import("./m")` — under object semantics that desugar read the keys in the wrong direction. The explicit form still works. `export { s: t } = obj` (#1321) is genuine destructuring and is unchanged — same expression/pattern duality as `{x: y}` elsewhere in the language.

Array-literal values (`export { a: [b, c] } from "./m"`) still fall through to the old dynamize path; reserving/extending those is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)