### PR TITLE
Zip iteration: `for [each] a, b of x, y`

### DIFF
--- a/civet.dev/.vitepress/config.mjs
+++ b/civet.dev/.vitepress/config.mjs
@@ -46,8 +46,17 @@ function tsLibPlugin() {
   };
 }
 
-export default async function vitePressConfig() {
+export default async function vitePressConfig({ command } = {}) {
   const highlighter = await getHighlighter();
+  const isDev = command === 'serve';
+  const devFallback = (label, fallback) => (error) => {
+    console.warn(
+      `[vitepress] Failed to load ${label}; using empty data in dev mode: ${
+        error?.message ?? error
+      }`
+    );
+    return fallback;
+  };
   return defineConfig({
     lang: 'en-US',
     title: 'Civet - A Programming Language for the New Millennium',
@@ -57,8 +66,18 @@ export default async function vitePressConfig() {
     cleanUrls: 'with-subfolders',
     appearance: 'dark',
     themeConfig: {
-      contributors: await getContributors(),
-      openCollective: await getOpenCollectiveInfo(),
+      contributors: await (
+        isDev
+          ? getContributors().catch(devFallback('contributors', []))
+          : getContributors()
+      ),
+      openCollective: await (
+        isDev
+          ? getOpenCollectiveInfo().catch(
+            devFallback('OpenCollective info', { sponsors: [], backers: [] })
+          )
+          : getOpenCollectiveInfo()
+      ),
       logo: 'https://user-images.githubusercontent.com/13007891/210392977-03a3b140-ec63-4ce9-b6e3-0a0f7cac6cbe.png',
       siteTitle: 'Civet',
       nav: [

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1995,6 +1995,71 @@ for key: keyof typeof object, value in object
   process key, value
 </Playground>
 
+### Zip Loops
+
+`for..of` and `for each..of` loops can iterate over multiple iterables/arrays
+in lockstep, like
+[Python's `zip`](https://docs.python.org/3/library/functions.html#zip):
+
+<Playground>
+for each item1, item2 of list1, list2
+  console.log item1, item2
+</Playground>
+
+<Playground>
+for item1, item2 of list1, list2
+  console.log item1, item2
+</Playground>
+
+By default, the `for` loop stops when any of the iterands stops, so that all
+items are always defined. You can instead specify some of the declarations
+as optional via `?` (default value of `undefined`) or with an explicit default
+value via `=`. If some iterands are not optional, they will define the length;
+otherwise, the length is the maximum of all iterands (like Python's
+[itertools.zip_longest](https://docs.python.org/3/library/itertools.html#itertools.zip_longest)).
+
+<Playground>
+for each item1, item2? of list1, list2
+  console.log item1, item2
+</Playground>
+
+<Playground>
+for item1 = 0, item2 = 0 of list1, list2
+  console.log item1 + item2
+</Playground>
+
+When combined with types, `?` acts like [optional types](#optional-types):
+
+<Playground>
+for each name?: Name, val?: Val of names, vals
+  console.log name, val
+</Playground>
+
+With `for each`, you can also request iterands to cycle around after reaching
+the end of an array, via `%`. These arrays are also ignored when determining
+the length.
+
+<Playground>
+for each item, color% of list, palette
+  console.log item, color
+</Playground>
+
+::: warning
+If all iterands are cyclic, then the loop will be infinite!
+:::
+
+You can access the loop index by listing one more variable before `of`:
+
+<Playground>
+for each item1, item2, index of list1, list2
+  console.log item1, item2, index
+</Playground>
+
+<Playground>
+for item1, item2, index of list1, list2
+  console.log item1, item2, index
+</Playground>
+
 ### Loop Expressions
 
 If needed, loops automatically assemble an array of the last value
@@ -2055,6 +2120,13 @@ coordinates := for {x, y} of objects
 keys := for key in object
 </Playground>
 
+With [zip loops](#zip-loops), the implicit body is a tuple:
+
+<Playground>
+function zip(list1, list2)
+  for item1, item2 of list1, list2
+</Playground>
+
 Loops that use `await` automatically get `await`ed.
 If you'd rather obtain the promise for the results so you can `await` them
 yourself, use `async for`.
@@ -2099,6 +2171,13 @@ Use `...x` to yield all items from another iterable `x` via `yield*`:
 function concatIter(iters)
   for* iter of iters
     ...iter
+</Playground>
+
+With [zip loops](#zip-loops):
+
+<Playground>
+function zip(list1, list2)
+  for* item1, item2 of list1, list2
 </Playground>
 
 ### Postfix Loop
@@ -2260,6 +2339,8 @@ If there is no body, it uses the item being looped over.
 <Playground>
 function flat1<T>(arrays: T[][]): T[]
   for concat array of arrays
+function alternating(list1, list2)
+  for concat each item1, item2 of list1, list2
 </Playground>
 
 Implicit bodies in `for sum/product/min/max/join/concat` reductions
@@ -2335,6 +2416,16 @@ i .= 0
 loop
   i++
   break if i > 5
+</Playground>
+
+`for each..of` loops are also infinite if all iterands are cyclic
+(as described in [zip loops](#zip-loops)):
+
+<Playground>
+for each message% of ['Thinking', 'Pondering']
+  console.log message, '...'
+  await sleep()
+  break if done()
 </Playground>
 
 ### Range Loop

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -5745,12 +5745,13 @@ ForDeclaration ::ForDeclaration
 
 # https://262.ecma-international.org/#prod-ForBinding
 ForBinding
-  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix Initializer?:initializer ::Binding ->
+  ( BindingPattern / BindingIdentifier ):pattern (_? "%")?:cycle TypeSuffix?:typeSuffix Initializer?:initializer ::Binding ->
     return {
       type: "Binding",
       children: [ pattern, typeSuffix ?? pattern.typeSuffix, initializer ],
       names: pattern.names,
       pattern,
+      cycle,
       typeSuffix: typeSuffix ?? pattern.typeSuffix,
       initializer,
       splices: [],

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -127,6 +127,7 @@ import type {
   FunctionRestParameter,
   Identifier,
   IfStatement,
+  Initializer,
   InterfaceDeclaration,
   ImportDeclaration,
   ImportClause,
@@ -5744,13 +5745,14 @@ ForDeclaration ::ForDeclaration
 
 # https://262.ecma-international.org/#prod-ForBinding
 ForBinding
-  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix ::Binding ->
+  ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix Initializer?:initializer ::Binding ->
     return {
       type: "Binding",
-      children: [ pattern, typeSuffix ?? pattern.typeSuffix ],
+      children: [ pattern, typeSuffix ?? pattern.typeSuffix, initializer ],
       names: pattern.names,
       pattern,
       typeSuffix: typeSuffix ?? pattern.typeSuffix,
+      initializer,
       splices: [],
       thisAssignments: [],
     }
@@ -6400,7 +6402,7 @@ MaybeNestedPostfixedExpression
   # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
   # the second case, where they get checked by PrimaryExpression,
   # which then allows for trailing binary operators etc.
-  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested PostfixedExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ::unknown ->
+  !NestedBulletedArray !NestedImplicitObjectLiteral PushIndent ( Nested PostfixedExpression )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ::ASTNode ->
     return $skip unless expression
     return expression unless trailing
     return [ expression, trailing ]
@@ -7079,7 +7081,7 @@ LexicalBinding
     }
 
 # https://262.ecma-international.org/#prod-Initializer
-Initializer
+Initializer ::Initializer
   __ Equals MaybeNestedPostfixedExpression:expression -> {
     type: "Initializer",
     expression,
@@ -9060,7 +9062,7 @@ TypeSuffix
     colon,
     children: $0,
   }
-  _? QuestionMark:optional _? ::unknown -> {
+  _? QuestionMark:optional ::unknown -> {
     type: "TypeSuffix",
     ts: true,
     optional,

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -27,6 +27,7 @@ import {
   dynamizeImportDeclarationExpression,
   escapeIdentifier,
   expressionizeTypeIf,
+  declarationIterand,
   forRange,
   gatherBindingCode,
   gatherBindingPatternTypeSuffix,
@@ -48,6 +49,7 @@ import {
   maybeRef,
   maybeRefAssignment,
   modifyString,
+  namesOf,
   negateCondition,
   parenthesizeExpression,
   precedenceCustomDefault,
@@ -111,8 +113,12 @@ import type {
   EmptyStatement,
   EnumDeclaration,
   ExpressionNode,
+  Extends,
+  CoffeeForBindingAssignment,
+  CoffeeForDeclaration as CoffeeForDeclarationType,
   ForReduction,
   ForControlDeclaration,
+  ForDeclaration,
   ForStatementControl,
   ForStatement,
   FromClause,
@@ -139,6 +145,7 @@ import type {
   NamedExports,
   NamespaceDeclaration,
   NonNullAssertion,
+  NonNullASTNode,
   ObjectBindingPattern,
   ObjectExpression,
   ObjectProperty,
@@ -153,17 +160,19 @@ import type {
   PinPattern,
   Property,
   RangeEnd,
+  RangeExpression,
   ReturnTypeAnnotation,
   ReturnValue,
   SpreadProperty,
   StatementExpression,
-  StatementNode,
   StatementTuple,
   SwitchStatement,
   ThisType,
   ThrowStatement,
   TryStatement,
   ThisAssignments,
+  TypeConditional,
+  TypeCondition,
   TypeDeclaration,
   TypeArgument,
   TypeArgumentList,
@@ -506,7 +515,7 @@ AssignmentExpressionSpread
       type: "SpreadElement",
       children: $0,
       expression,
-      names: expression!.names,
+      names: namesOf(expression),
     }
   AssignmentExpression:expression ( _? DotDotDot )? ->
     return $1 unless $2
@@ -514,14 +523,14 @@ AssignmentExpressionSpread
       type: "SpreadElement",
       children: [ ...$2, $1 ],
       expression,
-      names: expression!.names,
+      names: namesOf(expression),
     }
   _? DotDotDot AssignmentExpression:expression ->
     return {
       type: "SpreadElement",
       children: $0,
       expression,
-      names: expression!.names,
+      names: namesOf(expression),
     }
   AssignmentExpression:expression ( _? DotDotDot )? ->
     return $1 unless $2
@@ -529,7 +538,7 @@ AssignmentExpressionSpread
       type: "SpreadElement",
       children: [ ...$2, $1 ],
       expression,
-      names: expression!.names,
+      names: namesOf(expression),
     }
 
 # https://262.ecma-international.org/#prod-Arguments
@@ -1397,7 +1406,7 @@ WithClause ::WithClause
       targets: [[ws, t], ...rest.map(([ws1, _comma, ws2, target]) => [prepend(ws1, ws2), target])] as WithClause["targets"],
     }
 
-ExtendsToken
+ExtendsToken ::Extends
   # NOTE: Added "<" extends shorthand
   NotDedented:ws InsertSpace:s ExtendsShorthand:t " "? ->
     return {
@@ -1417,7 +1426,7 @@ ExtendsShorthand
   "<" ->
     return { $loc, token: "extends " }
 
-NotExtendsToken
+NotExtendsToken ::Extends
   Loc:l _?:ws1 OmittedNegation:ws2 ExtendsShorthand:t " "? ->
     // `!<` is eaten by NonNullable before reaching this rule, so ws1 and ws2
     // are never both falsy; the `{ ..., token: " " }` fallback is unreachable
@@ -3701,7 +3710,7 @@ _ArrayLiteral
     return {
       type: "ArrayExpression",
       children: [open, ...content, close],
-      names: content.flatMap((c) => c?.names || [])
+      names: content.flatMap(namesOf)
     }
   OpenBracket:open AllowAll ( ArrayLiteralContent __ CloseBracket )? RestoreAll ->
     return $skip unless $3
@@ -3714,7 +3723,7 @@ _ArrayLiteral
     children := [open, ...(content as any), ...ws, close]
 
     // Gather names when ArrayLiteral is used as a destructuring pattern
-    names := children.flatMap((c: any) => c?.names || [])
+    names := children.flatMap(namesOf)
 
     return {
       type: "ArrayExpression",
@@ -3755,9 +3764,9 @@ RangeDots
       children: [ws1, ws2]
     }
 
-OptionalRangeEnd
+OptionalRangeEnd ::RangeEnd
   RangeEnd
-  "" -> { increasing: undefined, inclusive: true, raw: "" }
+  "" -> { inclusive: true, raw: "" }
 
 RangeEnd
   /([<>])(=?)|([≤≥])/ ::RangeEnd ->
@@ -3776,7 +3785,7 @@ RangeEnd
       raw: $0,
     }
 
-RangeExpression
+RangeExpression ::RangeExpression
   Expression:start __:ws RangeDots:range Expression:end ->
     return processRangeExpression(start, ws, range, end)
 
@@ -4024,7 +4033,7 @@ BracedObjectLiteral ::ObjectExpression
     return {
       type: "ObjectExpression",
       children: [open, properties, close],
-      names: properties.flatMap((c: any) => c.names || []),
+      names: properties.flatMap(namesOf),
       properties,
     }
   OpenBrace:open AllowAll ( BracedObjectLiteralContent __ CloseBrace )? RestoreAll ->
@@ -4034,7 +4043,7 @@ BracedObjectLiteral ::ObjectExpression
     return {
       type: "ObjectExpression",
       children: [open, properties, close],
-      names: properties.flatMap((c: any) => c.names || []),
+      names: properties.flatMap(namesOf),
       properties,
     }
 
@@ -4370,7 +4379,7 @@ NamedProperty
     return {
       type: "SpreadProperty",
       children: [dots, paren],
-      names: exp!.names || [],
+      names: namesOf(exp),
       dots,
       value: paren,
     }
@@ -4381,7 +4390,7 @@ NamedProperty
       type: "Property",
       children: $0,
       name: name,
-      names: exp!.names || [],
+      names: namesOf(exp),
       value: exp,
     }
 
@@ -4397,7 +4406,7 @@ SnugNamedProperty
       type: "Property",
       children: [name, colon, expression],
       name,
-      names: (expression as any).names || [],
+      names: namesOf(expression),
     }
 
 PropertyName
@@ -5602,15 +5611,17 @@ CoffeeForStatementParameters ::ForStatementControl
       } satisfies ForControlDeclaration
 
       return {
-        declaration: forHead,
-        children: [$1, open, forHead, "; ", ...condition, counterRef, increment, close],
-        blockPrefix,
+        declaration: forHead
+        iterand: declarationIterand declaration
+        children: [$1, open, forHead, "; ", ...condition, counterRef, increment, close]
+        blockPrefix
       }
 
     return {
-      declaration,
-      children: [$1, open, declaration, $5, kind, " ", exp, close],
-      blockPrefix,
+      declaration
+      iterand: declarationIterand declaration
+      children: [$1, open, declaration, $5, kind, " ", exp, close]
+      blockPrefix
     }
   ForRangeParameters
 
@@ -5623,7 +5634,7 @@ CoffeeForIndex
       children: [...ws1 || [], ...ws2 || [], ...id.children]
     }
 
-CoffeeForDeclaration
+CoffeeForDeclaration ::CoffeeForDeclarationType | CoffeeForBindingAssignment
   # NOTE: Coffee doesn't allow expression bindings like `for a.x in b`
   ( __ Own )?:own ( __ LetOrConstOrVar )?:kind ForBinding:binding ->
     if kind
@@ -5641,6 +5652,9 @@ CoffeeForDeclaration
       own: Boolean(own),
       children: [binding],
       names: binding.names,
+      lhs: [],
+      assigned: binding,
+      expression: binding,
     }
 
 ForStatementParameters ::ForStatementControl
@@ -5662,17 +5676,17 @@ ForStatementParameters ::ForStatementControl
   # NOTE: Consolidated declarations
   # NOTE: Consolidated optional 'await'
   # NOTE: &OpenParen is to fill the spot normally taken by each/own
-  ( Await __ )? &OpenParen ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
+  ( Await __ )? &OpenParen ( OpenParen __ ) ForInOfDeclarations __ ( In / Of ) ForInOfExpressions ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
     return processForInOf($0)
   # NOTE: Added optional each/own modifiers,
   # which are tried second to allow them to still work as identifiers
-  ( Await __ )? ( (Each / Own) __ )? ( OpenParen __ ) ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
+  ( Await __ )? ( (Each / Own) __ )? ( OpenParen __ ) ForInOfDeclarations __ ( In / Of ) ForInOfExpressions ( __ By ExpressionWithObjectApplicationForbidden )? ( __ CloseParen ) ->
     return processForInOf($0)
   # NOTE: Added optional parens
   # NOTE: &ForInOfDeclaration is to fill the spot normally taken by each/own
-  ( Await __ )? &ForInOfDeclaration InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
+  ( Await __ )? &ForInOfDeclaration InsertOpenParen ForInOfDeclarations __ ( In / Of ) ForInOfExpressions ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
     return processForInOf($0)
-  ( Await __ )? ( (Each / Own) __ )? InsertOpenParen ForInOfDeclaration ( __ Comma __ ForInOfDeclaration )? __ ( In / Of ) ExpressionWithObjectApplicationForbidden ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
+  ( Await __ )? ( (Each / Own) __ )? InsertOpenParen ForInOfDeclarations __ ( In / Of ) ForInOfExpressions ( __ By ExpressionWithObjectApplicationForbidden )? InsertCloseParen ->
     return processForInOf($0)
   ForRangeParameters
 
@@ -5684,17 +5698,25 @@ ForStatementDeclaration ::ASTNode
 ForRangeParameters ::ForStatementControl
   # NOTE: CoffeeScript-style `for [start..end] by step` without declaration
   ( Await __ )? OpenParen:open OpenBracket RangeExpression:exp CloseBracket ( __ By ExpressionWithObjectApplicationForbidden )?:step CloseParen:close ->
-    return forRange(open, null, exp, step, close)
+    return forRange(open, undefined, exp, step, close)
   ( Await __ )? InsertOpenParen:open OpenBracket RangeExpression:exp CloseBracket ( __ By ExpressionWithObjectApplicationForbidden )?:step InsertCloseParen:close ->
-    return forRange(open, null, exp, step, close)
+    return forRange(open, undefined, exp, step, close)
 
 # NOTE: Consolidated declarations
-ForInOfDeclaration
+ForInOfDeclarations ::NonNullASTNode[]
+  ForInOfDeclaration:first ( __ Comma __ ForInOfDeclaration )*:rest ->
+    return [first, ...rest.map [, , ws, decl] => prepend(ws, decl)]
+
+ForInOfDeclaration ::NonNullASTNode
   ForDeclaration
   LeftHandSideExpression
 
+ForInOfExpressions ::NonNullASTNode[]
+  ExpressionWithObjectApplicationForbidden:first ( __ Comma __ ExpressionWithObjectApplicationForbidden )*:rest ->
+    return [first, ...rest.map [, , , exp] => exp]
+
 # https://262.ecma-international.org/#prod-ForDeclaration
-ForDeclaration
+ForDeclaration ::ForDeclaration
   LetOrConstOrVar:c ForBinding:binding ->
     return {
       type: "ForDeclaration",
@@ -5715,7 +5737,7 @@ ForDeclaration
     return {
       type: "ForDeclaration",
       children: [c, binding],
-      decl: c.token.trimEnd(),
+      decl: "const",
       binding,
       names: binding.names,
     }
@@ -6998,7 +7020,7 @@ LexicalDeclaration ::LexicalDeclaration
 
     return {
       type: "Declaration",
-      children: $0 as Children,
+      children: $0,
       names: bindings.flatMap((b) => b.names),
       bindings,
       decl: decl as DeclarationKind,
@@ -8722,7 +8744,7 @@ TypeDeclaration
       type: "Declaration",
       ts: true,
       children: $0,
-      names: "names" in d ? d.names : [],
+      names: namesOf(d),
     }
   ( Export _? )?:export_ ( Declare _? )?:declare TypeDeclarationRest:t ->
     return {
@@ -8763,7 +8785,7 @@ InterfaceDeclaration ::InterfaceDeclaration
     return {
       type: "InterfaceDeclaration",
       id,
-      children: $0,
+      children: $0 as Children,
       ts: true,
     }
 
@@ -9318,7 +9340,7 @@ TypeElement ::ASTNode
   # NOTE: Match named form first, to avoid matching `foo: bar,` as Type
   # and then DotDotDot from next entry.
   __:ws ( DotDotDot __ )?:dots1 IdentifierName:name ( _? DotDotDot )?:dots2 (__ (QuestionMark _?)? Colon __):colon Type:type ->
-    dots .= dots1 or (dots2 and [dots2[1], dots2[0]] /* space at end */)
+    dots: ASTNode .= dots1 or (dots2 and [dots2[1], dots2[0]] /* space at end */)
     if dots1 and dots2
       dots = [dots, {
         type: "Error",
@@ -9428,21 +9450,25 @@ TypeWithPostfix
       expressionizeTypeIf([ ...postfix[1], $1, undefined ]))
 
 TypeConditional ::ASTNode
-  _? /(?=if|unless)/ TypeIfThenElse ->
+  _? /(?=if|unless)/ TypeIfThenElse ::TypeConditional ->
     return prepend($1, expressionizeTypeIf($3))
-  TypeCondition NotDedented QuestionMark __ Type __ Colon __ Type ->
-    return [ $1, $2, $3, $4, $9, $6, $7, $8, $5 ] as ASTNode if $1.negated
-    return $0 as ASTNode
+  TypeCondition NotDedented QuestionMark __ Type __ Colon __ Type ::TypeConditional ->
+    children: Children := $1.negated ? [ $1, $2, $3, $4, $9, $6, $7, $8, $5 ] : $0
+    return {
+      type: "TypeConditional"
+      ts: true
+      children
+    }
   TypeBinary
 
-TypeCondition
+TypeCondition ::TypeCondition
   # NOTE: Type after `extends` needs to forbid TypePostfix,
   # or it could end up matching the "then" clause of an if/then/else
   TypeBinary IndentedFurther? ( ExtendsToken / NotExtendsToken ) TypeConditional ->
     return {
       type: "TypeCondition",
       negated: $3.negated,
-      children: $0,
+      children: $0 as Children,
     }
 
 TypeIfThenElse

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -2,6 +2,7 @@ import type {
   ArrayBindingPattern
   ASTNode
   ASTNodeObject
+  BindingIdentifier
   BindingPattern
   BindingProperty
   BindingRestElement
@@ -152,6 +153,33 @@ function gatherSubbindings(node: ASTNode, subbindings: ASTNode[] = []): ASTNode[
     subbindings.push ", ", subbinding
     gatherSubbindings subbinding, subbindings
   subbindings
+
+/**
+Find all bound variables in a pattern and return as an array
+Example: {x: [, y], z} -> [y, z]
+*/
+function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
+  bindings: BindingIdentifier[] := []
+  recurse pattern
+  return bindings
+
+  function recurse(pattern: ASTNodeObject): void
+    switch pattern.type
+      when "ArrayBindingPattern"
+        for each element of pattern.elements
+          recurse element
+      when "ObjectBindingPattern"
+        for each property of pattern.properties
+          recurse property
+      when "BindingElement"
+        recurse pattern.binding
+      when "BindingProperty"
+        recurse pattern.value ?? pattern.name
+      /* c8 ignore next 2 -- defensive: Binding nodes unwrap to .pattern before reaching here in practice */
+      when "Binding"
+        recurse pattern.pattern
+      when "Identifier", "AtBinding"
+        bindings.push pattern
 
 /**
 Simplify `{name: name}` to just `{name}` that results from
@@ -313,5 +341,6 @@ export {
   gatherSubbindings
   gatherBindingCode
   gatherBindingPatternTypeSuffix
+  patternBindings
   simplifyBindingProperties
 }

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -309,6 +309,7 @@ function processForInOf($0: [
   [awaits, eachOwn, open, declarations, ws, inOf, exps, step, close] .= $0
   // Hera 0.9.0: `&ForInOfDeclaration` assertion now yields `true` in the eachOwn slot.
   eachOwn = undefined if eachOwn <? "boolean"
+  each := eachOwn and eachOwn[0].token is "each"
 
   // ForInOfDeclaration is either ForDeclaration or LeftHandSideExpression
   // In the latter case, check valid LHS
@@ -363,6 +364,8 @@ function processForInOf($0: [
       return = initializer.expression
 
   defaultValues := itemDeclarations.map zipPaddingDefault
+  cycles := itemDeclarations.map (decl) =>
+    if decl.type is "ForDeclaration" then decl.binding.cycle
   if exps# is 1 and defaultValues[0]? is not "undefined"
     errors.push
       type: "Error"
@@ -371,6 +374,14 @@ function processForInOf($0: [
     errors.push
       type: "Error"
       message: "zip iteration index cannot have a default"
+  if indexDeclaration?.type is "ForDeclaration" and indexDeclaration.binding.cycle
+    errors.push
+      type: "Error"
+      message: "zip iteration index cannot be cyclic"
+  if cycles.some(&?) and not (each and inOf.token is "of")
+    errors.push
+      type: "Error"
+      message: "cyclic zip iteration is only supported in for each..of loops"
 
   // ensure space after in/of
   for each exp, i of exps
@@ -439,7 +450,7 @@ function processForInOf($0: [
 
   // for each item[, index] of array
   // for each item1, item2[, index] of array1, array2
-  if eachOwn and eachOwn[0].token is "each"
+  if each
     if inOf.token is "of"
       counterRef := makeRef "i"
       endRef := makeRef exps# > 1 ? "end" : "len"
@@ -452,24 +463,29 @@ function processForInOf($0: [
       lengthRefs: ASTNode[] := []
       for each defaultValue, i of defaultValues
         // `?` defaults to `undefined`, which out-of-bounds indexing already returns.
-        // Other defaults need a cached length for the bounds check.
-        if defaultValue? is not "undefined"
+        // Cyclic iterands and other defaults need a cached length.
+        if cycles[i]? or defaultValue? is not "undefined"
           lengthRefs[i] = makeRef "len"
           expRefDecs.push trimFirstSpace(lengthRefs[i]), " = ", trimFirstSpace(expRefs[i]), ".length, "
         else
           lengthRefs[i] = [trimFirstSpace(expRefs[i]), ".length"]
 
-      // If some iterand has no default, then we take min of their lengths.
+      // If there is a length-defining iterand (no default and no cycle),
+      // then we take min of their lengths.
       lengthFunction .= "Math.min"
       lenIndices .=
-        for each defaultValue, i of defaultValues when not defaultValue?
+        for each defaultValue, i of defaultValues when not defaultValue? and not cycles[i]?
           i
-      // Otherwise, we take the max of all lengths.
-      unless lenIndices# // all optional
+      // Otherwise, we take the max of all non-cyclic lengths (if any).
+      unless lenIndices#
         lengthFunction = "Math.max"
-        lenIndices = [0..<expRefs#]
-      lenExp :=
-        if lenIndices# is 1
+        lenIndices =
+          for each cycle, i of cycles when not cycle?
+            i
+      endExp :=
+        if not lenIndices#
+          undefined
+        else if lenIndices# is 1
           lengthRefs[lenIndices[0]]
         else
           . lengthFunction
@@ -479,24 +495,26 @@ function processForInOf($0: [
 
       declaration: ForControlDeclaration :=
         type: "Declaration"
-        children:
-          if exps# > 1
-            ["let ", ...expRefDecs, endRef, " = ", lenExp, ", ", counterRef, " = 0"]
-          else
-            ["let ", ...expRefDecs, counterRef, " = 0, ", endRef, " = ", lenExp]
+        children: [
+          "let ", ...expRefDecs
+          counterRef, " = 0"
+          ...if lenIndices# then [", ", endRef, " = ", endExp] else []
+        ]
         decl: "let"
         names: []
 
       for each decl, i of itemDeclarations
-        itemValue := [trimFirstSpace(expRefs[i]), "[", counterRef, "]"]
-        value := defaultValues[i]? is not "undefined"
+        itemValue := cycles[i]
+          ? [trimFirstSpace(expRefs[i]), "[", counterRef, cycles[i], lengthRefs[i], "]"]
+          : [trimFirstSpace(expRefs[i]), "[", counterRef, "]"]
+        value := not cycles[i]? and defaultValues[i]? is not "undefined"
           ? [counterRef, " < ", lengthRefs[i], " ? ", itemValue, " : ", trimFirstSpace(defaultValues[i])]
           : itemValue
         pushBlockDeclaration decl, value, true
       if indexDeclaration
         pushBlockDeclaration indexDeclaration, counterRef, true
 
-      condition := [counterRef, " < ", endRef, "; "]
+      condition := lenIndices# ? [counterRef, " < ", endRef, "; "] : ["; "]
       children := [...errors, open, declaration, "; ", condition, counterRef, "++", close]
       return { declaration, iterand, children, blockPrefix }
     else

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -314,7 +314,6 @@ function processForInOf($0: [
   // ForInOfDeclaration is either ForDeclaration or LeftHandSideExpression
   // In the latter case, check valid LHS
   for each decl of declarations
-    continue unless decl?
     unless decl.type is "ForDeclaration"
       checkValidLHS decl
 
@@ -421,28 +420,20 @@ function processForInOf($0: [
     value: ASTNode
     implicitLift = false
   ): void
-    let kind: "let" | "const" | "var"
-    let binding: ASTNode // portion of decl to use when appending to previous
-    switch decl.type
-      when "ForDeclaration"
-        kind = decl.decl
-        binding = trimFirstSpace decl.binding
-      when "Identifier"
-        kind = "const"
-        binding = trimFirstSpace decl
-      else // assignment like `for x.y of ...` - no declaration
-        blockPrefix.push ["", [trimFirstSpace(decl), " = ", value], ";"]
-        return
+    unless decl.type is "ForDeclaration" // assignment like `for x.y of ...` - no declaration
+      blockPrefix.push ["", [trimFirstSpace(decl), " = ", value], ";"]
+      return
+    binding := trimFirstSpace decl.binding // portion of decl to use when appending to previous
     previous := blockPrefix.-1?[1]
     previousImplicitLift := previous? and "implicitLift" in previous and previous.implicitLift
-    if previous?.type is "Declaration" and Boolean(previousImplicitLift) is implicitLift and previous.decl is kind
+    if previous?.type is "Declaration" and Boolean(previousImplicitLift) is implicitLift and previous.decl is decl.decl
       previous.children.push ", ", binding, " = ", value
       previous.names.push ...namesOf(decl)
     else
       blockPrefix.push ["", {
         type: "Declaration"
         children: [decl, " = ", value]
-        decl: kind
+        decl.decl
         // names may get mutated by future pushBlockDeclaration, so duplicate
         names: [...namesOf(decl)]
         implicitLift

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -16,6 +16,7 @@ import type {
 
 import {
   checkValidLHS
+  convertOptionalType
   isBigIntLiteral
   literalValue
   makeLeftHandSideExpression
@@ -23,6 +24,7 @@ import {
   makeNumericLiteral
   namesOf
   prepend
+  replaceNode
   startsWith
   trimFirstSpace
 } from ./util.civet
@@ -338,6 +340,38 @@ function processForInOf($0: [
   if declarations# > exps#
     [...itemDeclarations, indexDeclaration] = declarations
 
+  /**
+   * Normalize zip padding syntax on a declaration and return the padding value.
+   * `?` pads with `undefined`; `= value` overrides that padding value.
+   */
+  function zipPaddingDefault(decl: ASTNode): ASTNode
+    return unless decl?.type is "ForDeclaration"
+    { binding } := decl
+    // `?` after iterand declaration means pad with `undefined`
+    // `?: T` also converts declaration to `: undefined | T`, like `let x?: T`
+    typeSuffix := binding.typeSuffix
+    if typeSuffix?.type is "TypeSuffix" and typeSuffix.optional
+      // Remove `?` from declaration and convert `: T` to `: undefined | T`
+      if typeSuffix.t
+        convertOptionalType typeSuffix
+      else
+        replaceNode typeSuffix, undefined, binding
+        binding.typeSuffix = undefined
+      return = "undefined"
+    if initializer := binding.initializer
+      replaceNode initializer, undefined, binding
+      return = initializer.expression
+
+  defaultValues := itemDeclarations.map zipPaddingDefault
+  if exps# is 1 and defaultValues[0]? is not "undefined"
+    errors.push
+      type: "Error"
+      message: "zip iteration defaults need multiple iterands"
+  if zipPaddingDefault(indexDeclaration)?
+    errors.push
+      type: "Error"
+      message: "zip iteration index cannot have a default"
+
   // ensure space after in/of
   for each exp, i of exps
     unless startsWith exp, /^\s/
@@ -408,36 +442,61 @@ function processForInOf($0: [
   if eachOwn and eachOwn[0].token is "each"
     if inOf.token is "of"
       counterRef := makeRef "i"
-      lenRef := makeRef "len"
+      endRef := makeRef exps# > 1 ? "end" : "len"
 
       expRefs := exps.map maybeRef .
       expRefDecs: ASTNode[] := []
       for each expRef, i of expRefs
         unless expRef is exps[i]
           expRefDecs.push trimFirstSpace(expRef), " = ", trimFirstSpace(exps[i]), ", "
-
-      lenExp :=
-        if exps# > 1
-          . "Math.min("
-          . ...expRefs.flatMap (expRef, i) =>
-              [i ? ", " : "", trimFirstSpace(expRef), ".length"]
-          . ")"
+      lengthRefs: ASTNode[] := []
+      for each defaultValue, i of defaultValues
+        // `?` defaults to `undefined`, which out-of-bounds indexing already returns.
+        // Other defaults need a cached length for the bounds check.
+        if defaultValue? is not "undefined"
+          lengthRefs[i] = makeRef "len"
+          expRefDecs.push trimFirstSpace(lengthRefs[i]), " = ", trimFirstSpace(expRefs[i]), ".length, "
         else
-          [trimFirstSpace(expRefs[0]), ".length"]
+          lengthRefs[i] = [trimFirstSpace(expRefs[i]), ".length"]
+
+      // If some iterand has no default, then we take min of their lengths.
+      lengthFunction .= "Math.min"
+      lenIndices .=
+        for each defaultValue, i of defaultValues when not defaultValue?
+          i
+      // Otherwise, we take the max of all lengths.
+      unless lenIndices# // all optional
+        lengthFunction = "Math.max"
+        lenIndices = [0..<expRefs#]
+      lenExp :=
+        if lenIndices# is 1
+          lengthRefs[lenIndices[0]]
+        else
+          . lengthFunction
+          . "("
+          . ...lenIndices.flatMap (i, j) => [j ? ", " : "", lengthRefs[i]]
+          . ")"
 
       declaration: ForControlDeclaration :=
         type: "Declaration"
-        children: ["let ", ...expRefDecs, counterRef, " = 0, ", lenRef, " = ", lenExp]
+        children:
+          if exps# > 1
+            ["let ", ...expRefDecs, endRef, " = ", lenExp, ", ", counterRef, " = 0"]
+          else
+            ["let ", ...expRefDecs, counterRef, " = 0, ", endRef, " = ", lenExp]
         decl: "let"
         names: []
 
       for each decl, i of itemDeclarations
-        value := [trimFirstSpace(expRefs[i]), "[", counterRef, "]"]
+        itemValue := [trimFirstSpace(expRefs[i]), "[", counterRef, "]"]
+        value := defaultValues[i]? is not "undefined"
+          ? [counterRef, " < ", lengthRefs[i], " ? ", itemValue, " : ", trimFirstSpace(defaultValues[i])]
+          : itemValue
         pushBlockDeclaration decl, value, true
       if indexDeclaration
         pushBlockDeclaration indexDeclaration, counterRef, true
 
-      condition := [counterRef, " < ", lenRef, "; "]
+      condition := [counterRef, " < ", endRef, "; "]
       children := [...errors, open, declaration, "; ", condition, counterRef, "++", close]
       return { declaration, iterand, children, blockPrefix }
     else
@@ -462,6 +521,8 @@ function processForInOf($0: [
     iteratorInits: ASTNode[] := []
     for each exp, i of exps
       iteratorInits.push i ? ", " : "", iterRefs[i], " = ", trimFirstSpace(exp), "[Symbol.iterator]()"
+    for each nextRef of nextRefs
+      iteratorInits.push ", ", nextRef
     if counterRef
       iteratorInits.push ", ", counterRef, " = 0"
 
@@ -472,21 +533,27 @@ function processForInOf($0: [
       names: []
     } satisfies ForControlDeclaration
 
-    blockPrefix.push ["", {
-      type: "Declaration"
-      children: ["const ", ...nextRefs.flatMap((nextRef, i) =>
-        [i ? ", " : "", nextRef, " = ", iterRefs[i], ".next()"]
-      )]
-      decl: "const"
-      names: []
-    }, ";"]
-    blockPrefix.push ["", [
-      "if ("
-      ...nextRefs.flatMap (nextRef, i) => [i ? " || " : "", nextRef, ".done"]
-      ") break"
-    ], ";"]
+    // If some iterand has no default, then we stop when any of them is done.
+    doneJoin .= " || "
+    doneIndices .=
+      for each defaultValue, i of defaultValues when not defaultValue?
+        i
+    // Otherwise, we stop when all iterands are done.
+    unless doneIndices#
+      doneJoin = " && "
+      doneIndices = [0..<nextRefs#]
+    condition := [
+      ...nextRefs.flatMap((nextRef, i) =>
+        [nextRef, " = ", iterRefs[i], ".next()", ", "]
+      )
+      "!("
+      ...doneIndices.flatMap (i, j) => [j ? doneJoin : "", nextRefs[i], "?.done"]
+      ")"
+    ]
     for each decl, i of itemDeclarations
-      pushBlockDeclaration decl, [nextRefs[i], ".value"]
+      value .= [nextRefs[i], "?.value"]
+      value = [nextRefs[i], "?.done ? ", trimFirstSpace(defaultValues[i]), " : ", ...value] if defaultValues[i]?
+      pushBlockDeclaration decl, value
     if indexDeclaration
       pushBlockDeclaration indexDeclaration, counterRef
 
@@ -494,7 +561,8 @@ function processForInOf($0: [
       declaration
       iterand
       blockPrefix
-      children: [awaits, ...errors, open, declaration, "; ;", counterRef ? [counterRef, "++"] : undefined, close]
+      hoistDec
+      children: [awaits, ...errors, open, declaration, "; ", condition, ";", counterRef ? [counterRef, "++"] : undefined, close]
     }
 
   // At this point, we should have dealt with all valid zip iterations,

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -1,14 +1,13 @@
 import type {
-  AssignmentExpression
   ASTNode
-  ASTNodeObject
   ASTLeaf
   ASTError
   Binding
   Children
+  Declaration
   ForControlDeclaration
-  ForDeclaration
   ForStatementControl
+  NonNullASTNode
   RangeDots
   RangeExpression
   StatementTuple
@@ -22,6 +21,7 @@ import {
   makeLeftHandSideExpression
   makeNode
   makeNumericLiteral
+  namesOf
   prepend
   startsWith
   trimFirstSpace
@@ -154,10 +154,25 @@ function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, 
     increasing: range.increasing
   }
 
+/**
+ * The "main iterand" of the loop is used for the implicit body.
+ * This helper handles one declaration, not zip iterations.
+ */
+function declarationIterand(decl: ASTNode): ASTNode
+  if decl?.type is "ForDeclaration"
+    { pattern } := decl.binding
+    pattern
+  else if decl?.type is "AssignmentExpression" and decl.assigned?
+    decl.assigned
+  else if decl?.type is "Placeholder"
+    undefined
+  else
+    decl
+
 // Construct for loop from RangeLiteral
 function forRange(
   open: ASTLeaf
-  forDeclaration: ForDeclaration | AssignmentExpression
+  forDeclaration: ASTNode
   range: RangeExpression
   stepExp: ASTNode
   close: ASTLeaf
@@ -225,22 +240,22 @@ function forRange(
 
   let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign
   let blockPrefix: StatementTuple[]?
-  let names: string[] = forDeclaration?.names ?? []
+  names .= namesOf forDeclaration
   if forDeclaration?
     if forDeclaration.type is "AssignmentExpression" // Coffee-style for loop
       varAssign = varLetAssign = [forDeclaration, " = "]
       names = [] // assigned but not declared
-    else if forDeclaration.decl is "let" // let: declare within loop
+    else if forDeclaration is like {type: "ForDeclaration", decl: "let"} // let: declare within loop
       varName := forDeclaration.children.splice(1)  // strip let
       varAssign = [...trimFirstSpace(varName) as ASTNode[], " = "]
       varLet = [",", ...varName, " = ", counterRef]
     else // const or var or assignment like `for x[y] of z`: put inside loop
-      value := "StringLiteral" is start?.subtype ? ["String.fromCharCode(", counterRef, ")"] : counterRef
+      value := start?.type is "Literal" and start.subtype is "StringLiteral" ? ["String.fromCharCode(", counterRef, ")"] : counterRef
       blockPrefix = [
         ["", [forDeclaration, " = ", value], ";"]
       ]
 
-  declaration := {
+  declaration: Declaration := {
     type: "Declaration"
     children: ["let ", ...startRefDec, ...endRefDec, counterRef, " = ", ...varLetAssign, startRef, ...varLet, ...ascDec]
     names
@@ -271,6 +286,7 @@ function forRange(
     // This declaration doesn't always appear in the output,
     // but it's still helpful for determining the primary loop variable
     declaration: forDeclaration
+    iterand: declarationIterand forDeclaration
     children: [range.error, open, declaration, "; ", ...condition, "; ", ...increment, close]
     blockPrefix
   }
@@ -279,115 +295,234 @@ function processForInOf($0: [
   awaits: ASTNode
   eachOwn: [ASTLeaf, ASTNode] | boolean | undefined
   open: ASTLeaf
-  declaration: ASTNode
-  declaration2: [ws1: ASTNode, comma: ASTLeaf, ws2: ASTNode, decl2: ASTNode]
+  /** Declarations before in/of, with commas removed. */
+  declarations: NonNullASTNode[]
   ws: ASTNode
   inOf: ASTLeaf
-  exp: ASTNodeObject
+  /** Expressions after in/of, with commas removed. */
+  exps: NonNullASTNode[]
   step: [Whitespace, ASTLeaf, ASTNode]
   close: ASTLeaf
 ]): ForStatementControl
-  [awaits, eachOwn, open, declaration, declaration2, ws, inOf, exp, step, close] .= $0
+  [awaits, eachOwn, open, declarations, ws, inOf, exps, step, close] .= $0
   // Hera 0.9.0: `&ForInOfDeclaration` assertion now yields `true` in the eachOwn slot.
   eachOwn = undefined if eachOwn <? "boolean"
 
   // ForInOfDeclaration is either ForDeclaration or LeftHandSideExpression
   // In the latter case, check valid LHS
-  for each decl of [declaration, declaration2?.-1]
+  for each decl of declarations
     continue unless decl?
     unless decl.type is "ForDeclaration"
       checkValidLHS decl
 
-  // ensure space after in/of
-  unless startsWith exp, /^\s/
-    exp = prepend(" ", exp)
+  errors: ASTError[] := []
+  if exps# > 1 and inOf.token is not "of"
+    errors.push
+      type: "Error"
+      message: "zip iteration is only supported in for..of loops"
+    exps = exps[..<1]
+    declarations = declarations[..<2]
+  unless exps# <= declarations# <= exps# + 1
+    errors.push
+      type: "Error"
+      message: "zip iteration needs one declaration per iterand, plus an optional index"
+    if declarations# < exps#
+      exps = exps[..<declarations#]
+    else
+      declarations = declarations[..<exps# + 1]
 
-  if exp.type is "RangeExpression" and inOf.token is "of" and not declaration2
-    // TODO: add support for `declaration2` to efficient `forRange`
+  // If there are more declarations than expressions (by 1), then
+  // the last declaration is for the (optional) index.
+  itemDeclarations .= declarations
+  indexDeclaration: ASTNode .= undefined
+  if declarations# > exps#
+    [...itemDeclarations, indexDeclaration] = declarations
+
+  // ensure space after in/of
+  for each exp, i of exps
+    unless startsWith exp, /^\s/
+      exps[i] = prepend(" ", exp)
+
+  // `for item, index of [a..b]` without constructing `[a..b]` array
+  if exps[0].type is "RangeExpression" and inOf.token is "of" and declarations# is exps# is 1
+    // TODO: add support for `indexDeclaration` to efficient `forRange`
     return forRange
-      open, declaration, exp
+      open, declarations[0], exps[0]
       step and prepend(trimFirstSpace(step[0]), trimFirstSpace(step[2])) // omit "by" token
       close
   else if step
     throw new Error("for..of/in cannot use 'by' except with range literals")
 
-  let eachOwnError: ASTError?
+  // The "main iterand" of the loop is used for the implicit body.
+  iterand: ASTNode? .=
+    if itemDeclarations# is 1
+      declarationIterand itemDeclarations[0]
+    else // for zip iteration, tuple of the non-index iterands
+      type: "ArrayExpression"
+      children: [
+        "["
+        ...itemDeclarations.flatMap (decl, i) =>
+          [i ? ", " : "", declarationIterand decl]
+        "]"
+      ]
+      names: itemDeclarations.flatMap namesOf
+
   let hoistDec: ASTNode?
   blockPrefix: StatementTuple[] := []
 
-  // for each item[, index] of array
-  if eachOwn and eachOwn[0].token is "each"
-    if inOf.token is "of"
-      counterRef := makeRef("i")
-      lenRef := makeRef("len")
-      expRef := maybeRef(exp)
-
-      const increment = "++"
-      let assignmentNames = [...declaration!.names]
-
-      if declaration2
-        [, , ws2, decl2] := declaration2  // strip __ Comma __
-        blockPrefix.push(["", [
-          trimFirstSpace(ws2), decl2, " = ", counterRef
-        ], ";"])
-        assignmentNames.push(...decl2!.names)
-
-      expRefDec := (expRef !== exp)
-        // Trim a single leading space if present
-        ? [trimFirstSpace(expRef), " = ", trimFirstSpace(exp), ", "]
-        : []
-
+  /** Add a loop-body declaration, appending to the previous one if it has the same var/const/let kind. */
+  function pushBlockDeclaration(
+    decl: NonNullASTNode
+    value: ASTNode
+    implicitLift = false
+  ): void
+    let kind: "let" | "const" | "var"
+    let binding: ASTNode // portion of decl to use when appending to previous
+    switch decl.type
+      when "ForDeclaration"
+        kind = decl.decl
+        binding = trimFirstSpace decl.binding
+      when "Identifier"
+        kind = "const"
+        binding = trimFirstSpace decl
+      else // assignment like `for x.y of ...` - no declaration
+        blockPrefix.push ["", [trimFirstSpace(decl), " = ", value], ";"]
+        return
+    previous := blockPrefix.-1?[1]
+    previousImplicitLift := previous? and "implicitLift" in previous and previous.implicitLift
+    if previous?.type is "Declaration" and Boolean(previousImplicitLift) is implicitLift and previous.decl is kind
+      previous.children.push ", ", binding, " = ", value
+      previous.names.push ...namesOf(decl)
+    else
       blockPrefix.push ["", {
         type: "Declaration"
-        children: [declaration, " = ", trimFirstSpace(expRef), "[", counterRef, "]"]
-        names: assignmentNames
-        implicitLift: true
+        children: [decl, " = ", value]
+        decl: kind
+        // names may get mutated by future pushBlockDeclaration, so duplicate
+        names: [...namesOf(decl)]
+        implicitLift
       }, ";"]
 
-      eachDeclaration := declaration
-      declaration = {
+  // for each item[, index] of array
+  // for each item1, item2[, index] of array1, array2
+  if eachOwn and eachOwn[0].token is "each"
+    if inOf.token is "of"
+      counterRef := makeRef "i"
+      lenRef := makeRef "len"
+
+      expRefs := exps.map maybeRef .
+      expRefDecs: ASTNode[] := []
+      for each expRef, i of expRefs
+        unless expRef is exps[i]
+          expRefDecs.push trimFirstSpace(expRef), " = ", trimFirstSpace(exps[i]), ", "
+
+      lenExp :=
+        if exps# > 1
+          . "Math.min("
+          . ...expRefs.flatMap (expRef, i) =>
+              [i ? ", " : "", trimFirstSpace(expRef), ".length"]
+          . ")"
+        else
+          [trimFirstSpace(expRefs[0]), ".length"]
+
+      declaration: ForControlDeclaration :=
         type: "Declaration"
-        children: ["let ", ...expRefDec, counterRef, " = 0, ", lenRef, " = ", trimFirstSpace(expRef), ".length"]
+        children: ["let ", ...expRefDecs, counterRef, " = 0, ", lenRef, " = ", lenExp]
         decl: "let"
         names: []
-      } satisfies ForControlDeclaration
+
+      for each decl, i of itemDeclarations
+        value := [trimFirstSpace(expRefs[i]), "[", counterRef, "]"]
+        pushBlockDeclaration decl, value, true
+      if indexDeclaration
+        pushBlockDeclaration indexDeclaration, counterRef, true
 
       condition := [counterRef, " < ", lenRef, "; "]
-      children := [open, declaration, "; ", condition, counterRef, increment, close]
-      return { declaration, eachDeclaration, children, blockPrefix }
+      children := [...errors, open, declaration, "; ", condition, counterRef, "++", close]
+      return { declaration, iterand, children, blockPrefix }
     else
-      eachOwnError =
-        type: "Error",
-        message: "'each' is only meaningful in for..of loops",
+      errors.push
+        type: "Error"
+        message: "'each' is only meaningful in for..of loops"
 
   // for own..in
   own .= eachOwn and eachOwn[0].token is "own"
   let expRef: ASTNode?
   if own and inOf.token is not "in"
     own = false
-    eachOwnError =
+    errors.push
       type: "Error"
       message: "'own' is only meaningful in for..in loops"
+
+  // Iterator zip: for item1, item2[, index] of array1, array2
+  if exps# > 1 and inOf.token is "of"
+    iterRefs := exps.map => makeRef "iter"
+    nextRefs := exps.map => makeRef "next"
+    counterRef := if indexDeclaration then makeRef "i"
+    iteratorInits: ASTNode[] := []
+    for each exp, i of exps
+      iteratorInits.push i ? ", " : "", iterRefs[i], " = ", trimFirstSpace(exp), "[Symbol.iterator]()"
+    if counterRef
+      iteratorInits.push ", ", counterRef, " = 0"
+
+    declaration: ForControlDeclaration := {
+      type: "Declaration"
+      children: ["let ", ...iteratorInits]
+      decl: "let"
+      names: []
+    } satisfies ForControlDeclaration
+
+    blockPrefix.push ["", {
+      type: "Declaration"
+      children: ["const ", ...nextRefs.flatMap((nextRef, i) =>
+        [i ? ", " : "", nextRef, " = ", iterRefs[i], ".next()"]
+      )]
+      decl: "const"
+      names: []
+    }, ";"]
+    blockPrefix.push ["", [
+      "if ("
+      ...nextRefs.flatMap (nextRef, i) => [i ? " || " : "", nextRef, ".done"]
+      ") break"
+    ], ";"]
+    for each decl, i of itemDeclarations
+      pushBlockDeclaration decl, [nextRefs[i], ".value"]
+    if indexDeclaration
+      pushBlockDeclaration indexDeclaration, counterRef
+
+    return {
+      declaration
+      iterand
+      blockPrefix
+      children: [awaits, ...errors, open, declaration, "; ;", counterRef ? [counterRef, "++"] : undefined, close]
+    }
+
+  // At this point, we should have dealt with all valid zip iterations,
+  // so there should be one main declaration and expression,
+  // plus an optional indexDeclaration.
+  declaration: NonNullASTNode .= itemDeclarations[0]
+  exp: NonNullASTNode .= exps[0]
 
   // TypeScript doesn't support typed declarations in for loops,
   // so pull such declarations inside the loop:
   //   for var x: T of y -> for (const x1 of y) {var x: T = x1;
   // for..in loops need a similar ref-based declaration
   // for dereferencing to get the associated value.
-  { binding } := declaration
-  pattern .= binding?.pattern
+  binding := declaration.type is "ForDeclaration" ? declaration.binding : undefined
+  pattern: ASTNode .= binding?.pattern
   // Unwrap NamedBindingPattern to correctly detect "Identifier" and
   // avoid double subbinding
   if pattern?.type is "NamedBindingPattern"
     pattern = pattern.binding
+
   if binding?.typeSuffix or (
-    inOf.token is "in" and declaration2 and pattern.type is not "Identifier"
+    inOf.token is "in" and indexDeclaration and pattern?.type is not "Identifier"
   )
     itemRef := makeRef if inOf.token is "in" then "key" else "item"
     blockPrefix.push(["", {
       type: "Declaration"
       children: [declaration, " = ", itemRef]
-      names: declaration!.names
+      names: namesOf declaration
     } satisfies ForControlDeclaration, ";"])
     declaration =
       type: "ForDeclaration"
@@ -402,18 +537,16 @@ function processForInOf($0: [
       children: ["const ", itemRef]
       decl: "const"
       names: []
-    unless pattern.type is "Identifier"
+    unless pattern?.type is "Identifier"
       pattern = itemRef
 
-  unless declaration2 or own
+  unless indexDeclaration or own
     return {
       declaration
+      iterand
       blockPrefix
-      children: [awaits, eachOwnError, open, declaration, ws, inOf, expRef ?? exp, close] // omit declaration2, replace eachOwn with eachOwnError, replace exp with expRef
+      children: [awaits, ...errors, open, declaration, ws, inOf, expRef ?? exp, close] // omit indexDeclaration, replace eachOwn with errors, replace exp with expRef
     }
-
-  let ws2: ASTNode?, decl2: ASTNode?
-  if (declaration2) [, , ws2, decl2] = declaration2  // strip __ Comma __
 
   switch inOf.token
     when "of" // for item, index of iter
@@ -424,12 +557,18 @@ function processForInOf($0: [
         decl: "let"
         names: []
       } satisfies ForControlDeclaration
-      blockPrefix.push(["", {
-        type: "Declaration"
-        children: [trimFirstSpace(ws2), decl2, " = ", counterRef, "++"]
-        names: decl2!.names
-        decl: decl2!.decl
-      } satisfies ForControlDeclaration, ";"])
+      indexDecl := indexDeclaration!
+      indexAssignment: ASTNode :=
+        if indexDecl.type is "ForDeclaration"
+          {
+            type: "Declaration"
+            children: [trimFirstSpace(indexDecl), " = ", counterRef, "++"]
+            indexDecl.names
+            decl: indexDecl.decl
+          } satisfies ForControlDeclaration
+        else
+          [trimFirstSpace(indexDecl), " = ", counterRef, "++"]
+      blockPrefix.push(["", indexAssignment, ";"])
 
     // grammar guarantees inOf.token is "of" or "in" only
     when "in" // for key, value in object
@@ -449,7 +588,7 @@ function processForInOf($0: [
       if own
         hasPropRef := getHelperRef("hasProp")
         blockPrefix.push ["", ["if (!", hasPropRef, "(", trimFirstSpace(expRef), ", ", trimFirstSpace(pattern), ")) continue"], ";"]
-      if decl2
+      if indexDeclaration
         trimmedPattern := trimFirstSpace pattern
         expression := makeNode
           type: "MemberExpression"
@@ -460,8 +599,8 @@ function processForInOf($0: [
                 expression: trimmedPattern
                 children: [ "[", trimmedPattern, "]" ]
         blockPrefix.push ["",
-          if decl2.type is "ForDeclaration"
-            { binding, children } := decl2
+          if indexDeclaration.type is "ForDeclaration"
+            { binding, children } := indexDeclaration
             binding.children.push binding.initializer = makeNode {}
               type: "Initializer"
               expression
@@ -469,33 +608,29 @@ function processForInOf($0: [
             makeNode
               type: "Declaration"
               children: [
-                trimFirstSpace(ws2)
-                ...children
+                ...trimFirstSpace(children) as ASTNode[]
               ]
-              bindings: [decl2.binding]
-              decl: decl2.decl
-              names: decl2.names
+              bindings: [indexDeclaration.binding]
+              decl: indexDeclaration.decl
+              names: indexDeclaration.names
           else
-            makeNode {}
-              type: "AssignmentExpression"
-              children: [
-                trimFirstSpace(ws2), decl2, " = "
-                trimFirstSpace(expRef)
-                "[", trimFirstSpace(pattern), "]"
-              ]
-              names: decl2.names
-              lhs: decl2
-              assigned: decl2
+            [
+              trimFirstSpace(indexDeclaration), " = "
+              trimFirstSpace(expRef)
+              "[", trimFirstSpace(pattern), "]"
+            ]
           ";"]
 
   return {
     declaration,
-    children: [awaits, eachOwnError, open, declaration, ws, inOf, exp, close], // omit declaration2, replace each with eachOwnError
+    iterand,
+    children: [awaits, ...errors, open, declaration, ws, inOf, exp, close], // omit indexDeclaration, replace each with errors
     blockPrefix,
     hoistDec,
   }
 
 export {
+  declarationIterand
   forRange
   processForInOf
   processRangeExpression

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -382,7 +382,7 @@ function iterandAsValue(iterand: ASTNode): ASTNode
         subtype: "Warning"
         message: "Ignored binding in loop with implicit body"
     pattern := bindings[0]
-    if isASTNodeObject pattern then patternAsValue pattern else pattern
+    patternAsValue pattern
   else
     type: "Error"
     message: "Empty binding pattern in loop with implicit body"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -363,16 +363,24 @@ function patternAsValue(pattern: ASTNodeObject): ASTNode
     else
       pattern
 
-function iterandAsValue(iterand: ASTNode): ASTNode
+/**
+Convert a loop iterand pattern into the value used for an implicit body.
+When `firstBinding` is true, destructuring patterns use only their first
+binding, warning about the rest; reductions use this to reduce a single value.
+*/
+function iterandAsValue(iterand: ASTNode, firstBinding = false): ASTNode
   return iterand unless isASTNodeObject iterand
   // ArrayExpression iterands are zip tuples like `[a, b]`; recurse into
   // elements but preserve the tuple itself as the implicit value.
   if iterand.type is "ArrayExpression"
-    children: ASTNode[] := iterand.children.map (child): ASTNode => iterandAsValue child
+    children: ASTNode[] := iterand.children.map (child): ASTNode =>
+      iterandAsValue child, firstBinding
     return {
       ...iterand
       children
     } as ASTNode
+
+  return patternAsValue iterand unless firstBinding
 
   bindings := patternBindings iterand
   if bindings#
@@ -900,7 +908,7 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
         return true
 
   if statement.type is "ForStatement" and statement.iterand
-    fillBlock [ "", iterandAsValue(statement.iterand) ]
+    fillBlock [ "", iterandAsValue(statement.iterand, Boolean(reduction)) ]
     block.empty = false
 
   return false

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -11,7 +11,6 @@ import type {
   AtBindingProperty
   Binding
   BindingElement
-  BindingIdentifier
   BlockStatement
   BreakStatement
   CallExpression
@@ -53,6 +52,7 @@ import {
   gatherSubbindings
   gatherBindingCode
   gatherBindingPatternTypeSuffix
+  patternBindings
   simplifyBindingProperties
 } from ./binding.civet
 
@@ -84,6 +84,7 @@ import {
   hasTrailingComment
   hasYield
   inplacePrepend
+  isASTNodeObject
   isEmptyBareBlock
   isExit
   isFunction
@@ -362,32 +363,29 @@ function patternAsValue(pattern: ASTNodeObject): ASTNode
     else
       pattern
 
-/**
-Find all bound variables in a pattern and return as an array
-Example: {x: [, y], z} -> [y, z]
-*/
-function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
-  bindings: BindingIdentifier[] := []
-  recurse pattern
-  return bindings
+function iterandAsValue(iterand: ASTNode): ASTNode
+  return iterand unless isASTNodeObject iterand
+  // ArrayExpression iterands are zip tuples like `[a, b]`; recurse into
+  // elements but preserve the tuple itself as the implicit value.
+  if iterand.type is "ArrayExpression"
+    children: ASTNode[] := iterand.children.map (child): ASTNode => iterandAsValue child
+    return {
+      ...iterand
+      children
+    } as ASTNode
 
-  function recurse(pattern: ASTNodeObject): void
-    switch pattern.type
-      when "ArrayBindingPattern"
-        for each element of pattern.elements
-          recurse element
-      when "ObjectBindingPattern"
-        for each property of pattern.properties
-          recurse property
-      when "BindingElement"
-        recurse pattern.binding
-      when "BindingProperty"
-        recurse pattern.value ?? pattern.name
-      /* c8 ignore next 2 -- defensive: Binding nodes unwrap to .pattern before reaching here in practice */
-      when "Binding"
-        recurse pattern.pattern
-      when "Identifier", "AtBinding"
-        bindings.push pattern
+  bindings := patternBindings iterand
+  if bindings#
+    for binding of bindings[1..]
+      binding.children.unshift
+        type: "Error"
+        subtype: "Warning"
+        message: "Ignored binding in loop with implicit body"
+    pattern := bindings[0]
+    if isASTNodeObject pattern then patternAsValue pattern else pattern
+  else
+    type: "Error"
+    message: "Empty binding pattern in loop with implicit body"
 
 // Ensure an `abstract class` expression has a name, generating a ref if it
 // doesn't, so it can be emitted as a class declaration. Returns the
@@ -901,28 +899,9 @@ function iterationDefaultBody(statement: IterationStatement | ForStatement): boo
         braceBlock block
         return true
 
-  if statement.type is "ForStatement"
-    declaration := statement.eachDeclaration ?? statement.declaration
-    if declaration?.type is "ForDeclaration"
-      // For regular loops and object comprehensions, use entire pattern
-      // For reductions, use the first binding
-      if reduction
-        bindings := patternBindings declaration.binding.pattern
-        if bindings#
-          fillBlock [ "", bindings[0] ]
-          for binding of bindings[1..]
-            binding.children.unshift
-              type: "Error"
-              subtype: "Warning"
-              message: "Ignored binding in reduction loop with implicit body"
-        else
-          fillBlock [ "",
-            type: "Error"
-            message: "Empty binding pattern in reduction loop with implicit body"
-          ]
-      else
-        fillBlock [ "", patternAsValue declaration.binding.pattern ]
-      block.empty = false
+  if statement.type is "ForStatement" and statement.iterand
+    fillBlock [ "", iterandAsValue(statement.iterand) ]
+    block.empty = false
 
   return false
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -53,6 +53,7 @@ import type {
   SwitchStatement
   TypeArgument
   TypeArguments
+  TypeConditional
   TypeNode
   TypeSuffix
   Loc
@@ -94,6 +95,7 @@ import {
   makeNode
   maybeWrap
   maybeUnwrap
+  namesOf
   parenthesizeExpression
   parenthesizeType
   prepend
@@ -141,7 +143,7 @@ import {
 
 import { buildExportSplitClause, escapeIdentifier, propertyKey } from ./identifier.civet
 import { processPipelineExpressions } from ./pipe.civet
-import { forRange, processForInOf, processRangeExpression } from ./for.civet
+import { declarationIterand, forRange, processForInOf, processRangeExpression } from ./for.civet
 import {
   findSuperCall
   makeAmpersandFunction
@@ -420,7 +422,7 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
     children
   }
 
-function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any])
+function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any]): TypeConditional
   children := [
     "("
     trimFirstSpace condition
@@ -440,7 +442,11 @@ function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any])
       children.push "never:"
     children.push t
   children.push ")"
-  children
+  makeNode {
+    type: "TypeConditional"
+    ts: true
+    children
+  }
 
 /**
  * This adjusts #x.y().z and @x.y().z when used inside Object glob expressions
@@ -1309,8 +1315,9 @@ function processAssignments(statements: ASTNode): void
       when "AssignmentExpression"
         continue unless exp.lhs
         for each lhsPart of exp.lhs
-          if newLhs := extractAssignment(lhsPart[1])
-            lhsPart[1] = newLhs
+          if isASTNodeObject lhsPart[1]
+            if newLhs := extractAssignment(lhsPart[1])
+              lhsPart[1] = newLhs
       when "UpdateExpression"
         if newLhs := extractAssignment(exp.assigned)
           i := exp.children.indexOf(exp.assigned)
@@ -1452,7 +1459,7 @@ function processAssignments(statements: ASTNode): void
       [, lhs, , op] := lastAssignment
       continue unless op.token is "="
 
-      if lhs.type is like "ObjectExpression", "ObjectBindingPattern"
+      if lhs.type is "ObjectExpression" or lhs.type is "ObjectBindingPattern"
         // Wrap with parens to distinguish from braced blocks
         unless wrapped or insideParens
           wrapped = true
@@ -1556,7 +1563,7 @@ function processAssignments(statements: ASTNode): void
           names: []
 
     // Gather all identifier names from the lhs array
-    exp.names = $1.flatMap(([, l]) => l.names or [])
+    exp.names = $1.flatMap(([, l]) => namesOf l)
 
     if tail#
       index := exp.children.indexOf($2)
@@ -2435,6 +2442,7 @@ export {
   dedentBlockString
   dedentBlockSubstitutions
   deepCopy
+  declarationIterand
   processStaticImport
   duplicateBlock
   dynamizeImportDeclaration
@@ -2472,6 +2480,7 @@ export {
   maybeRef
   maybeRefAssignment
   modifyString
+  namesOf
   negateCondition
   parenthesizeExpression
   precedenceCustomDefault

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -6,6 +6,8 @@ export type ASTNode =
   | UntypedNode
   | undefined
 
+export type NonNullASTNode = NonNullable<ASTNode>
+
 // OtherNode includes BinaryOp which includes certain strings
 export type ASTNodeObject = Exclude<StatementNode | OtherNode | UntypedNode, string>
 
@@ -110,6 +112,7 @@ export type OtherNode =
   | ElisionElement
   | ElseClause
   | EmptyBinding
+  | Extends
   | FieldDefinition
   | FinallyClause
   | ForDeclaration
@@ -153,6 +156,7 @@ export type OtherNode =
   | ThisType
   | TypeArgument
   | TypeArguments
+  | TypeCondition
   | TypeSuffix
   | WhenClause
   | Yield
@@ -387,10 +391,10 @@ export type AssignmentExpression = ASTParent &
   names: string[] | null
   lhs: AssignmentExpressionLHS
   assigned: ASTNode
-  expression: ExpressionNode | ASTRef
+  expression: NonNullASTNode
   hoistDec?: ASTNode
 
-export type AssignmentExpressionLHS = [undefined, NonNullable<ASTNode>, [WSNode, [string, WSNode]], ASTLeaf][]
+export type AssignmentExpressionLHS = [undefined, NonNullASTNode, [WSNode, [string, WSNode]], ASTLeaf][]
 
 export type MemberExpression = ASTParent &
   type: "MemberExpression"
@@ -589,9 +593,8 @@ export type DoStatement = ASTParent &
 export type ForStatement = ASTParent &
   type: "ForStatement"
   declaration: (Declaration | ForDeclaration | ForControlDeclaration)?
-  /** Original declaration that got rewritten by `for each`
-  (used for implicit body) */
-  eachDeclaration?: (Declaration | ForDeclaration | ForControlDeclaration)?
+  /** Optional value used for implicit loop body. */
+  iterand?: ASTNode
   block: BlockStatement
   hoistDec: ASTNode
   /** From grammar `( _? Star )?`: optional [whitespace, Star] tuple. */
@@ -603,7 +606,8 @@ export type ForStatement = ASTParent &
 
 export type ForStatementControl = ASTParent &
   declaration?: ASTNode | null
-  eachDeclaration?: ASTNode
+  /** Optional value used for implicit loop body. */
+  iterand?: ASTNode
   blockPrefix?: StatementTuple[]?
   hoistDec?: ASTNode
   reduction?: ForReduction
@@ -621,6 +625,16 @@ export type ForDeclaration = ASTParent &
   binding: Binding
   decl: "let" | "const" | "var"
   own?: boolean
+
+export type CoffeeForDeclaration = ForDeclaration &
+  own: boolean
+  kind: Keyword
+
+export type CoffeeForBindingAssignment = Omit<AssignmentExpression, "names"> &
+  own: boolean
+  names: string[]
+  binding?: undefined
+  decl?: undefined
 
 export type ForReduction = ASTParent &
   type: "ForReduction"
@@ -673,6 +687,10 @@ export type EmptyStatement = ASTParent &
  */
 export type EmptyCondition = ASTParent &
   type: "EmptyCondition"
+
+export type Extends = ASTParent &
+  type: "Extends"
+  negated?: boolean
 
 export type LabelledStatement = ASTParent &
   type: "LabelledStatement"
@@ -1214,13 +1232,13 @@ export type SpreadProperty = ASTParent &
   type: "SpreadProperty"
   names: string[]
   dots: ASTNode
-  value: NonNullable<ASTNode>
+  value: NonNullASTNode
   delim?: ASTNode // attached when inside a comma-delimited property list
   usesRef?: boolean
 
 export type Property = ASTParent &
   type: "Property"
-  name: NonNullable<ASTNode>
+  name: NonNullASTNode
   names: string[]
   value: ASTNode
   delim?: ASTNode // attached when inside a comma-delimited property list
@@ -1289,7 +1307,7 @@ export type PipelineExpression =
 
 export type MethodDefinition = ASTParent &
   type: "MethodDefinition"
-  name: NonNullable<ASTNode>
+  name: NonNullASTNode
   async?: ASTNode[]?
   generator?: ASTNode[]?
   signature: FunctionSignature
@@ -1342,7 +1360,7 @@ export type OperatorSignature = FunctionSignature &
 
 export type MethodSignature = FunctionSignature &
   type: "MethodSignature"
-  name: NonNullable<ASTNode>
+  name: NonNullASTNode
 
 export type TypeSuffix = ASTParent &
   type: "TypeSuffix"
@@ -1502,7 +1520,7 @@ export type RangeDots = ASTParent &
   error?: ASTError
 
 export type RangeEnd
-  increasing: boolean?
+  increasing?: boolean
   inclusive: boolean
   raw: string
 
@@ -1519,6 +1537,7 @@ export type TypeNode =
   | TypeElement
   | TypeFunction
   | TypeParenthesized
+  | TypeConditional
   | TypeAsserts
   | TypePredicate
   | VoidType
@@ -1567,6 +1586,14 @@ export type TypeFunction = ASTParent &
 export type TypeParenthesized = ASTParent &
   type: "TypeParenthesized"
   ts: true
+
+export type TypeConditional = ASTParent &
+  type: "TypeConditional"
+  ts: true
+
+export type TypeCondition = ASTParent &
+  type: "TypeCondition"
+  negated: boolean?
 
 export type TypeLiteral = ASTParent &
   type: "TypeLiteral"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -964,6 +964,7 @@ export type Binding = ASTParent &
   type: "Binding"
   names: string[]
   pattern: BindingIdentifier | BindingPattern
+  cycle?: ASTNode?
   typeSuffix?: TypeSuffix?
   initializer?: Initializer?
   splices: unknown[]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -13,6 +13,7 @@ import type {
   IsToken
   IterationStatement
   Literal
+  NonNullASTNode
   NumericLiteral
   Parameter
   ParametersNode
@@ -353,6 +354,7 @@ function getTrimmingSpace(target: ASTNode): string?
 // Glom content e.g. whitespace into AST nodes
 // NOTE: This can get weird if we depend on the specific location of children
 function prepend<T extends ASTNodeObject>(prefix: ASTNode, node: T): T
+function prepend<T extends NonNullASTNode>(prefix: ASTNode, node: T): T extends ASTString ? NonNullASTNode : T
 function prepend(prefix: ASTNode, node: ASTNode): ASTNode
 function prepend(prefix: ASTNode, node: ASTNode): ASTNode
   return node if not prefix or prefix is like []
@@ -959,6 +961,12 @@ function flatJoin<T, S>(array: T[][], separator: S): (T | S)[]
     result.push ...items
   result
 
+function namesOf(node: unknown): string[]
+  if {names^: [...]} := node
+    names
+  else
+    []
+
 export {
   addParentPointers
   append
@@ -998,6 +1006,7 @@ export {
   makeNumericLiteral
   maybeWrap
   maybeUnwrap
+  namesOf
   parenthesizeExpression
   parenthesizeType
   prepend

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -272,7 +272,7 @@ describe "coffeeForLoops", ->
     xs = for [, s] in scripts
     ---
     var xs, s;
-    const results=[];for (let i = 0, len = scripts.length; i < len; i++) {[, s] = scripts[i];results.push(s)};xs = results
+    const results=[];for (let i = 0, len = scripts.length; i < len; i++) {[, s] = scripts[i];results.push([, s])};xs = results
   """
 
   testCase """
@@ -498,7 +498,7 @@ describe "coffeeForLoops", ->
     xs = for const [, s] from scripts
     ---
     var xs;
-    const results=[];for (const [, s] of scripts) {results.push(s)};xs = results
+    const results=[];for (const [, s] of scripts) {results.push( [, s])};xs = results
   """
 
   testCase """

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -256,6 +256,26 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for in with implicit body
+    ---
+    "civet coffeeCompat"
+    xs = for s in scripts
+    ---
+    var xs, s;
+    const results=[];for (let i = 0, len = scripts.length; i < len; i++) {s = scripts[i];results.push(s)};xs = results
+  """
+
+  testCase """
+    for in destructuring with implicit body
+    ---
+    "civet coffeeCompat"
+    xs = for [, s] in scripts
+    ---
+    var xs, s;
+    const results=[];for (let i = 0, len = scripts.length; i < len; i++) {[, s] = scripts[i];results.push(s)};xs = results
+  """
+
+  testCase """
     for in, index
     ---
     "civet coffee-compat"
@@ -459,6 +479,26 @@ describe "coffeeForLoops", ->
     for (const a of b) {
       console.log(a)
     }
+  """
+
+  testCase """
+    for const from with implicit body
+    ---
+    "civet coffee-compat"
+    xs = for const s from scripts
+    ---
+    var xs;
+    const results=[];for (const s of scripts) {results.push( s)};xs = results
+  """
+
+  testCase """
+    for const from destructuring with implicit body
+    ---
+    "civet coffee-compat"
+    xs = for const [, s] from scripts
+    ---
+    var xs;
+    const results=[];for (const [, s] of scripts) {results.push(s)};xs = results
   """
 
   testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -589,7 +589,7 @@ describe "for", ->
     for a, b of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a = next.value, b = next1.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a = next?.value, b = next1?.value;
       console.log(a, b)
     }
   """
@@ -600,8 +600,63 @@ describe "for", ->
     for a, b, i of x, y
       console.log a, b, i
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), i1 = 0; ;i1++) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a = next.value, b = next1.value, i = i1;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1, i1 = 0; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);i1++) {const a = next?.value, b = next1?.value, i = i1;
       console.log(a, b, i)
+    }
+  """
+
+  testCase """
+    of zip with padded declaration
+    ---
+    for a?, b of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a = next?.done ? undefined : next?.value, b = next1?.value;
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    of zip with second padded declaration
+    ---
+    for a, b? of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done);) {const a = next?.value, b = next1?.done ? undefined : next1?.value;
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    of zip with all declarations padded
+    ---
+    for a = 0, b? of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done && next1?.done);) {const a = next?.done ? 0 : next?.value, b = next1?.done ? undefined : next1?.value;
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    of zip with three declarations and padding
+    ---
+    for a?, b, c? of x, y, z
+      console.log a, b, c
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), iter2 = z[Symbol.iterator](), next, next1, next2; next = iter.next(), next1 = iter1.next(), next2 = iter2.next(), !(next1?.done);) {const a = next?.done ? undefined : next?.value, b = next1?.value, c = next2?.done ? undefined : next2?.value;
+      console.log(a, b, c)
+    }
+  """
+
+  testCase """
+    of zip with defaulted declaration
+    ---
+    for a = 0, b of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a = next?.done ? 0 : next?.value, b = next1?.value;
+      console.log(a, b)
     }
   """
 
@@ -610,7 +665,15 @@ describe "for", ->
     ---
     pairs := for a, b of x, y
     ---
-    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a = next.value, b = next1.value;results.push([a, b])};const pairs =results
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a = next?.value, b = next1?.value;results.push([a, b])};const pairs =results
+  """
+
+  testCase """
+    of zip with padded declaration and implicit body
+    ---
+    pairs := for a?, b of x, y
+    ---
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a = next?.done ? undefined : next?.value, b = next1?.value;results.push([a, b])};const pairs =results
   """
 
   testCase """
@@ -618,7 +681,7 @@ describe "for", ->
     ---
     pairs := for {a}, {b} of x, y
     ---
-    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const {a} = next.value, {b} = next1.value;results.push([a, b])};const pairs =results
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const {a} = next?.value, {b} = next1?.value;results.push([a, b])};const pairs =results
   """
 
   throws """
@@ -637,6 +700,35 @@ describe "for", ->
       console.log a, b, i, j
     ---
     ParseErrors: unknown:1:5 zip iteration needs one declaration per iterand, plus an optional index
+  """
+
+  throws """
+    of zip with padded index
+    ---
+    for a, b, i? of x, y
+      console.log a, b, i
+    ---
+    ParseErrors: unknown:1:5 zip iteration index cannot have a default
+  """
+
+  testCase """
+    of non-zip with padded declaration
+    ---
+    for a? of x
+      console.log a
+    ---
+    for (const a of x) {
+      console.log(a)
+    }
+  """
+
+  throws """
+    of non-zip with defaulted declaration
+    ---
+    for a = 0 of x
+      console.log a
+    ---
+    ParseErrors: unknown:1:5 zip iteration defaults need multiple iterands
   """
 
   throws """
@@ -780,7 +872,7 @@ describe "for", ->
       for each a, b of x, y
         console.log a, b
       ---
-      for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];
+      for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];
         console.log(a, b)
       }
     """
@@ -791,7 +883,7 @@ describe "for", ->
       for each a, b, i of x, y
         console.log a, b, i
       ---
-      for (let i1 = 0, len = Math.min(x.length, y.length); i1 < len; i1++) {const a = x[i1], b = y[i1], i = i1;
+      for (let end = Math.min(x.length, y.length), i1 = 0; i1 < end; i1++) {const a = x[i1], b = y[i1], i = i1;
         console.log(a, b, i)
       }
     """
@@ -802,8 +894,63 @@ describe "for", ->
       for each a, b of getX(), getY()
         console.log a, b
       ---
-      for (let ref = getX(), ref1 = getY(), i = 0, len = Math.min(ref.length, ref1.length); i < len; i++) {const a = ref[i], b = ref1[i];
+      for (let ref = getX(), ref1 = getY(), end = Math.min(ref.length, ref1.length), i = 0; i < end; i++) {const a = ref[i], b = ref1[i];
         console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with padded declaration
+      ---
+      for each a?, b of x, y
+        console.log a, b
+      ---
+      for (let end = y.length, i = 0; i < end; i++) {const a = x[i], b = y[i];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with second padded declaration
+      ---
+      for each a, b? of x, y
+        console.log a, b
+      ---
+      for (let end = x.length, i = 0; i < end; i++) {const a = x[i], b = y[i];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with all declarations padded
+      ---
+      for each a = 0, b? of x, y
+        console.log a, b
+      ---
+      for (let len = x.length, end = Math.max(len, y.length), i = 0; i < end; i++) {const a = i < len ? x[i] : 0, b = y[i];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with three declarations and padding
+      ---
+      for each a?, b, c? of x, y, z
+        console.log a, b, c
+      ---
+      for (let end = y.length, i = 0; i < end; i++) {const a = x[i], b = y[i], c = z[i];
+        console.log(a, b, c)
+      }
+    """
+
+    testCase """
+      each..of non-zip with padded declaration
+      ---
+      for each a? of x
+        console.log a
+      ---
+      for (let i = 0, len = x.length; i < len; i++) {const a = x[i];
+        console.log(a)
       }
     """
 
@@ -813,7 +960,7 @@ describe "for", ->
       for sum each a, b of x, y
         a * b
       ---
-      let results=0;for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];
+      let results=0;for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];
         results += a * b
       }results
     """
@@ -823,7 +970,7 @@ describe "for", ->
       ---
       pairs := for each a, b of x, y
       ---
-      const results=[];for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];results.push([a, b])};const pairs =results
+      const results=[];for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];results.push([a, b])};const pairs =results
     """
 
     testCase """
@@ -831,7 +978,7 @@ describe "for", ->
       ---
       pairs := for each {a}, {b} of x, y
       ---
-      const results=[];for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const {a} = x[i], {b} = y[i];results.push([a, b])};const pairs =results
+      const results=[];for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const {a} = x[i], {b} = y[i];results.push([a, b])};const pairs =results
     """
 
     testCase """
@@ -840,7 +987,7 @@ describe "for", ->
       for concat each a, b of x, y
       ---
       var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
-      let results=[];for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];concatAssign(results, [a, b])}results
+      let results=[];for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];concatAssign(results, [a, b])}results
     """
 
     throws """

--- a/test/for.civet
+++ b/test/for.civet
@@ -292,6 +292,14 @@ describe "for", ->
   """
 
   testCase """
+    for range expression with implicit sum reduction
+    ---
+    sum := for sum i of [1..9]
+    ---
+    let results=0;for (let i1 = 1; i1 <= 9; ++i1) {const i = i1;results += i};const sum =results
+  """
+
+  testCase """
     for bigint range
     ---
     for i of [1n..3n]
@@ -576,6 +584,71 @@ describe "for", ->
   """
 
   testCase """
+    of zip
+    ---
+    for a, b of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a = next.value, b = next1.value;
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    of zip with index
+    ---
+    for a, b, i of x, y
+      console.log a, b, i
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), i1 = 0; ;i1++) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a = next.value, b = next1.value, i = i1;
+      console.log(a, b, i)
+    }
+  """
+
+  testCase """
+    of zip with implicit body
+    ---
+    pairs := for a, b of x, y
+    ---
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a = next.value, b = next1.value;results.push([a, b])};const pairs =results
+  """
+
+  testCase """
+    of zip with destructuring implicit body
+    ---
+    pairs := for {a}, {b} of x, y
+    ---
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const {a} = next.value, {b} = next1.value;results.push([a, b])};const pairs =results
+  """
+
+  throws """
+    of zip with too few declarations
+    ---
+    for a of x, y
+      console.log a
+    ---
+    ParseErrors: unknown:1:5 zip iteration needs one declaration per iterand, plus an optional index
+  """
+
+  throws """
+    of zip with too many declarations
+    ---
+    for a, b, i, j of x, y
+      console.log a, b, i, j
+    ---
+    ParseErrors: unknown:1:5 zip iteration needs one declaration per iterand, plus an optional index
+  """
+
+  throws """
+    in zip
+    ---
+    for a, b in x, y
+      console.log a, b
+    ---
+    ParseErrors: unknown:1:5 zip iteration is only supported in for..of loops
+  """
+
+  testCase """
     in with two implicit declarations
     ---
     for key, value in array
@@ -685,7 +758,7 @@ describe "for", ->
       for each item, index of getArray()
         console.log item
       ---
-      for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {const index = i;const item = ref[i];
+      for (let ref = getArray(), i = 0, len = ref.length; i < len; i++) {const item = ref[i], index = i;
         console.log(item)
       }
     """
@@ -696,9 +769,96 @@ describe "for", ->
       for each var item, let index of array
         console.log item
       ---
-      for (let i = 0, len = array.length; i < len; i++) {let index = i;var item = array[i];
+      for (let i = 0, len = array.length; i < len; i++) {var item = array[i]; let index = i;
         console.log(item)
       }
+    """
+
+    testCase """
+      each..of zip
+      ---
+      for each a, b of x, y
+        console.log a, b
+      ---
+      for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with index
+      ---
+      for each a, b, i of x, y
+        console.log a, b, i
+      ---
+      for (let i1 = 0, len = Math.min(x.length, y.length); i1 < len; i1++) {const a = x[i1], b = y[i1], i = i1;
+        console.log(a, b, i)
+      }
+    """
+
+    testCase """
+      each..of zip with complex expressions
+      ---
+      for each a, b of getX(), getY()
+        console.log a, b
+      ---
+      for (let ref = getX(), ref1 = getY(), i = 0, len = Math.min(ref.length, ref1.length); i < len; i++) {const a = ref[i], b = ref1[i];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with sum reduction
+      ---
+      for sum each a, b of x, y
+        a * b
+      ---
+      let results=0;for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];
+        results += a * b
+      }results
+    """
+
+    testCase """
+      each..of zip with implicit body
+      ---
+      pairs := for each a, b of x, y
+      ---
+      const results=[];for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];results.push([a, b])};const pairs =results
+    """
+
+    testCase """
+      each..of zip with destructuring implicit body
+      ---
+      pairs := for each {a}, {b} of x, y
+      ---
+      const results=[];for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const {a} = x[i], {b} = y[i];results.push([a, b])};const pairs =results
+    """
+
+    testCase """
+      each..of zip with implicit concat reduction
+      ---
+      for concat each a, b of x, y
+      ---
+      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
+      let results=[];for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a = x[i], b = y[i];concatAssign(results, [a, b])}results
+    """
+
+    throws """
+      each..of zip with too few declarations
+      ---
+      for each a of x, y
+        console.log a
+      ---
+      ParseErrors: unknown:1:5 zip iteration needs one declaration per iterand, plus an optional index
+    """
+
+    throws """
+      each..of zip with too many declarations
+      ---
+      for each a, b, i, j of x, y
+        console.log a, b, i, j
+      ---
+      ParseErrors: unknown:1:5 zip iteration needs one declaration per iterand, plus an optional index
     """
 
     throws """
@@ -1235,9 +1395,28 @@ describe "for", ->
       ---
       => for x of y
       => for [x] of y
+      => for {x} of y
       ---
       () => { const results=[];for (const x of y) {results.push(x)};return results; };
-      () => { const results1=[];for (const [x] of y) {results1.push([x])};return results1; }
+      () => { const results1=[];for (const [x] of y) {results1.push(x)};return results1; };
+      () => { const results2=[];for (const {x} of y) {results2.push(x)};return results2; }
+    """
+
+    throws """
+      empty body with empty binding pattern
+      ---
+      pairs := for {} of arr
+      ---
+      ParseErrors: unknown:2:17 Empty binding pattern in loop with implicit body
+    """
+
+    throws """
+      empty body with multiple destructuring bindings
+      ---
+      pairs := for [x, y, z] of w
+      ---
+      ParseErrors: unknown:1:18 Ignored binding in loop with implicit body
+      unknown:1:21 Ignored binding in loop with implicit body
     """
 
     testCase """
@@ -1575,7 +1754,7 @@ describe "for", ->
       ---
       z = for sum {} of arr
       ---
-      ParseErrors: unknown:2:15 Empty binding pattern in reduction loop with implicit body
+      ParseErrors: unknown:2:15 Empty binding pattern in loop with implicit body
     """
 
     testCase """
@@ -1830,8 +2009,8 @@ describe "for", ->
       ---
       total := for sum [x, y, z] of w
       ---
-      ParseErrors: unknown:1:22 Ignored binding in reduction loop with implicit body
-      unknown:1:25 Ignored binding in reduction loop with implicit body
+      ParseErrors: unknown:1:22 Ignored binding in loop with implicit body
+      unknown:1:25 Ignored binding in loop with implicit body
     """
 
     testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -701,7 +701,7 @@ describe "for", ->
     ---
     pairs := for {a}, {b} of x, y
     ---
-    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const {a} = next?.value, {b} = next1?.value;results.push([a, b])};const pairs =results
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const {a} = next?.value, {b} = next1?.value;results.push([{a}, {b}])};const pairs =results
   """
 
   throws """
@@ -1073,7 +1073,7 @@ describe "for", ->
       ---
       pairs := for each {a}, {b} of x, y
       ---
-      const results=[];for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const {a} = x[i], {b} = y[i];results.push([a, b])};const pairs =results
+      const results=[];for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const {a} = x[i], {b} = y[i];results.push([{a}, {b}])};const pairs =results
     """
 
     testCase """
@@ -1640,25 +1640,24 @@ describe "for", ->
       => for {x} of y
       ---
       () => { const results=[];for (const x of y) {results.push(x)};return results; };
-      () => { const results1=[];for (const [x] of y) {results1.push(x)};return results1; };
-      () => { const results2=[];for (const {x} of y) {results2.push(x)};return results2; }
+      () => { const results1=[];for (const [x] of y) {results1.push([x])};return results1; };
+      () => { const results2=[];for (const {x} of y) {results2.push({x})};return results2; }
     """
 
-    throws """
+    testCase """
       empty body with empty binding pattern
       ---
       pairs := for {} of arr
       ---
-      ParseErrors: unknown:2:17 Empty binding pattern in loop with implicit body
+      const results=[];for (const {} of arr) {results.push({})};const pairs =results
     """
 
-    throws """
+    testCase """
       empty body with multiple destructuring bindings
       ---
       pairs := for [x, y, z] of w
       ---
-      ParseErrors: unknown:1:18 Ignored binding in loop with implicit body
-      unknown:1:21 Ignored binding in loop with implicit body
+      const results=[];for (const [x, y, z] of w) {results.push([x, y, z])};const pairs =results
     """
 
     testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -660,6 +660,15 @@ describe "for", ->
     }
   """
 
+  throws """
+    of zip with cyclic declaration
+    ---
+    for a, b% of x, y
+      console.log a, b
+    ---
+    ParseErrors: unknown:1:5 cyclic zip iteration is only supported in for each..of loops
+  """
+
   testCase """
     of zip with implicit body
     ---
@@ -872,7 +881,7 @@ describe "for", ->
       for each a, b of x, y
         console.log a, b
       ---
-      for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];
+      for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const a = x[i], b = y[i];
         console.log(a, b)
       }
     """
@@ -883,7 +892,7 @@ describe "for", ->
       for each a, b, i of x, y
         console.log a, b, i
       ---
-      for (let end = Math.min(x.length, y.length), i1 = 0; i1 < end; i1++) {const a = x[i1], b = y[i1], i = i1;
+      for (let i1 = 0, end = Math.min(x.length, y.length); i1 < end; i1++) {const a = x[i1], b = y[i1], i = i1;
         console.log(a, b, i)
       }
     """
@@ -894,8 +903,63 @@ describe "for", ->
       for each a, b of getX(), getY()
         console.log a, b
       ---
-      for (let ref = getX(), ref1 = getY(), end = Math.min(ref.length, ref1.length), i = 0; i < end; i++) {const a = ref[i], b = ref1[i];
+      for (let ref = getX(), ref1 = getY(), i = 0, end = Math.min(ref.length, ref1.length); i < end; i++) {const a = ref[i], b = ref1[i];
         console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with cyclic declaration
+      ---
+      for each a, b% of x, y
+        console.log a, b
+      ---
+      for (let len = y.length, i = 0, end = x.length; i < end; i++) {const a = x[i], b = y[i%len];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with cyclic declaration and whitespace
+      ---
+      for each a, b % of x, y
+        console.log a, b
+      ---
+      for (let len = y.length, i = 0, end = x.length; i < end; i++) {const a = x[i], b = y[i %len];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with first cyclic declaration
+      ---
+      for each a%, b of x, y
+        console.log a, b
+      ---
+      for (let len = x.length, i = 0, end = y.length; i < end; i++) {const a = x[i%len], b = y[i];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of zip with all declarations cyclic
+      ---
+      for each a%, b% of x, y
+        console.log a, b
+      ---
+      for (let len = x.length, len1 = y.length, i = 0; ; i++) {const a = x[i%len], b = y[i%len1];
+        console.log(a, b)
+      }
+    """
+
+    testCase """
+      each..of non-zip with cyclic declaration
+      ---
+      for each a% of x
+        console.log a
+      ---
+      for (let len = x.length, i = 0; ; i++) {const a = x[i%len];
+        console.log(a)
       }
     """
 
@@ -905,7 +969,7 @@ describe "for", ->
       for each a?, b of x, y
         console.log a, b
       ---
-      for (let end = y.length, i = 0; i < end; i++) {const a = x[i], b = y[i];
+      for (let i = 0, end = y.length; i < end; i++) {const a = x[i], b = y[i];
         console.log(a, b)
       }
     """
@@ -916,7 +980,7 @@ describe "for", ->
       for each a, b? of x, y
         console.log a, b
       ---
-      for (let end = x.length, i = 0; i < end; i++) {const a = x[i], b = y[i];
+      for (let i = 0, end = x.length; i < end; i++) {const a = x[i], b = y[i];
         console.log(a, b)
       }
     """
@@ -927,7 +991,7 @@ describe "for", ->
       for each a = 0, b? of x, y
         console.log a, b
       ---
-      for (let len = x.length, end = Math.max(len, y.length), i = 0; i < end; i++) {const a = i < len ? x[i] : 0, b = y[i];
+      for (let len = x.length, i = 0, end = Math.max(len, y.length); i < end; i++) {const a = i < len ? x[i] : 0, b = y[i];
         console.log(a, b)
       }
     """
@@ -938,7 +1002,7 @@ describe "for", ->
       for each a?, b, c? of x, y, z
         console.log a, b, c
       ---
-      for (let end = y.length, i = 0; i < end; i++) {const a = x[i], b = y[i], c = z[i];
+      for (let i = 0, end = y.length; i < end; i++) {const a = x[i], b = y[i], c = z[i];
         console.log(a, b, c)
       }
     """
@@ -960,7 +1024,7 @@ describe "for", ->
       for sum each a, b of x, y
         a * b
       ---
-      let results=0;for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];
+      let results=0;for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const a = x[i], b = y[i];
         results += a * b
       }results
     """
@@ -970,7 +1034,7 @@ describe "for", ->
       ---
       pairs := for each a, b of x, y
       ---
-      const results=[];for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];results.push([a, b])};const pairs =results
+      const results=[];for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const a = x[i], b = y[i];results.push([a, b])};const pairs =results
     """
 
     testCase """
@@ -978,7 +1042,7 @@ describe "for", ->
       ---
       pairs := for each {a}, {b} of x, y
       ---
-      const results=[];for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const {a} = x[i], {b} = y[i];results.push([a, b])};const pairs =results
+      const results=[];for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const {a} = x[i], {b} = y[i];results.push([a, b])};const pairs =results
     """
 
     testCase """
@@ -987,7 +1051,7 @@ describe "for", ->
       for concat each a, b of x, y
       ---
       var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
-      let results=[];for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a = x[i], b = y[i];concatAssign(results, [a, b])}results
+      let results=[];for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const a = x[i], b = y[i];concatAssign(results, [a, b])}results
     """
 
     throws """

--- a/test/for.civet
+++ b/test/for.civet
@@ -573,6 +573,17 @@ describe "for", ->
   """
 
   testCase """
+    of with index assignment
+    ---
+    for item, index.value of array
+      console.log index.value
+    ---
+    let i = 0;for (const item of array) {index.value = i++;
+      console.log(index.value)
+    }
+  """
+
+  testCase """
     of with two explicit declarations
     ---
     for var item, let index of array
@@ -720,6 +731,15 @@ describe "for", ->
     ParseErrors: unknown:1:5 zip iteration index cannot have a default
   """
 
+  throws """
+    of zip with cyclic index
+    ---
+    for each a, b, i% of x, y
+      console.log a, b, i
+    ---
+    ParseErrors: unknown:1:5 zip iteration index cannot be cyclic
+  """
+
   testCase """
     of non-zip with padded declaration
     ---
@@ -818,6 +838,17 @@ describe "for", ->
       ---
       for (let i = 0, len = array.length; i < len; i++) {const item = array[i];
         console.log(item)
+      }
+    """
+
+    testCase """
+      each..of assignment target
+      ---
+      for each item.value of array
+        console.log item.value
+      ---
+      for (let i = 0, len = array.length; i < len; i++) {item.value = array[i];
+        console.log(item.value)
       }
     """
 

--- a/test/if.civet
+++ b/test/if.civet
@@ -1428,7 +1428,7 @@ describe "if", ->
       if m? := s.match(re)
         s
       ---
-      let ref;if ((ref= s.match(re)) != null) {const m = ref;
+      let ref;if ((ref = s.match(re)) != null) {const m = ref;
         s
       }
     """
@@ -1440,7 +1440,7 @@ describe "if", ->
         p1 + p2
       ---
       function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
-      let ref;if (((ref= s.match(re)) != null) && Array.isArray(ref) && len(ref, 3)) {const [p0, p1, p2] = ref;
+      let ref;if (((ref = s.match(re)) != null) && Array.isArray(ref) && len(ref, 3)) {const [p0, p1, p2] = ref;
         p1 + p2
       }
     """
@@ -1582,7 +1582,7 @@ describe "if", ->
       if x? := if cond then a else b
         use x
       ---
-      let ref;if ((ref= (cond? a : b)) != null) {const x = ref;
+      let ref;if ((ref = (cond? a : b)) != null) {const x = ref;
         use(x)
       }
     """

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -47,7 +47,7 @@ describe "[TS] for", ->
     ---
     xs := for [a]: T of y
     ---
-    const results=[];for (const item of y) {const [a]: T = item;results.push(a)};const xs =results
+    const results=[];for (const item of y) {const [a]: T = item;results.push([a])};const xs =results
   """
 
   testCase """
@@ -203,7 +203,7 @@ describe "[TS] for", ->
     ---
     xs := for [a]: T, value in z
     ---
-    const results=[];for (const key in z) {const [a]: T = key;const value = z[key];results.push(a)};const xs =results
+    const results=[];for (const key in z) {const [a]: T = key;const value = z[key];results.push([a])};const xs =results
   """
 
   testCase """

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -24,6 +24,17 @@ describe "[TS] for", ->
   """
 
   testCase """
+    for..of with optional type
+    ---
+    for x?: T of y
+      console.log x
+    ---
+    for (const item of y) {const x: undefined | T = item;
+      console.log(x)
+    }
+  """
+
+  testCase """
     for..of with implicit body
     ---
     xs := for x: T of y
@@ -64,7 +75,7 @@ describe "[TS] for", ->
     for a: A, b: B of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a: A = next.value, b: B = next1.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a: A = next?.value, b: B = next1?.value;
       console.log(a, b)
     }
   """
@@ -75,8 +86,30 @@ describe "[TS] for", ->
     for a: A, b: B, i: number of x, y
       console.log a, b, i
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), i1 = 0; ;i1++) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a: A = next.value, b: B = next1.value, i: number = i1;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1, i1 = 0; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);i1++) {const a: A = next?.value, b: B = next1?.value, i: number = i1;
       console.log(a, b, i)
+    }
+  """
+
+  testCase """
+    for..of zip with typed padded declaration
+    ---
+    for a?: A, b: B of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a: undefined | A = next?.done ? undefined : next?.value, b: B = next1?.value;
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    for..of zip with typed defaulted declaration
+    ---
+    for a?: A = 0, b: B of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a: undefined | A = next?.done ? 0 : next?.value, b: B = next1?.value;
+      console.log(a, b)
     }
   """
 
@@ -86,7 +119,29 @@ describe "[TS] for", ->
     for each a: A, b: B of x, y
       console.log a, b
     ---
-    for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a: A = x[i], b: B = y[i];
+    for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a: A = x[i], b: B = y[i];
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    for each..of zip with typed padded declaration
+    ---
+    for each a?: A, b: B of x, y
+      console.log a, b
+    ---
+    for (let end = y.length, i = 0; i < end; i++) {const a: undefined | A = x[i], b: B = y[i];
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    for each..of zip with typed defaulted declaration
+    ---
+    for each a?: A = 0, b: B of x, y
+      console.log a, b
+    ---
+    for (let len = x.length, end = y.length, i = 0; i < end; i++) {const a: undefined | A = i < len ? x[i] : 0, b: B = y[i];
       console.log(a, b)
     }
   """
@@ -97,7 +152,7 @@ describe "[TS] for", ->
     for each a: A, b: B, i: number of x, y
       console.log a, b, i
     ---
-    for (let i1 = 0, len = Math.min(x.length, y.length); i1 < len; i1++) {const a: A = x[i1], b: B = y[i1], i: number = i1;
+    for (let end = Math.min(x.length, y.length), i1 = 0; i1 < end; i1++) {const a: A = x[i1], b: B = y[i1], i: number = i1;
       console.log(a, b, i)
     }
   """

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -119,7 +119,7 @@ describe "[TS] for", ->
     for each a: A, b: B of x, y
       console.log a, b
     ---
-    for (let end = Math.min(x.length, y.length), i = 0; i < end; i++) {const a: A = x[i], b: B = y[i];
+    for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const a: A = x[i], b: B = y[i];
       console.log(a, b)
     }
   """
@@ -130,7 +130,7 @@ describe "[TS] for", ->
     for each a?: A, b: B of x, y
       console.log a, b
     ---
-    for (let end = y.length, i = 0; i < end; i++) {const a: undefined | A = x[i], b: B = y[i];
+    for (let i = 0, end = y.length; i < end; i++) {const a: undefined | A = x[i], b: B = y[i];
       console.log(a, b)
     }
   """
@@ -141,7 +141,7 @@ describe "[TS] for", ->
     for each a?: A = 0, b: B of x, y
       console.log a, b
     ---
-    for (let len = x.length, end = y.length, i = 0; i < end; i++) {const a: undefined | A = i < len ? x[i] : 0, b: B = y[i];
+    for (let len = x.length, i = 0, end = y.length; i < end; i++) {const a: undefined | A = i < len ? x[i] : 0, b: B = y[i];
       console.log(a, b)
     }
   """
@@ -152,7 +152,7 @@ describe "[TS] for", ->
     for each a: A, b: B, i: number of x, y
       console.log a, b, i
     ---
-    for (let end = Math.min(x.length, y.length), i1 = 0; i1 < end; i1++) {const a: A = x[i1], b: B = y[i1], i: number = i1;
+    for (let i1 = 0, end = Math.min(x.length, y.length); i1 < end; i1++) {const a: A = x[i1], b: B = y[i1], i: number = i1;
       console.log(a, b, i)
     }
   """

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -24,6 +24,30 @@ describe "[TS] for", ->
   """
 
   testCase """
+    for..of with implicit body
+    ---
+    xs := for x: T of y
+    ---
+    const results=[];for (const item of y) {const x: T = item;results.push(x)};const xs =results
+  """
+
+  testCase """
+    destructuring for..of with implicit body
+    ---
+    xs := for [a]: T of y
+    ---
+    const results=[];for (const item of y) {const [a]: T = item;results.push(a)};const xs =results
+  """
+
+  testCase """
+    destructuring for..of reduction with implicit body
+    ---
+    total := for sum [, y]: T of z
+    ---
+    let results=0;for (const item of z) {const [, y]: T = item;results += y};const total =results
+  """
+
+  testCase """
     for each..of
     ---
     for each x: T of y
@@ -31,6 +55,50 @@ describe "[TS] for", ->
     ---
     for (let i = 0, len = y.length; i < len; i++) {const x: T = y[i];
       console.log(x)
+    }
+  """
+
+  testCase """
+    for..of zip
+    ---
+    for a: A, b: B of x, y
+      console.log a, b
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](); ;) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a: A = next.value, b: B = next1.value;
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    for..of zip with index
+    ---
+    for a: A, b: B, i: number of x, y
+      console.log a, b, i
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), i1 = 0; ;i1++) {const next = iter.next(), next1 = iter1.next();if (next.done || next1.done) break;const a: A = next.value, b: B = next1.value, i: number = i1;
+      console.log(a, b, i)
+    }
+  """
+
+  testCase """
+    for each..of zip
+    ---
+    for each a: A, b: B of x, y
+      console.log a, b
+    ---
+    for (let i = 0, len = Math.min(x.length, y.length); i < len; i++) {const a: A = x[i], b: B = y[i];
+      console.log(a, b)
+    }
+  """
+
+  testCase """
+    for each..of zip with index
+    ---
+    for each a: A, b: B, i: number of x, y
+      console.log a, b, i
+    ---
+    for (let i1 = 0, len = Math.min(x.length, y.length); i1 < len; i1++) {const a: A = x[i1], b: B = y[i1], i: number = i1;
+      console.log(a, b, i)
     }
   """
 
@@ -43,6 +111,14 @@ describe "[TS] for", ->
     for (const key in y) {const x: T = key;
       console.log(x)
     }
+  """
+
+  testCase """
+    for..in with implicit body
+    ---
+    xs := for x: T in y
+    ---
+    const results=[];for (const key in y) {const x: T = key;results.push(x)};const xs =results
   """
 
   testCase """
@@ -65,6 +141,14 @@ describe "[TS] for", ->
     for (const key in z) {const [a, b]: T = key;const value = z[key];
       console.log(x)
     }
+  """
+
+  testCase """
+    destructuring for..in with implicit body
+    ---
+    xs := for [a]: T, value in z
+    ---
+    const results=[];for (const key in z) {const [a]: T = key;const value = z[key];results.push(a)};const xs =results
   """
 
   testCase """

--- a/test/types/let-declaration.civet
+++ b/test/types/let-declaration.civet
@@ -67,14 +67,14 @@ describe "[TS] let declaration", ->
     let g? = x
     let h? = x.y[z]
     ---
-    let a : undefined | boolean= true
-    let b : undefined | number= 5
-    let c : undefined | bigint= 5n
-    let d : undefined | string= "hello"
-    let e : undefined | string= `hello`
-    let f : undefined | RegExp= /hello/
-    let g : undefined | (typeof x)= x
-    let h : undefined | (typeof x.y[z])= x.y[z]
+    let a: undefined | boolean = true
+    let b: undefined | number = 5
+    let c: undefined | bigint = 5n
+    let d: undefined | string = "hello"
+    let e: undefined | string = `hello`
+    let f: undefined | RegExp = /hello/
+    let g: undefined | (typeof x) = x
+    let h: undefined | (typeof x.y[z]) = x.y[z]
   """
 
   throws """

--- a/test/while.civet
+++ b/test/while.civet
@@ -160,7 +160,7 @@ describe "while", ->
       while node? := next()
         node.visit()
       ---
-      let ref;while ((ref= next()) != null) {const node = ref;
+      let ref;while ((ref = next()) != null) {const node = ref;
         node.visit()
       }
     """
@@ -171,7 +171,7 @@ describe "while", ->
       while {x, y}? := next()
         x++
       ---
-      let ref;while (((ref= next()) != null) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {const {x, y} = ref;
+      let ref;while (((ref = next()) != null) && typeof ref === 'object' && 'x' in ref && 'y' in ref) {const {x, y} = ref;
         x++
       }
     """


### PR DESCRIPTION
## Summary

Adds zip iteration to `for..of` and `for each..of` loops, with support for indexes, padding/defaults, cyclic `for each` iterands, typed declarations, and implicit loop bodies.

## Features

Zip loops iterate multiple iterands in lockstep and stop at the shortest iterand by default:

```js
for each a, b of xs, ys
  // stops at Math.min(xs.length, ys.length)
for a, b of xs, ys
  // stops when either iterator is done
```

One extra declaration captures the loop index:

```js
for each a, b, i of xs, ys
```

Declarations can be padded with `?`, which uses `undefined` as default, or with an explicit default value. Unpadded iterands define the length; if all iterands are padded, the loop runs to the longest iterand:

```js
for each a?, b of xs, ys
  // stops at b.length; if a stops early, use undefined from out-of-bound array accesses
for each a?, b? of xs, ys
  // stops at Math.max(a.length, b.length)
  // if a or b ends early, use undefined from out-of-bound array accesses
for each a = 0, b = 0 of xs, ys
  // stops at Math.max(a.length, b.length)
  // if a or b ends early, use default values of 0
for a?, b = 0 of xs, ys
  // stops when *both* a and b are done
  // if a or b is done early, use specified default value
```

Typed declarations work with zip padding/defaults:

```js
for each name?: Name, value: Value of names, values
  // const name: undefined | Name
  // const value: Value
  // length determined by values
```

`for each..of` also supports cyclic iterands with `%`. Cyclic iterands repeat by array index and do not define the loop length:

```js
for each item, color% of items, palette
  // stops at items.length
  // at index i, const color = palette[i % palette.length]
```

If all iterands are cyclic, the loop is infinite. This works even for non-zip loops:

```js
for each message% of ["Thinking", "Pondering"]
  console.log message
  break if done()
```

Zip loops also work with implicit bodies, reductions, and `for*`:

```js
pairs := for a, b of xs, ys

dot := for sum each a, b of xs, ys
  a * b

function zip(xs, ys)
  for* a, b of xs, ys
```

Implicit bodies for zip loops produce tuples, which is maybe useful for `for concat`.

As before, non-reduction implicit bodies preserve destructuring values, while reductions still reduce the first binding (of each iterand) and warn about ignored bindings.

## Other Changes

- Reject zip iteration in `for..in`. We could try to define this in the future.
- Report errors for mismatched declaration/iterand counts, defaulted indexes, and cyclic indexes.
- Add docs for zip loops, padding/defaults, cyclic `for each`, zip implicit bodies, and zip generators.
- Make VitePress dev mode tolerate contributor/OpenCollective API failures with a warning and empty fallback data. (Something I ran into because https://api.github.com/repos/DanielXMoore/Civet/contributors was timing out.)
- 39 type fixes:

  <details>

  ```
  source/parser.hera
    3899:23 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    3906:23 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    4336:23 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 141 more ... | { ...; }'.
    4373:19 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    4384:19 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    5494:5 TS2322 Type 'ASTNode' is not assignable to type '{ type: string; own: boolean; decl: "let" | "const" | "var"; kind: { type: "Keyword"; $loc: Loc; token: "let" | "const" | "var"; }; binding: Binding; children: ("" | Binding | (CommentNode | { ...; })[] | { ...; })[]; names: string[]; } | { ...; }'.
    5530:24 TS2339 Property 'names' does not exist on type '{ children: any[]; parent?: (ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; ... 7 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 134 more ... | undefined; ... 11 more ...; trailing?: ASTNode[]; } | ... 142 more ... | { ...; }'.
    5539:31 TS2345 Argument of type '{ type: string; own: boolean; decl: "let" | "const" | "var"; kind: { type: "Keyword"; $loc: Loc; token: "let" | "const" | "var"; }; binding: Binding; children: ("" | Binding | (CommentNode | { ...; })[] | { ...; })[]; names: string[]; } | { ...; }' is not assignable to parameter of type 'AssignmentExpression | ForDeclaration'.
    5550:9 TS2322 Type 'ASTNode' is not assignable to type '{ children: any[]; parent?: (ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; ... 7 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 134 more ... | undefined; ... 11 more ...; trailing?: ASTNode[]; } | ... 143 more ... | undefi...'.
    5552:44 TS2339 Property 'names' does not exist on type '{ children: any[]; parent?: (ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; ... 7 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 134 more ... | undefined; ... 11 more ...; trailing?: ASTNode[]; } | ... 142 more ... | { ...; }'.
    5687:27 TS2345 Argument of type 'null' is not assignable to parameter of type 'AssignmentExpression | ForDeclaration'.
    5689:27 TS2345 Argument of type 'null' is not assignable to parameter of type 'AssignmentExpression | ForDeclaration'.
    5935:24 TS2769 Argument of type '{ type: string; children: [{ type: "Keyword"; $loc: Loc; token: "finally"; }, BlockStatement]; block: BlockStatement; }' is not assignable to parameter of type 'ASTNodeObject'.
    6495:9 TS2322 Type 'string | { type: string; token: string; $loc: Loc; message?: never; } | { type: string; message: string; token?: never; $loc?: never; } | { type: string; message: string; }' is not assignable to type 'ASTNode'.
    7073:22 TS2322 Type 'string | CommentNode | { $loc: Loc; token: any; } | { type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: ["" | (CommentNode | { ...; })[], { ...; }, unknown]; }; splices: unknown[][]; thisAssignments: (string | ThisAssignment)[][]...' is not assignable to type 'ASTNode'.
    7073:29 TS2322 Type '{ type: string; children: any[]; names: any; pattern: any; typeSuffix: unknown; initializer: { type: string; expression: unknown; children: ["" | (CommentNode | { $loc: Loc; token: any; })[], { ...; }, unknown]; }; splices: unknown[][]; thisAssignments: (string | ThisAssignment)[][]; } | { ...; } | [...]' is not assignable to type 'ASTNode'.
    8927:18 TS2322 Type '{ ts: boolean; children: [[{ type: "Keyword"; $loc: Loc; token: "const"; }, (string | { $loc: Loc; token: any; } | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[]] | undefined, { ...; }, (string | ... 2 more ... | { readonly type: "Comment"; readonly...' is not assignable to type 'ASTNode'.
    9323:15 TS2322 Type '[{ $loc: Loc; token: "..."; } | { $loc: Loc; token: string; }, "" | (CommentNode | { $loc: Loc; token: any; })[]] | [{ $loc: Loc; token: "..."; } | { $loc: Loc; token: string; }, (string | ... 2 more ... | { ...; })[] | undefined] | undefined' is not assignable to type '{ $loc: Loc; token: "..."; } | { $loc: Loc; token: string; }'.
    9324:9 TS2353 Object literal may only specify known properties, and 'type' does not exist in type '(CommentNode | { $loc: Loc; token: any; })[]'.
    9427:5 TS2322 Type 'ASTNode' is not assignable to type 'TypeNode'.
    9444:19 TS2339 Property 'negated' does not exist on type '{ type: string; children: (FlatArray<string | { $loc: Loc; token: any; } | [(string | { $loc: Loc; token: any; } | CommentNode)[], { $loc: Loc; token: any; }][] | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; }, 0 | ... 20 more ... | 20>[] | { ...; })[]; } | { ...; } | { ...; } | {...'.
    9616:22 TS2345 Argument of type '{ type: string; children: (ASTNode[] | { $loc: Loc; token: string; })[]; } | [{ $loc: Loc; token: string; }[], ASTNode[], string, string | undefined, { $loc: Loc; token: string; }]' is not assignable to parameter of type 'ASTNode'.
    9638:5 TS2322 Type 'ASTNode' is not assignable to type 'TypeArgument | [[(string | { $loc: Loc; token: any; } | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[] | undefined, { ...; }], TypeArgument]'.
    160:3 TS6196 'StatementNode' is declared but never used.
  source/parser/for.civet
    238:42 TS2339 Property 'subtype' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    308:13 TS2345 Argument of type 'ASTNode' is not assignable to parameter of type 'AssignmentExpression | ForDeclaration'.
    326:46 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    333:40 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    377:5 TS2339 Property 'binding' does not exist on type 'ASTNode'.
    390:27 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    430:23 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    431:22 TS2339 Property 'decl' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 140 more ... | UntypedNode'.
    486:28 TS2339 Property 'names' does not exist on type 'BlockStatement | CommentNode | ASTString | Children | BreakStatement | ComptimeStatement | ... 139 more ... | UntypedNode'.
  source/parser/lib.civet
    1312:42 TS2345 Argument of type 'NonNullable<ASTNode>' is not assignable to parameter of type 'ASTNodeObject'.
    1400:43 TS2322 Type 'NonNullable<ASTNode>' is not assignable to type 'string'.
    1400:58 TS2322 Type 'ExpressionNode | ASTRef' is not assignable to type 'string'.
    1459:15 TS2339 Property 'children' does not exist on type 'NonNullable<ASTNode>'.
    1559:41 TS2339 Property 'names' does not exist on type 'NonNullable<ASTNode>'.
  source/parser/pipe.civet
    183:13 TS2322 Type 'Whitespace[]' is not assignable to type 'ExpressionNode | ASTRef'.
  ```

  </details>
