### PR TITLE
Fix pattern destructuring in some `for` loops

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -28,6 +28,7 @@ import {
   escapeIdentifier,
   expressionizeTypeIf,
   declarationIterand,
+  forDeclarationPatternPrefix,
   forRange,
   gatherBindingCode,
   gatherBindingPatternTypeSuffix,
@@ -67,6 +68,7 @@ import {
   processProgram,
   processProgramAsync,
   processRangeExpression,
+  pushForBlockDeclaration,
   processTryBlock,
   processUnaryExpression,
   processUnaryNestedExpression,
@@ -5619,7 +5621,9 @@ CoffeeForStatementParameters ::ForStatementControl
       varRef := declaration
       increment .= "++"
       let indexAssignment
-      assignmentNames .= [...varRef.names]
+      // Explicit declarations use pushForBlockDeclaration below; only Coffee's
+      // assignment form needs names here.
+      assignmentNames .= varRef.decl ? [] : [...varRef.names]
 
       if index
         index = trimFirstSpace(index)
@@ -5635,11 +5639,8 @@ CoffeeForStatementParameters ::ForStatementControl
         // With a declaration kind (const/let/var), emit a Declaration node so
         // autoVar doesn't also hoist the name. varRef already includes the
         // keyword in its children.
-        blockPrefix./**/push(["", {
-          type: "Declaration",
-          children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
-          names: [],
-        }, ";"])
+        pushForBlockDeclaration blockPrefix, varRef,
+          [expRef, "[", indexAssignment, counterRef, "]"], true
       else
         blockPrefix./**/push(["", {
           type: "AssignmentExpression",
@@ -5683,6 +5684,7 @@ CoffeeForStatementParameters ::ForStatementControl
         blockPrefix
       }
 
+    blockPrefix.unshift ...forDeclarationPatternPrefix(declaration)
     return {
       declaration
       iterand: declarationIterand declaration

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -56,7 +56,6 @@ import {
 } from ./pattern-matching.civet
 
 import {
-  append
   assert
   convertOptionalType
   getTrimmingSpace
@@ -185,20 +184,6 @@ function processDeclarations(statements: StatementTuple[]): void
       // ExportDeclaration), try to pull out any statement expressions
       if initializer and blockContainingStatement declaration
         prependStatementExpressionBlock initializer, declaration
-
-  for each statement of gatherRecursiveAll statements, .type is "ForStatement"
-    { declaration } := statement
-    continue unless declaration?.type is "ForDeclaration"
-    { binding } := declaration
-    blockPrefix := getPatternBlockPrefix
-      binding.pattern
-      undefined
-      append declaration.decl, " "
-      binding.typeSuffix
-    simplifyBindingProperties binding
-    if blockPrefix?
-      statement.block.expressions.unshift ...blockPrefix
-      braceBlock statement.block
 
 function prependStatementExpressionBlock(initializer: Initializer, statement: ASTNodeParent): ASTRef?
   {expression: exp} .= initializer

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -15,6 +15,7 @@ import type {
 } from ./types.civet
 
 import {
+  append
   checkValidLHS
   convertOptionalType
   isBigIntLiteral
@@ -37,6 +38,77 @@ import {
 import {
   getHelperRef
 } from ./helper.civet
+
+import {
+  simplifyBindingProperties
+} from ./binding.civet
+
+import {
+  getPatternBlockPrefix
+} from ./pattern-matching.civet
+
+/**
+ * Build the loop-body statements required by a source `ForDeclaration`
+ * pattern, such as named destructuring, post-rest splices, and `@` bindings.
+ */
+function forDeclarationPatternPrefix(
+  declaration: ASTNode
+  implicitLift = false
+): StatementTuple[]
+  return [] unless declaration?.type is "ForDeclaration"
+  { binding } := declaration
+  prefix := getPatternBlockPrefix
+    binding.pattern
+    undefined
+    append(declaration.decl, " ")
+    binding.typeSuffix
+  simplifyBindingProperties binding
+  return [] unless prefix
+  if implicitLift
+    for [, statement] of prefix
+      if statement?.type is "Declaration"
+        (statement as Declaration | ForControlDeclaration).implicitLift = true
+  prefix
+
+/**
+ * Add a loop-body binding followed by any statements required by its pattern,
+ * merging adjacent declarations with the same var/const/let kind when possible.
+ */
+function pushForBlockDeclaration(
+  blockPrefix: StatementTuple[]
+  decl: NonNullASTNode
+  value: ASTNode
+  implicitLift = false
+): void
+  unless decl.type is "ForDeclaration" // assignment like `for x.y of ...` - no declaration
+    blockPrefix.push ["", [trimFirstSpace(decl), " = ", value], ";"]
+    return
+  binding := trimFirstSpace decl.binding // portion of decl to use when appending to previous
+  previous := blockPrefix.-1?[1]
+  previousImplicitLift := previous? and "implicitLift" in previous and previous.implicitLift
+  if previous?.type is "Declaration" and Boolean(previousImplicitLift) is implicitLift and previous.decl is decl.decl
+    previous.children.push ", ", binding, " = ", value
+    previous.names.push ...namesOf(decl)
+  else
+    blockPrefix.push ["", {
+      type: "Declaration"
+      children: [decl, " = ", value]
+      decl.decl
+      // names may get mutated by future pushForBlockDeclaration, so duplicate
+      names: [...namesOf(decl)]
+      implicitLift
+    }, ";"]
+
+  // Add pattern follow-ups. Any initial declaration is guaranteed to match
+  // the loop binding just created, so merge them.
+  patternPrefix := forDeclarationPatternPrefix(decl, implicitLift)
+  if patternPrefix.0?[1]?.type is "Declaration"
+    patternDeclaration := patternPrefix.shift()![1] as Declaration | ForControlDeclaration
+    patternPrevious := blockPrefix.-1![1] as Declaration | ForControlDeclaration
+    [, ...patternChildren] := patternDeclaration.children
+    patternPrevious.children.push ", ", ...trimFirstSpace(patternChildren)
+    patternPrevious.names.push ...namesOf(patternDeclaration)
+  blockPrefix.push ...patternPrefix
 
 function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, end: ASTNode)
   ws1 = [ws1, range.children[0]] // whitespace before ..
@@ -241,7 +313,8 @@ function forRange(
       . stepRef
 
   let varAssign: ASTNode[] = [], varLetAssign = varAssign, varLet = varAssign
-  let blockPrefix: StatementTuple[]?
+  blockPrefix: StatementTuple[] := []
+  bindingInBlock .= false
   names .= namesOf forDeclaration
   if forDeclaration?
     if forDeclaration.type is "AssignmentExpression" // Coffee-style for loop
@@ -253,9 +326,11 @@ function forRange(
       varLet = [",", ...varName, " = ", counterRef]
     else // const or var or assignment like `for x[y] of z`: put inside loop
       value := start?.type is "Literal" and start.subtype is "StringLiteral" ? ["String.fromCharCode(", counterRef, ")"] : counterRef
-      blockPrefix = [
-        ["", [forDeclaration, " = ", value], ";"]
-      ]
+      pushForBlockDeclaration blockPrefix, forDeclaration, value, true
+      bindingInBlock = true
+
+  unless bindingInBlock
+    blockPrefix.unshift ...forDeclarationPatternPrefix(forDeclaration)
 
   declaration: Declaration := {
     type: "Declaration"
@@ -414,31 +489,6 @@ function processForInOf($0: [
   let hoistDec: ASTNode?
   blockPrefix: StatementTuple[] := []
 
-  /** Add a loop-body declaration, appending to the previous one if it has the same var/const/let kind. */
-  function pushBlockDeclaration(
-    decl: NonNullASTNode
-    value: ASTNode
-    implicitLift = false
-  ): void
-    unless decl.type is "ForDeclaration" // assignment like `for x.y of ...` - no declaration
-      blockPrefix.push ["", [trimFirstSpace(decl), " = ", value], ";"]
-      return
-    binding := trimFirstSpace decl.binding // portion of decl to use when appending to previous
-    previous := blockPrefix.-1?[1]
-    previousImplicitLift := previous? and "implicitLift" in previous and previous.implicitLift
-    if previous?.type is "Declaration" and Boolean(previousImplicitLift) is implicitLift and previous.decl is decl.decl
-      previous.children.push ", ", binding, " = ", value
-      previous.names.push ...namesOf(decl)
-    else
-      blockPrefix.push ["", {
-        type: "Declaration"
-        children: [decl, " = ", value]
-        decl.decl
-        // names may get mutated by future pushBlockDeclaration, so duplicate
-        names: [...namesOf(decl)]
-        implicitLift
-      }, ";"]
-
   // for each item[, index] of array
   // for each item1, item2[, index] of array1, array2
   if each
@@ -501,9 +551,9 @@ function processForInOf($0: [
         value := not cycles[i]? and defaultValues[i]? is not "undefined"
           ? [counterRef, " < ", lengthRefs[i], " ? ", itemValue, " : ", trimFirstSpace(defaultValues[i])]
           : itemValue
-        pushBlockDeclaration decl, value, true
+        pushForBlockDeclaration blockPrefix, decl, value, true
       if indexDeclaration
-        pushBlockDeclaration indexDeclaration, counterRef, true
+        pushForBlockDeclaration blockPrefix, indexDeclaration, counterRef, true
 
       condition := lenIndices# ? [counterRef, " < ", endRef, "; "] : ["; "]
       children := [...errors, open, declaration, "; ", condition, counterRef, "++", close]
@@ -562,9 +612,9 @@ function processForInOf($0: [
     for each decl, i of itemDeclarations
       value .= [nextRefs[i], "?.value"]
       value = [nextRefs[i], "?.done ? ", trimFirstSpace(defaultValues[i]), " : ", ...value] if defaultValues[i]?
-      pushBlockDeclaration decl, value
+      pushForBlockDeclaration blockPrefix, decl, value
     if indexDeclaration
-      pushBlockDeclaration indexDeclaration, counterRef
+      pushForBlockDeclaration blockPrefix, indexDeclaration, counterRef
 
     return {
       declaration
@@ -596,11 +646,7 @@ function processForInOf($0: [
     inOf.token is "in" and indexDeclaration and pattern?.type is not "Identifier"
   )
     itemRef := makeRef if inOf.token is "in" then "key" else "item"
-    blockPrefix.push(["", {
-      type: "Declaration"
-      children: [declaration, " = ", itemRef]
-      names: namesOf declaration
-    } satisfies ForControlDeclaration, ";"])
+    pushForBlockDeclaration blockPrefix, declaration, itemRef
     declaration =
       type: "ForDeclaration"
       binding: {
@@ -618,6 +664,7 @@ function processForInOf($0: [
       pattern = itemRef
 
   unless indexDeclaration or own
+    blockPrefix.unshift ...forDeclarationPatternPrefix(declaration)
     return {
       declaration
       iterand
@@ -634,18 +681,10 @@ function processForInOf($0: [
         decl: "let"
         names: []
       } satisfies ForControlDeclaration
-      indexDecl := indexDeclaration!
-      indexAssignment: ASTNode :=
-        if indexDecl.type is "ForDeclaration"
-          {
-            type: "Declaration"
-            children: [trimFirstSpace(indexDecl), " = ", counterRef, "++"]
-            indexDecl.names
-            decl: indexDecl.decl
-          } satisfies ForControlDeclaration
-        else
-          [trimFirstSpace(indexDecl), " = ", counterRef, "++"]
-      blockPrefix.push(["", indexAssignment, ";"])
+      indexDecl := trimFirstSpace indexDeclaration!
+      indexPrefix: StatementTuple[] := []
+      pushForBlockDeclaration indexPrefix, indexDecl, [counterRef, "++"]
+      blockPrefix.push ...indexPrefix
 
     // grammar guarantees inOf.token is "of" or "in" only
     when "in" // for key, value in object
@@ -675,29 +714,12 @@ function processForInOf($0: [
                 type: "Index"
                 expression: trimmedPattern
                 children: [ "[", trimmedPattern, "]" ]
-        blockPrefix.push ["",
-          if indexDeclaration.type is "ForDeclaration"
-            { binding, children } := indexDeclaration
-            binding.children.push binding.initializer = makeNode {}
-              type: "Initializer"
-              expression
-              children: ["", " = ", expression]
-            makeNode
-              type: "Declaration"
-              children: [
-                ...trimFirstSpace(children) as ASTNode[]
-              ]
-              bindings: [indexDeclaration.binding]
-              decl: indexDeclaration.decl
-              names: indexDeclaration.names
-          else
-            [
-              trimFirstSpace(indexDeclaration), " = "
-              trimFirstSpace(expRef)
-              "[", trimFirstSpace(pattern), "]"
-            ]
-          ";"]
+        indexDecl := trimFirstSpace indexDeclaration
+        indexPrefix: StatementTuple[] := []
+        pushForBlockDeclaration indexPrefix, indexDecl, expression
+        blockPrefix.push ...indexPrefix
 
+  blockPrefix.unshift ...forDeclarationPatternPrefix(declaration)
   return {
     declaration,
     iterand,
@@ -708,7 +730,9 @@ function processForInOf($0: [
 
 export {
   declarationIterand
+  forDeclarationPatternPrefix
   forRange
   processForInOf
   processRangeExpression
+  pushForBlockDeclaration
 }

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -143,7 +143,14 @@ import {
 
 import { buildExportSplitClause, escapeIdentifier, propertyKey } from ./identifier.civet
 import { processPipelineExpressions } from ./pipe.civet
-import { declarationIterand, forRange, processForInOf, processRangeExpression } from ./for.civet
+import {
+  declarationIterand
+  forDeclarationPatternPrefix
+  forRange
+  processForInOf
+  processRangeExpression
+  pushForBlockDeclaration
+} from ./for.civet
 import {
   findSuperCall
   makeAmpersandFunction
@@ -2473,6 +2480,7 @@ export {
   dedentBlockSubstitutions
   deepCopy
   declarationIterand
+  forDeclarationPatternPrefix
   processStaticImport
   duplicateBlock
   dynamizeImportDeclaration
@@ -2528,6 +2536,7 @@ export {
   processProgram
   processProgramAsync
   processRangeExpression
+  pushForBlockDeclaration
   processTryBlock
   processUnaryExpression
   processUnaryNestedExpression

--- a/test/compat/coffee-for-loops.civet
+++ b/test/compat/coffee-for-loops.civet
@@ -64,6 +64,18 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for const in character range with named destructuring
+    ---
+    "civet coffee-compat"
+    for const string^[first] in ['a'..'c']
+      console.log string, first
+    ---
+    for (let i = 97; i <= 99; ++i) {const string = String.fromCharCode(i), [first] =  string;
+      console.log(string, first)
+    }
+  """
+
+  testCase """
     for in range fixed reverse
     ---
     "civet coffee-compat"
@@ -482,6 +494,18 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for const from with named destructuring
+    ---
+    "civet coffee-compat"
+    for const pair^[, attr] from pairs
+      console.log pair, attr
+    ---
+    for (const pair of pairs) {const [, attr] =  pair;
+      console.log(pair, attr)
+    }
+  """
+
+  testCase """
     for const from with implicit body
     ---
     "civet coffee-compat"
@@ -613,6 +637,19 @@ describe "coffeeForLoops", ->
   """
 
   testCase """
+    for const of value with named destructuring
+    ---
+    "civet coffee-compat"
+    for const key^{length}, value of object
+      console.log key, length, value
+    ---
+    var value;
+    for (const key in object) {const {length} =  key;value = object[key];
+      console.log(key, length, value)
+    }
+  """
+
+  testCase """
     for let of value
     ---
     "civet coffee-compat"
@@ -647,6 +684,42 @@ describe "coffeeForLoops", ->
     ---
     for (let i = 0, len = b.length; i < len; i++) {const a = b[i];
       a.i
+    }
+  """
+
+  testCase """
+    for const in with named destructuring
+    ---
+    "civet coffee-compat"
+    for const pair^[, attr] in pairs
+      console.log pair, attr
+    ---
+    for (let i = 0, len = pairs.length; i < len; i++) {const pair = pairs[i], [, attr] =  pair;
+      console.log(pair, attr)
+    }
+  """
+
+  testCase """
+    for const in with @ binding
+    ---
+    "civet coffee-compat"
+    for const [@first] in pairs
+      console.log @first
+    ---
+    for (let i = 0, len = pairs.length; i < len; i++) {const [first] = pairs[i];this.first = first;
+      console.log(this.first)
+    }
+  """
+
+  testCase """
+    for const in with post-rest destructuring
+    ---
+    "civet coffee-compat"
+    for const [first, ...middle, last] in pairs
+      console.log first, middle, last
+    ---
+    for (let i = 0, len = pairs.length; i < len; i++) {const [first, ...middle] = pairs[i], [last] = middle.splice(-1);
+      console.log(first, middle, last)
     }
   """
 

--- a/test/for.civet
+++ b/test/for.civet
@@ -274,6 +274,50 @@ describe "for", ->
     }
   """
 
+  testCase """
+    for of character range with named destructuring
+    ---
+    for string^[first] of ['a'..'c']
+      console.log string, first
+    ---
+    for (let i = 97; i <= 99; ++i) {const string = String.fromCharCode(i), [first] = string;
+      console.log(string, first)
+    }
+  """
+
+  testCase """
+    for each of character range with named destructuring
+    ---
+    for each string^[first] of ['a'..'c']
+      console.log string, first
+    ---
+    for (let i = 97; i <= 99; ++i) {const string = String.fromCharCode(i), [first] = string;
+      console.log(string, first)
+    }
+  """
+
+  testCase """
+    for of character range with @ binding
+    ---
+    for [@first] of ['a'..'c']
+      console.log @first
+    ---
+    for (let i = 97; i <= 99; ++i) {const [first] = String.fromCharCode(i);this.first = first;
+      console.log(this.first)
+    }
+  """
+
+  testCase """
+    for of character range with post-rest destructuring
+    ---
+    for [first, ...middle, last] of ['a'..'c']
+      console.log first, middle, last
+    ---
+    for (let i = 97; i <= 99; ++i) {const [first, ...middle] = String.fromCharCode(i), [last] = middle.splice(-1);
+      console.log(first, middle, last)
+    }
+  """
+
   throws """
     for of multi-character string range
     ---
@@ -480,11 +524,44 @@ describe "for", ->
     """
 
     testCase """
+      typed named destructuring moved into body
+      ---
+      for pair^[, attr]: Pair of pairs
+        console.log pair, attr
+      ---
+      for (const item of pairs) {const pair: Pair = item, [, attr] = pair;
+        console.log(pair, attr)
+      }
+    """
+
+    testCase """
       in named properties
       ---
       for key^{length}, props^{array^: [lead^{item}, ...], x^, name^: {first, last}} in y
       ---
       for (const key in y) {const {length} = key;const props = y[key], {array, x, name} = props, [lead] = array, {item} = lead, {first, last} = name;;}
+    """
+
+    testCase """
+      in value with @ binding
+      ---
+      for key, [@value] in object
+        console.log key, @value
+      ---
+      for (const key in object) {const [value] = object[key];this.value = value;
+        console.log(key, this.value)
+      }
+    """
+
+    testCase """
+      in value with post-rest destructuring
+      ---
+      for key, [first, ...middle, last] in object
+        console.log key, first, middle, last
+      ---
+      for (const key in object) {const [first, ...middle] = object[key], [last] = middle.splice(-1);
+        console.log(key, first, middle, last)
+      }
     """
 
   testCase """
@@ -584,6 +661,17 @@ describe "for", ->
   """
 
   testCase """
+    of with named index
+    ---
+    for item, index^{toString} of items
+      console.log item, index, toString
+    ---
+    let i = 0;for (const item of items) {const index = i++, {toString} = index;
+      console.log(item, index, toString)
+    }
+  """
+
+  testCase """
     of with two explicit declarations
     ---
     for var item, let index of array
@@ -602,6 +690,17 @@ describe "for", ->
     ---
     for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a = next?.value, b = next1?.value;
       console.log(a, b)
+    }
+  """
+
+  testCase """
+    of zip with named destructuring
+    ---
+    for pair^[, attr], other^{x} of pairs, others
+      console.log pair, attr, other, x
+    ---
+    for (let iter = pairs[Symbol.iterator](), iter1 = others[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const pair = next?.value, [, attr] = pair, other = next1?.value, {x} = other;
+      console.log(pair, attr, other, x)
     }
   """
 
@@ -855,6 +954,17 @@ describe "for", ->
       ---
       for (let i = 0, len = array.length; i < len; i++) {const item = array[i];
         console.log(item)
+      }
+    """
+
+    testCase """
+      each..of with named destructuring (#2183)
+      ---
+      for each pair^[, attr] of $0
+        console.log attr
+      ---
+      for (let i = 0, len = $0.length; i < len; i++) {const pair = $0[i], [, attr] = pair;
+        console.log(attr)
       }
     """
 
@@ -1981,6 +2091,17 @@ describe "for", ->
     const results=[];for (const x of y) {if (!(x > 5)) continue;
       results.push(x*x)
     };bigSquares = results
+  """
+
+  testCase """
+    C-style with when
+    ---
+    for (let i = 0; i < 3; ++i) when i
+      console.log i
+    ---
+    for (let i = 0; i < 3; ++i) {if (!i) continue;
+      console.log(i)
+    }
   """
 
   testCase """


### PR DESCRIPTION
Fixes #2183 by handling `ForDeclaration` pattern follow-ups alongside their corresponding loop declarations.

Previously, named destructuring and related pattern transformations were added later by `processDeclarations`. This missed some loop forms, such as `for each`, and could place range-loop follow-ups before the primary binding was initialized. For example:

```js
for string^[first] of ["a".."c"]
---
for (let i = 97; i <= 99; ++i) {
  const [first] = string;
  const string = String.fromCharCode(i);
}
```

This PR:

- Moves loop-specific pattern expansion into the `for` processing code.
- Uses `pushForBlockDeclaration` for regular, `for each`, zip, range, secondary `in`/`of` bindings, and explicit-declaration Coffee-compatible loops.
- This ends up cleaning up a lot of code, and combining some declarations to boot.
- Keeps primary bindings and their named destructuring, post-rest, and `@` follow-ups in the correct order.
- Merges compatible adjacent declarations generated from the same loop binding.
- Fixes missing pattern follow-ups for `for...in` values and `for...of` indices.
- Removes the late `ForStatement` scan from `processDeclarations`.
- Adds regression coverage across Civet loop forms and explicit-declaration Coffee loops.

Coffee-compatible loops without an explicit `const`, `let`, or `var` use a separate assignment path and remain outside the scope of this PR. I think it's doable, but looking like a 200+ line change, so I'm not sure it's worth it...