### PR TITLE
Use `[]` fallback for `...if`/`...unless` inside array literals

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1649,6 +1649,20 @@ implicitly being `undefined`:
 [a, b if c, d unless e]
 </Playground>
 
+Spread array items with a postfix (or prefix) `if`/`unless`
+fall back to an empty array (`[]`) instead of `undefined`,
+so the surrounding array literal doesn't throw when the
+condition is false:
+
+<Playground>
+[
+  ...a if c
+  ...b unless c
+  ...if c then a
+  ...if c then a else b
+]
+</Playground>
+
 Function arguments that are either parenthesized or indented
 can have a postfix `if`:
 

--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1650,16 +1650,13 @@ implicitly being `undefined`:
 </Playground>
 
 Spread array items with a postfix (or prefix) `if`/`unless`
-fall back to an empty array (`[]`) instead of `undefined`,
-so the surrounding array literal doesn't throw when the
-condition is false:
+fall back to an empty array instead of `undefined`:
 
 <Playground>
 [
   ...a if c
   ...b unless c
   ...if c then a
-  ...if c then a else b
 ]
 </Playground>
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -401,7 +401,7 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
   // to the operand they came from so following generated syntax stays live.
   if b.trailing?#
     children.push b.trailing
-  elseFallback .= false
+  implicitElse .= undefined
   if e
     e2 := expressionizeBlock(e.block)
     unless e2
@@ -415,14 +415,13 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
     children.push ...e.children[3..]
   else
     children.push "\n" if b.trailing?#
-    children.push ":void 0"
-    elseFallback = true
+    children.push implicitElse = ":void 0"
   children.push closeParen
 
   makeNode {
     type: "IfExpression"
     children
-    elseFallback
+    implicitElse
   }
 
 function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any]): TypeConditional
@@ -1784,11 +1783,8 @@ function processArraySpreadIfFallback(statements: StatementTuple[]): void
     exp .= spread.expression as any
     if exp?.type is "StatementExpression"
       exp = exp.statement
-    continue unless exp?.type is "IfExpression" and exp.elseFallback
-    for i of [0...exp.children#]
-      if exp.children[i] is ":void 0"
-        exp.children[i] = ":[]"
-        break
+    continue unless exp?.type is "IfExpression" and exp.implicitElse
+    replaceNode exp.implicitElse, ":[]", exp
 
 /**
 Wrap any remaining statement expressions in IIFE.

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -401,6 +401,7 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
   // to the operand they came from so following generated syntax stays live.
   if b.trailing?#
     children.push b.trailing
+  elseFallback .= false
   if e
     e2 := expressionizeBlock(e.block)
     unless e2
@@ -415,11 +416,13 @@ function expressionizeIfStatement(statement: IfStatement): ASTNode
   else
     children.push "\n" if b.trailing?#
     children.push ":void 0"
+    elseFallback = true
   children.push closeParen
 
   makeNode {
     type: "IfExpression"
     children
+    elseFallback
   }
 
 function expressionizeTypeIf([ifOp, condition, t, e]: [any, any, any, any]): TypeConditional
@@ -1768,6 +1771,26 @@ function processTypes(node: ASTNode)
           suffixIndex--
 
 /**
+Rewrite auto-generated `:void 0` fallbacks to `:[]` in `IfExpression`s that
+are the direct expression of a `SpreadElement` inside an `ArrayExpression`,
+so that `[...if cond then arr]` yields `[]` (not a TypeError) when `cond`
+is falsy.
+*/
+function processArraySpreadIfFallback(statements: StatementTuple[]): void
+  for each spread of gatherRecursiveAll statements, .type is "SpreadElement"
+    continue unless spread.parent?.type is "ArrayExpression"
+    // Prefix `...if`/`...unless` wraps the IfExpression in a StatementExpression;
+    // postfix `...a if x` places the IfExpression directly under the spread.
+    exp .= spread.expression as any
+    if exp?.type is "StatementExpression"
+      exp = exp.statement
+    continue unless exp?.type is "IfExpression" and exp.elseFallback
+    for i of [0...exp.children#]
+      if exp.children[i] is ":void 0"
+        exp.children[i] = ":[]"
+        break
+
+/**
 Wrap any remaining statement expressions in IIFE.
 */
 function processStatementExpressions(statements: StatementTuple[]): void
@@ -2074,6 +2097,7 @@ function processProgram(root: BlockStatement): void
   processDeclarations(statements)
   processAssignments(statements)
   processStatementExpressions(statements)
+  processArraySpreadIfFallback(statements)
   processPatternMatching(statements)
   processIterationExpressions(statements, !!(config.iife or config.repl))
   processFinallyClauses(statements)

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -537,7 +537,7 @@ export type IfExpression = ASTParent &
   // The auto-generated `:void 0` else branch when the source had no `else`
   // clause. Used to rewrite the fallback to `:[]` when the IfExpression is
   // inside an array-literal spread.
-  implicitElse?: string
+  implicitElse?: string | undefined
 
 export type IterationExpression = ASTParent &
   type: "IterationExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -534,10 +534,10 @@ export type ElseToken = "else " | (Keyword & { token: "else" })
 
 export type IfExpression = ASTParent &
   type: "IfExpression"
-  // True when the else branch was auto-generated as `:void 0` because the
-  // source had no `else` clause. Used to rewrite the fallback to `:[]` when
-  // the IfExpression is inside an array-literal spread.
-  elseFallback?: boolean
+  // The auto-generated `:void 0` else branch when the source had no `else`
+  // clause. Used to rewrite the fallback to `:[]` when the IfExpression is
+  // inside an array-literal spread.
+  implicitElse?: string
 
 export type IterationExpression = ASTParent &
   type: "IterationExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -537,7 +537,7 @@ export type IfExpression = ASTParent &
   // The auto-generated `:void 0` else branch when the source had no `else`
   // clause. Used to rewrite the fallback to `:[]` when the IfExpression is
   // inside an array-literal spread.
-  implicitElse?: string | undefined
+  implicitElse?: string?
 
 export type IterationExpression = ASTParent &
   type: "IterationExpression"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -534,6 +534,10 @@ export type ElseToken = "else " | (Keyword & { token: "else" })
 
 export type IfExpression = ASTParent &
   type: "IfExpression"
+  // True when the else branch was auto-generated as `:void 0` because the
+  // source had no `else` clause. Used to rewrite the fallback to `:[]` when
+  // the IfExpression is inside an array-literal spread.
+  elseFallback?: boolean
 
 export type IterationExpression = ASTParent &
   type: "IterationExpression"

--- a/test/array.civet
+++ b/test/array.civet
@@ -283,8 +283,52 @@ describe "array", ->
     ]
     ---
     [
-      ...(x?a:void 0)
+      ...(x?a:[])
     ]
+  """
+
+  testCase """
+    prefix if with splat
+    ---
+    [
+      ...if x then a
+    ]
+    ---
+    [
+      ...(x? a:[])
+    ]
+  """
+
+  testCase """
+    prefix unless with splat
+    ---
+    [
+      ...unless x then a
+    ]
+    ---
+    [
+      ...(!x? a:[])
+    ]
+  """
+
+  testCase """
+    prefix if-else with splat keeps explicit else
+    ---
+    [
+      ...if x then a else b
+    ]
+    ---
+    [
+      ...(x? a : b)
+    ]
+  """
+
+  testCase """
+    ...if fallback stays void 0 outside array literal
+    ---
+    f(...if x then a)
+    ---
+    f(...(x? a:void 0))
   """
 
   testCase """


### PR DESCRIPTION
Closes #2170.

For a spread without an `else` clause, `expressionizeIfStatement` emits `:void 0`. That's a TypeError when spread into an array (`[...void 0]` throws), and makes it awkward to add optional parts to an array literal.

Mark auto-generated `void 0` fallbacks on the resulting `IfExpression` with `elseFallback: true` and, in `processArraySpreadIfFallback`, rewrite them to `:[]` when the `IfExpression` is the direct expression of a `SpreadElement` under an `ArrayExpression`. Handles both prefix (`[...if x then a]`) and postfix (`[...a if x]`) forms. Object spreads and non-array spreads keep `:void 0` since they don't throw.

Generated with [Claude Code](https://claude.ai/code)