### PR TITLE
Fix dropped comments before later pattern/catch clauses

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5797,6 +5797,11 @@ NestedCaseClause
       ...clause,
       // Bring the indent into the clause
       children: [indent, ...clause.children],
+      // Named leading whitespace so processPatternMatching can re-emit any
+      // comments without depending on positional children layout (issue #2151).
+      // Widened to ASTNode (like the children entry above) so the indent's
+      // narrow tuple type doesn't reshuffle the clause-type unions downstream.
+      leadingWs: indent as ASTNode,
     }
 
 # https://262.ecma-international.org/#prod-CaseClause
@@ -5905,12 +5910,13 @@ TryStatement
 
 # https://262.ecma-international.org/#prod-Catch
 CatchClause
-  ( Nested / _ ) Catch CatchBinding?:binding ( BracedThenClause / BracedOrEmptyBlock ):block ->
+  ( Nested / _ ):leadingWs Catch CatchBinding?:binding ( BracedThenClause / BracedOrEmptyBlock ):block ->
     return {
       type: "CatchClause",
       children: $0,
       block,
       binding,
+      leadingWs,
     }
 
 # NOTE: Added optional parentheses to catch binding

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -487,13 +487,18 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
       children: [ "(", ref, ")" ]
       expression: ref
     defaultClause .= false
-    clauses: CaseBlock["clauses"] := cs.map (clause) =>
+    clauses: CaseBlock["clauses"] := cs.map (clause, i) =>
+      // The first clause's leading trivia becomes the merged catch clause's
+      // leading whitespace (below); carry later clauses' trivia into the
+      // generated switch clause so processPatternMatching can re-emit comments
+      // that would otherwise be dropped before the `else` (issue #2151).
+      leadingTrivia := i > 0 ? [clause.children[0]] : []
       if {type: "CatchPattern", patterns} := clause.binding?.parameter
         {
           type: "PatternClause"
           patterns
           block: clause.block
-          children: [ patterns, clause.block ]
+          children: [ ...leadingTrivia, patterns, clause.block ]
         }
       else
         defaultClause = true
@@ -526,7 +531,7 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
 
         type: "DefaultClause"
         block: clause.block
-        children: [ "default: ", clause.block ]
+        children: [ ...leadingTrivia, "default: ", clause.block ]
 
     // If no default clause specified, add one that rethrows exception
     unless defaultClause

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -488,17 +488,18 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
       expression: ref
     defaultClause .= false
     clauses: CaseBlock["clauses"] := cs.map (clause, i) =>
-      // The first clause's leading trivia becomes the merged catch clause's
-      // leading whitespace (below); carry later clauses' trivia into the
-      // generated switch clause so processPatternMatching can re-emit comments
-      // that would otherwise be dropped before the `else` (issue #2151).
-      leadingTrivia := i > 0 ? [clause.children[0]] : []
+      // The first clause's leading whitespace becomes the merged catch clause's
+      // leading whitespace (below); carry later clauses' leading whitespace into
+      // the generated switch clause so processPatternMatching can re-emit
+      // comments that would otherwise be dropped before the `else` (issue #2151).
+      leadingWs := i > 0 ? clause.leadingWs : undefined
       if {type: "CatchPattern", patterns} := clause.binding?.parameter
         {
           type: "PatternClause"
           patterns
           block: clause.block
-          children: [ ...leadingTrivia, patterns, clause.block ]
+          children: [ patterns, clause.block ]
+          leadingWs
         }
       else
         defaultClause = true
@@ -529,9 +530,12 @@ function processTryBlock($0: [ASTLeaf, undefined, BlockStatement, CatchClause[],
             decl: "let"
           }, ";"]
 
-        type: "DefaultClause"
-        block: clause.block
-        children: [ ...leadingTrivia, "default: ", clause.block ]
+        {
+          type: "DefaultClause"
+          block: clause.block
+          children: [ "default: ", clause.block ]
+          leadingWs
+        }
 
     // If no default clause specified, add one that rethrows exception
     unless defaultClause

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -117,6 +117,16 @@ function processPatternMatching(statements: ASTNode): void
 
       l := clauses.length
       for each c, i of clauses
+        // Re-emit comments leading a second-or-later clause before the `else`
+        // that introduces it; otherwise the clause's leading trivia is dropped
+        // when the switch is rebuilt as an if/else chain (issue #2151).
+        if e?
+          comments := gatherRecursiveAll c.children[0], .type is "Comment"
+          if comments#
+            // e.children is ["\n", "else ", block]; insert the comments after
+            // the leading newline so they sit on their own lines before `else`.
+            e.children.splice 1, 0, ...comments.flatMap (comment) => [comment, "\n"]
+
         if c.type is "DefaultClause"
           if e?
             replaceNode e.block, c.block, e

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -118,10 +118,10 @@ function processPatternMatching(statements: ASTNode): void
       l := clauses.length
       for each c, i of clauses
         // Re-emit comments leading a second-or-later clause before the `else`
-        // that introduces it; otherwise the clause's leading trivia is dropped
-        // when the switch is rebuilt as an if/else chain (issue #2151).
+        // that introduces it; otherwise the clause's leading whitespace is
+        // dropped when the switch is rebuilt as an if/else chain (issue #2151).
         if e?
-          comments := gatherRecursiveAll c.children[0], .type is "Comment"
+          comments := gatherRecursiveAll c.leadingWs, .type is "Comment"
           if comments#
             // e.children is ["\n", "else ", block]; insert the comments after
             // the leading newline so they sit on their own lines before `else`.

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -635,15 +635,23 @@ export type CaseBlock = ASTParent &
   type: "CaseBlock"
   clauses: (PatternClause | CaseClause | WhenClause | DefaultClause)[]
 
+// `leadingWs` on the switch-clause types below is the clause's leading
+// whitespace/comments, populated by NestedCaseClause (and processTryBlock for
+// pattern-matching catch). Named so processPatternMatching can re-emit comments
+// without depending on positional children layout (issue #2151). Typed as the
+// broad ASTNode (the leading trivia is heterogeneous, and it matches
+// gatherRecursiveAll's parameter) to avoid reshuffling the clause-type unions.
 export type PatternClause = ASTParent &
   type: "PatternClause"
   patterns: PatternExpression[]
   block: BlockStatement
+  leadingWs?: ASTNode
 
 export type CaseClause = ASTParent &
   type: "CaseClause"
   cases: ASTNode[]
   block: BlockStatement
+  leadingWs?: ASTNode
 
 export type PatternMatchingStatement = ASTObject &
   type: "PatternMatchingStatement"
@@ -656,10 +664,12 @@ export type WhenClause = ASTParent &
   cases: ASTNode[]
   break: ASTNode
   block: BlockStatement
+  leadingWs?: ASTNode
 
 export type DefaultClause = ASTParent &
   type: "DefaultClause"
   block: BlockStatement
+  leadingWs?: ASTNode
 
 export type EmptyStatement = ASTParent &
   type: "EmptyStatement"
@@ -1021,6 +1031,9 @@ export type CatchClause = ASTObject &
   children: Children & [ Whitespace | ASTString, CatchToken, CatchBinding, BlockStatement ]
   block: BlockStatement
   binding: CatchBinding?
+  // Leading whitespace/comments before the clause (children[0]); named so
+  // consumers don't depend on positional layout (issue #2151).
+  leadingWs?: ASTNode
 
 export type CatchToken = Keyword & { token: "catch" }
 

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1698,6 +1698,31 @@ describe "switch", ->
         }
     """
 
+    // #2151: a comment indented inside a clause's block stays in that block;
+    // only a clause's own leading comment is relocated before the `else`.
+    testCase """
+      keeps comments indented inside a clause block
+      ---
+      switch x
+        null
+          a()
+          // comment inside block
+        undefined
+          b()
+        else
+          c()
+      ---
+      if(x === null) {
+          a()
+          // comment inside block
+      }
+      else if(x === undefined) {
+          b()}
+      else  {
+          c()
+        }
+    """
+
     testCase """
       pattern matching with default clause first
       ---

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1675,6 +1675,29 @@ describe "switch", ->
           'def'
     """
 
+    // #2151: leading comments before later pattern clauses were dropped
+    testCase """
+      preserves comments before later pattern clauses
+      ---
+      switch x
+        null
+          a()
+        // a comment here
+        undefined
+          b()
+        else
+          c()
+      ---
+      if(x === null) {
+          a()}
+      // a comment here
+      else if(x === undefined) {
+          b()}
+      else  {
+          c()
+        }
+    """
+
     testCase """
       pattern matching with default clause first
       ---

--- a/test/try.civet
+++ b/test/try.civet
@@ -475,6 +475,60 @@ describe "try", ->
       else  {throw e1}}
     """
 
+    // #2151: comments before second-and-later catch clauses were dropped
+    testCase """
+      preserves comments before later catch clauses
+      ---
+      try
+        foo()
+      catch null
+        a()
+      // eslint-disable-next-line prefer-const
+      catch e
+        b()
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 === null) {
+        a()
+      }
+      // eslint-disable-next-line prefer-const
+      else  {let e = e1;
+        b()
+      }}
+    """
+
+    testCase """
+      preserves comments before multiple later catch clauses
+      ---
+      try
+        foo()
+      catch null
+        a()
+      // comment A
+      catch undefined
+        b()
+      /* comment B */
+      catch e
+        c()
+      ---
+      try {
+        foo()
+      }
+      catch(e1) {if(e1 === null) {
+        a()
+      }
+      // comment A
+      else if(e1 === undefined) {
+        b()
+      }
+      /* comment B */
+      else  {let e = e1;
+        c()
+      }}
+    """
+
   describe "lone finally blocks", ->
     testCase """
       basic

--- a/test/try.civet
+++ b/test/try.civet
@@ -475,6 +475,31 @@ describe "try", ->
       else  {throw e1}}
     """
 
+    // #2151: comment before the first catch already worked (it becomes the
+    // merged catch clause's leading whitespace) — kept as a regression guard.
+    testCase """
+      preserves comment before first catch clause
+      ---
+      try
+        foo()
+      // comment before first catch
+      catch null
+        a()
+      catch e
+        b()
+      ---
+      try {
+        foo()
+      }
+      // comment before first catch
+      catch(e1) {if(e1 === null) {
+        a()
+      }
+      else  {let e = e1;
+        b()
+      }}
+    """
+
     // #2151: comments before second-and-later catch clauses were dropped
     testCase """
       preserves comments before later catch clauses


### PR DESCRIPTION
Fixes #2151.

## Cause
When a pattern-matching switch is rebuilt into an if/else chain in `processPatternMatching`, each clause's leading trivia is discarded — only `patterns` and `block` survive. So comments before the second-and-later clauses of a pattern-matching `try` (and a general `switch`) were silently dropped, breaking directive comments like `eslint-disable-next-line` and `@ts-expect-error`.

## Approach
- `processTryBlock` carries each later catch clause's leading trivia into the generated switch clause (the first clause's trivia is already consumed as the merged catch clause's leading whitespace).
- `processPatternMatching` gathers any `Comment` nodes from a clause's leading trivia and re-emits them before the `else` that introduces the clause.

This fixes both pattern-matching `catch` and general `switch` for second-and-later clauses.