### PR TITLE
Optional properties `{x?}` in patterns

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -1748,10 +1748,21 @@ switch a
     console.log "not array"
 </Playground>
 
-::: info
-Array patterns are exact; object patterns allow unmatched properties
-(similar to TypeScript types).
-:::
+Like TypeScript tuple types (but unlike JavaScript array destructuring),
+array patterns are exact, requiring a specific length;
+use `...` or `...rest` to allow extra elements.
+Like TypeScript object types and JavaScript object destructuring,
+object patterns are inexact:
+the object can have more properties than those listed in the pattern.
+
+Object pattern properties are required by default. Add `?` to make a
+property optional (with its binding `undefined` when absent):
+
+<Playground>
+switch user
+  {name, nickname?}
+    console.log name, nickname
+</Playground>
 
 <Playground>
 switch x

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2675,7 +2675,16 @@ BindingProperty
 
   # NOTE: Allow ::T type suffix before value
   # NOTE: name^ means we should bind name despite having a value
-  _?:ws1 PropertyName:name Caret?:bind _?:ws2 Colon:colon _?:ws3 ( BindingPattern / BindingIdentifier ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _?:ws1 PropertyName:name QuestionMarkTypeSuffix?:optional Caret?:bind _?:ws2 Colon:colon _?:ws3 ( BindingPattern / BindingIdentifier ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+    if optional // merge into typeSuffix
+      if typeSuffix and not typeSuffix.optional
+        typeSuffix = {
+          ...typeSuffix
+          optional.optional
+          children: [optional.optional, ...typeSuffix.children]
+        }
+      else
+        typeSuffix ?= optional
     // Convert `name^: pattern` into `name: name^pattern`
     if bind
       // For unicode `name`, PropertyName rewrote it to render as `"src"`.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -180,6 +180,7 @@ import type {
   TypeArgumentList,
   TypeFunction,
   TypeNode,
+  TypeSuffix,
   TypeTuple,
   VoidType,
   WhenClause,
@@ -2736,7 +2737,7 @@ BindingProperty
     }
 
   # NOTE: name^ means we should bind name, but we do anyway, so allow but ignore
-  _?:ws BindingIdentifier:binding Caret?:_bind BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _?:ws BindingIdentifier:binding Caret?:_bind BindingPropertyTypeSuffix?:typeSuffix Initializer?:initializer ->
     children .= [ws, binding, initializer]  // omit bind, typeSuffix
 
     if binding.type is "AtBinding"
@@ -2785,7 +2786,7 @@ BindingRestProperty
       children: [...(ws || []), dots, ...(id.children as any)],
     }
 
-BindingTypeSuffix
+BindingTypeSuffix ::TypeSuffix
   _? QuestionMark?:optional _? DoubleColonAsColon:colon MaybeNestedType:t ->
     return {
       type: "TypeSuffix",
@@ -2794,6 +2795,10 @@ BindingTypeSuffix
       t,
       children: $0,
     }
+
+BindingPropertyTypeSuffix ::TypeSuffix
+  BindingTypeSuffix
+  QuestionMarkTypeSuffix
 
 NestedBindingElements
   PushIndent NestedBindingElementList*:elements PopIndent ->
@@ -9078,13 +9083,7 @@ TypeSuffix
     colon,
     children: $0,
   }
-  _? QuestionMark:optional ::unknown -> {
-    type: "TypeSuffix",
-    ts: true,
-    optional,
-    colon: undefined,
-    children: $0,
-  }
+  QuestionMarkTypeSuffix
   # TypeScript has a special error for ! without : ("Declarations with definite
   # assignment assertions must also have type annotations.") but we parse it
   # so that the user can get this more useful error message.
@@ -9098,6 +9097,15 @@ TypeSuffix
       colon,
       children: [ $1, $2, colon, t ],
     }
+
+QuestionMarkTypeSuffix
+  _? QuestionMark:optional ::TypeSuffix -> {
+    type: "TypeSuffix"
+    ts: true
+    optional
+    colon: undefined
+    children: $0
+  }
 
 MaybeNestedType
   NestedTypeBulletedTuple
@@ -9400,7 +9408,7 @@ NestedTypeElement
     })
 
 # NOTE: Nested bulleted tuple starts with an indentation.
-NestedTypeBulletedTuple
+NestedTypeBulletedTuple ::TypeTuple
   ( InsertSpace InsertOpenBracket ):open PushIndent NestedTypeBullet*:content InsertCloseBracket:close PopIndent ->
     return $skip unless content#
     content = content.flat() // combine bullets into one array
@@ -9416,6 +9424,7 @@ NestedTypeBulletedTuple
 
     return {
       type: "TypeTuple",
+      ts: true,
       children: [...open, ...content, close],
     }
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -7,7 +7,6 @@ import type {
   ASTNodeObject
   BindingIdentifier
   BindingPattern
-  BindingProperty
   BindingRestElement
   Children
   HasSubbinding
@@ -375,14 +374,16 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
           if value := prop.value
             if "typeSuffix" in value
               typeSuffix ??= value.typeSuffix
+          // Don't treat a simple `?` suffix as a type suffix for the property
+          typeSuffix = undefined unless typeSuffix?.t
           count++ if typeSuffix
           typeSuffix ?= typeSuffixForExpression trimFirstSpace initializer.expression if initializer?
           typeSuffix ??=
             type: "TypeSuffix"
             ts: true
             children: [": unknown"]
-          if (prop as BindingProperty).initializer and not typeSuffix.optional
-            typeSuffix.children.unshift typeSuffix.optional = "?"
+          if prop.type is "BindingProperty" and (prop.typeSuffix?.optional or prop.initializer) and not typeSuffix.optional
+            typeSuffix.children.unshift typeSuffix.optional = prop.typeSuffix?.optional ?? "?"
           switch prop.type
             when "BindingProperty", "PinProperty"
               ws := prop.children[...prop.children.indexOf prop.name]

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -246,17 +246,18 @@ function getPatternConditions(
         switch p.type
           when "PinProperty", "BindingProperty"
             { name, value } := p
+            optional := p.type is "BindingProperty" and p.typeSuffix?.optional
             let subRef
             switch name.type
               when "ComputedPropertyName"
-                conditions.push([name.expression, " in ", ref])
+                conditions.push [name.expression, " in ", ref] unless optional
                 subRef = [ref, name]
               when "StringLiteral", "NumericLiteral"
-                conditions.push([name, " in ", ref])
+                conditions.push [name, " in ", ref] unless optional
                 subRef = [ref, "[", name, "]"]
               when "Identifier"
                 key := name.unicode ?? name.name
-                conditions.push(["'", key, "' in ", ref])
+                conditions.push ["'", key, "' in ", ref] unless optional
                 subRef = name.unicode
                   ? [ref, "[", `"${name.unicode}"`, "]"]
                   : [ref, ".", name.name]

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1378,6 +1378,50 @@ describe "switch", ->
     """
 
     testCase """
+      object pattern with optional property
+      ---
+      switch x
+        {foo?, bar}
+          console.log foo, bar
+      ---
+      if(typeof x === 'object' && x != null && 'bar' in x) {const {foo, bar} = x;
+          console.log(foo, bar)}
+    """
+
+    testCase """
+      object pattern with sole optional property
+      ---
+      switch x
+        {foo?}
+          console.log foo
+      ---
+      if(typeof x === 'object' && x != null) {const {foo} = x;
+          console.log(foo)}
+    """
+
+    testCase """
+      object pattern with optional typed properties
+      ---
+      switch x
+        {foo?, bar?:: string, baz:: number}
+          console.log foo, bar, baz
+      ---
+      if(typeof x === 'object' && x != null && 'baz' in x) {const {foo, bar, baz}: {foo?: unknown, bar?: string, baz: number} = x;
+          console.log(foo, bar, baz)}
+    """
+
+    testCase """
+      object pattern with optional property initializer
+      ---
+      switch x
+        {foo? = 1, bar:: string}
+          console.log foo, bar
+      ---
+      if(typeof x === 'object' && x != null && 'bar' in x) {const {foo = 1, bar}: {foo?: number, bar: string} = x;
+          console.log(foo, bar)}
+    """
+
+    testCase """
       empty object pattern
       ---
       switch x

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -1389,6 +1389,39 @@ describe "switch", ->
     """
 
     testCase """
+      object pattern with renamed optional property
+      ---
+      switch x
+        {foo?: local, bar}
+          console.log local, bar
+      ---
+      if(typeof x === 'object' && x != null && 'bar' in x) {const {foo: local, bar} = x;
+          console.log(local, bar)}
+    """
+
+    testCase """
+      object pattern with renamed optional typed property
+      ---
+      switch x
+        {foo?: local:: string, bar}
+          console.log local, bar
+      ---
+      if(typeof x === 'object' && x != null && 'bar' in x) {const {foo: local, bar}: {foo?: string, bar: unknown} = x;
+          console.log(local, bar)}
+    """
+
+    testCase """
+      object pattern with renamed optional typed binding
+      ---
+      switch x
+        {foo: local?:: string, bar}
+          console.log local, bar
+      ---
+      if(typeof x === 'object' && x != null && 'bar' in x) {const {foo: local, bar}: {foo?: string, bar: unknown} = x;
+          console.log(local, bar)}
+    """
+
+    testCase """
       object pattern with sole optional property
       ---
       switch x


### PR DESCRIPTION
Implements the optional object-property pattern portion of #335.

```civet
switch x
  {foo?, bar}
```

`foo` is bound through normal destructuring and becomes `undefined` when absent. Unlike required properties, it does not generate a `"foo" in x` condition. `bar` remains required.

## Implementation

- Adds `BindingPropertyTypeSuffix`, allowing bare `?` only on object binding properties.
- Factors the existing bare-question-mark suffix into `QuestionMarkTypeSuffix`.
- Stores optional-property metadata directly in `BindingProperty.typeSuffix`.
- Distinguishes metadata-only suffixes from actual type annotations during binding-type generation.
- Emits `foo?: unknown` when another property forces an object type annotation.
- Preserves initializer inference, e.g. `{foo? = 1, bar:: string}` produces `foo?: number`.
- Types `NestedTypeBulletedTuple` as `TypeTuple` and adds its missing `ts: true`, resolving six existing typecheck diagnostics.

Array and rest bindings continue to reject bare `?`.

## Examples

```civet
switch x
  {foo?, bar}
    console.log foo, bar
```

compiles to:

```ts
if (typeof x === "object" && x != null && "bar" in x) {
  const {foo, bar} = x
  console.log(foo, bar)
}
```

Typed properties are aggregated correctly:

```civet
switch x
  {foo?, bar?:: string, baz:: number}
```

```ts
const {foo, bar, baz}: {
  foo?: unknown
  bar?: string
  baz: number
} = x
```

Also removed 6 type errors via some more annotation.