### PR TITLE
Fix named destructuring `name^` hoisting

### DIFF
--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -143,7 +143,7 @@ function processDeclarations(statements: StatementTuple[]): void
 
     for i of [bindings#>..0]
       binding := bindings[i]
-      subbindings := gatherSubbindings binding
+      subbindings := gatherSubbindings binding.pattern
       if subbindings#
         simplifyBindingProperties binding
         simplifyBindingProperties subbindings

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -456,6 +456,24 @@ describe "assignment", ->
   """
 
   testCase """
+    named destructuring declaration inside IIFE stays local (#2162)
+    ---
+    result := (() =>
+      if item^{a} := value
+        item.a = undefined
+      return undefined
+    )()
+    ---
+    const result = (() => {
+      if ((value) && typeof value === 'object' && 'a' in value) {const item = value, {a} = item;
+        item.a = undefined
+      }
+      return undefined
+    }
+    )()
+  """
+
+  testCase """
     named destructuring declaration
     ---
     do const {a, b^: [c, d]} = y


### PR DESCRIPTION
Fixes #2162

[Before behavior](https://civet.dev/playground?code=ICAgIHJlc3VsdCA6PSAoKCkgPT4NCiAgICAgIGlmIGl0ZW1ee2F9IDo9IHZhbHVlDQogICAgICAgIGl0ZW0uYSA9IHVuZGVmaW5lZA0KICAgICAgcmV0dXJuIHVuZGVmaW5lZA0KICAgICkoKQ%3D%3D) on the test:

```js
    const result = (() => {
      if ((value) && typeof value === 'object' && 'a' in value) {const item = value, {a} = item;
        item.a = undefined
      }
      return undefined
    }
    )(), {a} = item
```