### PR TITLE
Fix pattern-to-value conversion with anonymous `...`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -86,6 +86,7 @@ import type {
   AccessStart,
   Argument,
   ArrayBindingPattern,
+  ArrayBindingPatternContent as ArrayBindingPatternContentType,
   ArrowFunction,
   AssignmentExpression,
   ASTError,
@@ -2608,12 +2609,9 @@ BindingPropertyList
 ArrayBindingPattern
   _?:ws1 OpenBracket:open ArrayBindingPatternContent:c __:ws2 CloseBracket:close ::ArrayBindingPattern ->
     return gatherBindingPatternTypeSuffix({
-      ...c, // names, blockPrefix, length
+      ...c, // names, blockPrefix, omittedRest, length
       type: "ArrayBindingPattern",
-      // `c.elements` may differ from `c.children` when adjustBindingElements
-      // omits an anonymous rest from the emitted destructure but still needs
-      // pattern matching / type generation to see it.
-      elements: c.elements ?? c.children,
+      elements: c.children,
       children: [ws1, open, c.children, ws2, close],
     })
 
@@ -2621,9 +2619,9 @@ ArrayBindingPatternContent
   # NOTE: Added indentation based binding elements
   NestedBindingElements
   BindingElementList?:elements ->
-    return { children: [], elements: undefined, names: [], length: 0 } unless elements
+    return { children: [], names: [], length: 0 } unless elements
 
-    return adjustBindingElements(elements)
+    return adjustBindingElements(elements as ArrayBindingPatternContentType)
 
 # children is an array of tuples of the form [ws, element, delim]
 BindingElementList
@@ -2803,7 +2801,7 @@ NestedBindingElements
 
     // Each item of elements is a list of BindingElements;
     // combine into one big array
-    return adjustBindingElements(elements.flat())
+    return adjustBindingElements(elements.flat() as ArrayBindingPatternContentType)
 
 # https://262.ecma-international.org/#prod-BindingElement
 # children is an array of tuples of the form [ws, element]
@@ -9647,9 +9645,10 @@ TypeArgumentList
     ]
   # NOTE: Added nested arguments on separate new lines
   ( NestedTypeBulletedTuple / NestedInterfaceBlock ) ( CommaDelimiter ( NestedTypeBulletedTuple / NestedInterfaceBlock / NestedTypeArgumentList ) )* ->
+    rest: [ASTNode, ASTNode][] := $2
     return [
       trimFirstSpace($1),
-      ...$2.flatMap(([comma, args]) =>
+      ...rest.flatMap(([comma, args]) =>
         Array.isArray(args) ? [comma, ...args] : [comma, args]
       ),
     ]

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -1,5 +1,8 @@
 import type {
   ArrayBindingPattern
+  ArrayBindingPatternContent
+  ArrayBindingPatternElement
+  ASTError
   ASTNode
   ASTNodeObject
   BindingIdentifier
@@ -9,6 +12,7 @@ import type {
   Children
   HasSubbinding
   ObjectBindingPattern
+  PostRestBindingElements
   ThisAssignments
 } from ./types.civet
 
@@ -21,6 +25,9 @@ import {
 } from ./ref.civet
 
 import {
+  assert
+  isComma
+  namesOf
   parenthesizeType
   trimFirstSpace
   updateParentPointers
@@ -56,11 +63,17 @@ function adjustAtBindings(statements: ASTNode, asThis = false): void
       unless ref.names![0] is ref.base
         binding.children.unshift(ref.base, ": ")
 
-function adjustBindingElements(elements: ASTNodeObject[])
-  names := elements.flatMap .names or []
+function adjustBindingElements(elements: ArrayBindingPatternContent): {
+  children: ArrayBindingPatternContent
+  names: string[]
+  blockPrefix: PostRestBindingElements?
+  omittedRest?: BindingRestElement
+  length: number
+}
+  names := elements.flatMap namesOf
   { length } := elements
 
-  let blockPrefix,
+  let blockPrefix: PostRestBindingElements?,
     restIndex = -1,
     restCount = 0
 
@@ -72,7 +85,6 @@ function adjustBindingElements(elements: ASTNodeObject[])
   if restCount is 0
     return {
       children: elements
-      elements: undefined
       names
       blockPrefix
       length
@@ -96,8 +108,8 @@ function adjustBindingElements(elements: ASTNodeObject[])
         type: "PostRestBindingElements"
         elements
         children: ["[", elements, "] = ", restIdentifier, ".splice(-", l.toString(), ")"]
-        names: after.flatMap((p) => p.names)
-      }
+        names: after.flatMap namesOf
+      } satisfies PostRestBindingElements
 
     restTrimmed := {
       ...rest
@@ -105,20 +117,16 @@ function adjustBindingElements(elements: ASTNodeObject[])
     }
     // Omit anonymous rest from the emitted destructure when nothing references it
     // (`[x, ...] = a` becomes `[x] = a` so TS doesn't flag an unused binding).
-    // `elements` keeps the rest so pattern matching still sees `rest: true`
-    // and emits `length >= n` instead of an exact-length check.
+    // `omittedRest` keeps the rest visible to pattern matching and type inference.
     if rest.binding.type is "EmptyBinding" and not l
       preceding := elements.slice(0, restIndex)
       last := preceding.-1
       if last and arrayElementHasTrailingComma last
-        preceding[preceding# - 1] = {
-          ...last
-          children: (last.children as ASTNode[]).slice(0, -1)
-        } as ASTNodeObject
+        preceding.-1 = trimArrayElementTrailingComma last
       return {
         names
         children: preceding
-        elements: [...preceding, restTrimmed] as ASTNodeObject[]
+        omittedRest: restTrimmed
         blockPrefix
         length
       }
@@ -126,19 +134,17 @@ function adjustBindingElements(elements: ASTNodeObject[])
     return {
       names
       children: [...elements.slice(0, restIndex), restTrimmed]
-      elements: undefined
       blockPrefix
       length
     }
 
-  err :=
+  err: ASTError :=
     type: "Error"
-    children: ["Multiple rest elements in array pattern"]
+    message: "Multiple rest elements in array pattern"
 
   return {
     names
     children: [...elements, err]
-    elements: undefined
     blockPrefix
     length
   }
@@ -155,6 +161,47 @@ function gatherSubbindings(node: ASTNode, subbindings: ASTNode[] = []): ASTNode[
   subbindings
 
 /**
+Return the source-level elements represented by an array binding pattern.
+Post-rest bindings like `[...rest, last]` are parsed into a JS-compatible
+prefix rest binding plus a `blockPrefix` splice for trailing elements; callers
+that derive values or bindings from the pattern need this reconstructed view.
+Anonymous `...` is omitted because it is not a source-level binding.
+*/
+function arrayPatternValueElements(pattern: ArrayBindingPattern): ArrayBindingPatternContent
+  { elements } := pattern
+  if postRest := pattern.blockPrefix
+    restIndex := elements.findIndex .type is "BindingRestElement"
+    valueElements: ArrayBindingPatternContent := [...elements[..<restIndex]]
+    rest := elements[restIndex]
+    if rest?.type is "BindingRestElement" and rest.binding.type is not "EmptyBinding"
+      assert not arrayElementHasTrailingComma(rest),
+        "named post-rest value element should have trimmed trailing comma"
+      valueElements.push {
+        ...rest
+        children: [
+          ...rest.children
+          ", "
+        ]
+      }
+    else if valueElements# and postRest.elements#
+      previous := valueElements.-1
+      switch previous.type
+        when "BindingElement", "BindingRestElement", "ElisionElement"
+          assert arrayElementHasTrailingComma(previous),
+            "anonymous post-rest preceding element should keep trailing comma"
+          valueElements.-1 = {
+            ...previous
+            children: [
+              ...previous.children
+              " "
+            ]
+          }
+    valueElements.push ...postRest.elements
+    return valueElements
+
+  elements
+
+/**
 Find all bound variables in a pattern and return as an array
 Example: {x: [, y], z} -> [y, z]
 */
@@ -166,7 +213,7 @@ function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
   function recurse(pattern: ASTNodeObject): void
     switch pattern.type
       when "ArrayBindingPattern"
-        for each element of pattern.elements
+        for each element of arrayPatternValueElements pattern
           recurse element
       when "ObjectBindingPattern"
         for each property of pattern.properties
@@ -266,9 +313,18 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
 
   return [splices, thisAssignments] as const
 
-function arrayElementHasTrailingComma(elementNode: any): boolean
-  const lastChild = elementNode.children.-1
-  return lastChild and lastChild[lastChild.length - 1]?.token is ","
+function arrayElementHasTrailingComma(elementNode: ArrayBindingPatternElement): boolean
+  /* c8 ignore next -- defensive: current parser call sites don't pass ASTError here */
+  return false if elementNode.type is "Error"
+  Boolean isComma elementNode.children.-1
+
+function trimArrayElementTrailingComma(elementNode: ArrayBindingPatternElement): ArrayBindingPatternElement
+  /* c8 ignore next -- defensive: current parser call sites don't pass ASTError here */
+  return elementNode if elementNode.type is "Error"
+  {
+    ...elementNode
+    children: (elementNode.children as ASTNode[]).slice(0, -1)
+  }
 
 // If an Array or ObjectBindingPattern doesn't have a typeSuffix, this function
 // extracts one from typeSuffixes for the binding properties (if present).
@@ -276,13 +332,24 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
   count .= 0
   switch pattern.type
     when "ArrayBindingPattern"
+      allElements := if pattern.omittedRest then [...pattern.elements, pattern.omittedRest] else pattern.elements
+      elements: Exclude<ArrayBindingPatternElement, ASTError>[] := []
+      for elem of allElements
+        switch elem.type
+          when "BindingElement", "BindingRestElement", "ElisionElement"
+            elements.push elem
       types: ASTNode[] :=
-        for each elem of pattern.elements
+        for each elem of elements
           { typeSuffix, initializer } .= elem
-          typeSuffix ??= elem.binding?.typeSuffix
+          switch elem.type
+            when "BindingElement", "BindingRestElement"
+              typeSuffix ??= elem.binding?.typeSuffix
           count++ if typeSuffix
           typeSuffix ?= typeSuffixForExpression trimFirstSpace initializer.expression if initializer?
-          typeElement .= [ typeSuffix?.t, elem.delim ]
+          let delim: ASTNode?
+          if elem.type is "BindingElement"
+            delim = elem.delim
+          typeElement .= [ typeSuffix?.t, delim ]
           if typeSuffix?.optional
             typeElement[0] = parenthesizeType typeElement[0]
             typeElement.unshift "undefined |"
@@ -305,7 +372,9 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
       types: ASTNode[] :=
         for each prop of pattern.properties
           { typeSuffix, initializer } .= prop
-          typeSuffix ??= prop.value?.typeSuffix
+          if value := prop.value
+            if "typeSuffix" in value
+              typeSuffix ??= value.typeSuffix
           count++ if typeSuffix
           typeSuffix ?= typeSuffixForExpression trimFirstSpace initializer.expression if initializer?
           typeSuffix ??=
@@ -338,6 +407,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
 export {
   adjustAtBindings
   adjustBindingElements
+  arrayPatternValueElements
   gatherSubbindings
   gatherBindingCode
   gatherBindingPatternTypeSuffix

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,6 +1,7 @@
 import type {
   AmpersandBlockBody
   ArrayBindingPattern
+  ArrayBindingPatternContent
   ArrowFunction
   ASTError
   ASTLeaf
@@ -24,6 +25,7 @@ import type {
   IterationExpression
   IterationFamily
   IterationStatement
+  ObjectBindingPatternContent
   ObjectBindingPattern
   Parameter
   ParametersNode
@@ -49,6 +51,7 @@ import {
 } from ./block.civet
 
 import {
+  arrayPatternValueElements
   gatherSubbindings
   gatherBindingCode
   gatherBindingPatternTypeSuffix
@@ -309,21 +312,23 @@ function processReturnValue(func: FunctionNode)
 
   return true
 
-function patternAsValue(pattern: ASTNodeObject): ASTNode
+function patternAsValue(pattern: ASTNodeObject): ASTNodeObject
   switch pattern.type
     when "ArrayBindingPattern"
       children := [...pattern.children]
       index := children.indexOf pattern.elements
       assert index >= 0, "failed to find elements in ArrayBindingPattern"
 
-      elements := children[index] = pattern.elements.map patternAsValue
+      elements: ArrayBindingPatternContent := arrayPatternValueElements(pattern).map(patternAsValue) as ArrayBindingPatternContent
+      children[index] = elements
       { ...pattern, elements, children }
     when "ObjectBindingPattern"
       children := [...pattern.children]
       index := children.indexOf pattern.properties
       assert index >= 0, "failed to find elements in ArrayBindingPattern"
 
-      properties := children[index] = pattern.properties.map patternAsValue
+      properties: ObjectBindingPatternContent := pattern.properties.map(patternAsValue) as ObjectBindingPatternContent
+      children[index] = properties
       { ...pattern, properties, children }
     when "BindingProperty"
       let children: Children

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -325,7 +325,7 @@ function patternAsValue(pattern: ASTNodeObject): ASTNodeObject
     when "ObjectBindingPattern"
       children := [...pattern.children]
       index := children.indexOf pattern.properties
-      assert index >= 0, "failed to find elements in ArrayBindingPattern"
+      assert index >= 0, "failed to find properties in ObjectBindingPattern"
 
       properties: ObjectBindingPatternContent := pattern.properties.map(patternAsValue) as ObjectBindingPatternContent
       children[index] = properties

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -207,7 +207,7 @@ function getPatternConditions(
   switch pattern.type
     when "ArrayBindingPattern"
       const { elements, length } = pattern,
-        hasRest = elements.some((e) => e.rest),
+        hasRest = Boolean(pattern.omittedRest) or elements.some((e) => e.rest),
         l = (length - +hasRest).toString(),
         lengthCheck = hasRest
         ? [ref, ".length >= ", l]
@@ -227,12 +227,14 @@ function getPatternConditions(
       // collect post rest conditions
       { blockPrefix } := pattern
       if blockPrefix
-        postElements := blockPrefix.children[1]
+        postElements := blockPrefix.elements
         { length: postLength } := postElements
 
-        postElements.forEach(({ children: [, e] }: any, i: number) => {
+        postElements.forEach((element, i: number) => {
+          /* c8 ignore next -- defensive: current post-rest pattern matching call sites only pass BindingElement here */
+          return unless element.type is "BindingElement"
           const subRef = [ref, "[", ref, ".length - ", (postLength + i).toString(), "]"]
-          getPatternConditions(e, subRef, conditions)
+          getPatternConditions(element.binding, subRef, conditions)
         })
 
     when "ObjectBindingPattern"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1109,12 +1109,18 @@ export type TemplateLiteral = ASTParent &
 export type ArrayBindingPattern = ASTParent &
   type: "ArrayBindingPattern"
   elements: ArrayBindingPatternContent
+  blockPrefix?: PostRestBindingElements
+  /** Anonymous terminal `...` omitted from emitted destructuring. */
+  omittedRest?: BindingRestElement
   length: number
   names: string[]
   typeSuffix?: TypeSuffix?
 
+export type ArrayBindingPatternElement =
+  BindingElement | BindingRestElement | ElisionElement | ASTError
+
 export type ArrayBindingPatternContent =
-  (BindingElement | BindingRestElement | ElisionElement | ASTError)[]
+  ArrayBindingPatternElement[]
 
 export type PostRestBindingElements = ASTParent &
   type: "PostRestBindingElements"

--- a/test/for.civet
+++ b/test/for.civet
@@ -1661,6 +1661,30 @@ describe "for", ->
     """
 
     testCase """
+      empty body with anonymous post-rest array destructuring
+      ---
+      pairs := for [..., x, y] of points
+      ---
+      const results=[];for (const [...ref] of points) {const [x, y] = ref.splice(-2);results.push([x, y])};const pairs =results
+    """
+
+    testCase """
+      empty body with named post-rest array destructuring
+      ---
+      pairs := for [a, ...rest, x, y] of points
+      ---
+      const results=[];for (const [a, ...rest] of points) {const [x, y] = rest.splice(-2);results.push([a, ...rest, x, y])};const pairs =results
+    """
+
+    testCase """
+      empty body with empty rest array destructuring
+      ---
+      pairs := for [...] of points
+      ---
+      const results=[];for (const [] of points) {results.push([])};const pairs =results
+    """
+
+    testCase """
       assigned empty body
       ---
       result = for x of y
@@ -2235,6 +2259,22 @@ describe "for", ->
       total := for sum [,x] of y
       ---
       let results=0;for (const [,x] of y) {results += x};const total =results
+    """
+
+    testCase """
+      implicit body post-rest array destructuring
+      ---
+      total := for sum [..., x] of y
+      ---
+      let results=0;for (const [...ref] of y) {const [x] = ref.splice(-1);results += x};const total =results
+    """
+
+    throws """
+      implicit body empty rest array destructuring
+      ---
+      total := for sum [...] of y
+      ---
+      ParseErrors: unknown:2:15 Empty binding pattern in loop with implicit body
     """
 
     testCase """

--- a/test/for.civet
+++ b/test/for.civet
@@ -705,6 +705,23 @@ describe "for", ->
   """
 
   throws """
+    of zip with destructuring implicit sum reduction
+    ---
+    for sum {x, y}, b of arr1, arr2
+    ---
+    ParseErrors: unknown:1:13 Ignored binding in loop with implicit body
+  """
+
+  testCase """
+    of zip with destructuring implicit concat reduction
+    ---
+    for concat {x}, {y} of a, b
+    ---
+    var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
+    let results=[];for (let iter = a[Symbol.iterator](), iter1 = b[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const {x} = next?.value, {y} = next1?.value;concatAssign(results, [x, y])}results
+  """
+
+  throws """
     of zip with too few declarations
     ---
     for a of x, y
@@ -1083,6 +1100,23 @@ describe "for", ->
       ---
       var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
       let results=[];for (let i = 0, end = Math.min(x.length, y.length); i < end; i++) {const a = x[i], b = y[i];concatAssign(results, [a, b])}results
+    """
+
+    throws """
+      each..of zip with destructuring implicit sum reduction
+      ---
+      for sum each {x, y}, b of arr1, arr2
+      ---
+      ParseErrors: unknown:1:18 Ignored binding in loop with implicit body
+    """
+
+    testCase """
+      each..of zip with destructuring implicit concat reduction
+      ---
+      for concat each {x}, {y} of a, b
+      ---
+      var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
+      let results=[];for (let i = 0, end = Math.min(a.length, b.length); i < end; i++) {const {x} = a[i], {y} = b[i];concatAssign(results, [x, y])}results
     """
 
     throws """

--- a/test/function.civet
+++ b/test/function.civet
@@ -1401,6 +1401,50 @@ describe "function", ->
     """
 
     testCase """
+      declaration with anonymous post-rest array destructuring
+      ---
+      ->
+        [..., x, y] := point
+      ---
+      (function() {
+        const [...ref] = point, [x, y] = ref.splice(-2);return [x, y]
+      })
+    """
+
+    testCase """
+      declaration with anonymous post-rest array destructuring after binding
+      ---
+      ->
+        [a, ..., x] := point
+      ---
+      (function() {
+        const [a, ...ref] = point, [x] = ref.splice(-1);return [a, x]
+      })
+    """
+
+    testCase """
+      declaration with anonymous post-rest array destructuring after elision
+      ---
+      ->
+        [a,, ..., x] := point
+      ---
+      (function() {
+        const [a,, ...ref] = point, [x] = ref.splice(-1);return [a,, x]
+      })
+    """
+
+    testCase """
+      declaration with empty rest array destructuring
+      ---
+      ->
+        [...] := point
+      ---
+      (function() {
+        const [] = point;return []
+      })
+    """
+
+    testCase """
       nested implicit return fat arrow
       ---
       function g() {

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -146,6 +146,14 @@ describe "[TS] destructuring", ->
     """
 
     testCase """
+      array with omitted rest
+      ---
+      [ first:: string, ... ] := person
+      ---
+      const [ first ]: [ string,...unknown[]] = person
+    """
+
+    testCase """
       object with nested array
       ---
       { name: [ first:: string, last?:: string ] } := person


### PR DESCRIPTION
This PR fixes pattern-to-value conversion for array destructuring with post-rest bindings, especially anonymous `...`.
~~It's currently based on #2160 because it touched similar code; should merge that first. Meanwhile, please look at just the last commit.~~ Rebased.

Previously, code that derived a value from an array binding pattern, such as implicit function returns and implicit `for` bodies, looked only at the lowered JS-compatible destructuring pattern. For post-rest patterns, that meant it could accidentally return the hidden rest array instead of the source-level trailing bindings.

This PR reconstructs the source-level array pattern when converting bindings back into values, while still emitting JS-compatible destructuring.

## Broken Examples Fixed

@STRd6 originally pointed out the first example in Discord.

| Civet | Before | After |
|---|---|---|
| `coordinates := for [..., x, y] of points` | implicit body was `[...]` / the hidden rest array, effectively collecting the prefix | implicit body is `[x, y]` |
| `pairs := for [a, ...rest, x, y] of points` | implicit body omitted trailing bindings, effectively `[a, ...rest]` | implicit body is `[a, ...rest, x, y]` |
| `pairs := for [...] of points` | implicit body could reference the hidden anonymous rest | implicit body is `[]` |
| `-> [..., x, y] := point` | implicit return was the hidden rest array / prefix | implicit return is `[x, y]` |
| `-> [a, ..., x] := point` | implicit return omitted `x` | implicit return is `[a, x]` |
| `-> [a,, ..., x] := point` | implicit return omitted `x` after an elision | implicit return is `[a,, x]` |
| `-> [...] := point` | implicit return could reference the hidden anonymous rest | implicit return is `[]` |
| `total := for sum [..., x] of y` | reduction used the wrong binding value | reduction uses `x` |
| `total := for sum [...] of y` | reduction could use an empty/hidden binding value | now reports `Empty binding pattern in loop with implicit body` |

## Implementation Notes

- New `arrayPatternValueElements` helper reconstructs the source-level array binding elements for value conversion.
- Track anonymous terminal `...` as `omittedRest` so emitted destructuring can omit it while pattern matching and type inference can still treat it as a rest pattern.
- `elements` now omits it too, not just `children`. Now `elements` appears in (actually is) `children`, which is usually assume.
- Update `patternAsValue` to use reconstructed array elements instead of the lowered JS destructuring shape.
- Keep post-rest pattern matching pointed at `blockPrefix.elements` directly instead of reaching through generated children.
- Tighten array binding pattern types around `ArrayBindingPatternElement` / `ArrayBindingPatternContent`.

## Tests

Added coverage for:

- implicit `for` bodies with anonymous and named post-rest array destructuring
- implicit function returns from anonymous post-rest array destructuring
- reductions over post-rest array destructuring
- empty anonymous rest behavior
- type inference for omitted rest
