### PR TITLE
Parenless parameters in `function`s

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2474,6 +2474,8 @@ ParameterElementDelimiter
   _? Comma
   # `::` stops arguments, to enable `function f arg, arg :: returnType`
   &( _? DoubleColon ) -> undefined
+  # `:=` stops bare function arguments, to enable `function f arg := body`
+  &( _? ConstAssignment ) -> undefined
   &( __ [)\]}] ) -> undefined
   &EOS InsertComma -> $2
 
@@ -2916,6 +2918,18 @@ FunctionSignature
 
 # https://262.ecma-international.org/#prod-FunctionExpression
 FunctionExpression
+  # Allow empty body after `:=`, e.g. `function f x :=` -> `function f(x) {}`
+  FunctionSignature:signature _?:ws1 ConstAssignment _?:ws2 BracedOrEmptyBlock:block ->
+    ws1 = trimFirstSpace(ws1) if ws1
+    ws2 = trimFirstSpace(ws2) if ws2
+    return {
+      ...signature,
+      type: "FunctionExpression",
+      signature,
+      children: [...signature.children, ws1, ws2, block],
+      block,
+    }
+
   # NOTE: block isn't actually optional in FunctionExpression only in declarations/TS overloads
   FunctionSignature:signature BracedBlock?:block ->
     // TS Function overloads

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2918,8 +2918,8 @@ FunctionSignature
 
 # https://262.ecma-international.org/#prod-FunctionExpression
 FunctionExpression
-  # Allow empty body after `:=`, e.g. `function f x :=` -> `function f(x) {}`
-  FunctionSignature:signature _?:ws1 ConstAssignment _?:ws2 BracedOrEmptyBlock:block ->
+  # Allow empty body after `:=`/`=`, e.g. `function f x :=` -> `function f(x) {}`
+  FunctionSignature:signature _?:ws1 ( ConstAssignment / Equals ):sep _?:ws2 BracedOrEmptyBlock:block ->
     ws1 = trimFirstSpace(ws1) if ws1
     ws2 = trimFirstSpace(ws2) if ws2
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -72,6 +72,7 @@ import {
   rewriteDynamicImportCall,
   rewriteModuleSpecifier,
   reorderBindingRestProperty,
+  replaceNode,
   replaceNodes,
   skipImplicitArguments,
   stripTrailingImplicitComma,
@@ -2333,6 +2334,25 @@ Parameters
       implicit: true,
     }
 
+# NOTE: Added bare/parenless function parameters, e.g. `function f x, y`.
+# NOTE: Not allowed in arrow functions or methods given ambiguities.
+FunctionParameters
+  TypeParameters?:tp Loc:p Parameter+:parameters ::ParametersNode ->
+    return $skip unless parameters#
+    // Strip the space between type parameters and the first bare parameter.
+    parameters = trimFirstSpace(parameters) if tp
+    lastParameter := parameters.-1
+    if lastParameter.delim?.implicit
+      replaceNode(lastParameter.delim, undefined, lastParameter)
+    return {
+      type: "Parameters",
+      children: [tp, {p.$loc, token: "("}, parameters, ")"],
+      tp,
+      parameters,
+      bare: true,
+    }
+  Parameters
+
 # Allow for [a, b] => ... or {a, b} -> ...
 ShortArrowParameters
   ( ObjectBindingPattern / ArrayBindingPattern ):binding ->
@@ -2452,6 +2472,8 @@ ParameterElement
 
 ParameterElementDelimiter
   _? Comma
+  # `::` stops arguments, to enable `function f arg, arg :: returnType`
+  &( _? DoubleColon ) -> undefined
   &( __ [)\]}] ) -> undefined
   &EOS InsertComma -> $2
 
@@ -2866,9 +2888,10 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:returnType ->
+  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:ws FunctionParameters:parameters ReturnTypeSuffix?:returnType ->
     async = [] unless async
     generator = [] unless generator
+    ws = trimFirstSpace(ws) if parameters.bare and ws
 
     id := wid?.[1]
     return {
@@ -2885,9 +2908,9 @@ FunctionSignature
       },
       block: null,
       children: !parameters.implicit
-        ? [ async, func, generator, wid, w, parameters, returnType ]
-        : [ async, func, generator, wid, parameters, w, returnType ],
-          // move whitespace w to after implicit () in parameters
+        ? [ async, func, generator, wid, ws, parameters, returnType ]
+        : [ async, func, generator, wid, parameters, ws, returnType ]
+          // move whitespace ws to after implicit () in parameters
     }
 
 # https://262.ecma-international.org/#prod-FunctionExpression
@@ -9105,11 +9128,11 @@ MaybeNestedTypeUnary
   NotDedented TypeUnary
 
 ReturnTypeSuffix ::ReturnTypeAnnotation
-  _? QuestionMark?:optional _? Colon ReturnType:t ->
+  _? QuestionMark?:optional _? ( Colon / DoubleColonAsColon ):colon ReturnType:t ->
     return {
       ...t,
       optional,
-      children: [ $1, optional, $3, $4, ...t.children ]
+      children: [ $1, optional, $3, colon, ...t.children ]
     }
 
 ReturnType

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2337,7 +2337,7 @@ Parameters
 # NOTE: Added bare/parenless function parameters, e.g. `function f x, y`.
 # NOTE: Not allowed in arrow functions or methods given ambiguities.
 FunctionParameters
-  TypeParameters?:tp Loc:p Parameter+:parameters ::ParametersNode ->
+  TypeParameters?:tp Loc:p !( Literal / RegularExpressionLiteral ) Parameter+:parameters ::ParametersNode ->
     return $skip unless parameters#
     // Strip the space between type parameters and the first bare parameter.
     parameters = trimFirstSpace(parameters) if tp
@@ -2888,9 +2888,10 @@ FunctionDeclaration
 
 FunctionSignature
   # NOTE: Merged in async and generator with optionals
-  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:ws FunctionParameters:parameters ReturnTypeSuffix?:returnType ->
+  ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier !( TypeSuffix? _? Comma ) )?:wid _?:ws FunctionParameters:parameters ReturnTypeSuffix?:returnType ->
     async = [] unless async
     generator = [] unless generator
+    wid = wid?[<2] // omit !( TypeSuffix? _? Comma )
     ws = trimFirstSpace(ws) if parameters.bare and ws
 
     id := wid?.[1]

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1384,6 +1384,8 @@ export type ParametersNode = ASTParent &
   names?: string[] // set eventually by processParams
   tp?: TypeParameters?
   implicit?: boolean // makeGetterMethod
+  /** Parenless function parameters? */
+  bare?: boolean
   blockPrefix?: PostRestBindingElements
 
 export type Parameter = ASTParent &

--- a/test/function.civet
+++ b/test/function.civet
@@ -355,6 +355,35 @@ describe "function", ->
     """
 
     testCase """
+      parenless parameters with separator
+      ---
+      function id x := x
+      ---
+      function id(x) {return x }
+    """
+
+    testCase """
+      parenless parameters with separator and indented block
+      ---
+      function id x :=
+        y := x
+        y
+      ---
+      function id(x) {
+        const y = x
+        return y
+      }
+    """
+
+    testCase """
+      parenless parameters with separator and no block
+      ---
+      function id x :=
+      ---
+      function id(x) {}
+    """
+
+    testCase """
       inline
       ---
       function f 5

--- a/test/function.civet
+++ b/test/function.civet
@@ -384,6 +384,46 @@ describe "function", ->
     """
 
     testCase """
+      parenthesized parameters with equals separator
+      ---
+      function id(x) = x
+      ---
+      function id(x) {return x }
+    """
+
+    testCase """
+      parenthesized parameters with const separator
+      ---
+      function id(x) := x
+      ---
+      function id(x) {return x }
+    """
+
+    testCase """
+      parameterless with equals separator
+      ---
+      function value = 5
+      ---
+      function value()  {return 5 }
+    """
+
+    testCase """
+      parameterless with const separator
+      ---
+      function value := 5
+      ---
+      function value()  {return 5 }
+    """
+
+    testCase """
+      parenless equals is default parameter
+      ---
+      function f x = 1
+      ---
+      function f(x = 1){}
+    """
+
+    testCase """
       inline
       ---
       function f 5

--- a/test/function.civet
+++ b/test/function.civet
@@ -331,7 +331,18 @@ describe "function", ->
       const f = async () => await 5
     """
 
-  describe "argumentless without parens", ->
+  describe "no parens", ->
+    testCase """
+      parenless parameters
+      ---
+      function add x, y
+        x + y
+      ---
+      function add(x, y) {
+        return x + y
+      }
+    """
+
     testCase """
       inline
       ---

--- a/test/function.civet
+++ b/test/function.civet
@@ -344,6 +344,17 @@ describe "function", ->
     """
 
     testCase """
+      anonymous parenless parameters
+      ---
+      function x, y
+        x + y
+      ---
+      (function(x, y) {
+        return x + y
+      })
+    """
+
+    testCase """
       inline
       ---
       function f 5

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -64,6 +64,39 @@ describe "[TS] function", ->
   """
 
   testCase """
+    parenless function parameters with types
+    ---
+    function add x: number, y: number
+      x + y
+    ---
+    function add(x: number, y: number) {
+      return x + y
+    }
+  """
+
+  testCase """
+    parenless function parameters with types and return type
+    ---
+    function add x: number, y: number :: number
+      x + y
+    ---
+    function add(x: number, y: number) : number {
+      return x + y
+    }
+  """
+
+  testCase """
+    parenless function parameters with type parameters
+    ---
+    function identity<T> x: T :: T
+      x
+    ---
+    function identity<T>(x: T) : T {
+      return x
+    }
+  """
+
+  testCase """
     function with indented return type
     ---
     function add<S, T>(a: S, b: T):
@@ -86,6 +119,28 @@ describe "[TS] function", ->
     ---
     function f(): void {
       console.log('hi')
+    }
+  """
+
+  testCase """
+    argumentless without parens and double-colon return type
+    ---
+    function f:: void
+      console.log 'hi'
+    ---
+    function f(): void {
+      console.log('hi')
+    }
+  """
+
+  testCase """
+    function double-colon return type
+    ---
+    function add(a: number, b: number):: number
+      return a + b
+    ---
+    function add(a: number, b: number): number {
+      return a + b
     }
   """
 

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -97,6 +97,22 @@ describe "[TS] function", ->
   """
 
   testCase """
+    parenless function parameters with separator
+    ---
+    function add x: number, y: number := x + y
+    ---
+    function add(x: number, y: number) {return x + y }
+  """
+
+  testCase """
+    parenless function parameters with return type and separator
+    ---
+    function add x: number, y: number :: number := x + y
+    ---
+    function add(x: number, y: number) : number {return x + y }
+  """
+
+  testCase """
     parenless function parameters with type parameters
     ---
     function identity<T> x: T :: T

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -113,6 +113,22 @@ describe "[TS] function", ->
   """
 
   testCase """
+    parenthesized function parameters with equals separator
+    ---
+    function add(x: number, y: number): number = x + y
+    ---
+    function add(x: number, y: number): number {return x + y }
+  """
+
+  testCase """
+    parameterless function with equals separator
+    ---
+    function value: number = 5
+    ---
+    function value(): number {return 5 }
+  """
+
+  testCase """
     parenless function parameters with type parameters
     ---
     function identity<T> x: T :: T

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -75,6 +75,17 @@ describe "[TS] function", ->
   """
 
   testCase """
+    anonymous parenless function parameters with types
+    ---
+    function x: number, y: number
+      x + y
+    ---
+    (function(x: number, y: number) {
+      return x + y
+    })
+  """
+
+  testCase """
     parenless function parameters with types and return type
     ---
     function add x: number, y: number :: number


### PR DESCRIPTION
## Summary

To enable more discussion, this PR implements the syntax proposed in [discussion #407](https://github.com/DanielXMoore/Civet/discussions/407): function declarations without parenthesized parameters, including typed parameters and return types.

```coffee
function add x, y
  x + y

function add x: number, y: number :: number
  x + y
```

compiles to:

```ts
function add(x, y) {
  return x + y
}

function add(x: number, y: number) : number {
  return x + y
}
```

## New syntax

Bare function parameters are supported for `function` declarations and expressions:

```coffee
function add x, y
  x + y

function identity<T> x: T :: T
  x

function x, y
  x + y
```

Return types can use `::` in this syntax, avoiding the visual ambiguity of a second `:` after typed parameters:

```coffee
function add x: number, y: number :: number
  x + y

function f:: void
  console.log "hi"
```

This fits Civet's existing uses of `::` to mean “type annotation where : would be ambiguous”.

## Anonymous functions

Anonymous parenless functions are supported when the parameter list has more than 1 parameter (or 0, as before):

```coffee
function x, y
  x + y

function x: number, y: number
  x + y
```

These compile to anonymous function expressions:

```ts
(function(x, y) {
  return x + y
})

(function(x: number, y: number) {
  return x + y
})
```

A single untyped anonymous parameter generally needs an explicit separator, because otherwise it conflicts with the existing no-argument inline body shorthand.

## Body separators

This PR also adds optional body separators for function declarations and expressions. This is essentially an alternative to #2153 for how to recommend one-liners.

For bare parenless parameters, `:=` can separate the parameter list from the body:

```coffee
function id x := x
function add x: number, y: number := x + y
function add x: number, y: number :: number := x + y
function x, y := x + y
```

It can also introduce an indented or empty body:

```coffee
function id x :=
  y := x
  y

function id x :=
```

For parenthesized or parameterless functions, both `=` and `:=` are allowed:

```coffee
function id(x) = x
function id(x) := x
function value = 5
function value := 5
function add(x: number, y: number): number = x + y
function value: number = 5
```

In the future, we could consider omitting `function` in cases with at least 1 parameter.

## Limitations

This PR is limited to `function` syntax. It does not add parenless parameters for arrow functions, or class or object methods. See below for possible extensions.

Bare parenless parameters must use `:=`, not `=`, as a body separator. This preserves default-parameter syntax:

```coffee
function f x = 1
```

compiles as:

```ts
function f(x = 1){}
```

Existing no-argument inline shorthand is preserved:

```coffee
function f 5
function 5
```

continue to mean no-argument functions with inline bodies, not functions with literal parameters.

## Future work

Discussion #407 also raised typing an entire function declaration with an existing function type, instead of spelling out parameter and return types locally. Syntax such as:

```coffee
function f as T
  ...
```

or related `as` forms could be explored separately. This PR does not implement whole-function type conformance or rewriting to a `var`/`const` function expression form; it only adds parameter-list syntax, return-type syntax, and body separators. It does consume `::` as possible syntax for that form, though.

Class and object methods could also be considered separately. The unrestricted parenless form is more ambiguous there because method syntax overlaps with object shorthand, calls, and existing method bodies, but a required `:=` separator may be enough to make some method cases unambiguous:

```coffee
class C
  method x, y := x + y

obj := {
  method x, y := x + y
}
```