### PR TITLE
Fix TypeScript narrowing in `for` iterator joins

### DIFF
--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -18,6 +18,7 @@ import {
   append
   checkValidLHS
   convertOptionalType
+  flatJoin
   isBigIntLiteral
   literalValue
   makeLeftHandSideExpression
@@ -592,23 +593,22 @@ function processForInOf($0: [
       names: []
     } satisfies ForControlDeclaration
 
-    // If some iterand has no default, then we stop when any of them is done.
-    doneJoin .= " || "
-    doneIndices .=
-      for each defaultValue, i of defaultValues when not defaultValue?
-        i
-    // Otherwise, we stop when all iterands are done.
-    unless doneIndices#
-      doneJoin = " && "
-      doneIndices = [0..<nextRefs#]
-    condition := [
-      ...nextRefs.flatMap((nextRef, i) =>
-        [nextRef, " = ", iterRefs[i], ".next()", ", "]
-      )
-      "!("
-      ...doneIndices.flatMap (i, j) => [j ? doneJoin : "", nextRefs[i], "?.done"]
-      ")"
-    ]
+    // Advance all iterands, and stop if we exhaust an iterand without default.
+    condition :=
+      for each nextRef, i of nextRefs
+        if defaultValues[i]?
+          // Load the next IteratorResult, which is always truthy.
+          ["(", nextRef, " = ", iterRefs[i], ".next())"]
+        else
+          // Stop when this iterator exhausts
+          ["!(", nextRef, " = ", iterRefs[i], ".next()).done"]
+      |> flatJoin ., " && "
+    // If all iterands have defaults, stop when all of them are exhausted.
+    if defaultValues.every &?
+      condition.push
+        " && ("
+        ...flatJoin nextRefs.map(["!", &, ".done"]), " || "
+        ")"
     for each decl, i of itemDeclarations
       value .= [nextRefs[i], "?.value"]
       value = [nextRefs[i], "?.done ? ", trimFirstSpace(defaultValues[i]), " : ", ...value] if defaultValues[i]?

--- a/test/for.civet
+++ b/test/for.civet
@@ -688,7 +688,7 @@ describe "for", ->
     for a, b of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a = next?.value, b = next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; !(next = iter.next()).done && !(next1 = iter1.next()).done;) {const a = next?.value, b = next1?.value;
       console.log(a, b)
     }
   """
@@ -699,7 +699,7 @@ describe "for", ->
     for pair^[, attr], other^{x} of pairs, others
       console.log pair, attr, other, x
     ---
-    for (let iter = pairs[Symbol.iterator](), iter1 = others[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const pair = next?.value, [, attr] = pair, other = next1?.value, {x} = other;
+    for (let iter = pairs[Symbol.iterator](), iter1 = others[Symbol.iterator](), next, next1; !(next = iter.next()).done && !(next1 = iter1.next()).done;) {const pair = next?.value, [, attr] = pair, other = next1?.value, {x} = other;
       console.log(pair, attr, other, x)
     }
   """
@@ -710,7 +710,7 @@ describe "for", ->
     for a, b, i of x, y
       console.log a, b, i
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1, i1 = 0; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);i1++) {const a = next?.value, b = next1?.value, i = i1;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1, i1 = 0; !(next = iter.next()).done && !(next1 = iter1.next()).done;i1++) {const a = next?.value, b = next1?.value, i = i1;
       console.log(a, b, i)
     }
   """
@@ -721,7 +721,7 @@ describe "for", ->
     for a?, b of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a = next?.done ? undefined : next?.value, b = next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; (next = iter.next()) && !(next1 = iter1.next()).done;) {const a = next?.done ? undefined : next?.value, b = next1?.value;
       console.log(a, b)
     }
   """
@@ -732,7 +732,7 @@ describe "for", ->
     for a, b? of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done);) {const a = next?.value, b = next1?.done ? undefined : next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; !(next = iter.next()).done && (next1 = iter1.next());) {const a = next?.value, b = next1?.done ? undefined : next1?.value;
       console.log(a, b)
     }
   """
@@ -743,7 +743,7 @@ describe "for", ->
     for a = 0, b? of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done && next1?.done);) {const a = next?.done ? 0 : next?.value, b = next1?.done ? undefined : next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; (next = iter.next()) && (next1 = iter1.next()) && (!next.done || !next1.done);) {const a = next?.done ? 0 : next?.value, b = next1?.done ? undefined : next1?.value;
       console.log(a, b)
     }
   """
@@ -754,7 +754,7 @@ describe "for", ->
     for a?, b, c? of x, y, z
       console.log a, b, c
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), iter2 = z[Symbol.iterator](), next, next1, next2; next = iter.next(), next1 = iter1.next(), next2 = iter2.next(), !(next1?.done);) {const a = next?.done ? undefined : next?.value, b = next1?.value, c = next2?.done ? undefined : next2?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), iter2 = z[Symbol.iterator](), next, next1, next2; (next = iter.next()) && !(next1 = iter1.next()).done && (next2 = iter2.next());) {const a = next?.done ? undefined : next?.value, b = next1?.value, c = next2?.done ? undefined : next2?.value;
       console.log(a, b, c)
     }
   """
@@ -765,7 +765,7 @@ describe "for", ->
     for a = 0, b of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a = next?.done ? 0 : next?.value, b = next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; (next = iter.next()) && !(next1 = iter1.next()).done;) {const a = next?.done ? 0 : next?.value, b = next1?.value;
       console.log(a, b)
     }
   """
@@ -784,7 +784,7 @@ describe "for", ->
     ---
     pairs := for a, b of x, y
     ---
-    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a = next?.value, b = next1?.value;results.push([a, b])};const pairs =results
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; !(next = iter.next()).done && !(next1 = iter1.next()).done;) {const a = next?.value, b = next1?.value;results.push([a, b])};const pairs =results
   """
 
   testCase """
@@ -792,7 +792,7 @@ describe "for", ->
     ---
     pairs := for a?, b of x, y
     ---
-    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a = next?.done ? undefined : next?.value, b = next1?.value;results.push([a, b])};const pairs =results
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; (next = iter.next()) && !(next1 = iter1.next()).done;) {const a = next?.done ? undefined : next?.value, b = next1?.value;results.push([a, b])};const pairs =results
   """
 
   testCase """
@@ -800,7 +800,7 @@ describe "for", ->
     ---
     pairs := for {a}, {b} of x, y
     ---
-    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const {a} = next?.value, {b} = next1?.value;results.push([{a}, {b}])};const pairs =results
+    const results=[];for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; !(next = iter.next()).done && !(next1 = iter1.next()).done;) {const {a} = next?.value, {b} = next1?.value;results.push([{a}, {b}])};const pairs =results
   """
 
   throws """
@@ -817,7 +817,7 @@ describe "for", ->
     for concat {x}, {y} of a, b
     ---
     var concatAssign: <B, A extends {push: (this: A, b: B) => void} | (B extends unknown[] ? {push: (this: A, ...b: B) => void} : never)>(lhs: A, rhs: B) => A = (lhs, rhs) => (((rhs as any)?.[Symbol.isConcatSpreadable] ?? Array.isArray(rhs)) ? (lhs as any).push.apply(lhs, rhs as any) : (lhs as any).push(rhs), lhs);
-    let results=[];for (let iter = a[Symbol.iterator](), iter1 = b[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const {x} = next?.value, {y} = next1?.value;concatAssign(results, [x, y])}results
+    let results=[];for (let iter = a[Symbol.iterator](), iter1 = b[Symbol.iterator](), next, next1; !(next = iter.next()).done && !(next1 = iter1.next()).done;) {const {x} = next?.value, {y} = next1?.value;concatAssign(results, [x, y])}results
   """
 
   throws """

--- a/test/types/for.civet
+++ b/test/types/for.civet
@@ -75,7 +75,7 @@ describe "[TS] for", ->
     for a: A, b: B of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);) {const a: A = next?.value, b: B = next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; !(next = iter.next()).done && !(next1 = iter1.next()).done;) {const a: A = next?.value, b: B = next1?.value;
       console.log(a, b)
     }
   """
@@ -86,7 +86,7 @@ describe "[TS] for", ->
     for a: A, b: B, i: number of x, y
       console.log a, b, i
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1, i1 = 0; next = iter.next(), next1 = iter1.next(), !(next?.done || next1?.done);i1++) {const a: A = next?.value, b: B = next1?.value, i: number = i1;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1, i1 = 0; !(next = iter.next()).done && !(next1 = iter1.next()).done;i1++) {const a: A = next?.value, b: B = next1?.value, i: number = i1;
       console.log(a, b, i)
     }
   """
@@ -97,8 +97,19 @@ describe "[TS] for", ->
     for a?: A, b: B of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a: undefined | A = next?.done ? undefined : next?.value, b: B = next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; (next = iter.next()) && !(next1 = iter1.next()).done;) {const a: undefined | A = next?.done ? undefined : next?.value, b: B = next1?.value;
       console.log(a, b)
+    }
+  """
+
+  testCase """
+    for..of zip narrows required declarations after padding
+    ---
+    for a?: A, b: B, c: C of x, y, z
+      console.log a, b, c
+    ---
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), iter2 = z[Symbol.iterator](), next, next1, next2; (next = iter.next()) && !(next1 = iter1.next()).done && !(next2 = iter2.next()).done;) {const a: undefined | A = next?.done ? undefined : next?.value, b: B = next1?.value, c: C = next2?.value;
+      console.log(a, b, c)
     }
   """
 
@@ -108,7 +119,7 @@ describe "[TS] for", ->
     for a?: A = 0, b: B of x, y
       console.log a, b
     ---
-    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; next = iter.next(), next1 = iter1.next(), !(next1?.done);) {const a: undefined | A = next?.done ? 0 : next?.value, b: B = next1?.value;
+    for (let iter = x[Symbol.iterator](), iter1 = y[Symbol.iterator](), next, next1; (next = iter.next()) && !(next1 = iter1.next()).done;) {const a: undefined | A = next?.done ? 0 : next?.value, b: B = next1?.value;
       console.log(a, b)
     }
   """


### PR DESCRIPTION
Fixes #2194: fix TypeScript narrowing for iterator results generated by iterable zip loops.

## Background

Civet previously transpiled an ordinary iterable zip loop to a condition like:

```ts
next = iter.next(),
next1 = iter1.next(),
!(next?.done || next1?.done)
```

Although entering the body means both iterator results exist and neither is done, TypeScript does not propagate that information into the body. Consequently, `next?.value` and `next1?.value` remain possibly `undefined`.

This resembles [microsoft/TypeScript#35484](https://github.com/microsoft/TypeScript/issues/35484), an older control-flow issue involving comma expressions. That issue was fixed, but the `for`-condition case still exposes related limitations that occur with multiple iterators. (One iterator seems to have been fixed.)

Both the old issue and the remaining TypeScript issue seem to stem from the comma operator, so the new transpilations below avoid comma operators.

## New transpilation

For iterators that control termination, the assignment is now attached directly to its discriminant check:

```ts
!(next = iter.next()).done &&
!(next1 = iter1.next()).done
```

This gives TypeScript enough information to narrow both `IteratorResult` values in the loop body. It also short-circuits later calls to `.next()` after an earlier required iterator is exhausted.

The generated code uses direct `.done` access instead of `?.done`: `Iterator.next()` must return an `IteratorResult` object, so optional chaining is unnecessary and interferes with narrowing.

## Padded iterators

Padded iterators (with defaults) do not control termination, so their results do not need narrowing. Their assignment is used directly as a truthy condition operand:

```ts
(next = paddedIter.next()) &&
!(next1 = requiredIter.next()).done
```

An `IteratorResult` is always an object and therefore truthy. This avoids the comma operator. Notably, we found that TypeScript does not fully narrow when using this transpilation:

```ts
next = iter.next(),
!(next1 = iter1.next()).done &&
!(next2 = iter2.next()).done
```

TypeScript 6.0.2 narrows `next1` but reports that `next2` may be undefined. Making the padded assignment part of the logical chain works:

```ts
(next = iter.next()) &&
!(next1 = iter1.next()).done &&
!(next2 = iter2.next()).done
```

A regression test covers this case.

## All-padded zip

When every iterator is padded, all iterators must advance before deciding whether to run the body:

```ts
(next = iter.next()) &&
(next1 = iter1.next()) &&
(!next.done || !next1.done)
```

The separate aggregate check is necessary. Attaching each `.done` check directly with `||` would short-circuit and skip later `.next()` calls, leaving their values stale or uninitialized.

The loop continues while at least one padded iterator has a value and stops once all are exhausted.

## Implementation

The condition builder now:

- Maps each iterator to either a truthy padded assignment or an assignment-attached `done` check.
- Uses `flatJoin` to join iterator conditions with `&&`. (I remembered that this existed. Old code would have benefitted too.)
- Appends the all-padded aggregate condition when necessary.
- Avoids comma operators throughout the generated zip-loop condition.
