### PR TITLE
Fix missing comma in `::` typed array destructuring with elision

### DIFF
--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -347,7 +347,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
           count++ if typeSuffix
           typeSuffix ?= typeSuffixForExpression trimFirstSpace initializer.expression if initializer?
           let delim: ASTNode?
-          if elem.type is "BindingElement"
+          if elem.type is "BindingElement" or elem.type is "ElisionElement"
             delim = elem.delim
           typeElement .= [ typeSuffix?.t, delim ]
           if typeSuffix?.optional

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1155,6 +1155,7 @@ export type ElisionElement = ASTParent &
   typeSuffix?: undefined
   names: string[]
   initializer?: undefined // holes don't have initializers
+  delim?: ASTNode
 
 export type Placeholder = ASTObject &
   type: "Placeholder"

--- a/test/types/destructuring.civet
+++ b/test/types/destructuring.civet
@@ -168,3 +168,27 @@ describe "[TS] destructuring", ->
       ---
       const [ { first, last }, ...rest ]: [{ first: string, last?: string},...unknown[]] = people
     """
+
+    testCase """
+      array with elision
+      ---
+      [, key, value:: string] .= match
+      ---
+      let [, key, value]: [unknown,unknown, string] = match
+    """
+
+    testCase """
+      array with multiple elisions
+      ---
+      [, , key:: string] .= match
+      ---
+      let [, , key]: [unknown,unknown , string] = match
+    """
+
+    testCase """
+      array with elision then rest
+      ---
+      [, ...rest:: T[]] .= match
+      ---
+      let [, ...rest]: [unknown,... T[]] = match
+    """


### PR DESCRIPTION
Fixes #2167

## Summary

In `gatherBindingPatternTypeSuffix` (`source/parser/binding.civet`), the comma delimiter was only extracted for `BindingElement`, not for `ElisionElement`. This caused the synthetic tuple type to render as `[unknownunknown, string]` instead of `[unknown, unknown, string]` when an array destructuring with an elision slot had a `::`-typed element.

## Changes

- `source/parser/binding.civet`: also extract `delim` for `ElisionElement`
- `source/parser/types.civet`: add `delim?` to the `ElisionElement` type definition
- `test/types/destructuring.civet`: new regression tests

## Test plan

- [x] `pnpm test` — all 4484 tests pass
- [x] Manual verification against the issue's example input

Generated with [Claude Code](https://claude.ai/code)