### PR TITLE
deno-civet: implement a deno loader for Civet files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The modern way to write TypeScript.
   [Jest](https://github.com/DanielXMoore/Civet/blob/main/integration/jest),
   [Gulp](integration/gulp),
   [Bun](source/bun-civet.civet),
+  [Deno](source/deno-civet.civet),
   [`<script>` tag](https://github.com/DanielXMoore/Civet/tree/main/integration/script)
 - Starter templates for [Solid](https://github.com/edemaine/civet-solid-vite-template) ([older](https://github.com/orenelbaum/solid-civet-template)) and [Solid Start](https://github.com/orenelbaum/solid-start-civet-template)
 

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -124,7 +124,7 @@ for name of ["config", "babel-plugin"]
     }).catch -> process.exit 1
 
 // esm needs to be a module for import.meta
-for name of ["esm", "node-worker"]
+for name of ["esm", "node-worker", "deno-civet"]
   build({
     entryPoints: [`source/${name}.civet`]
     bundle: true

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -124,7 +124,7 @@ for name of ["config", "babel-plugin"]
     }).catch -> process.exit 1
 
 // esm needs to be a module for import.meta
-for name of ["esm", "node-worker", "deno-civet"]
+for name of ["esm", "node-worker", "deno-civet", "deno-civet-register"]
   build({
     entryPoints: [`source/${name}.civet`]
     bundle: true

--- a/civet.dev/integrations.md
+++ b/civet.dev/integrations.md
@@ -139,6 +139,7 @@ hx --health civet
 - [Jest plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/jest)
 - [Gulp plugin](https://github.com/DanielXMoore/Civet/tree/main/integration/gulp)
 - [Bun plugin](https://github.com/DanielXMoore/Civet/blob/main/source/bun-civet.civet)
+- [Deno plugin](https://github.com/DanielXMoore/Civet/blob/main/source/deno-civet.civet)
 - [Meteor plugin](https://github.com/edemaine/meteor-civet)
 - [`<script>` tag](https://github.com/DanielXMoore/Civet/tree/main/integration/script)
 - [Civetman](https://github.com/zihan-ch/civetman) automatically compiles `.civet` files, making it easy to integrate with arbitrary build chains (see also [vite-plugin-civetman](https://github.com/krist7599555/vite-plugin-civetman))

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "./browser": "./dist/browser.js",
     "./browser.min": "./dist/browser.min.js",
     "./bun-civet": "./dist/bun-civet.mjs",
+    "./deno-civet": "./dist/deno-civet.mjs",
     "./esm": "./dist/esm.mjs",
     "./register": "./register.js",
     "./register-noconfig": "./register-noconfig.js",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "./browser.min": "./dist/browser.min.js",
     "./bun-civet": "./dist/bun-civet.mjs",
     "./deno-civet": "./dist/deno-civet.mjs",
+    "./deno-civet/register": "./dist/deno-civet-register.mjs",
     "./esm": "./dist/esm.mjs",
     "./register": "./register.js",
     "./register-noconfig": "./register-noconfig.js",

--- a/source/deno-civet-register.civet
+++ b/source/deno-civet-register.civet
@@ -1,0 +1,3 @@
+{ register } from ./deno-civet.civet
+
+await register()

--- a/source/deno-civet.civet
+++ b/source/deno-civet.civet
@@ -1,0 +1,71 @@
+###
+Deno loader for Civet files. You can either do one of the following:
+
+1. Import via CLI:
+  $ deno run --allow-read --allow-env --import "@danielx/civet/deno-civet" main.civet
+
+2. Import as module:
+  // run.ts
+  import { register } from "@danielx/civet/deno-civet"
+  await register()
+  await import("./main.civet")
+
+  $ deno run --allow-read --allow-env run.ts
+###
+
+import module, { type LoadHookSync } from node:module
+{ readFileSync } from node:fs
+{ fileURLToPath } from node:url
+
+{ compile, type CompilerOptions } from ./main.civet
+{ findConfig, loadConfig } from ./config.civet
+
+type ParseOptions = NonNullable<CompilerOptions['parseOptions']>
+
+export interface DenoCivetOptions
+  config?: string | false | null
+  parseOptions?: ParseOptions
+
+civetExtensionRE := /\.civet(?:$|[?#])/
+
+globalParseOptions: ParseOptions? .= undefined
+registered .= false
+
+loadFn: LoadHookSync := (url, context, nextLoad) =>
+  unless civetExtensionRE.test url
+    return nextLoad url, context
+  path := fileURLToPath url
+  source := readFileSync path, 'utf8'
+  compileOptions: CompilerOptions & { sync: true, js: true, inlineMap: true } :=
+    filename: path
+    js: true
+    inlineMap: true
+    sync: true
+
+  if globalParseOptions?
+    compileOptions.parseOptions = globalParseOptions
+  compiled := compile source, compileOptions
+  return
+    format: "module"
+    source: compiled
+    shortCircuit: true
+
+export async function register(options: DenoCivetOptions = {}): Promise<void>
+  return if registered
+  registered = true
+
+  // find, load and resolve configuration file
+  { config, parseOptions } := options
+  resolved: ParseOptions? .= parseOptions
+  configPath .= config
+  if configPath is undefined
+    configPath = await findConfig process.cwd()
+  if configPath
+    loaded := await loadConfig configPath
+    resolved = { ...loaded.parseOptions, ...parseOptions }
+  globalParseOptions = resolved
+
+  module.registerHooks { load: loadFn }
+
+// auto-register on import for convenience
+await register()

--- a/source/deno-civet.civet
+++ b/source/deno-civet.civet
@@ -13,7 +13,8 @@ Deno loader for Civet files. You can either do one of the following:
   $ deno run --allow-read --allow-env run.ts
 ###
 
-import module, { type LoadHookSync } from node:module
+module from node:module
+type { LoadHookSync } from node:module
 { readFileSync } from node:fs
 { fileURLToPath } from node:url
 

--- a/source/deno-civet.civet
+++ b/source/deno-civet.civet
@@ -2,12 +2,12 @@
 Deno loader for Civet files. You can either do one of the following:
 
 1. Import via CLI:
-  $ deno run --allow-read --allow-env --import "@danielx/civet/deno-civet" main.civet
+  $ deno run --allow-read --allow-env --import "npm:@danielx/civet/deno-civet/register" main.civet
 
-2. Import as module:
+2. Import as module with custom options:
   // run.ts
-  import { register } from "@danielx/civet/deno-civet"
-  await register()
+  import { register } from "npm:@danielx/civet/deno-civet"
+  await register({ parseOptions: { ... } })
   await import("./main.civet")
 
   $ deno run --allow-read --allow-env run.ts
@@ -35,7 +35,8 @@ registered .= false
 loadFn: LoadHookSync := (url, context, nextLoad) =>
   unless civetExtensionRE.test url
     return nextLoad url, context
-  path := fileURLToPath url
+
+  path := fileURLToPath url.replace(/[?#].*$/, '')
   source := readFileSync path, 'utf8'
   compileOptions: CompilerOptions & { sync: true, js: true, inlineMap: true } :=
     filename: path
@@ -53,7 +54,6 @@ loadFn: LoadHookSync := (url, context, nextLoad) =>
 
 export async function register(options: DenoCivetOptions = {}): Promise<void>
   return if registered
-  registered = true
 
   // find, load and resolve configuration file
   { config, parseOptions } := options
@@ -67,6 +67,4 @@ export async function register(options: DenoCivetOptions = {}): Promise<void>
   globalParseOptions = resolved
 
   module.registerHooks { load: loadFn }
-
-// auto-register on import for convenience
-await register()
+  registered = true


### PR DESCRIPTION
This loader allows deno to load Civet files using new deno [`Loader hooks`](https://docs.deno.com/runtime/reference/loader_hooks/).

```
deno run --allow-read --import "@danielx/civet/deno-civet/register" main.civet
```

However, as far as I test, it does not support `npm:`, `jsr:`, `http:` imports unless dependencies are specified in `deno.json` which is like `package.json`. But this is something to do with deno's API. 