### PR TITLE
Fix `export default` with nested implicit object literal (#2186)

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6932,7 +6932,12 @@ ExportDeclaration
     ]
   # NOTE: This covers all forms that can be directly export defaulted in TS.
   # NOTE: Using Expression to allow If/Switch expressions
-  Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration / MaybeNestedPostfixedExpressionOrCommaLoop ):declaration ->
+  Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration ):declaration ->
+    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
+  # NOTE: `_?` (not `__`) so that a value on the next line (e.g. a
+  # NestedImplicitObjectLiteral) is left for MaybeNestedPostfixedExpressionOrCommaLoop
+  # to handle its own indentation (#2186).
+  Decorators? Export __ Default _? MaybeNestedPostfixedExpressionOrCommaLoop:declaration ->
     return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
   Export __ ExportFromClause:exports __ FromClause ->
     if desugared := processConstructedExportFrom($0, exports, $5)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6938,7 +6938,7 @@ ExportDeclaration
   # NestedImplicitObjectLiteral) is left for MaybeNestedPostfixedExpressionOrCommaLoop
   # to handle its own indentation (#2186).
   Decorators? Export __ Default _? MaybeNestedPostfixedExpressionOrCommaLoop:declaration ->
-    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
+    return { type: "ExportDeclaration", declaration, children: $0 }
   Export __ ExportFromClause:exports __ FromClause ->
     if desugared := processConstructedExportFrom($0, exports, $5)
       return desugared

--- a/test/export.civet
+++ b/test/export.civet
@@ -85,13 +85,25 @@ describe "export", ->
     export default nested implicit object literal
     ---
     export default
-    	mode: 'development'
-    	entry: './main.civet'
+      mode: 'development'
+      entry: './main.civet'
     ---
     export default {
-    	mode: 'development',
-    	entry: './main.civet',
+      mode: 'development',
+      entry: './main.civet',
     }
+  """
+
+  testCase """
+    export default nested bulleted array
+    ---
+    export default
+      . a
+      . b
+    ---
+    export default [
+        a,
+        b]
   """
 
   describe "export default extensions", ->

--- a/test/export.civet
+++ b/test/export.civet
@@ -81,6 +81,19 @@ describe "export", ->
     export default (()=>{const results=[];for (const [a, b] of pairs) { results.push(a, b) }return results})()
   """
 
+  testCase """
+    export default nested implicit object literal
+    ---
+    export default
+    	mode: 'development'
+    	entry: './main.civet'
+    ---
+    export default {
+    	mode: 'development',
+    	entry: './main.civet',
+    }
+  """
+
   describe "export default extensions", ->
     testCase """
       export default const


### PR DESCRIPTION
Fixes #2186.

The `__` after `Default` greedily consumed the newline and indentation before the value, preventing `MaybeNestedPostfixedExpressionOrCommaLoop` from recognizing a `NestedImplicitObjectLiteral` spanning multiple lines. Split the rule so the nested-expression case uses `_?` (same-line whitespace only), leaving the newline+indent for the value to consume itself.

Generated with [Claude Code](https://claude.ai/code)