### PR TITLE
Bun loader: text import so `--watch` tracks plugin-loaded files

### DIFF
--- a/source/bun-civet.civet
+++ b/source/bun-civet.civet
@@ -11,8 +11,8 @@ After that, you can use .civet files with the Bun cli, like:
 $ bun file.civet
 ###
 
-import { plugin, file } from 'bun'
-//import { plugin, file, Transpiler } from 'bun'
+import { plugin } from 'bun'
+//import { plugin, Transpiler } from 'bun'
 
 await plugin {
   name: 'Civet loader'
@@ -21,7 +21,11 @@ await plugin {
     //transpiler := new Transpiler loader: 'tsx'
 
     builder.onLoad filter: /\.civet$/, ({path}) =>
-      source := file path |> .text() |> await
+      // Read the source via a text import so Bun registers the file with
+      // its watcher; plugin-loaded files are otherwise never watched
+      // (https://github.com/oven-sh/bun/issues/17270). The trailing ? keeps
+      // the import from re-matching this plugin's filter and recursing.
+      { default: source } := await import(`${path}?`, with: type: 'text')
       // Compiling and running at the same time, so enable comptime
       // to ensure any async promises get resolved
       contents .= await compile source, comptime: true


### PR DESCRIPTION
Fixes the `bun --watch` breakage from #1694.

Bun never registers files handled by a runtime plugin's `onLoad` with its watcher — the watcher is only populated from the open-file codepath, which the plugin bypasses (oven-sh/bun#17270; upstream fix oven-sh/bun#30608 is still unmerged). The entry point is covered by a separate fallback, so on current bun (1.3.14) the original #1694 repro recovers fine, but edits to **imported** `.civet` files trigger no reload at all — even valid ones. That also means #1694's cache-the-last-good-compile approach can't help the import case, since no reload event ever fires.

Workaround (suggested by @uinz in #1694): read the source via ``import(`${path}?`, { with: { type: "text" } })`` instead of `Bun.file().text()`. The import goes through Bun's module loader, which registers the file with the watcher. The trailing `?` keeps the import from re-matching this plugin's own filter and recursing.

Verified manually on bun 1.3.14 with a preloaded `dist/bun-civet.mjs`, entry importing a `.civet` dep: dep edits reload, syntax error is reported and a subsequent fix recovers, plain `bun run` and `bun build` behavior unchanged. No automated test — the plugin imports from `bun` so it can't run under the node suite.

Once oven-sh/bun#30608 lands this workaround can be reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)