### PR TITLE
Fix one-line then/else swallowing surrounding comma

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3406,9 +3406,13 @@ NonSingleBracedBlock ::BlockStatement
       children: [o, expressions, c],
     }
 
+# NOTE: NoCommaStatement (not Statement) so a single-line `then`/`else`/block
+# body doesn't swallow a top-level comma operator that belongs to a surrounding
+# array/call/argument list. Declaration still allows commas (loop accumulators
+# like `coords := x, y for ...`). (#2157)
 DeclarationOrStatement
   Declaration
-  Statement
+  NoCommaStatement
 
 # NOTE: SingleLineStatements includes the empty case
 SingleLineStatements

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3423,8 +3423,11 @@ SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
   ForbidNewlineBinaryOp ( _? SingleLineDeclarationOrStatement SemicolonDelimiter )*:stmts ( _? SingleLineDeclarationOrStatement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ::BlockStatement ->
-    expressions := [...stmts]
-    expressions.push(last) if last
+    // NOTE: the .map keeps `expressions` a loose union array (not a strict
+    // [prefix, statement, delim] tuple) so the optional final delimiter and the
+    // trailing-comment "\n" push below stay assignable.
+    expressions := stmts.map(([prefix, statement, delim]) => [prefix, statement, delim])
+    expressions.push([last[0], last[1], last[2]]) if last
 
     children := [expressions]
     children.push(["\n"]) if hasTrailingComment(expressions)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3215,7 +3215,7 @@ Block ::BlockStatement
 
   ThenClause
   # NOTE: !EOS prevents capturing a following unindented Statement
-  _?:ws !EOS DeclarationOrStatement:s ->
+  _?:ws !EOS SingleLineDeclarationOrStatement:s ->
     expressions: StatementTuple[] := [[ws, s]]
     return {
       type: "BlockStatement",
@@ -3406,11 +3406,13 @@ NonSingleBracedBlock ::BlockStatement
       children: [o, expressions, c],
     }
 
+# Only used in single-line block bodies (one-line `then`/`else`/block via
+# `Block`, and the `;`-separated `SingleLineStatements`).
 # NOTE: NoCommaStatement (not Statement) so a single-line `then`/`else`/block
 # body doesn't swallow a top-level comma operator that belongs to a surrounding
 # array/call/argument list. Declaration still allows commas (loop accumulators
 # like `coords := x, y for ...`). (#2157)
-DeclarationOrStatement
+SingleLineDeclarationOrStatement
   Declaration
   NoCommaStatement
 
@@ -3418,7 +3420,7 @@ DeclarationOrStatement
 SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
-  ForbidNewlineBinaryOp ( ( _? !EOS ) DeclarationOrStatement SemicolonDelimiter )*:stmts ( ( _? !EOS ) DeclarationOrStatement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ::BlockStatement ->
+  ForbidNewlineBinaryOp ( ( _? !EOS ) SingleLineDeclarationOrStatement SemicolonDelimiter )*:stmts ( ( _? !EOS ) SingleLineDeclarationOrStatement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ::BlockStatement ->
     expressions := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
     expressions.push([last[0][0], last[1], last[2]]) if last
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3214,8 +3214,9 @@ Block ::BlockStatement
   ExplicitBlock
 
   ThenClause
-  # NOTE: !EOS prevents capturing a following unindented Statement
-  _?:ws !EOS SingleLineDeclarationOrStatement:s ->
+  # NOTE: SingleLineDeclarationOrStatement's leading !EOS prevents capturing a
+  # following unindented Statement
+  _?:ws SingleLineDeclarationOrStatement:s ->
     expressions: StatementTuple[] := [[ws, s]]
     return {
       type: "BlockStatement",
@@ -3407,22 +3408,23 @@ NonSingleBracedBlock ::BlockStatement
     }
 
 # Only used in single-line block bodies (one-line `then`/`else`/block via
-# `Block`, and the `;`-separated `SingleLineStatements`).
+# `Block`, and the `;`-separated `SingleLineStatements`). The leading `!EOS`
+# (both callers always guarded it that way) prevents capturing a following
+# unindented statement and stops the line at end-of-statement.
 # NOTE: NoCommaStatement (not Statement) so a single-line `then`/`else`/block
 # body doesn't swallow a top-level comma operator that belongs to a surrounding
 # array/call/argument list. Declaration still allows commas (loop accumulators
 # like `coords := x, y for ...`). (#2157)
 SingleLineDeclarationOrStatement
-  Declaration
-  NoCommaStatement
+  !EOS ( Declaration / NoCommaStatement ) -> $2
 
 # NOTE: SingleLineStatements includes the empty case
 SingleLineStatements
   # NOTE: Statement can start with __ via AssignmentExpression.
   # Force staying on the same line via !/\n/ assertion.
-  ForbidNewlineBinaryOp ( ( _? !EOS ) SingleLineDeclarationOrStatement SemicolonDelimiter )*:stmts ( ( _? !EOS ) SingleLineDeclarationOrStatement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ::BlockStatement ->
-    expressions := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
-    expressions.push([last[0][0], last[1], last[2]]) if last
+  ForbidNewlineBinaryOp ( _? SingleLineDeclarationOrStatement SemicolonDelimiter )*:stmts ( _? SingleLineDeclarationOrStatement SemicolonDelimiter? )?:last RestoreNewlineBinaryOp ::BlockStatement ->
+    expressions := [...stmts]
+    expressions.push(last) if last
 
     children := [expressions]
     children.push(["\n"]) if hasTrailingComment(expressions)

--- a/test/do.civet
+++ b/test/do.civet
@@ -408,3 +408,13 @@ describe "do", ->
       yield 3
     }})()
   """
+
+  // #2157: a one-line `do` body must not swallow a top-level comma that belongs
+  // to the surrounding array/call.
+  testCase """
+    one-line do body comma stays with array
+    ---
+    [do x, extraItem]
+    ---
+    [(()=>{{ return x }})(), extraItem]
+  """

--- a/test/if.civet
+++ b/test/if.civet
@@ -482,6 +482,64 @@ describe "if", ->
     if (true) { y} else z
   """
 
+  // A one-line then/else block must not swallow a top-level comma operator;
+  // the comma belongs to the surrounding array/call/argument list. (#2157)
+  testCase """
+    one-line then comma stays with array
+    ---
+    [if counterRef then [counterRef, "++"], close]
+    ---
+    [(counterRef? [counterRef, "++"]:void 0), close]
+  """
+
+  testCase """
+    one-line then/else comma stays with array
+    ---
+    [if counterRef then [counterRef, "++"] else [], close]
+    ---
+    [(counterRef? [counterRef, "++"] : []), close]
+  """
+
+  testCase """
+    one-line then comma stays with call arguments
+    ---
+    f(if counterRef then [counterRef, "++"], close)
+    ---
+    f((counterRef? [counterRef, "++"]:void 0), close)
+  """
+
+  testCase """
+    one-line then/else comma stays with call arguments
+    ---
+    f(if c then a else b, g)
+    ---
+    f((c? a : b), g)
+  """
+
+  // Comma operators are still allowed inside an indented (multi-line) block,
+  // since there's no surrounding context to claim the comma. (#2157)
+  testCase """
+    indented if block keeps comma operator
+    ---
+    x := if foo
+      a, b
+    else
+      c
+    ---
+    const x = (foo?
+      (a, b)
+    :
+      c)
+  """
+
+  throws """
+    one-line then forbids top-level comma operator
+    ---
+    if x then a, b
+    ---
+    ParseError
+  """
+
   testCase """
     no parens
     ---

--- a/test/object.civet
+++ b/test/object.civet
@@ -584,6 +584,16 @@ describe "object", ->
     }
   """
 
+  // #2157: a one-line `if` used as an object-literal value must not swallow the
+  // following property; the comma belongs to the object, not the else branch.
+  testCase """
+    one-line if value comma stays with object literal
+    ---
+    { a: if c then x else y, b: 2 }
+    ---
+    ({ a: (c? x : y), b: 2 })
+  """
+
   describe "get shorthand", ->
     testCase """
       object getter

--- a/test/while.civet
+++ b/test/while.civet
@@ -111,6 +111,17 @@ describe "while", ->
     while (x) { return }
   """
 
+  // #2157: a one-line `while` body must not swallow a top-level comma that
+  // belongs to the surrounding array/call (it goes through the no-comma
+  // SingleLineDeclarationOrStatement, like `then`/`else`).
+  testCase """
+    one-line while body comma stays with array
+    ---
+    [while cond then x, extraItem]
+    ---
+    [(()=>{const results=[];while (cond) results.push(x);return results})(), extraItem]
+  """
+
   describe "iteration results", ->
     testCase """
       semi-colon suppresses result push


### PR DESCRIPTION
Fixes #2157.

## Cause

A one-line `then`/`else`/block body parses through `DeclarationOrStatement` → `Statement` → `CommaExpressionStatement`, which greedily consumes a top-level comma operator that belongs to the enclosing array/call/argument list:

```coffee
[if counterRef then [counterRef, "++"], close]
# was: [(counterRef? ([counterRef, "++"], close):void 0)]   -- close swallowed
# now: [(counterRef? [counterRef, "++"]:void 0), close]
```

## Approach

`DeclarationOrStatement` is used only in single-line block bodies, so route its statement alternative to the existing `NoCommaStatement` (the no-comma variant already used by arrow bodies) instead of `Statement`. `Declaration` still allows commas, so loop-accumulator declarations (`coords := x, y for {x, y} of points`) keep working, and indented multi-line blocks are unaffected.

This is per @edemaine's diagnosis in the issue. One fix covers every same-line block context — if/else, `unless`, `for`/`while`/`loop`/`do` bodies, object-literal values — in both array and call-argument positions. Explicit parens remain an escape hatch for a deliberate comma body: `[if c then (a, b), d]`.

Statement-level `if x then a, b` now errors instead of emitting `if (x) a, b`, matching the issue's intent to forbid comma operators in one-line then/else.

A before/after diff over ~20 constructs showed exactly the bug fixes plus that one error; pipes, binary ops, trailing-call/switch/try expressionization, and for/while/loop/do one-liners are byte-identical. Typecheck diff: 799→799 (0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)