### PR TITLE
Fix destructured parameter type when initialized and `@`

### DIFF
--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -382,7 +382,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
             type: "TypeSuffix"
             ts: true
             children: [": unknown"]
-          if prop.type is "BindingProperty" and (prop.typeSuffix?.optional or prop.initializer) and not typeSuffix.optional
+          if ((prop.type is "BindingProperty" and prop.typeSuffix?.optional) or initializer) and not typeSuffix.optional
             typeSuffix.children.unshift typeSuffix.optional = prop.typeSuffix?.optional ?? "?"
           switch prop.type
             when "BindingProperty", "PinProperty"

--- a/test/types/function.civet
+++ b/test/types/function.civet
@@ -737,6 +737,14 @@ describe "[TS] function", ->
       })
     """
 
+    testCase """
+      binding object pattern params with @ defaults
+      ---
+      function({ @foo:: string = "" })
+      ---
+      (function({ foo = "" }: { foo?: string}){this.foo = foo;})
+    """
+
   describe "automatic Promise in async", ->
     testCase """
       thin arrow


### PR DESCRIPTION
- Fixes #2190
- Treat default-initialized `@` properties in object binding patterns as optional
- Emit `{ foo?: string }` for `function({ @foo:: string = "" })`
- Add regression coverage
