### PR TITLE
LSP: Fix completions via better newline handling

### DIFF
--- a/lsp/server/package.json
+++ b/lsp/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@danielx/civet-language-server",
   "description": "Civet Language Server (standalone, editor-agnostic)",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "repository": {
     "type": "git",
     "url": "https://github.com/DanielXMoore/civet.git"

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -1048,6 +1048,28 @@ describe "LSP features (shared project server)", ->
       resolved := await client.request "completionItem/resolve", target
       assert resolved, "expected resolved completion"
 
+  it "returns member completions in an unindented chained call argument", ->
+    uri := docUri path.join(projectRoot, "chained-call-completion.civet")
+    text := "new ResizeObserver (entries) ->\n.observe document.b\n"
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    lines := text.split "\n"
+    useLine := lines.findIndex (line) => line.includes "document.b"
+    result := await client.request "textDocument/completion", {
+      textDocument: { uri }
+      position: {
+        line: useLine
+        character: lines[useLine].indexOf("document.b") + "document.b".length
+      }
+    }
+    list := result?.items ?? result
+    assert Array.isArray(list), `expected completion items array, got ${JSON.stringify(result)}`
+    assert list.some((item: any) => item.label is "body"),
+      `expected body member completion, got ${list.map((item: any) => item.label).join(", ")}`
+
   it "returns member completions for bare @ shorthand trigger", ->
     uri := docUri path.join(projectRoot, "at-completion.civet")
     text := """

--- a/lsp/server/test/util.civet
+++ b/lsp/server/test/util.civet
@@ -100,6 +100,23 @@ describe "util", ->
       srcStr := src.slice(srcColumn, srcColumn + 7)
       assert.equal srcStr.replace(" ", "("), generatedLines[pos.line].slice(pos.character, pos.character + 7)
 
+  it "should keep an exact cursor before generated punctuation", ->
+    src := "new ResizeObserver (entries) ->\n.observe document.b\n"
+    {code, sourceMap} := await Civet.compile(src, {
+      filename: "test.civet"
+      sourceMap: true
+    })
+
+    sourcePosition := {
+      line: 1
+      character: ".observe document.b".length
+    }
+    generatedPosition := forwardMap sourceMap.lines, sourcePosition
+    generatedLine := code.split("\n")[generatedPosition.line]
+
+    assert.equal generatedLine[generatedPosition.character], ")",
+      "cursor after document.b should stay before the generated closing parenthesis"
+
   it "should forward map @ shorthand", ->
     // When user types @bar in a class method, @ maps to `this.` in TypeScript.
     // The cursor after @ (at the 'b' position) should map to 'b' in `this.bar`.

--- a/lsp/vscode/e2e/completion.test.civet
+++ b/lsp/vscode/e2e/completion.test.civet
@@ -26,6 +26,23 @@ suite 'Completion', =>
     labels := completions.items.map(getLabel)
     assert labels.includes('log'), `Expected 'log' in console completions, got: ${labels.join(', ')}`
 
+  test 'Returns member completions in an unindented chained call argument', =>
+    docUri := getDocUri('chained-call-completion.civet')
+    await activate(docUri)
+
+    completions := await poll(
+      () => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position(1, '.observe document.b'.length)
+      ) as Promise<CompletionList>
+      (list) => list?.items.some((item) => getLabel(item) is 'body')
+    )
+
+    labels := completions.items.map(getLabel)
+    assert labels.includes('body'),
+      `Expected 'body' in document completions, got: ${labels.join(', ')}`
+
   test 'Resolves completion item details', =>
     docUri := getDocUri('console.civet')
     await activate(docUri)

--- a/lsp/vscode/e2e/fixture/chained-call-completion.civet
+++ b/lsp/vscode/e2e/fixture/chained-call-completion.civet
@@ -1,0 +1,2 @@
+new ResizeObserver (entries) ->
+.observe document.b

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Civet",
   "description": "Civet Language Server",
   "icon": "images/civet.webp",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "publisher": "DanielX",
   "repository": {
     "type": "git",

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -132,6 +132,11 @@ export class SourceMap
       @colOffset = line.length
       @srcColumn += line.length
 
+      // A newline-only token splits into empty segments on either side of the
+      // line break.  The line state advances above, but neither segment has
+      // generated characters to map.
+      continue unless line#
+
       if inputPos?
         // srcLine and srcCol are absolute here
         @lines[@line].push [l, 0, srcLine!+i, srcCol!]

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -6,6 +6,16 @@ assert from assert
 { transform } from esbuild
 
 describe "source map", ->
+  it "does not emit mappings for empty newline segments", ->
+    sourceMap := new SourceMap "a\n", "input.civet"
+    sourceMap.updateSourceMap "a", 0
+    sourceMap.updateSourceMap "\n", 1
+
+    assert.deepEqual sourceMap.lines, [
+      [[0, 0, 0, 0]]
+      []
+    ]
+
   it "should parse from base64Encoded", ->
     src := """
       x := a + 3


### PR DESCRIPTION
Fix LSP member completion when a Civet expression ends immediately before a generated closing delimiter and the source file has a trailing newline.

For example (as reported by kutu on Discord):

```civet
new ResizeObserver (entries) ->
.observe document.b
```

With cursor after `b`, VS Code previously offered global completions such as `bigint`, `boolean`, and `break` instead of `document.body`.

The fix avoids emitting source-map entries for empty segments created when a generated newline-only token is split into lines. These segments contain no generated characters, so they should not introduce mapping positions.

## Root cause

Civet generates:

```typescript
new ResizeObserver(function(entries) {})
.observe(document.b)
```

The completion cursor is after `b` in the Civet source:

```text
.observe document.b|
                   ^ source column 19
```

The corresponding generated cursor should be before the compiler-inserted `)`:

```text
.observe(document.b|)
                   ^ generated column 19
```

This lets TypeScript see that the cursor is completing `document.b`, so it returns members of `Document`, including `body`.

The source-map generator processes output one token at a time. Near the end of this expression, it processes:

1. The generated `")"` token.
2. The generated `"\n"` token.

Both tokens are anchored at the end of the Civet line, source column 19.

Processing `")"` correctly creates this mapping:

| Generated position | Source position | Meaning |
| --- | --- | --- |
| Line 1, column 19 | Line 1, column 19 | Before the generated `)` |

The problem occurred while processing `"\n"`. `updateSourceMap` splits every output token at line breaks:

```civet
outLines := outputStr.split(EOL)
```

Splitting the newline-only token produces:

```javascript
["", ""]
```

These are zero-width segments on either side of the line break. The old code nevertheless emitted mappings for them. In particular, the first empty segment produced:

| Generated position | Source position | Meaning |
| --- | --- | --- |
| Line 1, column 20 | Line 1, column 19 | After the generated `)` |

There were therefore two generated positions for the same source position:

```text
generated 1:19 ─┐
                 ├── source 1:19
generated 1:20 ─┘
```

`forwardMap` resolves equally good source mappings in favor of the later generated mapping, so it chose generated column 20. TypeScript consequently received this cursor:

```text
.observe(document.b)|
                    ^ generated column 20
```

At that position, the call expression is already complete. The cursor is no longer inside `document.b`, so TypeScript returns scope-level completions instead of `Document` members.

This also explains why the problem depended on a trailing newline. Without the generated newline token, the redundant mapping at column 20 was never created, and the cursor remained at column 19.

## Fix

Skip empty segments after performing the necessary line-state updates:

```civet
// A newline-only token splits into empty segments on either side of the
// line break. The line state advances above, but neither segment has
// generated characters to map.
continue unless line#
```

The newline still advances the generated and source line state. It simply does not create mappings for positions that cover no generated characters.

After this change, the only applicable mapping is generated column 19, before the inserted `)`. The existing `forwardMap` behavior then produces the correct completion position without any LSP-specific cursor adjustment or mapping bias.

## Tests

Added coverage at three levels:

- Source-map generation does not emit mappings for empty newline segments.
- Forward mapping keeps the completion cursor before generated closing punctuation.
- Protocol-level and VS Code end-to-end tests verify that `document.body` is offered inside the chained `.observe` call.

Validation:

- Compiler: 4,620 passing, 21 pending
- LSP: 302 passing
- VS Code E2E: 58 passing
