### PR TITLE
Fix object get/set shorthand with `!` non-null assertion

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4633,7 +4633,12 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
           })
         }
 
-    lastAccess := lastAccessInCallExpression({children: rest})
+    // Match CallExpression's flattened children so lastAccessInCallExpression
+    // can find the base before postfix operators such as `!`.
+    lastAccess := lastAccessInCallExpression
+      type: "CallExpression"
+      children: [base, ...rest.flat()]
+    return $skip unless lastAccess
     { name } := lastAccess
 
     return makeGetterMethod(name, ws, value, returnType, block, kind)

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4641,7 +4641,13 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     return $skip unless lastAccess
     { name } := lastAccess
 
-    return makeGetterMethod(name, ws, value, returnType, block, kind)
+    let setValueSuffix
+    // Trailing `!` asserts the incoming setter value, not the assignment target
+    if kind.token is "set" and last.type is "NonNullAssertion"
+      setValueSuffix = last
+      value[1] = rest[<-1]
+
+    return makeGetterMethod(name, ws, value, returnType, block, kind, true, setValueSuffix)
 
 MethodModifier
   # NOTE: Merged get/set definitions

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1172,7 +1172,7 @@ function convertObjectToJSXAttributes(obj: ObjectExpression): Children
 /**
  * Returns a new MethodDefinition node.
  */
-function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType: ASTNode, block?: BlockStatement, kind: { token: "get" | "set" } = { token: "get" }, autoReturn: boolean = true): MethodDefinition
+function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType: ASTNode, block?: BlockStatement, kind: { token: "get" | "set" } = { token: "get" }, autoReturn: boolean = true, setValueSuffix?: ASTNode): MethodDefinition
   { token } := kind
   ws = trimFirstSpace ws
   let setVal
@@ -1204,7 +1204,7 @@ function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType
     finalStatement: StatementTuple := isGet ?
       [ [expressions[0]?.[0] or "", ws], wrapWithReturn(value) ]
     :
-      [ [expressions[0]?.[0] or "", ws], [ value, " = ", setVal ] ]
+      [ [expressions[0]?.[0] or "", ws], [ value, " = ", setVal, setValueSuffix ] ]
 
     expressions.push finalStatement
 

--- a/test/object.civet
+++ b/test/object.civet
@@ -661,7 +661,23 @@ describe "object", ->
       ---
       { set x! }
       ---
-      ({ set x(value){ x! = value } })
+      ({ set x(value){ x = value! } })
+    """
+
+    testCase """
+      object setter moves only trailing non-null assertion
+      ---
+      { set data.x! }
+      ---
+      ({ set x(value){ data.x = value! } })
+    """
+
+    testCase """
+      object setter preserves internal non-null assertion
+      ---
+      { set data!.x }
+      ---
+      ({ set x(value){ data!.x = value } })
     """
 
     testCase """

--- a/test/object.civet
+++ b/test/object.civet
@@ -647,6 +647,49 @@ describe "object", ->
       })
     """
 
+    // Issue #2189
+    testCase """
+      object getter shorthand with non-null assertion
+      ---
+      { get x! }
+      ---
+      ({ get x(){ return x! } })
+    """
+
+    testCase """
+      object setter shorthand with non-null assertion
+      ---
+      { set x! }
+      ---
+      ({ set x(value){ x! = value } })
+    """
+
+    testCase """
+      object get property with non-null literal call argument
+      ---
+      { get 1! }
+      ---
+      ({ get: get(1!) })
+    """
+
+    testCase """
+      object set property with non-null literal call argument
+      ---
+      { set 1! }
+      ---
+      ({ set: set(1!) })
+    """
+
+    for kind of ["get", "set"]
+      for value of ["x", "1"]
+        throws ```
+          incomplete object ${kind} shorthand with ${value}
+          ---
+          { ${kind} ${value}!
+          ---
+          ParseError
+        ```
+
   testCase """
     async method definition
     ---


### PR DESCRIPTION
Fixes #2189: object `get`/`set` shorthand with a trailing TypeScript non-null assertion (with or without closing `}`) no longer crashes the compiler.

- `{ get x! }` now emits a getter returning `x!`.
- `{ set x! }` now emits a setter assigning `value!` to `x`.
- Assertions within setter targets remain in place:
  - `set data.x!` → `data.x = value!`
  - `set data!.x` → `data!.x = value`
- Literal forms fall back to ordinary implicit-call properties.
- Incomplete forms now produce a normal `ParseError` instead of crashing.

Underlying issue: The parser now searches the complete call-expression shape for the property name, including the base before postfix operators.