### PR TITLE
Null-safe pipe `?|>`

### DIFF
--- a/civet.dev/reference.md
+++ b/civet.dev/reference.md
@@ -942,14 +942,36 @@ fetch url |> await
 |> return
 </Playground>
 
+Null-safe pipes `?|>` skip the remaining steps of the current pipeline when
+the left-hand value is `null` or `undefined`:
+
+<Playground>
+user
+  ?|> .profile
+  ?|> normalizeProfile
+  |> renderProfile
+</Playground>
+
+Use parentheses to keep steps from being aborted by a null-safe pipe:
+
+<Playground>
+(user
+  ?|> .profile
+  ?|> normalizeProfile
+) |> renderProfile
+</Playground>
+
 Pipe assignment:
 
 <Playground>
 data |>= .content
 </Playground>
 
-Fat pipes `||>` pass the left-hand value to the next two steps in the pipeline
-(ignoring the output from the right-hand side):
+Fat pipes `||>` are tap or tee pipes:
+they run the right-hand side but ignore its result,
+preserving the same left-hand value for the next step.
+(Similar to [Elixir's `Kernel.tap/2`](https://hexdocs.pm/elixir/Kernel.html#tap/2)
+and [magrittr's `%T>%` tee pipe](https://magrittr.tidyverse.org/reference/tee.html).)
 
 <Playground>
 array
@@ -980,10 +1002,16 @@ document.createElement('div')
 ||> .appendChild document.createTextNode 'Civet'
 </Playground>
 
+<Playground>
+document.querySelector('#main')
+?||> .className = 'civet'
+||> .click()
+</Playground>
+
 Unicode forms:
 
 <Playground>
-data ▷= func1 |▷ func2 ▷ func3
+data ▷= func1 |▷ func2 ▷ func3 ?▷ func4
 </Playground>
 
 ### Await Operators
@@ -1054,7 +1082,8 @@ Here is a table of all currently supported:
 | `≣` | `===` | `≢` | `!==` | `≔` | `:=` | `≕` | `=:` |
 | `⁇` | `??` | `‖` | `\|\|` | `≪` | `<<` | `≫` | `>>` |
 | `⋙` | `>>>` | `…` | `...` | `‥` | `..` | `∈` | `is in` |
-| `∉` | `is not in` | `▷` | `\|>` | `→` | `->` | `⇒` | `=>` |
+| `∉` | `is not in` | `▷` | `\|>` | `?▷` | `?\|>` | `\|▷` | `\|\|>` |
+| `?\|▷` | `?\|\|>` | `▷=` | `\|>=` | `→` | `->` | `⇒` | `=>` |
 | `’s` | `'s` | `⧺` | `++` | `—` | `--` | `÷` | `%/` |
 | `•` | `.` bullet |
 

--- a/source/generate.civet
+++ b/source/generate.civet
@@ -13,7 +13,7 @@ export type Options =
   filename?: string
   errors?: ParseError[]
 
-function stringify(node: ASTNode): string
+export function stringify(node: ASTNode): string
   try
     removeParentPointers node
     return JSON.stringify node

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -7940,6 +7940,12 @@ Protected
     return { type: "Keyword" as const, $loc, token: $1 }
 
 Pipe
+  "?||>" / "?|▷" ->
+    return { $loc, token: "?||>" }
+
+  "?|>" / "?▷" ->
+    return { $loc, token: "?|>" }
+
   "||>" / "|▷" ->
     return { $loc, token: "||>" }
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -524,8 +524,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
         assignResults block, collect
       return
     when "PipelineExpression"
-      // Child 0 is whitespace; if child 1 is exiting statement, don't wrap
-      return if exp.children.1?.type is like "ReturnStatement", "ThrowStatement"
+      return if exp.exits
       // At statement level, pipeline generates semicolons between statements
       // Return the last one
       semi := exp.children.lastIndexOf ";"
@@ -684,8 +683,7 @@ function insertReturn(node: ASTNode): void
       // NOTE: do not insert a return in the finally block
       return
     when "PipelineExpression"
-      // Child 0 is whitespace; if child 1 is exiting statement, don't return it
-      return if exp.children.1?.type is like "ReturnStatement", "ThrowStatement"
+      return if exp.exits
       // At statement level, pipeline generates semicolons between statements
       // Return the last one
       semi := exp.children.lastIndexOf ";"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -1,8 +1,8 @@
 import type {
   AmpersandBlockBody
+  AmpersandFunction
   ArrayBindingPattern
   ArrayBindingPatternContent
-  ArrowFunction
   ASTError
   ASTLeaf
   ASTNode
@@ -1488,8 +1488,8 @@ function processCoffeeDo(ws: Whitespace, expression: ASTNode): ASTNode
     }
   ]
 
-function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
-  {ref, typeSuffix, body} .= rhs
+function makeAmpersandFunction(rhs: AmpersandBlockBody): AmpersandFunction
+  {ref, typeSuffix, body, placeholders} .= rhs
   unless ref?
     ref = makeRef "$"
     inplacePrepend ref, body
@@ -1530,7 +1530,8 @@ function makeAmpersandFunction(rhs: AmpersandBlockBody): ASTNode
     parameters
     ampersandBlock: true
     body
-  } as ArrowFunction
+    placeholders
+  } as AmpersandFunction
 
   if isStatement body
     braceBlock block

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -104,6 +104,7 @@ import {
   stripTrailingImplicitComma
   trimFirstSpace
   typeSuffixForExpression
+  updateParentPointers
   wrapIIFE
   wrapWithReturn
 } from ./util.civet
@@ -1815,7 +1816,8 @@ function processStatementExpressions(statements: StatementTuple[]): void
 function processNegativeIndexAccess(statements: StatementTuple[]): void
   gatherRecursiveAll(statements, (n) => n.type is "NegativeIndex")
     .forEach (exp): void =>
-      { children } := exp.parent!
+      parent := exp.parent!
+      { children } := parent
 
       let start = 0
       start++ while start < children# and isWhitespaceOrEmpty children[start]
@@ -1834,8 +1836,9 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
 
       if subexp
         { refAssignment } := makeRefAssignment ref, subexp
-        children.splice start, 0, makeLeftHandSideExpression refAssignment
-        refAssignment.parent = exp
+        replacement := makeLeftHandSideExpression refAssignment
+        children.splice start, 0, replacement
+        updateParentPointers replacement, parent
 
       exp.len.children = [
         ref,
@@ -2297,7 +2300,7 @@ function processPlaceholders(statements: StatementTuple[]): void
     // Function wrapping can change parent; use original for replaceNode
     {parent} := ancestor
     body := maybeUnwrap ancestor
-    fnExp .= makeAmpersandFunction { ref, typeSuffix, body }
+    fnExp: ASTNode .= makeAmpersandFunction { ref, typeSuffix, body, placeholders }
 
     // Arrow function needs to be wrapped in parens in many contexts.
     // This doesn't happen with "&", but can with ".".

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -8,6 +8,7 @@
 
 import type {
   AccessStart
+  AmpersandFunction
   ASTLeaf
   ASTNode
   ASTNodeObject
@@ -1833,6 +1834,16 @@ function processNegativeIndexAccess(statements: StatementTuple[]): void
         assert index > start+1, "Invalid parse tree for negative index access"
         ref = makeRef()
         subexp = children.splice start, index - start
+
+      // Negative indexing uses `ref` as both the receiver and in `.length`.
+      // If it is an ampersand parameter (or its placeholder wrapper),
+      // unrolling would duplicate the input.
+      { ancestor } := findAncestor exp,
+        (ancestor): ancestor is AmpersandFunction =>
+          ancestor is like { type: "ArrowFunction", ampersandBlock: true } and
+          (ancestor.ref is ref or
+           ((ancestor.placeholders?.some (is ref)) ?? false))
+      ancestor.ampersandBlock = false if ancestor
 
       if subexp
         { refAssignment } := makeRefAssignment ref, subexp

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -8,8 +8,8 @@ type {
   BlockStatement
   Call
   Children
-  Condition
   ConditionalExpression
+  ElseClause
   IfStatement
   PipelineExpression
   ReturnStatement
@@ -53,8 +53,8 @@ function constructInvocation(fn: ExprWithComments, arg: ASTNode!)
 
     (ref as { type: "Ref" | "PipedExpression" }).type = "PipedExpression"
     ref.children = [makeLeftHandSideExpression(arg)]
-    // `ampersandBlock` guarantees a single use.  Once the shared ref becomes
-    // a real body node, its sole placeholder is its unambiguous parent.
+    // Once the shared ref becomes a real body node, its sole syntactic
+    // placeholder (when present) is its unambiguous parent.
     updateParentPointers ref, placeholders?[0]
 
     return makeNode {
@@ -159,8 +159,22 @@ function processPipelineExpression(s: PipelineExpression): void
   comma .= blockContainingStatement(s) ? ";" : ","
 
   let usingRef: ASTRef?
+  let assignmentTarget: ASTNode?
+  // Does this pipeline end in `|> return`?  Unlike `exits`, this does not
+  // mean that the current pipeline segment definitely exits,
+  // as there might  be optional `?|>` that would stop it.
   pipelineReturns := body.some [,,, expression] =>
     expression is like {token: "return"}
+
+  function assignPipelineValue(value: ASTNode): UnwrappedExpression
+    assigned := deepCopy assignmentTarget as ASTNode
+    removeHoistDecs assigned
+    expression: ASTNode[] := [assigned, " = ", value]
+    makeNode {
+      type: "UnwrappedExpression"
+      expression
+      children: expression
+    } satisfies UnwrappedExpression
 
   function finishPipelineSegment(finalArg: ASTNode): void
     if usingRef
@@ -174,7 +188,7 @@ function processPipelineExpression(s: PipelineExpression): void
     updateParentPointers finalArg, s
 
     // Wrap with parens because comma operator has low precedence
-    if not children.some(?.type is "ReturnStatement") and children.some & is ","
+    if not (finalArg is like { type: "ReturnStatement" }) and children.includes ","
       // Capture parent before parenthesizeExpression makes s its child.
       { parent } := s
       replaceNode s, parenthesizeExpression(s), parent
@@ -196,47 +210,57 @@ function processPipelineExpression(s: PipelineExpression): void
             continue switch
           when "CallExpression"
             const access = arg.children.pop()
-            // processAssignments will check that this is a valid
-            // last access to assign to
+            // checkValidLHS above validates the last access before we remove it.
 
             usingRef = makeRef()
             initRef = makeNode {
               type: "AssignmentExpression"
-              children: [usingRef, " = ", arg, comma]
+              children: [usingRef, " = ", arg, pipelineReturns ? ";" : comma]
               // missing `lhs`, hence cast below
             } as AssignmentExpression
 
-            arg = {
+            arg = makeNode {
               type: "MemberExpression"
               children: [usingRef, access]
             }
 
-        // assignment node
-        lhs := [[
-          [initRef]
-          arg
-          []
-          { token: "=", children: [" = "] }
-        ]]
-
-        Object.assign s, {
-          type: "AssignmentExpression"
-          children: [lhs, children]
-          names: null
-          lhs
-          assigned: arg
-          expression: children
-        } satisfies AssignmentExpression
-        updateParentPointers s
+        if pipelineReturns
+          assignmentTarget = arg
+          if initRef
+            (initRef as ASTParentWithHoist).hoistDec = {
+              type: "Declaration"
+              children: ["let ", usingRef]
+              names: []
+            }
+            children.push initRef
+            initRef.parent = s
+            usingRef = undefined
+          // `s` remains a pipeline because each returning branch performs
+          // the assignment explicitly below.
+          (s as ASTParent).children = children
+        else
+          lhs := [[
+            [initRef]
+            arg
+            []
+            { token: "=", children: [" = "] }
+          ]]
+          Object.assign s, {
+            type: "AssignmentExpression"
+            children: [lhs, children]
+            names: null
+            lhs
+            assigned: arg
+            expression: children
+          } satisfies AssignmentExpression
+          updateParentPointers s
 
         // Clone so that the same node isn't on the left and right because splice manipulation
         // moves things around and can cause a loop in the graph
         arg = deepCopy arg
-        removeHoistDecs arg
-
-        // except keep the ref the same
-        if arg!.children[0].type is "Ref"
-          arg!.children[0] = usingRef
+        // A returning assignment has no original LHS left to carry hoists
+        // (for example, the ref used by a negative-index target).
+        removeHoistDecs arg unless pipelineReturns
 
       else
         children.unshift {
@@ -258,7 +282,7 @@ function processPipelineExpression(s: PipelineExpression): void
         // Use the existing ref if present
         usingRef ?= ref
         guardedArg = usingRef
-        testArg = makeLeftHandSideExpression [usingRef, " = ", arg]
+        testArg = parenthesizeExpression [usingRef, " = ", arg]
 
       suffix: PipelineExpression :=
         type: "PipelineExpression"
@@ -274,15 +298,31 @@ function processPipelineExpression(s: PipelineExpression): void
           bare: false
         } satisfies BlockStatement
 
-        condition: Condition := parenthesizeExpression [testArg, " != null"]
+        condition := parenthesizeExpression [testArg, " != null"]
+
+        let elseClause: ElseClause?
+        if assignmentTarget
+          failureAssignment := assignPipelineValue guardedArg
+          failureExpressions: StatementTuple[] := [["", failureAssignment]]
+          failureBlock := makeNode {
+            type: "BlockStatement"
+            expressions: failureExpressions
+            children: ["{", failureExpressions, "}"]
+            bare: false
+          } satisfies BlockStatement
+          elseClause = makeNode {
+            type: "ElseClause"
+            block: failureBlock
+            children: [" ", "else ", failureBlock]
+          } satisfies ElseClause
 
         guardedReturn := makeNode {
           type: "IfStatement"
           condition
           negated: undefined
           then: block
-          else: undefined
-          children: ["if", condition, block]
+          else: elseClause
+          children: ["if", condition, block, elseClause]
         } satisfies IfStatement
 
         hoistTarget: ASTParentWithHoist .= guardedReturn
@@ -360,7 +400,19 @@ function processPipelineExpression(s: PipelineExpression): void
       arg
       returning
 
+    if result is like {
+      type: "StatementExpression"
+      statement: { type: "ThrowStatement" }
+    }
+      s.exits = true
+
     if result!.type is "ReturnStatement"
+      s.exits = true
+      if assignmentTarget
+        returned := result.expression
+        result.expression = assignPipelineValue returned
+        result.children = result.children.map & is returned ? result.expression : &
+        updateParentPointers result.expression, result
       // Attach errors/warnings if there are more steps
       if i < body# - 1
         result.children.push {

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -1,21 +1,32 @@
 type {
+  AmpersandFunction
   ASTNode
   ASTParent
+  ASTParentWithHoist
+  ASTRef
   AssignmentExpression
+  BlockStatement
   Call
+  Children
+  Condition
   ConditionalExpression
+  IfStatement
   PipelineExpression
+  ReturnStatement
+  StatementTuple
   ThrowStatement
   UnaryOpElement
+  UnwrappedExpression
 } from ./types.civet
 { gatherRecursiveAll } from ./traversal.civet
 {
-  addParentPointers
   checkValidLHS
-  clone
+  deepCopy
   makeLeftHandSideExpression
   makeNode
+  parenthesizeExpression
   removeHoistDecs
+  replaceNode
   skipIfOnlyWS
   updateParentPointers
 } from ./util.civet
@@ -38,11 +49,13 @@ function constructInvocation(fn: ExprWithComments, arg: ASTNode!)
   while expr.type is "ParenthesizedExpression"
     expr = expr.expression
   if expr.ampersandBlock
-    { ref, body } := expr
+    { ref, body, placeholders } := expr as AmpersandFunction
 
-    ref.type = "PipedExpression"
+    (ref as { type: "Ref" | "PipedExpression" }).type = "PipedExpression"
     ref.children = [makeLeftHandSideExpression(arg)]
-    updateParentPointers ref
+    // `ampersandBlock` guarantees a single use.  Once the shared ref becomes
+    // a real body node, its sole placeholder is its unambiguous parent.
+    updateParentPointers ref, placeholders?[0]
 
     return makeNode {
       type: "UnwrappedExpression"
@@ -61,9 +74,10 @@ function constructInvocation(fn: ExprWithComments, arg: ASTNode!)
   if (comment) (lhs.children as any[]).push comment
   comment = skipIfOnlyWS(fn.leadingComment)
   if (comment) (lhs.children as any[]).splice(1, 0, comment)
+  updateParentPointers lhs
 
   args := [arg]
-  call: Call := {
+  call: Call := makeNode {
     type: "Call"
     args
     children: ["(", args, ")"]
@@ -71,17 +85,17 @@ function constructInvocation(fn: ExprWithComments, arg: ASTNode!)
   // Turn `|> new Foo` into `new Foo(arg)` by adding to existing CallExpression
   if lhs.type is "NewExpression"
     { expression } .= lhs
-    expression = {
+    expression = makeNode {
       type: "CallExpression"
       children: [ expression, call ]
     }
-    {
+    makeNode {
       ...lhs
       expression
       children: lhs.children.map & is lhs.expression ? expression : &
     }
   else
-    {
+    makeNode {
       type: "CallExpression"
       children: [lhs, call]
     }
@@ -104,9 +118,9 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
         returning
       ]
     when "throw"
-      statement: ThrowStatement := { type: "ThrowStatement", children }
+      statement: ThrowStatement := makeNode { type: "ThrowStatement", children }
       return
-        . {
+        . makeNode {
             type: "StatementExpression"
             statement
             children: [statement]
@@ -114,10 +128,13 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
         . null
     when "return"
       // Return ignores ||> returning argument
-      return [{
-        type: "ReturnStatement"
-        children
-      }, null]
+      return
+        . makeNode {
+            type: "ReturnStatement"
+            expression: arg
+            children: children as Children
+          } satisfies ReturnStatement
+        . null
 
   return [
     constructInvocation(fn, arg)
@@ -130,21 +147,37 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
 /**
  * Transpile one pipeline. Normally, side-effecting `||>` steps are separated
  * with semicolons at statement level and commas in expression position.
- * `forceExpression` forces commas instead. A null-safe suffix (`?|>` or
- * `?||>`) uses this mode because it is a conditional operand, even when the
- * outer pipeline is a statement. StatementExpression nodes are expressionized
- * later; `|> return` is detected and rejected below.
- * Returns whether the pipeline ends in a `|> return` step.
+ * A null-safe value suffix (`?|>` or `?||>`) uses commas because it is a
+ * conditional operand. If the pipeline `return`s, guards instead transpile to
+ * `if` statements. Other StatementExpression nodes are expressionized later.
  */
-function processPipelineExpression(s: PipelineExpression, forceExpression = false): boolean
-  [ws, , body] := s.children
+function processPipelineExpression(s: PipelineExpression): void
+  [ws, , body] .= s.children
   [, arg] .= s.children
 
-  children: ASTNode[] := [ws]
-  comma := not forceExpression and blockContainingStatement(s) ? ";" : ","
+  children: ASTNode[] .= [ws]
+  comma .= blockContainingStatement(s) ? ";" : ","
 
-  usingRef .= null
-  pipelineReturns .= false
+  let usingRef: ASTRef?
+  pipelineReturns := body.some [,,, expression] =>
+    expression is like {token: "return"}
+
+  function finishPipelineSegment(finalArg: ASTNode): void
+    if usingRef
+      s.hoistDec = {
+        type: "Declaration"
+        children: ["let ", usingRef]
+        names: []
+      }
+
+    children.push finalArg
+    updateParentPointers finalArg, s
+
+    // Wrap with parens because comma operator has low precedence
+    if not children.some(?.type is "ReturnStatement") and children.some & is ","
+      // Capture parent before parenthesizeExpression makes s its child.
+      { parent } := s
+      replaceNode s, parenthesizeExpression(s), parent
 
   for each step, i of body
     [leadingComment, pipe, trailingComment, expr] := step
@@ -167,10 +200,11 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
             // last access to assign to
 
             usingRef = makeRef()
-            initRef = {
+            initRef = makeNode {
               type: "AssignmentExpression"
               children: [usingRef, " = ", arg, comma]
-            }
+              // missing `lhs`, hence cast below
+            } as AssignmentExpression
 
             arg = {
               type: "MemberExpression"
@@ -193,10 +227,11 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
           assigned: arg
           expression: children
         } satisfies AssignmentExpression
+        updateParentPointers s
 
         // Clone so that the same node isn't on the left and right because splice manipulation
         // moves things around and can cause a loop in the graph
-        arg = clone arg
+        arg = deepCopy arg
         removeHoistDecs arg
 
         // except keep the ref the same
@@ -204,11 +239,12 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
           arg!.children[0] = usingRef
 
       else
-        children.unshift({
-          type: "Error",
-          $loc: pipe.token.$loc,
-          message: "Can't use |>= in the middle of a pipeline",
-        })
+        children.unshift {
+          type: "Error"
+          $loc: pipe.token.$loc
+          message: "Can't use |>= in the middle of a pipeline"
+          parent: s
+        }
     else
       if i is 0
         // After transpiling, children no longer has the parsed PipelineExpression tuple shape.
@@ -216,10 +252,6 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
 
     if pipe.token.startsWith "?" // "?|>" or "?||>"
       // Null-safe guard the entire remaining syntactic pipeline.
-      // Transpile that suffix recursively, changing only this first guarded
-      // step into a corresponding unguarded pipe:
-      //   value ?|> f |> g
-      //   value != null ? g(f(value)) : value
       guardedArg .= arg
       testArg .= arg
       if ref := needsRef arg
@@ -230,44 +262,92 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
 
       suffix: PipelineExpression :=
         type: "PipelineExpression"
-        children:
-          . []
-          . guardedArg
-          . . . leadingComment
-              . {...pipe, token: returns ? "||>" : "|>"}
-              . trailingComment
-              . expr
-            . ...body[i + 1..]
+        children: [[], guardedArg, []]
         parent: s
-      if processPipelineExpression suffix, true
-        children.unshift
-          type: "Error"
-          $loc: pipe.$loc
-          message: "Can't use |> return in a null-safe pipeline"
-        pipelineReturns = true
 
-      conditional: ConditionalExpression :=
-        type: "ConditionalExpression"
-        children:
-          . testArg
-          . " != null ? "
-          . suffix
-          . " : "
-          . guardedArg
-      arg = conditional
-      break
+      if pipelineReturns
+        suffixExpressions: StatementTuple[] := [["", suffix]]
+        block := makeNode {
+          type: "BlockStatement"
+          expressions: suffixExpressions
+          children: [" {", suffixExpressions, "}"]
+          bare: false
+        } satisfies BlockStatement
+
+        condition: Condition := parenthesizeExpression [testArg, " != null"]
+
+        guardedReturn := makeNode {
+          type: "IfStatement"
+          condition
+          negated: undefined
+          then: block
+          else: undefined
+          children: ["if", condition, block]
+        } satisfies IfStatement
+
+        hoistTarget: ASTParentWithHoist .= guardedReturn
+        expressions: StatementTuple[] .= [[ws, guardedReturn]]
+        if children# > 1
+          // This pipeline is now in statement position, so previous ||>
+          // steps no longer need comma separators forced by an outer guard.
+          prefixChildren := children[1..].map & is "," ? ";" : &
+          prefix := makeNode {
+            type: "UnwrappedExpression"
+            expression: prefixChildren
+            children: prefixChildren
+          } satisfies UnwrappedExpression
+          hoistTarget = prefix
+          expressions = [
+            [ws, prefix]
+            ["", guardedReturn]
+          ]
+
+        if usingRef
+          hoistTarget.hoistDec = {
+            type: "Declaration"
+            children: ["let ", usingRef]
+            names: []
+          }
+
+        replacement := makeNode {
+          type: "BlockStatement"
+          expressions
+          children: [expressions]
+          bare: true
+        } satisfies BlockStatement
+
+        replaceNode s, replacement, s.parent
+      else
+        conditional: ConditionalExpression :=
+          type: "ConditionalExpression"
+          children:
+            . testArg
+            . " != null ? "
+            . suffix
+            . " : "
+            . guardedArg
+        finishPipelineSegment conditional
+
+      // Continue the same loop inside the suffix placeholder. Later guards
+      // mutate nested placeholders in place, so no unwinding is needed.
+      s = suffix
+      ws = []
+      children = [ws]
+      (s as ASTParent).children = children
+      arg = guardedArg
+      usingRef = undefined
+      returning = returns ? arg : null
+      comma = ","
 
     if returns
       if ref := needsRef arg
         // Use the existing ref if present
         usingRef ?= ref
-        arg = {
-          type: "ParenthesizedExpression",
-          children: ["(", {
-            type: "AssignmentExpression"
-            children: [usingRef, " = ", arg]
-          }, ")"],
-        }
+        arg = parenthesizeExpression makeNode {
+          type: "AssignmentExpression"
+          children: [usingRef, " = ", arg]
+          // missing `lhs`, hence cast below
+        } as AssignmentExpression
         returning = usingRef
 
     let result
@@ -281,13 +361,13 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
       returning
 
     if result!.type is "ReturnStatement"
-      pipelineReturns = true
       // Attach errors/warnings if there are more steps
-      if i < body.length - 1
-        result.children.push({
-          type: "Error",
-          message: "Can't continue a pipeline after returning",
-        })
+      if i < body# - 1
+        result.children.push {
+          type: "Error"
+          message: "Can't continue a pipeline after returning"
+          parent: result
+        }
       arg = result
       if children.-1 is ","
         children.pop()
@@ -297,30 +377,11 @@ function processPipelineExpression(s: PipelineExpression, forceExpression = fals
     if returning
       arg = returning
       children.push(result, comma)
+      updateParentPointers result, s
     else
       arg = result
 
-  if usingRef
-    s.hoistDec = {
-      type: "Declaration",
-      children: ["let ", usingRef],
-      names: [],
-    }
-
-  children.push(arg)
-
-  // Wrap with parens because comma operator has low precedence
-  if !children.some(?.type is "ReturnStatement") and children.some & is ","
-    { parent } := s
-    parenthesizedExpression := makeLeftHandSideExpression { ...s }
-    Object.assign s, parenthesizedExpression, {
-      parent
-      hoistDec: undefined
-    }
-
-  // Update parent pointers
-  addParentPointers(s, s.parent)
-  return pipelineReturns
+  finishPipelineSegment arg
 
 function processPipelineExpressions(statements: ASTNode): void
   for each s of gatherRecursiveAll statements, .type is "PipelineExpression"

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -1,7 +1,10 @@
 type {
   ASTNode
+  ASTParent
   AssignmentExpression
   Call
+  ConditionalExpression
+  PipelineExpression
   ThrowStatement
   UnaryOpElement
 } from ./types.civet
@@ -124,86 +127,140 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
 // head: expr
 // body: [ws, pipe, ws, expr][]
 
-function processPipelineExpressions(statements: ASTNode): void
-  for each s of gatherRecursiveAll statements, .type is "PipelineExpression"
-    [ws, , body] := s.children
-    [, arg] .= s.children
+/**
+ * Transpile one pipeline. Normally, side-effecting `||>` steps are separated
+ * with semicolons at statement level and commas in expression position.
+ * `forceExpression` forces commas instead. A null-safe suffix (`?|>` or
+ * `?||>`) uses this mode because it is a conditional operand, even when the
+ * outer pipeline is a statement. StatementExpression nodes are expressionized
+ * later; `|> return` is detected and rejected below.
+ * Returns whether the pipeline ends in a `|> return` step.
+ */
+function processPipelineExpression(s: PipelineExpression, forceExpression = false): boolean
+  [ws, , body] := s.children
+  [, arg] .= s.children
 
-    children := [ws]
-    comma := blockContainingStatement(s) ? ";" : ","
+  children: ASTNode[] := [ws]
+  comma := not forceExpression and blockContainingStatement(s) ? ";" : ","
 
-    let usingRef = null
+  usingRef .= null
+  pipelineReturns .= false
 
-    for each step, i of body
-      const [leadingComment, pipe, trailingComment, expr] = step
-      const returns = pipe.token is "||>"
-      let ref, result,
-        returning = returns ? arg : null
+  for each step, i of body
+    [leadingComment, pipe, trailingComment, expr] := step
+    returns := pipe.token.endsWith "||>" // "||>" or "?||>"
+    returning .= returns ? arg : null
 
-      if pipe.token is "|>="
-        let initRef
-        if i is 0
-          checkValidLHS arg
+    if pipe.token is "|>="
+      let initRef
+      if i is 0
+        checkValidLHS arg
 
-          :outer switch arg!.type
-            when "MemberExpression"
-              // If there is only a single access then we don't need a ref
-              break if arg.children.length <= 2
-              continue switch
-            when "CallExpression"
-              const access = arg.children.pop()
-              // processAssignments will check that this is a valid
-              // last access to assign to
+        switch arg!.type
+          when "MemberExpression"
+            // If there is only a single access then we don't need a ref
+            break if arg.children.length <= 2
+            continue switch
+          when "CallExpression"
+            const access = arg.children.pop()
+            // processAssignments will check that this is a valid
+            // last access to assign to
 
-              usingRef = makeRef()
-              initRef = {
-                type: "AssignmentExpression"
-                children: [usingRef, " = ", arg, comma]
-              }
+            usingRef = makeRef()
+            initRef = {
+              type: "AssignmentExpression"
+              children: [usingRef, " = ", arg, comma]
+            }
 
-              arg = {
-                type: "MemberExpression"
-                children: [usingRef, access]
-              }
+            arg = {
+              type: "MemberExpression"
+              children: [usingRef, access]
+            }
 
-          // assignment node
-          lhs := [[
-            [initRef]
-            arg
-            []
-            { token: "=", children: [" = "] }
-          ]]
+        // assignment node
+        lhs := [[
+          [initRef]
+          arg
+          []
+          { token: "=", children: [" = "] }
+        ]]
 
-          Object.assign s, {
-            type: "AssignmentExpression"
-            children: [lhs, children]
-            names: null
-            lhs
-            assigned: arg
-            expression: children
-          } satisfies AssignmentExpression
+        Object.assign s, {
+          type: "AssignmentExpression"
+          children: [lhs, children]
+          names: null
+          lhs
+          assigned: arg
+          expression: children
+        } satisfies AssignmentExpression
 
-          // Clone so that the same node isn't on the left and right because splice manipulation
-          // moves things around and can cause a loop in the graph
-          arg = clone arg
-          removeHoistDecs arg
+        // Clone so that the same node isn't on the left and right because splice manipulation
+        // moves things around and can cause a loop in the graph
+        arg = clone arg
+        removeHoistDecs arg
 
-          // except keep the ref the same
-          if arg!.children[0].type is "Ref"
-            arg!.children[0] = usingRef
+        // except keep the ref the same
+        if arg!.children[0].type is "Ref"
+          arg!.children[0] = usingRef
 
-        else
-          children.unshift({
-            type: "Error",
-            $loc: pipe.token.$loc,
-            message: "Can't use |>= in the middle of a pipeline",
-          })
       else
-        if (i is 0) s.children = children
+        children.unshift({
+          type: "Error",
+          $loc: pipe.token.$loc,
+          message: "Can't use |>= in the middle of a pipeline",
+        })
+    else
+      if i is 0
+        // After transpiling, children no longer has the parsed PipelineExpression tuple shape.
+        (s as ASTParent).children = children
 
-      if returns and (ref = needsRef(arg))
+    if pipe.token.startsWith "?" // "?|>" or "?||>"
+      // Null-safe guard the entire remaining syntactic pipeline.
+      // Transpile that suffix recursively, changing only this first guarded
+      // step into a corresponding unguarded pipe:
+      //   value ?|> f |> g
+      //   value != null ? g(f(value)) : value
+      guardedArg .= arg
+      testArg .= arg
+      if ref := needsRef arg
         // Use the existing ref if present
-        usingRef = usingRef or ref
+        usingRef ?= ref
+        guardedArg = usingRef
+        testArg = makeLeftHandSideExpression [usingRef, " = ", arg]
+
+      suffix: PipelineExpression :=
+        type: "PipelineExpression"
+        children:
+          . []
+          . guardedArg
+          . . . leadingComment
+              . {...pipe, token: returns ? "||>" : "|>"}
+              . trailingComment
+              . expr
+            . ...body[i + 1..]
+        parent: s
+      if processPipelineExpression suffix, true
+        children.unshift
+          type: "Error"
+          $loc: pipe.$loc
+          message: "Can't use |> return in a null-safe pipeline"
+        pipelineReturns = true
+
+      conditional: ConditionalExpression :=
+        type: "ConditionalExpression"
+        children:
+          . testArg
+          . " != null ? "
+          . suffix
+          . " : "
+          . guardedArg
+      arg = conditional
+      break
+
+    if returns
+      if ref := needsRef arg
+        // Use the existing ref if present
+        usingRef ?= ref
         arg = {
           type: "ParenthesizedExpression",
           children: ["(", {
@@ -213,54 +270,61 @@ function processPipelineExpressions(statements: ASTNode): void
         }
         returning = usingRef
 
-      [result, returning] = constructPipeStep
-        {
-          leadingComment: skipIfOnlyWS(leadingComment)
-          trailingComment: skipIfOnlyWS(trailingComment)
-          expr
-        }
-        arg
-        returning
-
-      if result!.type is "ReturnStatement"
-        // Attach errors/warnings if there are more steps
-        if i < body.length - 1
-          result.children.push({
-            type: "Error",
-            message: "Can't continue a pipeline after returning",
-          })
-        arg = result
-        if children.-1 is ","
-          children.pop()
-          children.push(";")
-        break
-
-      if returning
-        arg = returning
-        children.push(result, comma)
-      else
-        arg = result
-
-    if usingRef
-      s.hoistDec = {
-        type: "Declaration",
-        children: ["let ", usingRef],
-        names: [],
+    let result
+    [result, returning] = constructPipeStep
+      {
+        leadingComment: skipIfOnlyWS(leadingComment)
+        trailingComment: skipIfOnlyWS(trailingComment)
+        expr
       }
+      arg
+      returning
 
-    children.push(arg)
+    if result!.type is "ReturnStatement"
+      pipelineReturns = true
+      // Attach errors/warnings if there are more steps
+      if i < body.length - 1
+        result.children.push({
+          type: "Error",
+          message: "Can't continue a pipeline after returning",
+        })
+      arg = result
+      if children.-1 is ","
+        children.pop()
+        children.push(";")
+      break
 
-    // Wrap with parens because comma operator has low precedence
-    if !children.some(?.type is "ReturnStatement") and children.some & is ","
-      { parent } := s
-      parenthesizedExpression := makeLeftHandSideExpression { ...s }
-      Object.assign s, parenthesizedExpression, {
-        parent
-        hoistDec: undefined
-      }
+    if returning
+      arg = returning
+      children.push(result, comma)
+    else
+      arg = result
 
-    // Update parent pointers
-    addParentPointers(s, s.parent)
+  if usingRef
+    s.hoistDec = {
+      type: "Declaration",
+      children: ["let ", usingRef],
+      names: [],
+    }
+
+  children.push(arg)
+
+  // Wrap with parens because comma operator has low precedence
+  if !children.some(?.type is "ReturnStatement") and children.some & is ","
+    { parent } := s
+    parenthesizedExpression := makeLeftHandSideExpression { ...s }
+    Object.assign s, parenthesizedExpression, {
+      parent
+      hoistDec: undefined
+    }
+
+  // Update parent pointers
+  addParentPointers(s, s.parent)
+  return pipelineReturns
+
+function processPipelineExpressions(statements: ASTNode): void
+  for each s of gatherRecursiveAll statements, .type is "PipelineExpression"
+    processPipelineExpression s
 
 export {
   processPipelineExpressions

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1329,6 +1329,8 @@ export type AmpersandBlockBody =
 
 export type PipelineExpression = ASTParentWithHoist &
   type: "PipelineExpression"
+  /** This pipeline segment definitely exits its containing control flow, via `|> return` or `|> throw`. */
+  exits?: boolean
   children: Children & [
     ws: Whitespace
     head: ASTNode

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -184,6 +184,10 @@ export type ASTObject =
 export type ASTParent = ASTObject &
   children: Children
 
+// Parent node that can request a declaration before its containing statement.
+export type ASTParentWithHoist = ASTParent &
+  hoistDec?: ASTNode
+
 // Shared base for leaf-or-parent nodes (`Await`, `Yield`) that carry either
 // a bare `token` or `children`, depending on the grammar alternative matched.
 export type ASTTokenOrParent = ASTObject &
@@ -1320,8 +1324,10 @@ export type AmpersandBlockBody =
   ref?: ASTRef
   typeSuffix?: TypeSuffix?
   body: ASTNode
+  /** Syntactic placeholder occurrences that share `ref`; absent for synthetic refs. */
+  placeholders?: Placeholder[]
 
-export type PipelineExpression =
+export type PipelineExpression = ASTParentWithHoist &
   type: "PipelineExpression"
   children: Children & [
     ws: Whitespace
@@ -1333,7 +1339,6 @@ export type PipelineExpression =
       expression: ASTNode
     ][]
   ]
-  parent?: Parent
 
 export type MethodDefinition = ASTParent &
   type: "MethodDefinition"
@@ -1362,8 +1367,19 @@ export type ArrowFunction = ASTParent &
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
+  // The next four properties are metadata installed by
+  // `makeAmpersandFunction` to decide and perform pipeline unrolling.
+  // Use `AmpersandFunction` for guaranteed fields.
   ampersandBlock?: boolean  // unrollable single-argument function
   body?: ASTNode
+  ref?: ASTRef
+  /** Syntactic occurrences of `ref`; absent for synthetic refs. */
+  placeholders?: Placeholder[]
+
+export type AmpersandFunction = ArrowFunction &
+  ref: ASTRef
+  body: ASTNode
+  ampersandBlock: boolean
 
 export type FunctionSignature = ASTParent &
   type: "MethodSignature" | "FunctionSignature"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -53,6 +53,7 @@ export type ExpressionNode =
   | CallExpression
   | ClassExpression
   | ComptimeExpression
+  | ConditionalExpression
   | Existence
   | FunctionNode
   | Identifier
@@ -517,6 +518,9 @@ export type ParenthesizedExpression = ASTParent &
   type: "ParenthesizedExpression"
   expression: ASTNode!
   implicit?: boolean
+
+export type ConditionalExpression = ASTParent &
+  type: "ConditionalExpression"
 
 export type IfStatement = ASTParent &
   type: "IfStatement"
@@ -1324,7 +1328,7 @@ export type PipelineExpression =
     head: ASTNode
     tail: [
       ws1: Whitespace
-      pipe: ASTLeaf
+      pipe: ASTLeaf // `|>`, `?|>`, `||>`, `?||>`, or `|>=`
       ws2: Whitespace
       expression: ASTNode
     ][]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -72,19 +72,8 @@ function addParentPointers(node: ASTNode, parent?: ASTNodeObject): void
       addParentPointers(child, node)
 
 /**
- * Clone an AST node including children (removing parent pointes)
- * This gives refs new identities which may not be what we want.
- *
- * TODO: preserve ref identities
- */
-function clone(node: ASTNode)
-  removeParentPointers(node)
-  return deepCopy(node)
-
-/**
- * Remove parent pointers from an AST node and its children. Only used in stringify and clone.
+ * Remove parent pointers from an AST node and its children. Used in stringify.
  * This makes the AST unsuitable for further processing until the parent pointers are restored.
- * `clone` calls `deepCopy` after which reparents the nodes.
  */
 function removeParentPointers(node: ASTNode): void
   return unless node? <? "object"
@@ -972,7 +961,6 @@ export {
   append
   assert
   checkValidLHS
-  clone
   convertOptionalType
   deepCopy
   firstNonSpace

--- a/test/generate.civet
+++ b/test/generate.civet
@@ -1,4 +1,4 @@
-gen from ../source/generate.civet
+gen, { stringify } from ../source/generate.civet
 assert from assert
 
 describe "gen error handling", ->
@@ -6,6 +6,13 @@ describe "gen error handling", ->
     assert.throws =>
       gen { type: "Ref" } as any, {}
     , /Unpopulated ref \{.*"type":"Ref".*\}/
+
+  it "stringifies unpopulated Ref nodes with parent pointers", ->
+    ref := { type: "Ref" } as any
+    ref.parent = ref
+    assert.throws =>
+      gen ref, {}
+    , /Unpopulated ref \{"type":"Ref","parent":null\}/
 
   it "throws for unknown object nodes without children, $loc, or token", ->
     assert.throws =>
@@ -16,3 +23,13 @@ describe "gen error handling", ->
     assert.throws =>
       gen 42 as any, {}
     , /Unknown node/
+
+describe "stringify", ->
+  it "removes parent pointers throughout an AST", ->
+    child := { type: "Child" } as any
+    parent := { type: "Parent", children: [child] } as any
+    child.parent = parent
+
+    assert.deepEqual JSON.parse(stringify [parent]), [
+      { type: "Parent", children: [{ type: "Child", parent: null }], parent: null }
+    ]

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -1,4 +1,4 @@
-{ testCase, throws } from ./helper.civet
+{ evalsTo, testCase, throws } from ./helper.civet
 
 describe "pipe", ->
   testCase """
@@ -478,6 +478,203 @@ describe "pipe", ->
       ---
       ($ => $+$)(x())
     """
+
+  describe "null-safe", ->
+    testCase """
+      basic
+      ---
+      x ?|> f
+      ---
+      x != null ? f(x) : x
+    """
+
+    testCase """
+      Unicode alias
+      ---
+      x ?▷ f |> g
+      ---
+      x != null ? g(f(x)) : x
+    """
+
+    testCase """
+      guards the remaining pipeline
+      ---
+      x ?|> f |> g |> h
+      ---
+      x != null ? h(g(f(x))) : x
+    """
+
+    testCase """
+      evaluates a complex input once
+      ---
+      getX() ?|> f |> g
+      ---
+      let ref;(ref = getX()) != null ? g(f(ref)) : ref
+    """
+
+    testCase """
+      second guard checks an intermediate result
+      ---
+      x ?|> f ?|> g
+      ---
+      let ref;x != null ? (ref = f(x)) != null ? g(ref) : ref : x
+    """
+
+    testCase """
+      ordinary steps before the guard still run
+      ---
+      x |> f ?|> g |> h
+      ---
+      let ref;(ref = f(x)) != null ? h(g(ref)) : ref
+    """
+
+    testCase """
+      parentheses end the guarded pipeline
+      ---
+      (x ?|> f |> g) |> recover
+      ---
+      recover((x != null ? g(f(x)) : x))
+    """
+
+    testCase """
+      postfix existence remains distinct
+      ---
+      x? |> f
+      x ?|> f
+      ---
+      f((x != null))
+      x != null ? f(x) : x
+    """
+
+    testCase """
+      multiline
+      ---
+      x
+      ?|> f
+      |> g
+      ---
+      x != null ? g(f(x)) : x
+    """
+
+    testCase """
+      thick pipe inside guarded suffix
+      ---
+      x ?|> f ||> tap |> g
+      ---
+      let ref;x != null ? (tap((ref = f(x))),g(ref)) : x
+    """
+
+    testCase """
+      thick pipe before guard is unconditional
+      ---
+      x ||> tap ?|> f |> g
+      ---
+      tap(x);x != null ? g(f(x)) : x
+    """
+
+    testCase """
+      throw inside guarded suffix
+      ---
+      x ?|> f |> throw
+      ---
+      x != null ? (()=>{throw f(x)})() : x
+    """
+
+    throws """
+      return inside guarded suffix is unsupported
+      ---
+      x ?|> f |> return
+      ---
+      ParseErrors: unknown:1:3 Can't use |> return in a null-safe pipeline
+    """
+
+    it "short-circuits at runtime", ->
+      evalsTo """
+        calls := []
+        step := (value) ->
+          calls.push value
+          value + 1
+        [
+          null ?|> step |> step
+          1 ?|> step |> step
+          calls
+        ]
+      """, [null, 3, [1, 2]]
+
+    it "repeated guard short-circuits an intermediate null", ->
+      evalsTo """
+        calls := []
+        stop := (value) ->
+          calls.push "stop"
+          null
+        after := (value) ->
+          calls.push "after"
+          value
+        result := 1 ?|> stop ?|> after
+        [result, calls]
+      """, [null, ["stop"]]
+
+    describe "guarded tap", ->
+      testCase """
+        basic
+        ---
+        x ?||> tap
+        ---
+        x != null ? (tap(x),x) : x
+      """
+
+      testCase """
+        guards later ordinary and thick pipes
+        ---
+        x ?||> tap |> f ||> log |> g
+        ---
+        let ref;x != null ? (tap(x),log((ref = f(x))),g(ref)) : x
+      """
+
+      testCase """
+        evaluates a complex input once
+        ---
+        getX() ?||> tap |> f
+        ---
+        let ref;(ref = getX()) != null ? (tap(ref),f(ref)) : ref
+      """
+
+      testCase """
+        Unicode alias
+        ---
+        x ?|▷ tap |> f
+        ---
+        x != null ? (tap(x),f(x)) : x
+      """
+
+      testCase """
+        postfix existence remains distinct
+        ---
+        x? ||> tap
+        x ?||> tap
+        ---
+        let ref;tap((ref = (x != null)));ref
+        x != null ? (tap(x),x) : x
+      """
+
+      it "retains its input and guards later ordinary and thick pipes", ->
+        evalsTo """
+          calls := []
+          tap := (value) ->
+            calls.push ["tap", value]
+            "ignored"
+          transform := (value) ->
+            calls.push ["transform", value]
+            value * 2
+          results := [
+            null ?||> tap |> transform ||> tap |> & + 1
+            2 ?||> tap |> transform ||> tap |> & + 1
+          ]
+          [results, calls]
+        """, [
+          [null, 5]
+          [["tap", 2], ["transform", 2], ["tap", 4]]
+        ]
 
   describe "thicc", ->
     testCase """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -580,12 +580,96 @@ describe "pipe", ->
       x != null ? (()=>{throw f(x)})() : x
     """
 
-    throws """
-      return inside guarded suffix is unsupported
+    testCase """
+      yield inside guarded suffix
+      ---
+      x ?|> f |> yield |> g
+      ---
+      x != null ? g(yield f(x)) : x
+    """, wrapper: """
+      function* f() {
+        CODE
+      }
+    """
+
+    testCase """
+      return inside guarded suffix
       ---
       x ?|> f |> return
       ---
-      ParseErrors: unknown:1:3 Can't use |> return in a null-safe pipeline
+      if(x != null) {return f(x)}
+    """
+
+    testCase """
+      return after guarded tap
+      ---
+      x ?||> tap |> f |> return
+      ---
+      if(x != null) {tap(x);return f(x)}
+    """
+
+    testCase """
+      return after complex input
+      ---
+      getX() ?|> f |> return
+      ---
+      let ref;if((ref = getX()) != null) {return f(ref)}
+    """
+
+    testCase """
+      return after repeated guard
+      ---
+      x ?|> f ?|> g |> return
+      ---
+      if(x != null) {let ref;if((ref = f(x)) != null) {return g(ref)}}
+    """
+
+    testCase """
+      tap before repeated returning guard
+      ---
+      x ?|> f ||> tap ?|> g |> return
+      ---
+      if(x != null) {let ref;tap((ref = f(x)));if(ref != null) {return g(ref)}}
+    """
+
+    testCase """
+      return guarded input directly
+      ---
+      x ?|> return
+      ---
+      if(x != null) {return x}
+    """
+
+    testCase """
+      ordinary pipe before returning guard is unconditional
+      ---
+      x |> f ?|> g |> return
+      ---
+      let ref;if((ref = f(x)) != null) {return g(ref)}
+    """
+
+    testCase """
+      thick pipe before returning guard is unconditional
+      ---
+      x ||> tap ?|> f |> return
+      ---
+      tap(x);if(x != null) {return f(x)}
+    """
+
+    testCase """
+      parentheses end returning guard
+      ---
+      (x ?|> f) |> return
+      ---
+      return (x != null ? f(x) : x)
+    """
+
+    throws """
+      guarded pipe after return is error
+      ---
+      x ?|> f |> return |> g
+      ---
+      ParseErrors: unknown:1:3 Can't continue a pipeline after returning
     """
 
     it "short-circuits at runtime", ->
@@ -600,6 +684,35 @@ describe "pipe", ->
           calls
         ]
       """, [null, 3, [1, 2]]
+
+    it "falls through on null before return", ->
+      evalsTo """
+        choose := (value) ->
+          value ?|> & + 1 |> return
+          "fallback"
+        [choose(null), choose(1)]
+      """, ["fallback", 2]
+
+    it "runs an ordinary pipe before a returning guard", ->
+      evalsTo """
+        calls := []
+        prepare := (value) ->
+          calls.push value
+          value > 0 ? value * 2 : null
+        choose := (value) ->
+          value |> prepare ?|> & + 1 |> return
+          "fallback"
+        [choose(0), choose(2), calls]
+      """, ["fallback", 5, [0, 2]]
+
+    it "falls through when a repeated returning guard gets null", ->
+      evalsTo """
+        step := (value) -> value is 1 ? null : value + 1
+        choose := (value) ->
+          value ?|> step ?|> & * 2 |> return
+          "fallback"
+        [choose(null), choose(1), choose(2)]
+      """, ["fallback", "fallback", 6]
 
     it "repeated guard short-circuits an intermediate null", ->
       evalsTo """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -464,6 +464,31 @@ describe "pipe", ->
     """
 
     testCase """
+      negative index ampersand expansion
+      ---
+      get() |> &.-1
+      ---
+      ($ => $[$.length-1])(get())
+    """
+
+    testCase """
+      negative index after access can still unwrap
+      ---
+      value |> &.items.-1
+      ---
+      let ref;(ref = value.items)[ref.length-1]
+    """
+
+    it "does not duplicate input after ampersand expansion", ->
+      evalsTo """
+        let calls = 0
+        get := ->
+          calls++
+          [1, 2]
+        [get() |> &.-1, calls]
+      """, [2, 1]
+
+    testCase """
       typed
       ---
       &: number |> (+ 1) |> &/2 |> Math.ceil
@@ -609,6 +634,50 @@ describe "pipe", ->
     """
 
     testCase """
+      returning pipeline is not implicitly returned again
+      ---
+      choose := (x) ->
+        x ||> tap |> return
+      ---
+      const choose = function(x) {
+        tap(x);return x
+      }
+    """
+
+    testCase """
+      guarded returning pipeline marks only its returning segment
+      ---
+      choose := (x) ->
+        x ?|> f |> return
+      ---
+      const choose = function(x) {
+        if(x != null) {return f(x)};return
+      }
+    """
+
+    testCase """
+      throwing pipeline is not implicitly returned
+      ---
+      choose := (x) ->
+        x ||> tap |> throw
+      ---
+      const choose = function(x) {
+        tap(x);throw x
+      }
+    """
+
+    testCase """
+      guarded throwing pipeline retains its null result
+      ---
+      choose := (x) ->
+        x ?|> throw
+      ---
+      const choose = function(x) {
+        return x != null ? (()=>{throw x})() : x
+      }
+    """
+
+    testCase """
       return after complex input
       ---
       getX() ?|> f |> return
@@ -646,6 +715,30 @@ describe "pipe", ->
       x |> f ?|> g |> return
       ---
       let ref;if((ref = f(x)) != null) {return g(ref)}
+    """
+
+    testCase """
+      assignment before returning guard
+      ---
+      x |>= f ?|> g |> return
+      ---
+      let ref;if((ref = f(x)) != null) {return x = g(ref)} else {x = ref}
+    """
+
+    testCase """
+      assignment ending in return
+      ---
+      x |>= f |> return
+      ---
+      return x = f(x)
+    """
+
+    testCase """
+      complex assignment before returning guard
+      ---
+      get().x |>= f ?|> g |> return
+      ---
+      let ref;let ref1;ref = get();if((ref1 = f(ref.x)) != null) {return ref.x = g(ref1)} else {ref.x = ref1}
     """
 
     testCase """
@@ -704,6 +797,24 @@ describe "pipe", ->
           "fallback"
         [choose(0), choose(2), calls]
       """, ["fallback", 5, [0, 2]]
+
+    it "assigns both outcomes of a returning guard", ->
+      evalsTo """
+        choose := (value) ->
+          let x = value
+          x |>= & ?|> & + 1 |> return
+          ["fallback", x]
+        [choose(null), choose(1)]
+      """, [["fallback", null], 2]
+
+    it "preserves target refs in a returning assignment", ->
+      evalsTo """
+        choose := (value) ->
+          body := children: [value]
+          body.children.-1 |>= & ?|> & + 1 |> return
+          body.children.-1
+        [choose(null), choose(1)]
+      """, [null, 2]
 
     it "falls through when a repeated returning guard gets null", ->
       evalsTo """

--- a/test/pipe.civet
+++ b/test/pipe.civet
@@ -479,6 +479,14 @@ describe "pipe", ->
       let ref;(ref = value.items)[ref.length-1]
     """
 
+    testCase """
+      unrelated negative index in ampersand function can still unwrap
+      ---
+      get() |> (+ foo.-1)
+      ---
+      get()+ foo[foo.length-1]
+    """
+
     it "does not duplicate input after ampersand expansion", ->
       evalsTo """
         let calls = 0


### PR DESCRIPTION
## Summary

Adds null-safe pipes `?|>` and taps `?||>`, including guarded `return` support. Complicated example:

```js
data |>= process ?|> filter |> return
---
let ref;
if ((ref = process(data)) != null) {
  return (data = filter(ref));
} else {
  data = ref;
}
```

Fixes #897 (assuming we don't want truthy pipes). See https://github.com/DanielXMoore/Civet/issues/897#issuecomment-5054923797 for why I chose this notation.

## Syntax and behavior

- Adds null-safe pipe `?|>` with Unicode alias `?▷`.
- Adds null-safe tap pipe `?||>` with Unicode alias `?|▷`.
- Null-safe pipes guard the remaining syntactic pipeline when the current value is `null` or `undefined`:
  ```js
  value ?|> f |> g
  ---
  value != null ? g(f(value)) : value
  ```
  This won't call `f` or `g` unless `value?`.
- Parentheses delimit the guarded pipeline:
  ```js
  (value ?|> f) |> g
  ---
  g(value != null ? f(value) : value)
  ```
  This won't call `f` unless `value?`, but will always call `g`.
- Null-safe taps `?||>` run their tap only for non-nullish values, preserve the input value, and guard subsequent steps.
- Complex guarded inputs are evaluated once.
- Guarded pipelines compose with ordinary pipes, taps, `yield`, `throw`, and repeated guards.

## Returning pipelines

With some effort, this PR supports `|> return` inside null-safe pipelines:

```civet
value ?|> f |> return
```

This transpiles to an `if`, allowing the function to fall through when the value is nullish:

```js
if (value != null) {
  return f(value)
}
```

Returning pipelines now work with:

- Ordinary and tap steps before or after a guard.
- Repeated null-safe guards.
- Direct guarded returns.
- Complex inputs requiring temporary refs.
- Parenthesized pipelines.
- Pipe assignment (`|>=`).

For returning pipe assignments:

- Successful guarded paths assign the final value and return it.
- Nullish paths assign the guarded value and fall through.
- Complex assignment targets are evaluated once.
- Negative-index targets preserve and hoist their generated refs.

## Bug fixes

- Fix implicit-return handling for pipelines ending in `return` or `throw`.
  - Replaces positional AST inspection with an `exits` property meaning the active pipeline segment definitely exits.
  - Prevents invalid output such as `return return value` and `return throw value`.
  - Correctly distinguishes a definitely exiting guarded suffix from an outer conditional pipeline that may fall through.
- Fix `get() |> &.-1` evaluating `get()` twice.
  - Negative-index expansion now marks an ampersand function non-unrollable when it duplicates its parameter or placeholder.
  - Safe cases such as `value |> &.items.-1` remain unrolled.
- Fix stale and missing AST parent pointers introduced while rebuilding pipe and negative-index nodes.
- Preserve shared ref identities when deeply copying pipeline assignment targets.
- Ensure `?||>` is tokenized before its `?|>` prefix.
- Improve AST typing for ampersand functions, pipeline hoists, return expressions, and placeholder metadata.

## Implementation cleanup

- Rework optional-pipe processing into the existing pipeline loop instead of recursively processing suffixes.
- Track nested guarded suffixes as they are constructed.
- Use explicit AST node constructors and targeted parent updates.
- Centralize final pipeline-segment handling.
- Document the distinction between syntactic `pipelineReturns` lookahead and definite `exits` metadata.
- Resolve 9 type errors

## Documentation

- Document null-safe pipe semantics and the effect of parentheses.
- Document null-safe taps.
- Add all ASCII and Unicode pipe forms to the operator reference.
- Link Civet tap pipes to related constructs in Elixir and magrittr.
