### PR TITLE
Add LICENSE to Zed extension directory

### DIFF
--- a/lsp/zed/LICENSE
+++ b/lsp/zed/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Daniel X Moore and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Zed's extension packaging ([package-extensions.js](https://github.com/zed-industries/extensions/blob/main/src/package-extensions.js)) validates the license inside the extension directory (the `path` from `extensions.toml`), so the repo-root LICENSE doesn't cover the `lsp/zed` subdirectory extension. Copies the MIT LICENSE into `lsp/zed/`.

Unblocks zed-industries/extensions#5606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)