### PR TITLE
Fix `autoLet`/`autoConst` handling of refs

### DIFF
--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -122,8 +122,9 @@ function createConstLetDecs(statements: any, scopes: any, letOrConst: "let" | "c
         else
           createConstLetDecs(block.expressions, scopes, letOrConst)
         continue
-      // Assignment and Declaration all use 'names'.
-      names := node.names.filter (name: string) => not hasDec name
+      // Synthetic assignments (such as a `do` expression's result ref) may
+      // not introduce any source-level names.
+      names := (node.names ?? []).filter (name: string) => not hasDec name
       if node.type is "AssignmentExpression"
         undeclaredIdentifiers.push ...names
       for each name of names

--- a/test/auto-let.civet
+++ b/test/auto-let.civet
@@ -483,6 +483,24 @@ describe "auto-let", ->
     a = []
   """
 
+  testCase """
+    do expression (#2182)
+    ---
+    "civet autoLet"
+    x = do
+      y = 2
+      y*y
+
+    console.log x
+    ---
+    let ref;{
+      let y = 2
+      ref = y*y
+    };let x = ref
+
+    console.log(x)
+  """
+
 describe "complicated auto-let", ->
     testCase """
         auto let nest


### PR DESCRIPTION
Fixes #2182.

Compiler-generated assignments used to capture `do` expression results do not have source-level binding names. The shared `autoLet`/`autoConst` declaration pass assumed every assignment had a `names` array, causing it to crash while processing these assignments.

- Treat nameless synthetic assignments as introducing no declarations, matching the existing behavior of the separate `autoVar` pass.
- Add a regression test for an assigned `do` block using `autoLet`.