### PR TITLE
Docs: One-line functions don't require `do`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1193,6 +1193,17 @@ function count()
 ### One-Line Functions
 
 <Playground>
+function f(x) console.log x
+function greet() console.log "Hello"
+function f sideEffect()
+</Playground>
+
+An identifier immediately after `function` is treated as the
+function's name, so an anonymous one-liner whose body starts with
+an identifier needs `do` to mark where the body begins.
+You can also write `do` after any function header for clarity:
+
+<Playground>
 function do console.log "Anonymous"
 function f do console.log "Named"
 function f(x) do console.log x

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1198,9 +1198,11 @@ function greet() console.log "Hello"
 function f sideEffect()
 </Playground>
 
-An identifier immediately after `function` is treated as the
-function's name, so an anonymous one-liner whose body starts with
-an identifier needs `do` to mark where the body begins.
+Only the first identifier after `function` is treated as the
+function's name; everything after the name is the body, never a
+parameter list (parameters always need parentheses).
+An anonymous one-liner whose body starts with an identifier
+therefore needs `do` to mark where the body begins.
 You can also write `do` after any function header for clarity:
 
 <Playground>


### PR DESCRIPTION
Fixes #723

The One-Line Functions section showed only `do`-forms, implying `do` is required. It's only needed for anonymous one-liners whose body starts with an identifier (e.g. `function console.log x` parses `console` as the function name); named and parenthesized forms work without it, and tests lock that in. Lead with the plain forms and explain when `do` matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)