### PR TITLE
Keep JSX class shorthand at original position

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/parser": "^7.29.2",
-    "@danielx/civet": "0.11.12",
+    "@danielx/civet": "0.11.15",
     "@danielx/hera": "0.9.8",
     "@types/assert": "^1.5.6",
     "@types/babel__core": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     ],
     "exclude": [
       "source/parser/types.civet",
+      "source/ts-service/types.civet",
       "source/bun-civet.civet",
       "source/node-worker.civet",
       "lsp/zed/grammars/**"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^7.29.2
         version: 7.29.2
       '@danielx/civet':
-        specifier: 0.11.12
-        version: 0.11.12(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)
+        specifier: 0.11.15
+        version: 0.11.15(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)
       '@danielx/hera':
         specifier: 0.9.8
         version: 0.9.8
@@ -881,8 +881,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@danielx/civet@0.11.12':
-    resolution: {integrity: sha512-bckxDYPKRE10Vmf0LAKPL2sXnNJwDyNRChsIno+93UvSbHxTXoAP+1nCn8hASkvadeI0QKEDVYhiumglr0JsBg==}
+  '@danielx/civet@0.11.15':
+    resolution: {integrity: sha512-z1XFSukJMKaIiadrkhMP1rMCvr/aJE1n+KcABKEd5R5Nv2GcumW1tlPxElEH/Gkg/IFh/o1SBjeNUo7jhlIl/A==}
     engines: {node: '>=19 || ^18.6.0 || ^16.17.0'}
     hasBin: true
     peerDependencies:
@@ -8598,7 +8598,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@danielx/civet@0.11.12(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)':
+  '@danielx/civet@0.11.15(@danielx/hera@0.9.8)(typescript@6.0.2)(yaml@2.8.3)':
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       unplugin: 2.3.11

--- a/scripts/coverage-check.civet
+++ b/scripts/coverage-check.civet
@@ -72,6 +72,7 @@ try
     '--extension', '.ts'
     '--include', '**/source/ts-service/**'
     '--exclude', '**/node_modules/**'
+    '--exclude', '**/source/ts-service/types.civet'
     // Same rationale as coverage-merge.civet: keep sibling worktree copies and
     // the vendored zed grammar out of the on-demand ts-service report.
     '--exclude', '**/.claude/**'

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8267,11 +8267,6 @@ JSXAttributes
       else if attr is like {type: "JSXAttribute"}
         attrs.push [pair[0], attr]
     if classes#
-      function isBraced(c: ASTNode): c is Children
-        Array.isArray(c) and c[0] is like "{", {token: "{"}
-      function unbrace(c: Children): Children
-        // Remove leading "{" and trailing "}" tokens
-        c[<..<]
       function parseClass(token: string): string
         if token.startsWith "'"
           token = '"' +
@@ -8282,24 +8277,25 @@ JSXAttributes
       strings: string[] := []
       exprs: ASTNode[] := []
       for each let c: ASTNode of classes
-        while Array.isArray(c) and c# is 1 then c = c[0]
-        if isBraced c
-          exprs.push unbrace c
-          exprs.push ", "
-        else if c <? "string"
+        if c <? "string"
           strings.push parseClass c
         else if {type: "StringLiteral", token} := c
           strings.push parseClass token
         else if c?
-          exprs.push c
-          exprs.push ", "
+          // Remove braces
+          c = c[<..<] if Array.isArray(c) and c[0] is like "{", {token: "{"}
+          // Flush strings to preserve order
+          if strings#
+            if stringPart := strings.filter(Boolean).join(" ")
+              exprs.push JSON.stringify(stringPart), ", "
+            strings.length = 0
+          exprs.push c, ", "
 
       stringPart := strings.filter(Boolean).join(" ")
       let classValue
       if exprs# // some expressions
+        exprs.push JSON.stringify(stringPart), ", " if stringPart
         exprs.pop()  // remove trailing comma
-        if stringPart // some strings too
-          exprs.unshift(JSON.stringify(stringPart), ", ")
         if exprs# is 1
           // Single expression doesn't need array, filter, or join.
           root: ASTNode .= exprs[0]
@@ -8412,12 +8408,10 @@ JSXAttribute
       name = {...last, type: "ComputedPropertyName"}
       value = expr
       attrChildren = ["{...{", name, ": ", value, "}}"]
-    else if last.name
+    else
       {name} = last
       value = ["{", expr, "}"]
       attrChildren = [name, "=", value]
-    else
-      return $skip
     return {
       type: "JSXAttribute"
       name
@@ -8447,12 +8441,10 @@ JSXAttribute
       name = {...last, type: "ComputedPropertyName"}
       value = expr
       children = ["{...{", name, ": ", value, "}}"]
-    else if last.name
-      name = last.name
+    else
+      {name} = last
       value = ["{", expr, "}"]
       children = [name, "=", value]
-    else
-      return $skip
     return {
       type: "JSXAttribute"
       name

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8237,35 +8237,31 @@ JSXIdentifierName
 # https://facebook.github.io/jsx/#prod-JSXAttributes
 JSXAttributes
   ( Whitespace? JSXAttribute )* ->
-    // Extract all .class shorthands into `classes` array.
-    // Also record the original index of the first JSXClass so we can
-    // re-insert the synthesized attribute at that position rather than
-    // always prepending it.
+    // Extract all .class shorthands into `classes` array, remembering the
+    // position of the first one so the merged attribute keeps its source
+    // position relative to other attributes and spreads.
     classes := []
-    firstClassOriginalIndex .= -1
-    attrs .= $0.filter((pair, i) => {
+    insertIndex .= 0
+    kept .= 0
+    attrs .= $0.filter((pair) => {
       attr := pair[1]
       if attr.type is "JSXClass"
-        if firstClassOriginalIndex < 0
-          firstClassOriginalIndex = i
+        insertIndex = kept unless classes#
         classes.push(attr.class)
         return false
+      kept++
       return true
     })
     if classes#
-      // Check for non-shorthand class or className attribute.
-      // Track how many are removed before the first shorthand position
-      // so we can adjust the insertion index.
+      // Check for non-shorthand class or className attribute
       className .= config.react ? "className" : "class"
-      removedBeforeAnchor .= 0
       attrs = attrs.filter((pair: any, i) => {
         attr := pair[1]
         if (attr[0][0] is "class" or attr[0][0] is "className") and
             not attr[0][1]
           className = attr[0][0]
           classes.push(attr[1][attr[1].length-1])
-          if firstClassOriginalIndex >= 0 and i < firstClassOriginalIndex
-            removedBeforeAnchor++
+          insertIndex-- if i < insertIndex
           return false
         return true
       })
@@ -8316,11 +8312,11 @@ JSXAttributes
             classValue = ["{", ...exprs, "}"]
           else
             // Other expressions get `|| ""` to avoid e.g. `undefined` class.
-            classValue = ["{(", ...exprs, ') || ""}']
+            classValue = ["{(", ...exprs, ") || \"\"}"]
         else
           // In general, wrap expressions in array and filter out falsy values,
           // to avoid accidental e.g. `undefined` classes.
-          classValue = ["{[", ...exprs, '].filter(Boolean).join(" ")}']
+          classValue = ["{[", ...exprs, "].filter(Boolean).join(\" \")}"]
       else // strings only
         if not stringPart.includes('&') and not stringPart.includes('"')
           classValue = `"${stringPart}"`
@@ -8328,9 +8324,6 @@ JSXAttributes
           classValue = `'${stringPart}'`
         else
           classValue = `{${JSON.stringify(stringPart)}}`
-      // Insert at the position of the first .class shorthand, adjusted for
-      // any explicit class/className entries that were removed before it.
-      insertIndex := firstClassOriginalIndex < 0 ? 0 : firstClassOriginalIndex - removedBeforeAnchor
       attrs.splice(insertIndex, 0, [" ", [className, ["=", classValue]]])
     return attrs.map((pair) => {
       [space, attr] := pair

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -139,7 +139,7 @@ import type {
   IterationFamily,
   IterationStatement,
   JSXAttribute,
-  JSXAttributeInitializer,
+  JSXClass,
   Label,
   LabelledStatement,
   LexicalDeclaration,
@@ -8247,7 +8247,10 @@ JSXAttributes
     explicitClasses: ASTNode[] .= []
     className .= config.react ? "className" : "class"
     attrs: [ASTLeaf | ASTString | undefined, JSXAttribute][] := []
-    classAnchor: Children .= []
+    classAnchor: JSXAttribute .=
+      type: "JSXAttribute"
+      value: undefined
+      children: []
     for pair^[, attr] of $0
       if attr is like {type: "JSXClass"}
         unless classes#
@@ -8255,17 +8258,14 @@ JSXAttributes
           classes.push ...explicitClasses
           explicitClasses = classes
         classes.push attr.class
-      else if attr is like [["class", undefined], ...], [["className", undefined], ...]
+      else if attr is like {type: "JSXAttribute", name: ["class", undefined]}, {type: "JSXAttribute", name: ["className", undefined]}
         unless classes# or explicitClasses#
           classAnchor = attr
           attrs.push pair
-        initializer := attr[1]
-        classValue := initializer is like {type: "JSXAttributeInitializer"} ?
-          initializer.value : undefined
-        explicitClasses.push classValue
-        className = attr[0][0]
-      else
-        attrs.push pair
+        explicitClasses.push attr.value
+        className = attr.name[0]
+      else if attr is like {type: "JSXAttribute"}
+        attrs.push [pair[0], attr]
     if classes#
       function isBraced(c: ASTNode): c is Children
         Array.isArray(c) and c[0] is like "{", {token: "{"}
@@ -8328,23 +8328,21 @@ JSXAttributes
           classValue = `'${stringPart}'`
         else
           classValue = `{${JSON.stringify(stringPart)}}`
-      classAnchor[0] = className
-      classAnchor[1] =
-        type: "JSXAttributeInitializer"
-        value: classValue
-        children: ["=", classValue]
+      classAnchor.name = className
+      classAnchor.value = classValue
+      classAnchor.children = [className, "=", classValue]
     // Without a shorthand, leave explicit class attributes untouched.
     return (classes# ? attrs : $0).map (pair) =>
       [space, attr] := pair
       // Sometimes JSXAttribute adds a leading space to separate from previous.
       // Remove that space if there's already whitespace here.
-      if space and attr is like [" ", ...]
-        [space, attr[<..]]
+      if space and attr is like {type: "JSXAttribute", children: [" ", ...]}
+        [space, {...attr, children: attr.children[<..]}]
       else
         pair
 
 # NOTE: Merged SpreadAttribute and Attribute
-JSXAttribute ::JSXAttribute
+JSXAttribute
   # https://facebook.github.io/jsx/#prod-JSXSpreadAttribute
   # allows something like
   #   OpenBrace __ DotDotDot Expression __ CloseBrace
@@ -8353,31 +8351,47 @@ JSXAttribute ::JSXAttribute
   # {foo} is equivalent to foo={foo}, and
   # {foo, bar: baz} is equivalent to foo={foo} and bar={baz}.
   # {...foo} is a special case.
-  BracedObjectLiteral ->
-    return convertObjectToJSXAttributes($1)
+  BracedObjectLiteral:obj ::JSXAttribute ->
+    value := convertObjectToJSXAttributes(obj)
+    return {
+      type: "JSXAttribute"
+      value
+      children: value
+    }
 
   # https://facebook.github.io/jsx/#prod-JSXAttribute
-  JSXAttributeName:name ( JSXAttributeInitializer / &JSXAttributeSpace ):rawInitializer ->
+  JSXAttributeName:name ( JSXAttributeInitializer / &JSXAttributeSpace ):rawInitializer ::JSXAttribute ->
     // Hera 0.9.0: `&JSXAttributeSpace` assertion now yields `true`; normalize to falsy.
-    initializer: JSXAttributeInitializer? :=
-      rawInitializer <? "boolean" ? undefined : rawInitializer
+    initializer := rawInitializer <? "boolean" ? undefined : rawInitializer
+    value: ASTNode .= initializer?.value
+    let children: Children
     if name.type is "ComputedPropertyName"
       // React and SolidJS define a bare attribute to mean setting it to true.
-      value: NonNullASTNode .= initializer?.value ?? "true"
+      value ?= "true"
       // Strip off braces if present
-      if Array.isArray(value) and value[0] is like {token: "{"} and
-          value.-1 is like {token: "}"}
+      if Array.isArray(value) and value[0] is like {token: "{"} and value.-1 is like {token: "}"}
         value = value[<..<]
-      return ["{...{", name, ": ", value, "}}"]
+      children = ["{...{", name, ": ", value, "}}"]
     else
-      return [name, initializer]
+      children = [name, initializer?.children]
+    return {
+      type: "JSXAttribute"
+      name
+      value
+      children
+    }
 
   # NOTE: Adding ...foo shorthand for {...foo}
-  InsertInlineOpenBrace DotDotDot InlineJSXAttributeValue InsertCloseBrace &JSXAttributeSpace -> [$1, $2, $3, $4]
+  InsertInlineOpenBrace:open DotDotDot:dots InlineJSXAttributeValue:value InsertCloseBrace:close &JSXAttributeSpace ::JSXAttribute ->
+    return {
+      type: "JSXAttribute"
+      value
+      children: [open, dots, value, close]
+    }
 
   # NOTE: @foo and @@foo shorthands
   # for foo={this.foo} and foo={this.foo.bind(this)}
-  AtThis:at Identifier?:id InlineJSXCallExpressionRest*:rest &JSXAttributeSpace ->
+  AtThis:at Identifier?:id InlineJSXCallExpressionRest*:rest &JSXAttributeSpace ::JSXAttribute ->
     children := [ at, ...rest.flat() ]
     if id
       children.splice(1, 0, {
@@ -8391,49 +8405,85 @@ JSXAttribute ::JSXAttribute
     })
     last := lastAccessInCallExpression(expr)
     assert last, "AtThis+id/rest guarantees lastAccess"
+    let name: NonNullASTNode
+    let value: ASTNode
+    let attrChildren: Children
     if last.type is "Index"
-      return [
-        "{...{",
-        {...last, type: "ComputedPropertyName"},
-        ": ", expr, "}}"
-      ]
+      name = {...last, type: "ComputedPropertyName"}
+      value = expr
+      attrChildren = ["{...{", name, ": ", value, "}}"]
     else if last.name
-      return [last.name, "={", expr, "}"]
-    return $skip
+      {name} = last
+      value = ["{", expr, "}"]
+      attrChildren = [name, "=", value]
+    else
+      return $skip
+    return {
+      type: "JSXAttribute"
+      name
+      value
+      children: attrChildren
+    }
 
   # NOTE: foo(), foo.bar, foo?.bar, foo!, foo[bar], foo@bar don't need braces
-  Identifier:id InlineJSXCallExpressionRest+:rest &JSXAttributeSpace ->
+  Identifier:id InlineJSXCallExpressionRest+:rest &JSXAttributeSpace ::JSXAttribute ->
     expr := processCallMemberExpression({
       type: "CallExpression",
       children: [ id, ...rest.flat() ],
     })
     if expr!.type is "ObjectExpression"  // glob
-      return convertObjectToJSXAttributes(expr)
+      value := convertObjectToJSXAttributes expr
+      return {
+        type: "JSXAttribute"
+        value
+        children: value
+      }
     last := lastAccessInCallExpression(expr)
     assert last, "Identifier base guarantees lastAccess"
+    let name: NonNullASTNode
+    let value: ASTNode
+    let children: Children
     if last.type is "Index"
-      return [
-        "{...{",
-        {...last, type: "ComputedPropertyName"},
-        ": ", expr, "}}"
-      ]
+      name = {...last, type: "ComputedPropertyName"}
+      value = expr
+      children = ["{...{", name, ": ", value, "}}"]
     else if last.name
-      return [last.name, "={", expr, "}"]
-    return $skip
+      name = last.name
+      value = ["{", expr, "}"]
+      children = [name, "=", value]
+    else
+      return $skip
+    return {
+      type: "JSXAttribute"
+      name
+      value
+      children
+    }
 
   # NOTE: #id shorthand
-  "#" JSXShorthandString ->
-    return [ " ", "id=", $2 ]
-  Dot JSXShorthandString ->
+  "#" JSXShorthandString:value ::JSXAttribute ->
+    name := "id"
     return {
-      type: "JSXClass",
-      class: $2,
+      type: "JSXAttribute"
+      name
+      value
+      children: [" ", name, "=", value]
+    }
+  Dot JSXShorthandString ::JSXClass ->
+    return {
+      type: "JSXClass"
+      class: $2
     }
 
   # NOTE: Matching LiveScript flagging shorthand in addition +x -y !z -> x={true} y={false} z={false}
-  $[!+-]:toggle JSXAttributeName:id &JSXAttributeSpace ->
-    value := toggle is "+" ? "true" : "false"
-    return [ " ", id, "={", value, "}" ]
+  $[!+-]:toggle JSXAttributeName:name &JSXAttributeSpace ::JSXAttribute ->
+    value := ["{", toggle is "+" ? "true" : "false", "}"]
+    return {
+      type: "JSXAttribute"
+      name
+      value
+      children: [" ", name, "=", value]
+    }
 
 JSXAttributeSpace
   /[\s>]|\/>/
@@ -8466,19 +8516,17 @@ JSXAttributeName ::NonNullASTNode
   ComputedPropertyName
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeInitializer
-JSXAttributeInitializer ::JSXAttributeInitializer
+JSXAttributeInitializer ::{children: Children, value: ASTNode}
   # Outside CoffeeScript compatibility mode,
   # allow attribute value to be an indented expression
   # Forbid trailing expressions outside the indentation, as that should be JSX
   !CoffeeJSXEnabled Whitespace?:ws1 Equals:equals &( NonNewlineWhitespace* EOL ) InsertInlineOpenBrace:open NestedPostfixedExpressionNoTrailing:expression InsertCloseBrace:close ->
     value: Children := [open, trimFirstSpace(expression), close]
     return {
-      type: "JSXAttributeInitializer"
       value
       children: [ws1, equals, value]
     }
   Whitespace? Equals Whitespace? JSXAttributeValue:value -> {
-    type: "JSXAttributeInitializer"
     value
     children: $0
   }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8237,11 +8237,17 @@ JSXIdentifierName
 # https://facebook.github.io/jsx/#prod-JSXAttributes
 JSXAttributes
   ( Whitespace? JSXAttribute )* ->
-    // Extract all .class shorthands into `classes` array
+    // Extract all .class shorthands into `classes` array.
+    // Also record the original index of the first JSXClass so we can
+    // re-insert the synthesized attribute at that position rather than
+    // always prepending it.
     classes := []
-    attrs .= $0.filter((pair) => {
+    firstClassOriginalIndex .= -1
+    attrs .= $0.filter((pair, i) => {
       attr := pair[1]
       if attr.type is "JSXClass"
+        if firstClassOriginalIndex < 0
+          firstClassOriginalIndex = i
         classes.push(attr.class)
         return false
       return true
@@ -8317,7 +8323,18 @@ JSXAttributes
           classValue = `'${stringPart}'`
         else
           classValue = `{${JSON.stringify(stringPart)}}`
-      attrs.splice(0, 0, [" ", [className, ["=", classValue]]])
+      // Compute the adjusted insertion index: take the original index of the
+      // first JSXClass and subtract the number of JSXClass entries that were
+      // removed before it (each removed entry shifts subsequent indices down by 1).
+      // JSXClass entries before the anchor reduce its effective position, so
+      // the adjusted index equals the number of non-JSXClass entries originally
+      // before firstClassOriginalIndex (i.e. firstClassOriginalIndex minus
+      // the count of JSXClass entries before it, which is 0 since it IS first).
+      // Simplified: adjustedIndex = number of non-JSXClass pairs before anchor
+      // = firstClassOriginalIndex - 0 = firstClassOriginalIndex
+      // (no JSXClass entries precede the first one).
+      insertIndex := firstClassOriginalIndex < 0 ? 0 : firstClassOriginalIndex
+      attrs.splice(insertIndex, 0, [" ", [className, ["=", classValue]]])
     return attrs.map((pair) => {
       [space, attr] := pair
       // Sometimes JSXAttribute adds a leading space to separate from previous.

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8253,14 +8253,19 @@ JSXAttributes
       return true
     })
     if classes#
-      // Check for non-shorthand class or className attribute
+      // Check for non-shorthand class or className attribute.
+      // Track how many are removed before the first shorthand position
+      // so we can adjust the insertion index.
       className .= config.react ? "className" : "class"
-      attrs = attrs.filter((pair: any) => {
+      removedBeforeAnchor .= 0
+      attrs = attrs.filter((pair: any, i) => {
         attr := pair[1]
         if (attr[0][0] is "class" or attr[0][0] is "className") and
             not attr[0][1]
           className = attr[0][0]
           classes.push(attr[1][attr[1].length-1])
+          if firstClassOriginalIndex >= 0 and i < firstClassOriginalIndex
+            removedBeforeAnchor++
           return false
         return true
       })
@@ -8311,11 +8316,11 @@ JSXAttributes
             classValue = ["{", ...exprs, "}"]
           else
             // Other expressions get `|| ""` to avoid e.g. `undefined` class.
-            classValue = ["{(", ...exprs, ") || \"\"}"]
+            classValue = ["{(", ...exprs, ') || ""}']
         else
           // In general, wrap expressions in array and filter out falsy values,
           // to avoid accidental e.g. `undefined` classes.
-          classValue = ["{[", ...exprs, "].filter(Boolean).join(\" \")}"]
+          classValue = ["{[", ...exprs, '].filter(Boolean).join(" ")}']
       else // strings only
         if not stringPart.includes('&') and not stringPart.includes('"')
           classValue = `"${stringPart}"`
@@ -8323,17 +8328,9 @@ JSXAttributes
           classValue = `'${stringPart}'`
         else
           classValue = `{${JSON.stringify(stringPart)}}`
-      // Compute the adjusted insertion index: take the original index of the
-      // first JSXClass and subtract the number of JSXClass entries that were
-      // removed before it (each removed entry shifts subsequent indices down by 1).
-      // JSXClass entries before the anchor reduce its effective position, so
-      // the adjusted index equals the number of non-JSXClass entries originally
-      // before firstClassOriginalIndex (i.e. firstClassOriginalIndex minus
-      // the count of JSXClass entries before it, which is 0 since it IS first).
-      // Simplified: adjustedIndex = number of non-JSXClass pairs before anchor
-      // = firstClassOriginalIndex - 0 = firstClassOriginalIndex
-      // (no JSXClass entries precede the first one).
-      insertIndex := firstClassOriginalIndex < 0 ? 0 : firstClassOriginalIndex
+      // Insert at the position of the first .class shorthand, adjusted for
+      // any explicit class/className entries that were removed before it.
+      insertIndex := firstClassOriginalIndex < 0 ? 0 : firstClassOriginalIndex - removedBeforeAnchor
       attrs.splice(insertIndex, 0, [" ", [className, ["=", classValue]]])
     return attrs.map((pair) => {
       [space, attr] := pair

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -8255,16 +8255,22 @@ JSXAttributes
     if classes#
       // Check for non-shorthand class or className attribute
       className .= config.react ? "className" : "class"
+      // Each explicit class removed ahead of the anchor shifts it back one.
+      // Count them against the pre-filter indices, then adjust once, so the
+      // comparison isn't made against an already-shifted anchor.
+      anchor := insertIndex
+      removed .= 0
       attrs = attrs.filter((pair: any, i) => {
         attr := pair[1]
         if (attr[0][0] is "class" or attr[0][0] is "className") and
             not attr[0][1]
           className = attr[0][0]
           classes.push(attr[1][attr[1].length-1])
-          insertIndex-- if i < insertIndex
+          removed++ if i < anchor
           return false
         return true
       })
+      insertIndex = anchor - removed
       function isBraced(c: any) {
         return c[0] === "{" || c[0]?.token === "{"
       }

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -93,6 +93,7 @@ import type {
   ASTLeaf,
   ASTNode,
   ASTRef,
+  ASTString,
   BinaryOp,
   BinaryOpRHS,
   Binding,
@@ -137,6 +138,8 @@ import type {
   IterationExpression,
   IterationFamily,
   IterationStatement,
+  JSXAttribute,
+  JSXAttributeInitializer,
   Label,
   LabelledStatement,
   LexicalDeclaration,
@@ -181,6 +184,7 @@ import type {
   TypeArgumentList,
   TypeFunction,
   TypeNode,
+  TypeParameters,
   TypeSuffix,
   TypeTuple,
   VoidType,
@@ -7604,7 +7608,7 @@ __
   /(?=\s|\/|#)/ ( Whitespace / Comment )* -> $2
   ""
 
-Whitespace
+Whitespace ::ASTLeaf
   [\s]+ ->
     return { $loc, token: $0 }
 
@@ -8237,65 +8241,58 @@ JSXIdentifierName
 # https://facebook.github.io/jsx/#prod-JSXAttributes
 JSXAttributes
   ( Whitespace? JSXAttribute )* ->
-    // Extract all .class shorthands into `classes` array, remembering the
-    // position of the first one so the merged attribute keeps its source
-    // position relative to other attributes and spreads.
-    classes := []
-    insertIndex .= 0
-    kept .= 0
-    attrs .= $0.filter((pair) => {
-      attr := pair[1]
-      if attr.type is "JSXClass"
-        insertIndex = kept unless classes#
-        classes.push(attr.class)
-        return false
-      kept++
-      return true
-    })
+    // Collect all class sources while retaining only the first one's
+    // attribute pair as an anchor for the merged attribute.
+    classes: ASTNode[] := []
+    explicitClasses: ASTNode[] .= []
+    className .= config.react ? "className" : "class"
+    attrs: [ASTLeaf | ASTString | undefined, JSXAttribute][] := []
+    classAnchor: Children .= []
+    for pair^[, attr] of $0
+      if attr is like {type: "JSXClass"}
+        unless classes#
+          attrs.push [" ", classAnchor] unless explicitClasses#
+          classes.push ...explicitClasses
+          explicitClasses = classes
+        classes.push attr.class
+      else if attr is like [["class", undefined], ...], [["className", undefined], ...]
+        unless classes# or explicitClasses#
+          classAnchor = attr
+          attrs.push pair
+        initializer := attr[1]
+        classValue := initializer is like {type: "JSXAttributeInitializer"} ?
+          initializer.value : undefined
+        explicitClasses.push classValue
+        className = attr[0][0]
+      else
+        attrs.push pair
     if classes#
-      // Check for non-shorthand class or className attribute
-      className .= config.react ? "className" : "class"
-      // Each explicit class removed ahead of the anchor shifts it back one.
-      // Count them against the pre-filter indices, then adjust once, so the
-      // comparison isn't made against an already-shifted anchor.
-      anchor := insertIndex
-      removed .= 0
-      attrs = attrs.filter((pair: any, i) => {
-        attr := pair[1]
-        if (attr[0][0] is "class" or attr[0][0] is "className") and
-            not attr[0][1]
-          className = attr[0][0]
-          classes.push(attr[1][attr[1].length-1])
-          removed++ if i < anchor
-          return false
-        return true
-      })
-      insertIndex = anchor - removed
-      function isBraced(c: any) {
-        return c[0] === "{" || c[0]?.token === "{"
-      }
-      function unbrace(c: any) {
+      function isBraced(c: ASTNode): c is Children
+        Array.isArray(c) and c[0] is like "{", {token: "{"}
+      function unbrace(c: Children): Children
         // Remove leading "{" and trailing "}" tokens
-        return c.slice(1, -1)
-      }
-      function parseClass(c: any) {
-        c = c.token || c
-        if (c.startsWith("'")) {
-          c = '"' +
-            c.slice(1, -1)
+        c[<..<]
+      function parseClass(token: string): string
+        if token.startsWith "'"
+          token = '"' +
+            token[<..<]
             .replace(/\\*"/g, (m: string) => m# % 2 == 0 ? m : "\\"+m) +
             '"'
-        }
-        return JSON.parse(c)
-      }
-      [strings, exprs] := [[], []]
-      classes.forEach (c) =>
+        JSON.parse token
+      strings: string[] := []
+      exprs: ASTNode[] := []
+      for each let c: ASTNode of classes
+        while Array.isArray(c) and c# is 1 then c = c[0]
         if isBraced c
-          exprs.push(unbrace(c))
-          exprs.push(", ")
-        else
-          strings.push(parseClass(c))
-        return
+          exprs.push unbrace c
+          exprs.push ", "
+        else if c <? "string"
+          strings.push parseClass c
+        else if {type: "StringLiteral", token} := c
+          strings.push parseClass token
+        else if c?
+          exprs.push c
+          exprs.push ", "
 
       stringPart := strings.filter(Boolean).join(" ")
       let classValue
@@ -8305,15 +8302,16 @@ JSXAttributes
           exprs.unshift(JSON.stringify(stringPart), ", ")
         if exprs# is 1
           // Single expression doesn't need array, filter, or join.
-          root .= exprs[0]
+          root: ASTNode .= exprs[0]
           // Remove trailing whitespace, e.g. in JSXShorthandString rule
-          while root# and isWhitespaceOrEmpty(root[root#-1])
-            root = root.slice(0, -1)
+          while Array.isArray(root) and root# and isWhitespaceOrEmpty root.-1
+            root = root[..<]
           // Unwrap possibly resulting singleton arrays
-          while root?# is 1 then root = root[0]
+          while Array.isArray(root) and root# is 1 then root = root[0]
           // processUnaryExpression wraps in {children: [...]}
-          root = root.children if root?.children
-          if root?.[0]?.token is "`"
+          if root is like {children} and Array.isArray root.children
+            root = root.children
+          if Array.isArray(root) and root[0] is like {token: "`"}
             // Template literals work just as-is.
             classValue = ["{", ...exprs, "}"]
           else
@@ -8330,18 +8328,23 @@ JSXAttributes
           classValue = `'${stringPart}'`
         else
           classValue = `{${JSON.stringify(stringPart)}}`
-      attrs.splice(insertIndex, 0, [" ", [className, ["=", classValue]]])
-    return attrs.map((pair) => {
+      classAnchor[0] = className
+      classAnchor[1] =
+        type: "JSXAttributeInitializer"
+        value: classValue
+        children: ["=", classValue]
+    // Without a shorthand, leave explicit class attributes untouched.
+    return (classes# ? attrs : $0).map (pair) =>
       [space, attr] := pair
       // Sometimes JSXAttribute adds a leading space to separate from previous.
       // Remove that space if there's already whitespace here.
-      if space and attr[0] is " "
-        pair = [space, attr.slice(1)]
-      return pair
-    })
+      if space and attr is like [" ", ...]
+        [space, attr[<..]]
+      else
+        pair
 
 # NOTE: Merged SpreadAttribute and Attribute
-JSXAttribute
+JSXAttribute ::JSXAttribute
   # https://facebook.github.io/jsx/#prod-JSXSpreadAttribute
   # allows something like
   #   OpenBrace __ DotDotDot Expression __ CloseBrace
@@ -8354,24 +8357,20 @@ JSXAttribute
     return convertObjectToJSXAttributes($1)
 
   # https://facebook.github.io/jsx/#prod-JSXAttribute
-  JSXAttributeName:name ( JSXAttributeInitializer / &JSXAttributeSpace ):value ->
+  JSXAttributeName:name ( JSXAttributeInitializer / &JSXAttributeSpace ):rawInitializer ->
     // Hera 0.9.0: `&JSXAttributeSpace` assertion now yields `true`; normalize to falsy.
-    value = undefined if value <? "boolean"
+    initializer: JSXAttributeInitializer? :=
+      rawInitializer <? "boolean" ? undefined : rawInitializer
     if name.type is "ComputedPropertyName"
-      if value
-        // Strip off equals sign and whitespace from JSXAttributeInitializer
-        value = value[value#-1]
-        // Strip off braces if present
-        if value[0]?.token is "{" and
-            value[value#-1]?.token is "}"
-          value = value.slice(1, -1)
-      else
-        // React and SolidJS define a bare attribute to mean setting it to true.
-        // We need to specify a value here, so this seems a reasonable choice.
-        value = "true"
+      // React and SolidJS define a bare attribute to mean setting it to true.
+      value: NonNullASTNode .= initializer?.value ?? "true"
+      // Strip off braces if present
+      if Array.isArray(value) and value[0] is like {token: "{"} and
+          value.-1 is like {token: "}"}
+        value = value[<..<]
       return ["{...{", name, ": ", value, "}}"]
     else
-      return [name, value]
+      return [name, initializer]
 
   # NOTE: Adding ...foo shorthand for {...foo}
   InsertInlineOpenBrace DotDotDot InlineJSXAttributeValue InsertCloseBrace &JSXAttributeSpace -> [$1, $2, $3, $4]
@@ -8450,7 +8449,7 @@ JSXShorthandString
   OpenBrace PostfixedExpressionOrCommaLoop __ CloseBrace
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeName
-JSXAttributeName
+JSXAttributeName ::NonNullASTNode
   # `<div 😊={x}>` — tried first so it claims the whole identifier (incl.
   # ASCII parts adjacent to unicode); wrapped as a synthetic
   # ComputedPropertyName so JSXAttribute emits `{...{"😊": value}}`.
@@ -8467,13 +8466,22 @@ JSXAttributeName
   ComputedPropertyName
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeInitializer
-JSXAttributeInitializer
+JSXAttributeInitializer ::JSXAttributeInitializer
   # Outside CoffeeScript compatibility mode,
   # allow attribute value to be an indented expression
   # Forbid trailing expressions outside the indentation, as that should be JSX
   !CoffeeJSXEnabled Whitespace?:ws1 Equals:equals &( NonNewlineWhitespace* EOL ) InsertInlineOpenBrace:open NestedPostfixedExpressionNoTrailing:expression InsertCloseBrace:close ->
-    return [ ws1, equals, open, trimFirstSpace(expression), close ]
-  Whitespace? Equals Whitespace? JSXAttributeValue
+    value: Children := [open, trimFirstSpace(expression), close]
+    return {
+      type: "JSXAttributeInitializer"
+      value
+      children: [ws1, equals, value]
+    }
+  Whitespace? Equals Whitespace? JSXAttributeValue:value -> {
+    type: "JSXAttributeInitializer"
+    value
+    children: $0
+  }
 
 # https://facebook.github.io/jsx/#prod-JSXAttributeValue
 JSXAttributeValue
@@ -9386,7 +9394,7 @@ TypeIdentifier
     return {
       type: "TypeIdentifier",
       children: $0,
-      raw: [$2.name, ...$3.map(([dot, id]) => dot.token + id.name), ].join(''),
+      raw: [$2.name, ...$3.map(([, id]) => "." + id.name), ].join(''),
       args,
     }
   _? BasicThisLiteral ->
@@ -9793,7 +9801,7 @@ TypeArgument
 TypeArgumentDelimiter
   TypeParameterDelimiter
 
-TypeParameters
+TypeParameters ::TypeParameters
   OpenAngleBracket TypeParameter+:parameters __ CloseAngleBracket ->
     return {
       type: "TypeParameters",

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1135,7 +1135,7 @@ function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynami
 // {foo} is equivalent to foo={foo}, and
 // {foo, bar: baz} is equivalent to foo={foo} and bar={baz}.
 // {...foo} is a special case.
-function convertObjectToJSXAttributes(obj: ObjectExpression)
+function convertObjectToJSXAttributes(obj: ObjectExpression): Children
   parts := [] // JSX attributes
   rest := []  // parts that need to be in {...rest} form
   for part, i of obj.properties

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -122,7 +122,7 @@ export type OtherNode =
   | OperatorImportClause
   | Index
   | Initializer
-  | JSXAttributeInitializer
+  | JSXAttribute
   | Keyword
   | Label
   | LiteralContent
@@ -1660,10 +1660,9 @@ export type WithClause = ASTParent &
   targets: [WSNode, ExpressionNode][]
 
 // JSX
-export type JSXAttribute = NonNullASTNode | JSXClass
-
-export type JSXAttributeInitializer = ASTParent &
-  type: "JSXAttributeInitializer"
+export type JSXAttribute = ASTParent &
+  type: "JSXAttribute"
+  name?: NonNullASTNode
   value: ASTNode
 
 export type JSXClass =

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -122,6 +122,7 @@ export type OtherNode =
   | OperatorImportClause
   | Index
   | Initializer
+  | JSXAttributeInitializer
   | Keyword
   | Label
   | LiteralContent
@@ -157,6 +158,7 @@ export type OtherNode =
   | TypeArgument
   | TypeArguments
   | TypeCondition
+  | TypeParameters
   | TypeSuffix
   | WhenClause
   | Yield
@@ -1183,7 +1185,7 @@ export type NamedBindingPattern = ASTParent &
 export type HasSubbinding = BindingProperty | NamedBindingPattern
 
 // _?, __
-export type Whitespace = (ASTLeaf | ASTString | CommentNode)[]?
+export type Whitespace = ASTString | (ASTLeaf | ASTString | CommentNode)[]?
 
 export type Delimiter = ASTLeaf | ASTString | Delimiter[]
 
@@ -1449,7 +1451,10 @@ export type FunctionParameter =
 type AccessModifier = ASTNode
 type ParameterElementDelimiter = ASTNode
 
-export type TypeParameters = ASTNode
+export type TypeParameters = ASTParent &
+  type: "TypeParameters"
+  parameters: ASTNode[]
+  ts: true
 
 export type FunctionNode = FunctionExpression | ArrowFunction | MethodDefinition
 
@@ -1653,3 +1658,14 @@ export type ThisAssignments = ThisAssignment[]
 export type WithClause = ASTParent &
   type: "WithClause"
   targets: [WSNode, ExpressionNode][]
+
+// JSX
+export type JSXAttribute = NonNullASTNode | JSXClass
+
+export type JSXAttributeInitializer = ASTParent &
+  type: "JSXAttributeInitializer"
+  value: ASTNode
+
+export type JSXClass =
+  type: "JSXClass"
+  class: NonNullASTNode

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -601,7 +601,7 @@ describe "JSX class shorthand", ->
     ---
     <div#id.foo/>
     ---
-    <div class="foo" id="id"/>
+    <div id="id" class="foo"/>
   """
 
   testCase """
@@ -609,7 +609,7 @@ describe "JSX class shorthand", ->
     ---
     <div#id.class1.class2.t-[5px].{myClass()} class={anotherClass}/>
     ---
-    <div class={["class1 class2 t-[5px]", myClass(), anotherClass].filter(Boolean).join(" ")} id="id"/>
+    <div id="id" class={["class1 class2 t-[5px]", myClass(), anotherClass].filter(Boolean).join(" ")}/>
   """
 
   testCase """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -507,6 +507,14 @@ describe "JSX class shorthand", ->
   """
 
   testCase """
+    bare class before shorthand
+    ---
+    <div class .foo/>
+    ---
+    <div class="foo"/>
+  """
+
+  testCase """
     two classes without space
     ---
     <div .foo.bar/>
@@ -556,11 +564,32 @@ describe "JSX class shorthand", ->
   """
 
   testCase """
+    shorthand with indented class
+    ---
+    <div .bar class=
+      foo
+    />
+    ---
+    <div class={["bar",\x20
+      foo].filter(Boolean).join(" ")}
+    />
+  """
+
+  testCase """
     short and long className
     ---
     <div .foo className={bar()} />
     ---
     <div className={["foo", bar()].filter(Boolean).join(" ")} />
+  """
+
+  testCase """
+    react: explicit class resets attribute name
+    ---
+    "civet react"
+    <div class="bar" .foo />
+    ---
+    <div class="bar foo" />
   """
 
   testCase """
@@ -654,11 +683,36 @@ describe "JSX class shorthand", ->
   """
 
   testCase """
+    explicit class before spread anchors later shorthand
+    ---
+    <div class="a" {...props} .b />
+    ---
+    <div class="a b" {...props} />
+  """
+
+  testCase """
+    shorthand before spread anchors later explicit class
+    ---
+    <div .a {...props} class="b" />
+    ---
+    <div class="a b" {...props} />
+  """
+
+  testCase """
+    react: explicit className before spread anchors later shorthand
+    ---
+    "civet react"
+    <div className="a" {...props} .b />
+    ---
+    <div className="a b" {...props} />
+  """
+
+  testCase """
     explicit class before shorthand before spread
     ---
     <div class="a" .b {...props} />
     ---
-    <div class="b a" {...props} />
+    <div class="a b" {...props} />
   """
 
   testCase """
@@ -666,7 +720,7 @@ describe "JSX class shorthand", ->
     ---
     <div class="a" class="b" .c {...props} />
     ---
-    <div class="c a b" {...props} />
+    <div class="a b c" {...props} />
   """
 
   throws """
@@ -766,6 +820,18 @@ describe "JSX object literal shorthand", ->
       >
         Hello
       </div>
+    """
+
+    testCase """
+      computed name
+      ---
+      <div 😊=
+        foo
+      />
+      ---
+      <div {...{"😊":\x20
+        foo}}
+      />
     """
 
     testCase """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -617,7 +617,40 @@ describe "JSX class shorthand", ->
     ---
     <div x .y>
     ---
-    <div class="y" x />
+    <div x class="y" />
+  """
+
+  testCase """
+    spread before class shorthand
+    ---
+    <div {...props} .foo />
+    ---
+    <div {...props} class="foo" />
+  """
+
+  testCase """
+    react: attrs before class shorthand
+    ---
+    "civet react"
+    <div onClick={f} .foo />
+    ---
+    <div onClick={f} className="foo" />
+  """
+
+  testCase """
+    multiple shorthands interleaved with attrs
+    ---
+    <div x .foo y .bar z />
+    ---
+    <div x class="foo bar" y z />
+  """
+
+  testCase """
+    class shorthand before spread stays before spread
+    ---
+    <div .foo {...props} />
+    ---
+    <div class="foo" {...props} />
   """
 
   throws """

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -653,6 +653,14 @@ describe "JSX class shorthand", ->
     <div class="foo" {...props} />
   """
 
+  testCase """
+    explicit class before shorthand before spread
+    ---
+    <div class="a" .b {...props} />
+    ---
+    <div class="b a" {...props} />
+  """
+
   throws """
     requires space between attribute and class shorthand
     ---

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -576,6 +576,14 @@ describe "JSX class shorthand", ->
   """
 
   testCase """
+    shorthand with JSX element class
+    ---
+    <div class=<Foo /> .bar />
+    ---
+    <div class={[<Foo />, "bar"].filter(Boolean).join(" ")} />
+  """
+
+  testCase """
     short and long className
     ---
     <div .foo className={bar()} />

--- a/test/jsx/attr.civet
+++ b/test/jsx/attr.civet
@@ -661,6 +661,14 @@ describe "JSX class shorthand", ->
     <div class="b a" {...props} />
   """
 
+  testCase """
+    multiple explicit classes before shorthand before spread
+    ---
+    <div class="a" class="b" .c {...props} />
+    ---
+    <div class="c a b" {...props} />
+  """
+
   throws """
     requires space between attribute and class shorthand
     ---


### PR DESCRIPTION
Spaced `.class` shorthands get merged into a single `class`/`className` attribute, but the merged attribute was always spliced in at index 0. That moves it ahead of attributes that came before it in the source.

Mostly cosmetic, except with spreads, where position decides precedence:

```jsx
<div {...props} .foo />
```

should emit `<div {...props} class="foo" />` so the explicit class wins. Front-insertion gave `<div class="foo" {...props} />` instead, letting the spread clobber it.

## Fix

Track where the first shorthand lands among the surviving attributes and splice there. Explicit `class`/`className` attributes are pulled into the merge too, so removing one ahead of the anchor shifts it back by one.

`#id` is lowered in place by the grammar and never had this problem — but a couple of existing fixtures did assert the old ordering (`<div#id.foo/>` used to put `class` before an `id` that preceded it in source), so those expectations are updated.

## Tests

Five new fixtures in `test/jsx/attr.civet` covering spreads on both sides of the shorthand, React `className`, interleaved shorthands, and an explicit `class` before the anchor.
