### PR TITLE
Fix semantic highlighting of generated code

### DIFF
--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -144,6 +144,71 @@ describe "LSP features (shared project server)", ->
     assert Array.isArray(tokens.data), "expected tokens.data to be an array"
     assert tokens.data.length > 0, "expected at least one token"
 
+  it "semantic tokens skip generated wrappers around JSX loop values", ->
+    // Regression test for #2176: collecting a loop value wraps its final
+    // expression in `results.push(...)`.  Semantic tokens for that generated
+    // wrapper must not be projected onto the source JSX.
+    uri := docUri path.join(projectRoot, "semtok-jsx-loop.civet")
+    text := """
+      // @ts-nocheck
+
+      function ForLoop
+        for foo in bar
+          <BazComponent attr />
+
+      function ForLoopOneNotReturned
+        for foo in bar
+          <BazComponent attr />
+        for foo in bar
+          <BazComponent attr />
+
+      function ForLoopNotBeingReturned: void
+        for foo in bar
+          <BazComponent attr />
+
+      function ForLoopBeingAssigned
+        x := for foo in bar
+          <BazComponent attr />
+        null
+    """
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    tokens := await client.request "textDocument/semanticTokens/full", {
+      textDocument: { uri }
+    }
+    assert tokens, "expected semantic tokens response"
+
+    decoded: { line: number, character: number, length: number, tokenType: number }[] := []
+    line .= 0
+    char .= 0
+    for i of [0...tokens.data.length] by 5
+      deltaLine := tokens.data[i]
+      deltaChar := tokens.data[i + 1]
+      length := tokens.data[i + 2]
+      tokenType := tokens.data[i + 3]
+      if deltaLine > 0
+        line += deltaLine
+        char = deltaChar
+      else
+        char += deltaChar
+      decoded.push { line, character: char, length, tokenType }
+
+    jsxLines := text.split("\n")
+      .map((source, line) => ({ source, line }))
+      .filter(({ source }) => source.includes("<BazComponent"))
+    assert.equal jsxLines.length, 5
+
+    // TypeScript does not classify this unresolved JSX name.  In particular,
+    // tokens for compiler-generated `results` and `push` must not be projected
+    // onto any part of the source JSX line.
+    for { line } of jsxLines
+      phantom := decoded.find (token) => token.line is line
+      assert.equal phantom, undefined,
+        `expected no phantom token on JSX line ${line}; got ${JSON.stringify phantom}`
+
   it "semantic tokens cover names in destructured imports", ->
     uri := docUri path.join(projectRoot, "semtok-destruct-import.civet")
     text := """

--- a/source/ts-diagnostic.civet
+++ b/source/ts-diagnostic.civet
@@ -39,12 +39,13 @@ export function remapPosition(
   sourcemapLines?: SourcemapLines
 ): Position
   return position unless sourcemapLines
-  return remapPositionStrict(position, sourcemapLines) ?? walkBack(position, sourcemapLines) ?? position
+  return remapPositionOnLine(position, sourcemapLines, false) ?? walkBack(position, sourcemapLines) ?? position
 
 /**
  * Like `remapPosition`, but returns `undefined` when `position` has no
- * direct source mapping on the queried line — i.e. the generated line
- * has no 4-tuple mapping at or before `position.character`.  Does NOT
+ * direct source mapping on the queried line — i.e. the generated position
+ * is not covered by a 4-tuple mapping.  A 1-tuple starts an explicitly
+ * unmapped generated span and clears any preceding source mapping.  Does NOT
  * walk back to preceding lines; for that, use `remapPosition`.
  *
  * This narrow semantics lets the semantic-tokens path drop tokens in
@@ -54,7 +55,22 @@ export function remapPosition(
 export function remapPositionStrict(
   position: Position,
   sourcemapLines: SourcemapLines
-): Position | undefined
+): Position?
+  remapPositionOnLine position, sourcemapLines, true
+
+/**
+ * Find the source mapping that covers a generated position on the same line.
+ *
+ * In strict mode, a generated-only 1-tuple ends the preceding mapped span;
+ * this lets semantic-token callers drop compiler-generated tokens.  Loose
+ * mode preserves `remapPosition`'s historical interpolation across such
+ * segments so diagnostics and navigation retain a best-effort source anchor.
+ */
+function remapPositionOnLine(
+  position: Position
+  sourcemapLines: SourcemapLines
+  strict: boolean
+): Position?
   { line, character } := position
 
   textLine := sourcemapLines[line]
@@ -70,9 +86,20 @@ export function remapPositionStrict(
     mapping := textLine[i]!
     p += mapping[0]!
 
+    if strict
+      // This segment starts after the queried position, so the preceding
+      // segment still covers it.  In particular, do not let a later unmapped
+      // segment clear a valid mapping immediately before its boundary.
+      break if p > character
+
     if mapping.length === 4
       lastMapping = mapping
       lastMappingPosition = p
+    else if strict
+      // A generated-only segment terminates the preceding mapped span.
+      // Keeping `lastMapping` here would interpolate compiler-inserted text
+      // such as `results.push(` onto unrelated source identifiers (#2176).
+      lastMapping = undefined
 
     if p >= character
       break

--- a/test/infra/ts-diagnostic.civet
+++ b/test/infra/ts-diagnostic.civet
@@ -48,6 +48,11 @@ describe "ts-diagnostic", ->
       sourcemapLines: SourcemapLines := [[[2], [2, 0, 0, 10]]]
       assert.deepEqual remapPosition(pos, sourcemapLines), { line: 0, character: 11 }
 
+    it "retains loose interpolation through a generated-only span", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 2, 3], [4]]]
+      assert.deepEqual remapPosition({ line: 0, character: 7 }, sourcemapLines),
+        { line: 2, character: 10 }
+
     it "handles multiple lines independently", ->
       sourcemapLines: SourcemapLines := [
         [[0, 0, 0, 0]]
@@ -122,6 +127,18 @@ describe "ts-diagnostic", ->
     it "applies character offset beyond mapping anchor", ->
       pos := { line: 0, character: 4 }
       assert.deepEqual remapPositionStrict(pos, [[[0, 0, 1, 3]]]), { line: 1, character: 7 }
+
+    it "returns undefined inside a generated-only span", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 2, 3], [4]]]
+      assert.deepEqual remapPositionStrict({ line: 0, character: 3 }, sourcemapLines),
+        { line: 2, character: 6 }
+      assert.equal remapPositionStrict({ line: 0, character: 4 }, sourcemapLines), undefined
+      assert.equal remapPositionStrict({ line: 0, character: 7 }, sourcemapLines), undefined
+
+    it "resumes mapping after a generated-only span", ->
+      sourcemapLines: SourcemapLines := [[[0, 0, 2, 3], [4], [3, 0, 5, 6]]]
+      assert.deepEqual remapPositionStrict({ line: 0, character: 7 }, sourcemapLines),
+        { line: 5, character: 6 }
 
   describe "remapRange", ->
     it "remaps both start and end positions", ->


### PR DESCRIPTION
Fixes #2176

## Problem

Consider this basic loop accumulation from #2176:

```js
function ForLoop
  for foo in bar
    <BazComponent attr />
```

which compiles to roughly:

```tsx
function ForLoop() {
  const results = []
  for (const foo in bar) {
    results.push(<BazComponent attr />)
  }
  return results
}
```

TypeScript computes semantic tokens against the generated TSX, after which the LSP maps those token positions back to the original Civet source.

The generated `results.push(` text has no corresponding Civet source. Civet correctly represents this using one-field source-map segments, which denote explicitly unmapped generated code according to [ECMA-426](https://tc39.es/ecma426/).

However, `remapPositionStrict` previously ignored these generated-only segment boundaries. Once it encountered a preceding four-field source mapping, it continued interpolating from that mapping across later one-field segments.

Consequently, TypeScript semantic tokens for generated identifiers such as `results` and `push` were projected onto parts of the source JSX:

```civet
<BazComponent attr />
```

Those incorrect semantic tokens then overrode the normal JSX syntax highlighting in VS Code. Loops whose values were discarded did not receive a `results.push(...)` wrapper and therefore appeared correctly highlighted.

## Fix

Strict source-map lookup now treats one-field segments as boundaries that begin explicitly unmapped regions.

For the segment active at the queried generated position:

- A four-field segment establishes a source mapping.
- A one-field segment clears the current mapping.
- A later four-field segment can establish a new mapping.
- A segment beginning after the queried position does not affect that position.

Therefore, a semantic token located in generated `results.push(` code has no original source position. `remapPositionStrict` returns `undefined`, and the semantic-token provider skips it instead of projecting it onto unrelated Civet text.

This matches the source-map format: generated-only segments explicitly indicate that the generated code has no corresponding original source.

## Why the change is isolated

Civet has two different source-mapping needs, and they should intentionally behave differently.

### Semantic tokens

Semantic tokens are optional visual annotations. If a token belongs to compiler-generated code, there is no correct place to display it in the original Civet document.

The safe behavior is therefore to drop that token. Displaying it at a nearby source location produces actively misleading highlighting.

The semantic-token paths use strict remapping, so they now respect generated-only regions.

### Diagnostics and other language features

Diagnostics and navigation-related features often need a best-effort source location even when TypeScript reports something in generated code.

For example, an error involving compiler-generated scaffolding should still be associated with the nearest relevant Civet expression. Returning a nearby source anchor is generally more useful than:

- exposing a generated `.civet.tsx` position,
- returning a position outside the Civet document, or
- discarding the diagnostic entirely.

For this reason, ordinary `remapPosition` retains its previous loose interpolation and walk-back behavior. The shared per-line lookup accepts whether generated-only segments should invalidate the current mapping:

- `remapPositionStrict`: generated-only segments clear the mapping.
- `remapPosition`: preserves the existing best-effort behavior.

This keeps the behavioral change limited to strict semantic-token filtering. Diagnostics, hover, navigation, and other ordinary remapping retain their previous behavior.

## Boundary handling

The implementation explicitly distinguishes positions around an unmapped segment boundary.

Given a mapped segment starting at column `0` and a generated-only segment starting at column `4`:

- Column `3` remains covered by the preceding mapped segment.
- Column `4` is unmapped.
- Later columns remain unmapped until another four-field segment begins.
- A later mapped segment resumes normal source mapping from its own boundary.

This prevents a later segment from incorrectly changing the result for a position immediately before it.

## Tests

Added focused source-map tests covering:

- positions immediately before a generated-only segment,
- positions exactly at the boundary,
- positions inside the generated-only region,
- mapping resuming after a later four-field segment, and
- ordinary non-strict remapping preserving its previous interpolation behavior.

Added an end-to-end LSP regression test based on all five cases from #2176:

- an implicitly returned loop,
- multiple loops where the final loop is returned,
- a non-returned earlier loop,
- a function with an explicit `void` return type, and
- a loop whose result is assigned.

The regression test verifies that TypeScript tokens for generated `results` and `push` code are not emitted anywhere on the source JSX lines.
