### PR TITLE
LSP: Fix sourcemapping of trimmed spaces and `#` length shorthand

### DIFF
--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@danielx/civet-language-server",
   "description": "Civet Language Server (standalone, editor-agnostic)",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "repository": {
     "type": "git",
     "url": "https://github.com/DanielXMoore/civet.git"

--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -360,6 +360,8 @@ export function measureTokenLength(
 ): { length: number, remaining: number }
   lineEnd := civetText.indexOf('\n', offset)
   remaining := (if lineEnd < 0 then civetText.length else lineEnd) - offset
-  match := civetText.slice(offset, offset + remaining).match(/^[@#]?\w+/)
+  // Standalone @ and # expand to identifier-like targets (`this` and
+  // `length`), so semantic tokens remapped onto them should stay 1 char.
+  match := civetText.slice(offset, offset + remaining).match(/^(?:[@#]?\w+|[@#])/)
   length := if match then match[0].length else defaultLen
   { length, remaining }

--- a/lsp/server/test/completions.civet
+++ b/lsp/server/test/completions.civet
@@ -273,6 +273,11 @@ describe "completions helpers", ->
       { length } := measureTokenLength(text, offset, 99)
       assert.equal length, "@name".length
 
+    it "measures standalone @ and # shorthands as one character", ->
+      for shorthand of ["@", "#"]
+        { length } := measureTokenLength(shorthand + " }", 0, 99)
+        assert.equal length, 1
+
     it "clamps remaining to line end (before newline)", ->
       offset := text.indexOf("world")
       { remaining } := measureTokenLength(text, offset, 99)

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -1198,6 +1198,41 @@ describe "LSP features (shared project server)", ->
       edits := Object.values(result.changes)[0] as any[]
       assert Array.isArray(edits) and edits.length >= 1, "expected rename edits"
 
+  it "rename preserves whitespace before implicit-call arguments", ->
+    uri := docUri path.join(projectRoot, "rename-implicit-call.civet")
+    text := """
+      foo := (x: number) => x
+      data := 1
+      foo data
+
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    result := await client.request "textDocument/rename", {
+      textDocument: { uri }
+      position: { line: 1, character: 0 }
+      newName: "renamed"
+    }
+    assert result, "expected rename result"
+    uriKey := Object.keys(result.changes ?? {}).find (key) => sameUri(key, uri)
+    assert uriKey, "expected rename edits for source file; result=" + JSON.stringify result
+    edits := result.changes![uriKey] as any[]
+    assert Array.isArray(edits), "expected rename edits for source file"
+
+    lines := text.split "\n"
+    callLine := lines.findIndex (line) => line.includes "foo data"
+    assert callLine >= 0, "expected implicit-call line in fixture"
+    callDataColumn := lines[callLine].indexOf("data")
+    callEdit := edits.find (edit) =>
+      edit.range.start.line is callLine and edit.range.end.line is callLine
+    assert callEdit, "expected rename edit on implicit-call line; edits=" + JSON.stringify edits
+    assert.deepEqual callEdit.range,
+      start: { line: callLine, character: callDataColumn }
+      end: { line: callLine, character: callDataColumn + "data".length }
+
   it "workspace/symbol finds top-level symbols across the project", ->
     uri := docUri path.join(projectRoot, "wssym-a.civet")
     text := """

--- a/lsp/server/test/util.civet
+++ b/lsp/server/test/util.civet
@@ -1,5 +1,5 @@
 // TODO: figure out the magic ts-note/TypeScript config to make this work without destructuring from default import
-{ collectCommentTokens, intersectRanges, containsRange, makeRange, remapPosition, forwardMap } from ../source/lib/util.civet
+{ collectCommentTokens, intersectRanges, containsRange, makeRange, remapPosition, remapPositionStrict, forwardMap } from ../source/lib/util.civet
 { TextDocument } from vscode-languageserver-textdocument
 assert from assert
 Civet from @danielx/civet
@@ -60,6 +60,25 @@ describe "util", ->
     pos := { line: 5, character: 3 }
     result := forwardMap([], pos)
     assert.deepEqual result, pos
+
+  it "should not map trimmed implicit-call whitespace onto the first argument", ->
+    src := "buffer.copyToChannel data, 0\n"
+
+    {code, sourceMap} := await Civet.compile(src, {
+      filename: "test.civet"
+      sourceMap: true
+    })
+
+    generatedDataColumn := code.indexOf("data")
+    assert generatedDataColumn >= 0, `expected generated code to contain data; got ${code}`
+
+    assert.deepEqual remapPositionStrict({
+      line: 0
+      character: generatedDataColumn
+    }, sourceMap.lines), {
+      line: 0
+      character: src.indexOf("data")
+    }
 
   it "should forward map", ->
     src := '''

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "publisher": "DanielX",
   "repository": {
     "type": "git",

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -115,6 +115,11 @@ export class SourceMap
       @srcLine = srcLine
       @srcColumn = srcCol
 
+    // Empty output has no source-map span to represent. Keep the source
+    // cursor update above for later errors, but avoid a zero-width mapping
+    // entry that can override the following real token.
+    return unless outputStr#
+
     for each line, i of outLines
       if i > 0
         @line++


### PR DESCRIPTION
This PR fixes source-map handling and thus semantic token drift for:
1. Zero-length generated output
   Empty generated tokens still update the source cursor for later error locations, but they should not emit a source-map mapping entry because there is no generated span to map. Emitting those zero-width mappings caused cases like implicit call whitespace to override the following real token mapping, making semantic highlighting start one character early.
2. Standalone Civet shorthands `@` (for `this`) and `#` (for `length`), 
   Ensure these measure as one-character semantic token targets instead of inheriting the generated identifier `this` or `length`.

Bonus: LSP rename for implicit-call arguments no longer eats the space in `foo data` when renaming `data`.

## Before screenshot

<img width="1560" height="276" alt="image" src="https://github.com/user-attachments/assets/cf952500-a5bc-4186-8921-9d91fd735845" />

1. The five characters `#, sam` gets highlighted blue in the first line. This is because `length` has five characters. (It's actually the generated key `length:` that causes this coloring, and `length` maps to the `#`. But it should highlight just the `#`.)
2. The last character of `data` and `buffer` are not properly highlighted. This is because of the trimmed space in the implicit function call shifting things by 1.

## After screenshot

<img width="1407" height="282" alt="image" src="https://github.com/user-attachments/assets/65091fb3-d62d-4529-b03c-bde44bde1664" />
