### PR TITLE
Dev: Improve various types such as operators

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -49,6 +49,7 @@ import {
   makeRef,
   maybeRef,
   maybeRefAssignment,
+  staticPropertyName,
   modifyString,
   namesOf,
   negateCondition,
@@ -87,6 +88,7 @@ import {
 import type {
   AccessStart,
   Argument,
+  ArrayExpression,
   ArrayBindingPattern,
   ArrayBindingPatternContent as ArrayBindingPatternContentType,
   ArrowFunction,
@@ -94,11 +96,13 @@ import type {
   ASTError,
   ASTLeaf,
   ASTNode,
+  ASTNodeObject,
   ASTRef,
   ASTString,
   BinaryOp,
   BinaryOpRHS,
   Binding,
+  BindingIdentifier,
   BindingRestElement,
   BlockStatement,
   CaseBlock,
@@ -130,6 +134,7 @@ import type {
   FunctionExpression,
   FunctionParameter,
   FunctionRestParameter,
+  FunctionSignature,
   Identifier,
   IfStatement,
   Initializer,
@@ -163,6 +168,7 @@ import type {
   OperatorImportSpecifier,
   OperatorSignature,
   Parameter,
+  ParametersNode as ParsedParameters,
   ParenthesizedExpression,
   PatternClause,
   PinPattern,
@@ -182,9 +188,11 @@ import type {
   TypeConditional,
   TypeCondition,
   TypeDeclaration,
+  TypeDeclarationBinding,
   TypeArgument,
   TypeArgumentList,
   TypeFunction,
+  TypeLexicalDeclaration,
   TypeNode,
   TypeParameters,
   TypeSuffix,
@@ -220,7 +228,7 @@ interface ParserState
   forbidInlineObjectLiteral: boolean[]
   JSXTagStack: unknown[]
   indentLevels: { level: number, token?: string }[]
-  operators: Map<string, any>
+  operators: Map<string, OperatorBehavior?>
   helperRefs: any
   prelude: any
   lastIndent: any
@@ -823,9 +831,9 @@ BinaryOpRHS ::BinaryOpRHS
   # +b
   NewlineBinaryOpAllowed NotDedentedBinaryOp:op WRHS:rhs ->
     // > operator needs to have space on both sides (or neither)
-    return $skip if op[1].token is ">" and op[0].length is 0
+    return $skip if op is like [[], {token: ">"}]
     // NOTE: Flatten NotDedentedBinaryOp into whitespace and operator
-    return [...op, ...rhs] as BinaryOpRHS
+    return [...op, ...rhs]
   !NewlineBinaryOpAllowed SingleLineBinaryOpRHS -> $2
 
 IsLike ::BinaryOp
@@ -1367,13 +1375,14 @@ ClassDeclaration
 # https://262.ecma-international.org/#prod-ClassExpression
 ClassExpression
   Decorators?:decorators ( Abstract __ )?:abstract Class:class_ !":" ClassBinding?:binding ClassHeritage?:heritage ClassBody:body ->
+    id := binding?.[0]
     return {
       type: "ClassExpression",
       decorators,
       abstract,
       binding,
-      id: binding?.[0],
-      name: binding?.[0]?.name,
+      id,
+      name: id is like {name} ? id.name : undefined,
       heritage,
       body,
       children: [decorators, abstract, class_, binding, heritage, body],
@@ -1603,7 +1612,7 @@ ClassElementDefinition
   ( MethodDefinition / FieldDefinition )
 
 # `declare class` form of ClassDeclaration, where all methods are signatures
-ClassSignature
+ClassSignature ::Children
   Decorators? AbstractModifier? Class ClassBinding? ClassHeritage? ClassSignatureBody
 
 ClassSignatureBody
@@ -2349,12 +2358,13 @@ MetaProperty
 # NOTE: Special `return.value` (and `return =` shorthand)
 # for changing the automatic return value of function
 ReturnValue ::ReturnValue
-  "return.value" NonIdContinue ->
-    return { type: "ReturnValue", children: [$1[0]] }
+  "return.value":placeholder NonIdContinue ->
+    { type: "ReturnValue", children: [placeholder], placeholder, names: [] }
   ReturnAsValue:value &AfterReturnShorthand -> value
 
 ReturnAsValue ::ReturnValue
-  Return:value -> { type: "ReturnValue", children: [value] }
+  Return:placeholder ->
+    { type: "ReturnValue", children: [placeholder], placeholder, names: [] }
 
 AfterReturnShorthand
   WAssignmentOp
@@ -2502,14 +2512,14 @@ ParameterElementDelimiter
   &EOS InsertComma -> $2
 
 # https://262.ecma-international.org/#prod-BindingIdentifier
-BindingIdentifier
+BindingIdentifier ::BindingIdentifier
   # NOTE: Added @param for binding identifiers
   # The parser will allow them in const/let/var declarations but JS/TS doesn't allow them there
   __:ws NWBindingIdentifier:identifier ->
     return prepend(ws, identifier)
 
 # Non-whitespace version of BindingIdentifier
-NWBindingIdentifier
+NWBindingIdentifier ::BindingIdentifier
   # NOTE: Added @param for binding identifiers
   # The parser will allow them in const/let/var declarations but JS/TS doesn't allow them there
   At:at AtIdentifierRef:ref ->
@@ -2531,8 +2541,7 @@ NWBindingIdentifier
     }
   Identifier:id
   # NOTE: Support for return := 1 and let return: number
-  ReturnValue ->
-    return { children: [$1], names: [] }
+  ReturnValue
 
 AtIdentifierRef ::ASTRef
   # `@is`, `@loop`, etc. fall through to IdentifierName; makeRef +
@@ -2750,7 +2759,7 @@ BindingProperty
   _?:ws Caret:_pin BindingIdentifier:binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     // Note that this has the name but not the value.
     // This is what we want when destructuring, but not in function params.
-    children := [ws, binding]
+    children: Children := [ws, binding]
     // TODO make this work with pin
     if binding.type is "AtBinding"
       children.push({
@@ -2781,7 +2790,7 @@ BindingProperty
 
   # NOTE: name^ means we should bind name, but we do anyway, so allow but ignore
   _?:ws BindingIdentifier:binding Caret?:_bind BindingPropertyTypeSuffix?:typeSuffix Initializer?:initializer ->
-    children .= [ws, binding, initializer]  // omit bind, typeSuffix
+    children: Children .= [ws, binding, initializer]  // omit bind, typeSuffix
 
     if binding.type is "AtBinding"
       return {
@@ -2795,7 +2804,7 @@ BindingProperty
       }
 
     // `{ 😊 }` → `{ "😊": u$1F60A$ }` so the lookup uses the source name.
-    if binding.unicode
+    if binding.type is "Identifier" and binding.unicode
       children = [ws, propertyKey(binding), ": ", binding, initializer]
 
     return {
@@ -2804,7 +2813,7 @@ BindingProperty
       name: binding,
       // Setting value to the binding when expanded keeps the AST shape
       // consistent (downstream code distinguishes shorthand by `value: undefined`).
-      value: binding.unicode ? binding : undefined,
+      value: binding.type is "Identifier" and binding.unicode ? binding : undefined,
       typeSuffix,
       initializer,
       names: binding.names,
@@ -2912,15 +2921,15 @@ EmptyBindingPattern
     }
 
 # https://262.ecma-international.org/#prod-FunctionDeclaration
-FunctionDeclaration
+FunctionDeclaration ::FunctionExpression | ParenthesizedExpression
   # Wrap nameless function declarations with parens, as needed in JS.
-  FunctionExpression ->
+  FunctionExpression:functionExpression ->
     // Do not treat ArrowFunctions, as generated by & and (+), as declarations
-    return $skip if $1.type !== "FunctionExpression"
-    return $1 if $1.id
-    return makeLeftHandSideExpression($1)
+    return $skip unless functionExpression is like {type: "FunctionExpression"}
+    return functionExpression if functionExpression.id
+    return parenthesizeExpression(functionExpression)
 
-FunctionSignature
+FunctionSignature ::FunctionSignature
   # NOTE: Merged in async and generator with optionals
   ( Async _ )?:async Function:func ( _? Star )?:generator ( _? NWBindingIdentifier )?:wid _?:w Parameters:parameters ReturnTypeSuffix?:returnType ->
     async = [] unless async
@@ -2930,7 +2939,7 @@ FunctionSignature
     return {
       type: "FunctionSignature",
       id,
-      name: id?.name,
+      name: id is like {name} ? id.name : undefined,
       parameters,
       returnType,
       async,
@@ -2949,7 +2958,7 @@ FunctionSignature
 # https://262.ecma-international.org/#prod-FunctionExpression
 FunctionExpression
   # NOTE: block isn't actually optional in FunctionExpression only in declarations/TS overloads
-  FunctionSignature:signature BracedBlock?:block ->
+  FunctionSignature:signature BracedBlock?:block ::FunctionExpression ->
     // TS Function overloads
     unless block
       return {
@@ -2969,46 +2978,59 @@ FunctionExpression
     }
 
   # BinaryOp function shorthand (op)
-  !ArrowFunction OpenParen:open __:ws1 BinaryOp:op __:ws2 CloseParen:close ->
+  # op.call is a NonNullASTNode, so this alternative cannot use ::ArrowFunction.
+  !ArrowFunction OpenParen:open __:ws1 BinaryOp:op __:ws2 CloseParen:close ::NonNullASTNode ->
     // (foo) doesn't need an arrow wrapper; just foo suffices
-    return op.call if op.special and op.call and not op.negated
+    return op.call if op is like {special: true} and op.call and not op.negated
 
-    ws1 = op.spaced ? [" "] : [] unless ws1
-    ws2 = op.spaced ? [" "] : [] unless ws2
+    ws1 or= op is like {spaced: true} ? [" "] : []
+    ws2 or= op is like {spaced: true} ? [" "] : []
     refA := makeRef("a")
     refB := makeRef("b")
     body := processBinaryOpExpression([refA, [
       [ws1, op, ws2, refB] // BinaryOpRHS
     ]])
 
-    parameterList := [ [ refA, "," ], refB ]
-    parameters := {
+    parameterList: FunctionParameter[] := [ [ refA, "," ], refB ]
+    parameters: ParsedParameters := {
       type: "Parameters",
       children: ["(", parameterList, ")"],
       parameters: parameterList
     }
 
-    block := {
-      expressions: [body],
+    expressions: StatementTuple[] := [["", body]]
+    block: BlockStatement := {
+      type: "BlockStatement",
+      bare: true,
+      expressions,
+      children: [expressions],
+      implicitlyReturned: true,
     }
+    signature: FunctionSignature := {
+      type: "FunctionSignature",
+      modifier: {},
+      parameters,
+      block,
+      children: [parameters],
+    }
+    async: ASTNode[] := []
 
     return {
       type: "ArrowFunction",
-      signature: {
-        modifier: {},
-      },
-      children: [open, parameters, " => ", body, close],
+      signature,
+      children: [open, async, parameters, " => ", body, close],
       body,
       parenthesized: true,
       parenthesizedOp: op,
       block,
       parameters,
-    }
+      async,
+    } satisfies ArrowFunction
 
   # Haskell-style sections
-  OpenParen:open NonPipelineAssignmentExpression:lhs __:ws1 BinaryOp:op __:ws2 CloseParen:close ->
-    ws1 = op.spaced ? [" "] : [] unless ws1
-    ws2 = op.spaced ? [" "] : [] unless ws2
+  OpenParen:open NonPipelineAssignmentExpression:lhs __:ws1 BinaryOp:op __:ws2 CloseParen:close ::ParenthesizedExpression ->
+    ws1 or= op is like {spaced: true} ? [" "] : []
+    ws2 or= op is like {spaced: true} ? [" "] : []
     refB := makeRef("b")
     fn := makeAmpersandFunction({
       ref: refB,
@@ -3022,7 +3044,7 @@ FunctionExpression
       expression: fn,
     }
   # Assignment version based on ActualAssignment rule
-  OpenParen:open ( NotDedented UpdateExpression WAssignmentOp )+:lhs __:ws2 CloseParen:close ->
+  OpenParen:open ( NotDedented UpdateExpression WAssignmentOp )+:lhs __:ws2 CloseParen:close ::ParenthesizedExpression ->
     lhs = lhs.map((x) => [x[0], x[1], ...x[2]])
     refB := makeRef("b")
     fn := makeAmpersandFunction({
@@ -3041,7 +3063,7 @@ FunctionExpression
       children: [ open, fn, close ],
       expression: fn,
     }
-  OpenParen:open __:ws1 IsLike:op __:ws2 PatternExpressionList:rhs CloseParen:close ->
+  OpenParen:open __:ws1 IsLike:op __:ws2 PatternExpressionList:rhs CloseParen:close ::ParenthesizedExpression ->
     refA := makeRef("a")
     fn := makeAmpersandFunction({
       ref: refA,
@@ -3054,9 +3076,9 @@ FunctionExpression
       children: [ open, fn, close ],
       expression: fn,
     }
-  OpenParen:open __:ws1 !/\+\+|--|⧺|—|[\+\-&]\S/ !( Placeholder ( TypePostfix / BinaryOpRHS ) ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
-    ws1 = op.spaced ? [" "] : [] unless ws1
-    ws2 = op.spaced ? [" "] : [] unless ws2
+  OpenParen:open __:ws1 !/\+\+|--|⧺|—|[\+\-&]\S/ !( Placeholder ( TypePostfix / BinaryOpRHS ) ) BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ::ParenthesizedExpression ->
+    ws1 or= op is like {spaced: true} ? [" "] : []
+    ws2 or= op is like {spaced: true} ? [" "] : []
     refA := makeRef("a")
     fn := makeAmpersandFunction({
       ref: refA,
@@ -3146,7 +3168,7 @@ OperatorPrecedence ::OperatorBehavior
     let prec: number, error: ASTError?
     if op.type is "Identifier"
       if state.operators.has(op.name)
-        prec = state.operators.get(op.name).prec
+        prec = state.operators.get(op.name)?.prec ?? precedenceCustomDefault
       else
         prec = precedenceCustomDefault
         error = {
@@ -3482,7 +3504,7 @@ SingleLineStatements
     // NOTE: the .map keeps `expressions` a loose union array (not a strict
     // [prefix, statement, delim] tuple) so the optional final delimiter and the
     // trailing-comment "\n" push below stay assignable.
-    expressions := stmts.map(([prefix, statement, delim]) => [prefix, statement, delim])
+    expressions: StatementTuple[] := stmts.map(([prefix, statement, delim]) => [prefix, statement, delim])
     expressions.push([last[0], last[1], last[2]]) if last
 
     children := [expressions]
@@ -3516,7 +3538,7 @@ BracedObjectSingleLineStatements
 
 PostfixedSingleLineStatements
   ( ( _? !EOS ) StatementListItem SemicolonDelimiter )*:stmts ( ( _? !EOS ) StatementListItem SemicolonDelimiter? )?:last ->
-    children := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
+    children: StatementTuple[] := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
     children.push([last[0][0], last[1], last[2]]) if last
 
     return {
@@ -3528,7 +3550,7 @@ PostfixedSingleLineStatements
 
 PostfixedSingleLineNoCommaStatements
   ( ( _? !EOS ) NoCommaStatementListItem SemicolonDelimiter )*:stmts ( ( _? !EOS ) NoCommaStatementListItem SemicolonDelimiter? )?:last ::BlockStatement ->
-    children := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
+    children: StatementTuple[] := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
     children.push([last[0][0], last[1], last[2]]) if last
 
     return {
@@ -3979,7 +4001,7 @@ ArrayElementExpression
     }
 
 # NOTE: Nested bulleted array starts with an indentation.
-NestedBulletedArray
+NestedBulletedArray ::ArrayExpression
   ( InsertSpace InsertOpenBracket ):open PushIndent AllowPipeline NestedArrayBullet*:content RestorePipeline InsertCloseBracket:close PopIndent ->
     return $skip unless content#
     content = content.flat() // combine bullets into one array
@@ -4147,7 +4169,7 @@ BracedObjectLiteralContent
 
 # NOTE: Nested implicit object literal starts with an indentation.
 # All properties can be spaced out and must have a colon.
-NestedImplicitObjectLiteral
+NestedImplicitObjectLiteral ::ObjectExpression
   InsertOpenBrace:open PushIndent AllowPipeline NestedImplicitPropertyDefinitions?:properties RestorePipeline PopIndent InsertNewline:newline InsertIndent:indent InsertCloseBrace:close ->
     return $skip unless properties
     return {
@@ -4538,10 +4560,10 @@ Decorator
   # Might want to disallow import, super, and return CallExpressions
   AtAt CallExpression
 
-Decorators
-  ForbidClassImplicitCall ( __ Decorator )*:decorators __ RestoreClassImplicitCall ->
+Decorators ::Children
+  ForbidClassImplicitCall ( __ Decorator )*:decorators __:ws RestoreClassImplicitCall ->
     return $skip unless decorators#
-    return $0
+    return [decorators, ws]
 
 # https://262.ecma-international.org/#prod-MethodDefinition
 MethodDefinition ::MethodDefinition | MultiMethodDefinition
@@ -4549,7 +4571,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     return {
       type: "MethodDefinition",
       children: $0,
-      name: signature.name,
+      signature.{id,name}
       abstract: true,
       signature,
       parameters: signature.parameters,
@@ -4563,7 +4585,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
     return {
       type: "MethodDefinition",
       children: [signature, block],
-      name: signature.name,
+      signature.{id,name}
       signature,
       block,
       parameters: signature.parameters,
@@ -4680,11 +4702,12 @@ MethodModifier
     }
 
 MethodSignature ::MethodSignature
-  ConstructorShorthand NonEmptyParameters:parameters ->
+  ConstructorShorthand:id NonEmptyParameters:parameters ->
     return {
       type: "MethodSignature",
       children: $0,
-      name: $1.token,
+      id,
+      name: id.token,
       modifier: {},
       returnType: undefined,
       parameters,
@@ -4692,22 +4715,19 @@ MethodSignature ::MethodSignature
 
   # NOTE: If this node layout changes, be sure to update
   # `convertMethodToFunction`
-  MethodModifier:modifier ClassElementName:authoredName _?:ws1 QuestionMark?:optional _?:ws2 NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ->
+  MethodModifier:modifier ClassElementName:id _?:ws1 QuestionMark?:optional _?:ws2 NonEmptyParameters:parameters ReturnTypeSuffix?:returnType ->
     // Normalize name so we can check if it is `constructor`
-    name .= authoredName
-    if name.name
-      name = name.name
-    else if name.token
-      name = name.token.match(/^(?:"|')/) ? name.token[<..<] : name.token
+    name := staticPropertyName id
 
     // TypeScript supports optional methods with bodies; remove ? from JS output
     if optional then optional = { ...optional, ts: true } as any
 
     return {
       type: "MethodSignature",
-      children: [ ...modifier.children, authoredName, ws1, optional, ws2, parameters, returnType ],
+      children: [ ...modifier.children, id, ws1, optional, ws2, parameters, returnType ],
       async: modifier.async,
       generator: modifier.generator,
+      id,
       name,
       optional,
       modifier: modifier.modifier, // get/set/async/generator
@@ -4861,7 +4881,7 @@ CoffeeWordAssignmentOp
 
 # NOTE: Similar to `NotDedented BinaryOp`,
 # but forbid Nested with custom infix operators
-NotDedentedBinaryOp
+NotDedentedBinaryOp ::[ASTNode, BinaryOp]
   IndentedFurther?:ws1 _?:ws2 BinaryOp:op ->
     ws := []
     ws.push(...ws1) if ws1
@@ -4875,10 +4895,10 @@ IdentifierBinaryOp
     return id if state.operators.has(id.name)
     return $skip
 
-BinaryOp
+BinaryOp ::BinaryOp
   /(?=\p{ID_Start}|[_$^≪≫⋙≤≥∈∋∉∌≣≡≢≠=⩶⩵‖⁇&|*\/!?%÷<>⧺+-])/ _BinaryOp:op -> op
 
-_BinaryOp
+_BinaryOp ::BinaryOp
   BinaryOpSymbol ->
     if typeof $1 === "string" then return { $loc, token: $1 }
     return $1
@@ -4901,7 +4921,7 @@ _BinaryOp
     }
 
 # NOTE: Condensed binary operator symbols into one rule
-BinaryOpSymbol
+BinaryOpSymbol ::BinaryOp
   "**"
   "*"
   "%/" / "÷" / ( CoffeeDivEnabled "//" ) ->
@@ -5006,7 +5026,7 @@ BinaryOpSymbol
     }
   CoffeeOfEnabled CoffeeOfOp:op -> op
   OmittedNegation __ NotOp:op ->
-    return { ...op, $loc }
+    return { ...op, $loc } satisfies ASTLeaf & BinaryOp
   ( Is __ In ) / "∈" ->
     return {
       method: "includes",
@@ -5065,7 +5085,7 @@ ActualIn
   CoffeeOfEnabled Of -> $2
   !CoffeeOfEnabled In -> $2
 
-CoffeeOfOp
+CoffeeOfOp ::BinaryOp
   Of -> "in"
   In ->
     return {
@@ -5092,7 +5112,9 @@ CoffeeOfOp
       special: true,
     }
 
-NotOp
+# ASTLeaf forces an object, but TypeScript does not infer that it excludes
+# BinaryOp's string arm, so we do so explicitly.
+NotOp ::ASTLeaf & Exclude<BinaryOp, string>
   "instanceof" NonIdContinue ->
     return {
       $loc,
@@ -5159,12 +5181,12 @@ PostfixedStatement
     return addPostfixStatement(statement, ...post) if post
     return statement
 
-NoCommaStatementListItem
+NoCommaStatementListItem ::ASTNode
   Declaration
   # NOTE: Added postfix conditionals/loops
   PostfixedNoCommaStatement
 
-PostfixedNoCommaStatement
+PostfixedNoCommaStatement ::ASTNode
   NoCommaStatement:statement ( _? PostfixStatement )?:post ->
     return addPostfixStatement(statement, ...post) if post
     return statement
@@ -5321,7 +5343,7 @@ LabelIdentifier ::Label
       children: [id],
     }
 
-LabelledItem
+LabelledItem ::ASTNodeObject
   Statement
   FunctionDeclaration
 
@@ -6530,7 +6552,7 @@ NestedPostfixedExpressionNoTrailing
     return $skip unless expression
     return expression
 
-MaybeNestedExpression ::unknown
+MaybeNestedExpression ::NonNullASTNode
   # Leave NestedBulletedArray and NestedImplicitObjectLiteral for
   # the second case, where they get checked by PrimaryExpression,
   # which then allows for trailing binary operators etc.
@@ -6950,7 +6972,7 @@ ExportDeclaration
   # NOTE: This covers all forms that can be directly export defaulted in TS.
   # NOTE: Using Expression to allow If/Switch expressions
   Decorators? Export __ Default __ ( HoistableDeclaration / ClassDeclaration / InterfaceDeclaration ):declaration ->
-    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
+    return { type: "ExportDeclaration", declaration, ts: "ts" in declaration and declaration.ts, children: $0 }
   # NOTE: `_?` (not `__`) so that a value on the next line (e.g. a
   # NestedImplicitObjectLiteral) is left for MaybeNestedPostfixedExpressionOrCommaLoop
   # to handle its own indentation (#2186).
@@ -6984,10 +7006,10 @@ ExportDeclaration
       return {
         type: "ExportDeclaration",
         declaration,
-        ts: declaration.ts,
+        ts: "ts" in declaration and declaration.ts,
         children: [dec, declaration, splitClause],  // omit Export keyword + ws
       }
-    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
+    return { type: "ExportDeclaration", declaration, ts: "ts" in declaration and declaration.ts, children: $0 }
 
 # CoffeeScript style `export x = 3` -> `export var x = 3`
 # Respect autoConst/autoLet so `export x = 3` becomes `export const x = 3`
@@ -6995,12 +7017,13 @@ ExportDeclaration
 # declaration so auto-dec.civet can split it into `<assign>; export {names}`
 # when any name is already declared, pre-declaring any new ones with `let`
 # (avoiding TDZ/redeclaration errors).
-ExportVarDec
+ExportVarDec ::Declaration
   InsertVar VariableDeclarationList ->
-    token := config.autoConst ? "const " : config.autoLet ? "let " : "var "
+    decl := config.autoConst ? "const" : config.autoLet ? "let" : "var"
     return {
       ...$2,
-      children: [{...$1, token}, ...$2.children]
+      children: [{...$1, token: `${decl} `}, ...$2.children]
+      decl
       autoExport: true
     }
 
@@ -7111,7 +7134,7 @@ HoistableDeclaration
 LexicalDeclaration ::LexicalDeclaration
   # NOTE: Eliminated left recursion
   LetOrConst:decl LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
-    bindings: Binding[] := [binding as Binding].concat(tail.map(([,,,b]) => b as Binding))
+    bindings: Binding[] := [binding].concat(tail.map(([,,,b]) => b))
     thisAssignments: ThisAssignments := bindings.flatMap((b) => b.thisAssignments)
 
     return {
@@ -7119,7 +7142,7 @@ LexicalDeclaration ::LexicalDeclaration
       children: $0,
       names: bindings.flatMap((b) => b.names),
       bindings,
-      decl: decl as DeclarationKind,
+      decl,
       splices: bindings.flatMap((b) => b.splices),
       thisAssignments,
     }
@@ -7156,8 +7179,9 @@ BackwardLetAssignment
   "=." ![0-9] ->
     return { $loc, token: "=", decl: "let " }
 
-BackwardBindingIdentifier
-  ReturnValue / ReturnAsValue -> { children: [$1], names: [] }
+BackwardBindingIdentifier ::ReturnValue
+  ReturnValue
+  ReturnAsValue
 
 TypeAssignment
   "::=" ->
@@ -7165,7 +7189,7 @@ TypeAssignment
 
 # https://262.ecma-international.org/#prod-LexicalBinding
 # merged with https://262.ecma-international.org/#prod-VariableDeclaration
-LexicalBinding
+LexicalBinding ::Binding
   BindingPattern:pattern TypeSuffix?:typeSuffix Initializer:initializer ->
     [splices, thisAssignments] := gatherBindingCode(pattern)
     typeSuffix ??= pattern.typeSuffix
@@ -7212,7 +7236,7 @@ VariableStatement ::Declaration
     }
 
 # https://262.ecma-international.org/#prod-VariableDeclarationList
-VariableDeclarationList
+VariableDeclarationList ::Omit<Declaration, "decl">
   LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
     bindings := [binding].concat(tail.map(([,,,b]) => b))
 
@@ -7320,7 +7344,7 @@ SingleLineStringLiteral
     } as const
 
 # SingleLineStringLiteral but with no closing quote, for generating errors
-UnclosedSingleLineStringLiteral
+UnclosedSingleLineStringLiteral ::Children
   ( $( DoubleQuote /(?:\\.|[^"\n])*/ ) / $( SingleQuote /(?:\\.|[^'\n])*/ ) ) &EOS ->
     return [
       {
@@ -7410,7 +7434,8 @@ HeregexLiteral
         children,
       }
 
-    source := body.map(.token).join("")
+    // Excluding the `type: "Substitution"` HeregexPart leaves only ASTLeaf.
+    source := (body as ASTLeaf[]).map(.token).join("")
     if not source#
       pos := open.$loc.pos + open.$loc#
       empty :=
@@ -7884,7 +7909,7 @@ Infer
     return { type: "Keyword" as const, $loc, token: $1 }
 
 # https://262.ecma-international.org/#prod-LetOrConst
-LetOrConst
+LetOrConst ::DeclarationKind
   ( "let" / "const" ) NonIdContinue ->
     return { type: "Keyword" as const, $loc, token: $1 }
 
@@ -8596,7 +8621,7 @@ InlineJSXAttributeValue
 # BinaryOpRHS without whitespace and without ExpressionizedStatement,
 # forbidding operators starting with < or > (possible JSX tags),
 # and forbidding implicitly parenthesized assignments.
-InlineJSXBinaryOpRHS
+InlineJSXBinaryOpRHS ::BinaryOpRHS
   ![<>] BinaryOp:op InlineJSXUnaryExpression:rhs ->
     // NOTE: Inserting empty whitespace arrays to be compatible with BinaryOpRHS and `processBinaryOpExpression`
     return [[], op, [], rhs]
@@ -8954,7 +8979,7 @@ TypeDeclaration
     }
 
 # NOTE: These are declarations even without a `declare` prefix
-TypeDeclarationRest
+TypeDeclarationRest ::TypeDeclaration | InterfaceDeclaration | NamespaceDeclaration | FunctionSignature
   TypeAliasDeclaration
   InterfaceDeclaration
   NamespaceDeclaration
@@ -9001,7 +9026,7 @@ OptionalEquals
   &IndentedFurther InsertSpaceEquals -> $2
 
 # NOTE: These are all guaranteed to be preceded by a `declare` keyword
-TypeLexicalDeclaration
+TypeLexicalDeclaration ::ASTNode
   TypeLetOrConstDeclaration
   __ EnumDeclaration
   ClassSignature
@@ -9009,7 +9034,7 @@ TypeLexicalDeclaration
   Module _ StringLiteral DeclareBlock?
   Global DeclareBlock?
 
-TypeLetOrConstDeclaration
+TypeLetOrConstDeclaration ::TypeLexicalDeclaration
   __ LetOrConstOrVar TypeDeclarationBinding:first ( CommaDelimiter __ TypeDeclarationBinding )*:rest ->
     names := first.names.concat(...rest.map((b) => b[2].names))
     return {
@@ -9019,7 +9044,7 @@ TypeLetOrConstDeclaration
       names,
     }
 
-TypeDeclarationBinding
+TypeDeclarationBinding ::TypeDeclarationBinding
   # NOTE: This is almost the same as LexicalBinding except it cannot have an initializer
   ( BindingPattern / BindingIdentifier ) TypeSuffix? ->
     return {
@@ -9108,7 +9133,7 @@ NestedModuleItems
 NestedModuleItem
   Nested ModuleItem StatementDelimiter
 
-DeclareBlock
+DeclareBlock ::Children
   __ OpenBrace NestedDeclareElements __ CloseBrace
   __ OpenBrace ( __ DeclareElement InterfacePropertyDelimiter)* __ CloseBrace
   # NOTE: Added indentation based implied braces
@@ -9125,8 +9150,8 @@ NestedDeclareElement
 # NOTE: Variation on TypeDeclaration where Declare already applied.
 DeclareElement ::ASTNode
   Decorators? Export __ Default __ ( Identifier / ClassSignature / InterfaceDeclaration ):declaration
-  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 } as ASTNode
-  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 } as ASTNode
+  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
+  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 }
 
 EnumDeclaration ::EnumDeclaration
   ( Const _ )?:_isConst Enum _? IdentifierName:id EnumBlock:block ->

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -245,7 +245,7 @@ function processReturnValue(func: FunctionNode)
 
   let declaration
   for each value of values
-    value.children = [ref]
+    replaceNode value.placeholder, ref, value
 
     // Check whether return.value already declared within this function
     { ancestor, child } := findAncestor
@@ -1024,8 +1024,8 @@ function processParams(f: FunctionNode): void
           ]
         bindingIndex := rest.rest.children.indexOf rest.rest.binding
         assert.notEqual bindingIndex, -1, "Could not find binding in rest parameter"
-        rest.rest.children[bindingIndex] = rest.rest.binding =
-          { ...rest.rest.binding, js: true }
+        binding := { ...rest.rest.binding, js: true }
+        rest.rest.children[bindingIndex] = rest.rest.binding = binding
         rest.rest.children.splice bindingIndex+1, 0,
           children: [ ref ]
           ts: true
@@ -1268,6 +1268,7 @@ function transformArrowFunctionWithYield(f: any): void
 
 function processSignature(f: FunctionNode): void
   {block, signature} := f
+  return unless block
 
   addAsync .= false
   addGenerator .= false
@@ -1297,7 +1298,7 @@ function processSignature(f: FunctionNode): void
 
   for each overload of [f, ...precedingOverloads f]
     if addAsync and overload.async? and not overload.async#
-      overload.async.push "async "
+      overload.async.push "async", " "
       overload.signature.modifier.async = true
     if addGenerator and overload.generator? and not overload.generator#
       overload.generator.push "*"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -13,6 +13,7 @@ import type {
   ASTNode
   ASTNodeObject
   ASTRef
+  ASTString
   BlockStatement
   BreakStatement
   Call
@@ -32,7 +33,9 @@ import type {
   CoffeeClassPrototype
   ExpressionNode
   ForStatement
+  FunctionExpression
   IfStatement
+  Identifier
   Index
   Initializer
   IterationExpression
@@ -43,6 +46,7 @@ import type {
   MemberExpression
   MethodDefinition
   MethodSignature
+  NonNullASTNode
   NormalCatchParameter
   ObjectExpression
   ObjectProperty
@@ -391,7 +395,7 @@ function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
     for every [, s] of expressions
       isExpression(s)
 
-function expressionizeIfStatement(statement: IfStatement): ASTNode
+function expressionizeIfStatement(statement: IfStatement): NonNullASTNode
   { condition, then: b, else: e } := statement
   [ ...condRest, closeParen ] := condition.children  // separate ')'
 
@@ -1030,20 +1034,39 @@ function lastAccessInCallExpression(exp: any)
   if exp.type is "Identifier" or exp.type is "PropertyAccess" or exp.type is "Index"
     exp
 
-// Given a MethodDefinition, convert into a FunctionExpression.
-// Returns undefined if the method is a getter or setter.
-function convertMethodToFunction(method: any)
+/**
+ * Return the static string name of a property key, if it has one.
+ */
+function staticPropertyName(id: NonNullASTNode): string?
+  return id if id <? "string"
+  return unless isASTNodeObject id
+  return id.name if "name" in id and id.name <? "string"
+  if "token" in id and id.token <? "string"
+    token := id.token
+    return token.match(/^(?:"|')/) ? token[<..<] : token
+
+/**
+ * Given a MethodDefinition, convert into a FunctionExpression.
+ * Returns undefined if the method must remain a method.
+ */
+function convertMethodToFunction(method: MethodDefinition): (FunctionExpression & {id: Identifier, name: string})?
   { signature, block } := method
-  { async, modifier, optional } := signature
+  { async, id, modifier, optional } := signature
 
   return if modifier?.get or modifier?.set
-  func := ["function "]
+  /* c8 ignore next -- object-literal MethodDefinitions always have blocks; this guard helps TypeScript understand that invariant */
+  return unless block
+  return unless id is like {type: "Identifier"}
+  {name} := id
+  func: Children := ["function "]
   if async?
     // put `function` after `async`
     func.unshift async
-    // ensure space after `async` (absent in e.g. `async* f()`)
-    if async# and not async.-1?.#
-      async.push " "
+    // Ensure a space after `async` (absent in e.g. `async* f()`).
+    // Nonempty MethodSignature.async is a [keyword/token, whitespace] tuple;
+    // help TypeScript understand that the computed final index is its
+    // whitespace slot (1).
+    async[async# - 1 as 1] = " " if async# > 1 and not async[async# - 1 as 1]?#
 
   sigChildren := signature.children.slice(1)
   if optional
@@ -1052,7 +1075,8 @@ function convertMethodToFunction(method: any)
 
   return {
     ...signature
-    id: signature.name
+    id
+    name
     signature
     type: "FunctionExpression"
     children: [
@@ -1073,6 +1097,7 @@ function convertFunctionToMethod(id: any, exp: any)
   {
     ...exp,
     type: "MethodDefinition",
+    id,
     name: id.name,
     signature: {
       ...exp.signature
@@ -1091,6 +1116,7 @@ function convertArrowFunctionToMethod(id: any, exp: any)
   exp = {
     ...exp,
     type: "MethodDefinition",
+    id,
     name: id.name,
     signature: {
       ...exp.signature
@@ -1161,9 +1187,8 @@ function convertObjectToJSXAttributes(obj: ObjectExpression): Children
       when "SpreadProperty"
         parts.push(['{', part.dots, part.value, '}'])
       when "MethodDefinition"
-        const func = convertMethodToFunction(part)
-        if func
-          parts.push([part.name, '={', convertMethodToFunction(part), '}'])
+        if func := convertMethodToFunction part
+          parts.push [func.name, '={', func, '}']
         else
           rest.push(part)
   if rest#
@@ -1174,7 +1199,7 @@ function convertObjectToJSXAttributes(obj: ObjectExpression): Children
 /**
  * Returns a new MethodDefinition node.
  */
-function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType: ASTNode, block?: BlockStatement, kind: { token: "get" | "set" } = { token: "get" }, autoReturn: boolean = true, setValueSuffix?: ASTNode): MethodDefinition
+function makeGetterMethod(id: ClassElementName | ASTString, ws: ASTNode, value: ASTNode, returnType: ASTNode, block?: BlockStatement, kind: { token: "get" | "set" } = { token: "get" }, autoReturn: boolean = true, setValueSuffix?: ASTNode): MethodDefinition
   { token } := kind
   ws = trimFirstSpace ws
   let setVal
@@ -1210,11 +1235,13 @@ function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType
 
     expressions.push finalStatement
 
-  children := [kind, " ", name, parameters, returnType, block]
+  name := staticPropertyName id
+  children := [kind, " ", id, parameters, returnType, block]
 
   return {
     type: "MethodDefinition"
     children
+    id
     name
     signature: {
       type: "MethodSignature"
@@ -1223,6 +1250,7 @@ function makeGetterMethod(name: ASTNode, ws: ASTNode, value: ASTNode, returnType
         set: token is "set"
         async: false
       }
+      id
       name
       returnType
       parameters
@@ -1646,7 +1674,7 @@ function unchainOptionalMemberExpression(exp: MemberExpression | CallExpression,
   else // Unchanged
     exp
 
-function attachPostfixStatementAsExpression(exp: ASTNode, post: [WSNode, IfStatement | IterationStatement | DoStatement | ForStatement])
+function attachPostfixStatementAsExpression(exp: ASTNode, post: [WSNode, IfStatement | IterationStatement | DoStatement | ForStatement]): NonNullASTNode
   postfixStatement := post[1]
 
   switch postfixStatement.type
@@ -1988,6 +2016,7 @@ function processCoffeeClasses(statements: StatementTuple[]): void
         signature: MethodSignature := {}
           type: "MethodSignature"
           children: [ "constructor(", parameters, ")" ]
+          id: "constructor"
           name: "constructor"
           parameters
           modifier: {}
@@ -2561,6 +2590,7 @@ export {
   replaceNode
   replaceNodes
   skipImplicitArguments
+  staticPropertyName
   stripTrailingImplicitComma
   trimFirstSpace
   typeSuffixForExpression

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -1,4 +1,5 @@
 import type {
+  ASTError
   ASTNode
   BinaryOp
   ChainOp
@@ -112,7 +113,7 @@ function processExpandedBinaryOpExpression(expandedOps: ASTNode[])
           end += 4
         false
 
-      let error
+      let error: ASTError?
       switch op.assoc
         when "left", undefined
           advanceLeft true

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -118,6 +118,7 @@ export type OtherNode =
   | FinallyClause
   | ForDeclaration
   | FunctionRestParameter
+  | FunctionSignature
   | ImportAssertion
   | ImportClause
   | OperatorImportClause
@@ -159,6 +160,8 @@ export type OtherNode =
   | TypeArgument
   | TypeArguments
   | TypeCondition
+  | TypeDeclarationBinding
+  | TypeLexicalDeclaration
   | TypeParameters
   | TypeSuffix
   | WhenClause
@@ -347,26 +350,28 @@ export type BinaryOp = (string &
   relational?: never
   assoc?: never
   type?: undefined
-) | (ASTLeaf &
-  type?: undefined
+) | ((ASTLeaf | Keyword | (Partial<ASTLeaf> & {special: true})) &
   spaced?: boolean
   special?: true
-  // The following are allowed only when special is true:
-  prec?: string | number | undefined
-  assoc?: string?
-  call?: ASTNode
+  // The following are meaningful only when special is true:
+  prec?: string | number
+  assoc?: OperatorAssoc?
+  call?: NonNullASTNode
   method?: ASTNode
   relational?: boolean
   reversed?: boolean
   negated?: boolean
   asConst?: boolean
+  suffix?: ASTNode
 ) | (PatternTest &
   token?: never
+  call?: never
   relational?: never
   assoc?: never
   asConst?: never
 ) | (ChainOp &
   token?: never
+  call?: never
   relational?: never
 )
 
@@ -876,7 +881,7 @@ export type ImportClause = ASTParent & DeclarationProbe &
   binding?: ASTNodeObject & { names: string[] }
   star?: Star
   specifiers?: Extract<NamedImportElement, { type?: undefined }>[]
-  rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
+  rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>?
 
 /** Clause for `import operator {…}` — separate specifier shape from ImportClause. */
 export type OperatorImportClause = ASTParent & DeclarationProbe &
@@ -928,6 +933,15 @@ export type TypeDeclaration = ASTParent &
   id: Identifier
   ts: true
 
+export type TypeLexicalDeclaration = ASTParent &
+  type: "TypeLexicalDeclaration"
+  names: string[]
+  ts: true
+
+export type TypeDeclarationBinding = ASTParent &
+  type: "TypeDeclarationBinding"
+  names: string[]
+
 export type InterfaceDeclaration = ASTParent &
   type: "InterfaceDeclaration"
   id: Identifier
@@ -974,6 +988,7 @@ export type Declaration = ASTParent &
   names: string[]
   bindings: Binding[]
   decl: DeclarationKind
+  autoExport?: true
   splices?: unknown[]
   thisAssignments?: ThisAssignments
   // Should placeholders in contents be lifted above the parent block,
@@ -1032,6 +1047,8 @@ export type Identifier =
 
 export type ReturnValue = ASTParent &
   type: "ReturnValue"
+  placeholder: NonNullASTNode
+  names: []
 
 export type StatementExpression = ASTParent &
   type: "StatementExpression"
@@ -1101,7 +1118,11 @@ export type FinallyToken = "finally " | (Keyword & { token: "finally" })
 
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 
-export type BindingPattern = BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | NamedBindingPattern | Literal | RegularExpressionLiteral
+export type BindingPattern = (
+  BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | NamedBindingPattern | Literal | RegularExpressionLiteral
+) &
+  /** Post-rest parameter rewriting emits a JS-only copy of the binding. */
+  js?: boolean
 
 // Includes things that appear inside BindingPatterns (when recursing)
 // but aren't patterns by themselves
@@ -1157,13 +1178,14 @@ export type BindingRestElement = ASTParent &
   names: string[]
   rest: true
   typeSuffix?: TypeSuffix?
-  binding: BindingIdentifier | BindingPattern | EmptyBinding
+  binding: BindingPattern | EmptyBinding
   initializer?: undefined // rest elements don't accept initializers
 
 export type EmptyBinding = ASTParent &
   type: "EmptyBinding"
   names: string[]
   ref: ASTRef
+  js?: boolean
 
 export type ElisionElement = ASTParent &
   type: "ElisionElement"
@@ -1189,6 +1211,7 @@ export type NamedBindingPattern = ASTParent &
   binding: BindingIdentifier
   pattern: BindingPattern
   subbinding?: ASTNode
+  typeSuffix?: TypeSuffix?
 
 export type HasSubbinding = BindingProperty | NamedBindingPattern
 
@@ -1314,13 +1337,16 @@ export type Argument = ASTParent &
 
 export type FunctionExpression = ASTParent &
   type: "FunctionExpression"
-  name: string
-  id: Identifier
-  async?: ASTNode[]
-  generator?: ASTNode[]
-  signature: FunctionSignature
-  block: BlockStatement
+  /** String version of function name, or undefined for an anonymous function. */
+  name?: string?
+  /** Function name as an AST node, or undefined for an anonymous function. */
+  id?: BindingIdentifier?
+  async?: ASTNode[]?
+  generator?: ASTNode[]?
+  signature: FunctionSignature | MethodSignature
+  block: BlockStatement | null
   parameters: ParametersNode
+  ts?: boolean
 
 export type AmpersandBlockBody =
   ref?: ASTRef
@@ -1346,10 +1372,11 @@ export type PipelineExpression = ASTParentWithHoist &
 
 export type MethodDefinition = ASTParent &
   type: "MethodDefinition"
-  name: NonNullASTNode
+  id: ClassElementName | ASTString
+  name?: string?
   async?: ASTNode[]?
   generator?: ASTNode[]?
-  signature: FunctionSignature
+  signature: MethodSignature
   block?: BlockStatement
   parameters: ParametersNode
   autoBind?: boolean? // CoffeeScript => bound methods
@@ -1362,7 +1389,8 @@ export type MultiMethodDefinition = ASTParent &
 
 export type ArrowFunction = ASTParent &
   type: "ArrowFunction"
-  name: string
+  /** String version of function name, or undefined for an anonymous function. */
+  name?: string?
   async: ASTNode[]
   // Arrow functions can't grammatically be generators; FunctionNode machinery
   // reads `.generator` uniformly, so declare it as never so readers see
@@ -1371,6 +1399,9 @@ export type ArrowFunction = ASTParent &
   signature: FunctionSignature
   block: BlockStatement
   parameters: ParametersNode
+  returnType?: ReturnTypeAnnotation?
+  parenthesized?: boolean
+  parenthesizedOp?: BinaryOp
   // The next four properties are metadata installed by
   // `makeAmpersandFunction` to decide and perform pipeline unrolling.
   // Use `AmpersandFunction` for guaranteed fields.
@@ -1385,32 +1416,45 @@ export type AmpersandFunction = ArrowFunction &
   body: ASTNode
   ampersandBlock: boolean
 
-export type FunctionSignature = ASTParent &
-  type: "MethodSignature" | "FunctionSignature"
-  /** undefined means anonymous (e.g. arrow function) */
-  name?: ASTNode
-  id?: Identifier?
+export type FunctionSignatureBase = ASTParent &
   async?: ASTNode[]?
   generator?: ASTNode[]?
   modifier: MethodModifier
   optional?: ASTNode?
   returnType?: ReturnTypeAnnotation?
   parameters: ParametersNode
-  block?: BlockStatement | null
   /**
   Force implicit return for this function for IIFE
   (overriding "civet -implicitReturns")
   */
   implicitReturn?: boolean?
 
-export type OperatorSignature = FunctionSignature &
+export type FunctionSignature = FunctionSignatureBase &
   type: "FunctionSignature"
+  /** String version of function name, or undefined for an anonymous function. */
+  name?: string?
+  /** Function name as an AST node, or undefined for an anonymous function. */
+  id?: BindingIdentifier?
+  block: BlockStatement | null
+
+export type OperatorSignature = FunctionSignature &
   id: Identifier
   behavior?: OperatorBehavior?
 
-export type MethodSignature = FunctionSignature &
+export type MethodSignature = FunctionSignatureBase &
   type: "MethodSignature"
-  name: NonNullASTNode
+  /**
+   * Method name. `ClassElementName` covers parsed method names and `ASTString`
+   * covers synthesized ones. When this is a computed property name, the `name`
+   * property below is undefined.
+   */
+  id: ClassElementName | ASTString
+  /** String version of method name. */
+  name?: string?
+  /**
+   * Async keyword/token and following whitespace, or empty when absent.
+   */
+  async?: [] | [ASTString | Keyword, Whitespace]
 
 export type TypeSuffix = ASTParent &
   type: "TypeSuffix"
@@ -1593,6 +1637,7 @@ export type TypeNode =
   | TypeConditional
   | TypeAsserts
   | TypePredicate
+  | UniqueSymbolType
   | VoidType
 
 export type TypeIdentifier = ASTParent &
@@ -1668,7 +1713,10 @@ export type TypePredicate = ASTParent &
 
 export type VoidType = ASTLeafWithType "VoidType"
 
-export type TypeLiteralNode = ASTLeaf | ASTString | VoidType
+export type UniqueSymbolType = ASTParent &
+  type: "UniqueSymbolType"
+
+export type TypeLiteralNode = ASTLeaf | ASTString | UniqueSymbolType | VoidType
 
 export type ThisAssignment =
   | [string, ASTRef]

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -824,15 +824,15 @@ function parenthesizeType(type: ASTNode)
  * Uses function* instead of arrow function if given generator star.
  * Returns an Array suitable for `children`.
  */
-function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorStar?: ASTNode): ASTNode
+function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorStar?: ASTNode): NonNullASTNode
   let awaitPrefix: ASTNode?
   generator := generatorStar ? [ generatorStar ] : []
 
   async := []
   if asyncFlag
-    async.push "async "
+    async.push "async", " "
   else if hasAwait expressions
-    async.push "async "
+    async.push "async", " "
     awaitPrefix =
       type: "Await"
       children: ["await "]
@@ -860,6 +860,7 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
 
   signature: FunctionSignature := {}
     type: "FunctionSignature"
+    block: null
     modifier:
       async: !!async#
       generator: !!generator#

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -141,7 +141,12 @@ export class SourceMap
         // srcLine and srcCol are absolute here
         @lines[@line].push [l, 0, srcLine!+i, srcCol!]
       else if l != 0
-        @lines[@line].push [l]
+        if @lines[@line]#
+          @lines[@line].push [l]
+        else
+          // No mapping precedes this generated text, so an unmapped segment is
+          // redundant. Carry its width into the first real mapping instead.
+          @colOffset += l
 
   /** Compose this downstream source map with an upstream source map, modifying this */
   composeUpstream(upstreamMap: string | SourceMapJSON | SourceMapJSONWithLines): void

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1159,6 +1159,22 @@ describe "custom identifier infix operators", ->
       baz(bar(foo(baz(bar(foo(a, b), c), d), e), f), g)
     """
 
+    testCase """
+      same as operator with default behavior
+      ---
+      operator foo (a, b)
+        a
+      operator bar same foo (a, b)
+        a
+      ---
+      function foo (a, b) {
+        return a
+      }
+      function bar (a, b) {
+        return a
+      }
+    """
+
     throws """
       invalid identifier
       ---

--- a/test/identifier.civet
+++ b/test/identifier.civet
@@ -507,6 +507,14 @@ describe "identifier", ->
     """
 
     testCase """
+      export type declaration with unicode name
+      ---
+      export declare const 😊: string
+      ---
+      declare const u$1F60A$: string; export { u$1F60A$ as "😊" }
+    """
+
+    testCase """
       combined export-declaration with destructured unicode
       ---
       export { 😊 } := data

--- a/test/jsx/objects.civet
+++ b/test/jsx/objects.civet
@@ -130,6 +130,14 @@ describe "JSX object shorthand", ->
   """
 
   testCase """
+    computed method name in braces
+    ---
+    <div {[foo()](x){x}} />
+    ---
+    <div {...{[foo()](x){return x}}} />
+  """
+
+  testCase """
     mix of computed and regular property names in braces
     ---
     <div {[foo()]: bar, regular, [bar()]: baz} />

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -16,6 +16,17 @@ describe "source map", ->
       []
     ]
 
+  it "does not emit redundant unmapped segments before the first mapping", ->
+    sourceMap := new SourceMap "function", "input.civet"
+    sourceMap.updateSourceMap "generated-prefix"
+    sourceMap.updateSourceMap " "
+    sourceMap.updateSourceMap "function", 0
+
+    assert.deepEqual sourceMap.lines, [
+      [[17, 0, 0, 0]]
+    ]
+    assert sourceMap.json("output.js").mappings
+
   it "should parse from base64Encoded", ->
     src := """
       x := a + 3


### PR DESCRIPTION
This typing cleanup batch started with a realization that `ParserState`'s `operators` Map was typed as `Map<string, any>` instead of `Map<string, OperatorBehavior?>`. This ended up causing some `any` types returned by parser rules, which was making things typecheck that shouldn't. Of course, fixing this caused a slew of other issues...

This PR aligns more parser AST types with the nodes actually produced by Hera, enabling more precise rule annotations and removing several casts and `any`-driven assumptions. Key changes:

- Fix types for operators, custom-operator registry, and grammar rules, removing casts and covering default operator behavior.
- Split function and method signature types, with consistent `id` AST nodes and optional string `name` values.
- Preserve computed methods when converting JSX object shorthand, fixing invalid output.
- Make `ReturnValue` directly usable as a binding and replace its explicit placeholder instead of relying on child position.
- Correct binary-operator, binding, declaration, import/export, and TypeScript node shapes.
- Preserve the selected declaration kind and autoExport metadata used by CoffeeScript-style export rewriting.
- Add concrete annotations to parser rules and helper return types.
- Add coverage for computed JSX methods, default operator behavior, and Unicode TypeScript exports.
- Reduce typecheck diagnostics from 683 to 647 with no regressions.

Because the PR is long and changes are all over the place, I asked GPT to prepare an annotated diff that clusters together related edits, and explains why they're there. It's actually quite readable! I'll consider this approach in the future. Still long though, so I'm putting it here:

<details>
<summary>Annotated diff</summary>

# Annotated repository diff

This documents the complete source-and-test diff relative to `origin/main`
(`51ecb049`). Changes are grouped by behavior rather than by file, because most
of the type improvements require matching grammar or transform changes in
another file. Each diff block has a filename caption immediately above it.

## 1. Register concrete AST nodes for TypeScript declarations

Three grammar products now have concrete types and participate in `ASTNode`.
`FunctionSignature` belongs there because a TypeScript `declare function` can
appear directly in a block's children. `TypeLexicalDeclaration` and
`TypeDeclarationBinding` describe the nodes produced for declared
`let`/`const`/`var` forms and retain the `names` metadata used by declaration
processing.

**`source/parser/types.civet`**

```diff
 export type OtherNode =
   ...
+  | FunctionSignature
   ...
+  | TypeDeclarationBinding
+  | TypeLexicalDeclaration

+export type TypeLexicalDeclaration = ASTParent &
+  type: "TypeLexicalDeclaration"
+  names: string[]
+  ts: true
+
+export type TypeDeclarationBinding = ASTParent &
+  type: "TypeDeclarationBinding"
+  names: string[]
```

The corresponding Hera rules can now state their actual return types.
Collection rules that return raw child arrays are annotated as `Children`. The
existing `DeclareElement ::ASTNode` annotation already contextually checks each
alternative, so its two object-returning alternatives can simply drop their
casts.

**`source/parser.hera`**

```diff
-ClassSignature
+ClassSignature ::Children
   Decorators? AbstractModifier? Class ClassBinding? ClassHeritage? ClassSignatureBody

-Decorators
+Decorators ::Children
   ForbidClassImplicitCall ( __ Decorator )*:decorators __:ws RestoreClassImplicitCall ->
     return $skip unless decorators#
-    return $0
+    return [decorators, ws]

-TypeDeclarationRest
+TypeDeclarationRest ::TypeDeclaration | InterfaceDeclaration | NamespaceDeclaration | FunctionSignature
   TypeAliasDeclaration
   InterfaceDeclaration
   NamespaceDeclaration
   FunctionSignature

-TypeLexicalDeclaration
+TypeLexicalDeclaration ::ASTNode
   TypeLetOrConstDeclaration
   __ EnumDeclaration
   ClassSignature
   ...

-TypeLetOrConstDeclaration
+TypeLetOrConstDeclaration ::TypeLexicalDeclaration
   __ LetOrConstOrVar TypeDeclarationBinding:first ( CommaDelimiter __ TypeDeclarationBinding )*:rest ->
     ...

-TypeDeclarationBinding
+TypeDeclarationBinding ::TypeDeclarationBinding
   ( BindingPattern / BindingIdentifier ) TypeSuffix? ->
     ...

-DeclareBlock
+DeclareBlock ::Children
   __ OpenBrace NestedDeclareElements __ CloseBrace
   ...

 DeclareElement ::ASTNode
   Decorators? Export __ Default __ ( Identifier / ClassSignature / InterfaceDeclaration ):declaration
-  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 } as ASTNode
+  Decorators? ( Export _? )? TypeLexicalDeclaration -> { ts: true, children: $0 }
-  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 } as ASTNode
+  ( Export _? )? TypeDeclarationRest -> { ts: true, children: $0 }
```

## 2. Describe every binary-operator shape

`BinaryOp` previously assumed that every ordinary object-shaped operator was a
complete `ASTLeaf`. Synthetic operators can omit `token` or `$loc`, while
keyword operators retain the `Keyword` discriminator. The shared intersection
keeps operator behavior fields in one place, requires incomplete synthetic
operators to be `special`, and adds the `suffix` field read by lowering.

**`source/parser/types.civet`**

```diff
 export type BinaryOp = (string &
   ...
-) | (ASTLeaf &
-  type?: undefined
+) | ((ASTLeaf | Keyword | (Partial<ASTLeaf> & {special: true})) &
   spaced?: boolean
   special?: true
-  // The following are allowed only when special is true:
-  prec?: string | number | undefined
-  assoc?: string?
+  // The following are meaningful only when special is true:
+  prec?: string | number
+  assoc?: OperatorAssoc?
-  call?: ASTNode
+  call?: NonNullASTNode
   method?: ASTNode
   relational?: boolean
   reversed?: boolean
   negated?: boolean
   asConst?: boolean
+  suffix?: ASTNode
 ) | (PatternTest &
+  call?: never
   ...
 ) | (ChainOp &
+  call?: never
   ...
```

The custom-operator registry stores only `OperatorBehavior`; parsed operator
fields such as `token`, `call`, and `special` are attached later. Typing the map
removes its `any`, while the optional lookup preserves the existing default
precedence behavior.

**`source/parser.hera`**

```diff
 interface ParserState
-  operators: Map<string, any>
+  operators: Map<string, OperatorBehavior?>

 OperatorPrecedence ::OperatorBehavior
   ...
-        prec = state.operators.get(op.name).prec
+        prec = state.operators.get(op.name)?.prec ?? precedenceCustomDefault
```

The binary-operator grammar now returns the declared shape directly. `is like`
checks provide local narrowing for optional behavior fields, while the
`::BinaryOpRHS` rule annotation contextually checks the flattened return value.
`NotOp` excludes `BinaryOp`'s raw-string arm, which makes the captured operator
provably object-shaped and allows a checked, non-mutating spread.

**`source/parser.hera`**

```diff
 BinaryOpRHS ::BinaryOpRHS
   NewlineBinaryOpAllowed NotDedentedBinaryOp:op WRHS:rhs ->
-    return $skip if op[1].token is ">" and op[0].length is 0
+    return $skip if op is like [[], {token: ">"}]
-    return [...op, ...rhs] as BinaryOpRHS
+    return [...op, ...rhs]

 FunctionExpression
   !ArrowFunction OpenParen:open __:ws1 BinaryOp:op __:ws2 CloseParen:close ->
-    return op.call if op.special and op.call and not op.negated
+    return op.call if op is like {special: true} and op.call and not op.negated

-    ws1 = op.spaced ? [" "] : [] unless ws1
-    ws2 = op.spaced ? [" "] : [] unless ws2
+    ws1 or= op is like {spaced: true} ? [" "] : []
+    ws2 or= op is like {spaced: true} ? [" "] : []

   # The same `is like {spaced: true}` narrowing is used by both
   # Haskell-style section alternatives.

-NotDedentedBinaryOp
+NotDedentedBinaryOp ::[ASTNode, BinaryOp]
   IndentedFurther?:ws1 _?:ws2 BinaryOp:op ->
     ...

-BinaryOp
+BinaryOp ::BinaryOp
   ...

-_BinaryOp
+_BinaryOp ::BinaryOp
   ...

-BinaryOpSymbol
+BinaryOpSymbol ::BinaryOp
   ...
   OmittedNegation __ NotOp:op ->
-    return { ...op, $loc }
+    return { ...op, $loc } satisfies ASTLeaf & BinaryOp

-CoffeeOfOp
+CoffeeOfOp ::BinaryOp
   ...

-NotOp
+# ASTLeaf forces an object, but TypeScript does not infer that it excludes
+# BinaryOp's string arm, so we do so explicitly.
+NotOp ::ASTLeaf & Exclude<BinaryOp, string>
   ...

-InlineJSXBinaryOpRHS
+InlineJSXBinaryOpRHS ::BinaryOpRHS
   ![<>] BinaryOp:op InlineJSXUnaryExpression:rhs ->
     return [[], op, [], rhs]
```

The default-behavior test covers a registered operator whose map value is
undefined, exercising the optional lookup when another operator copies its
precedence.

**`test/binary-op.civet`**

```diff
+    testCase """
+      same as operator with default behavior
+      ---
+      operator foo (a, b)
+        a
+      operator bar same foo (a, b)
+        a
+      ---
+      function foo (a, b) {
+        return a
+      }
+      function bar (a, b) {
+        return a
+      }
+    """
```

The operator reducer's error local is also declared explicitly, completing the
flow from the grammar's `ASTError` metadata to the emitted expression.

**`source/parser/op.civet`**

```diff
 import type {
+  ASTError
   ASTNode
   BinaryOp
   ...

-      let error
+      let error: ASTError?
       switch op.assoc
```

## 3. Make `ReturnValue` directly usable as a binding

`ReturnValue` now carries the empty `names` list required by
`BindingIdentifier`. Its `placeholder` aliases the semantic child that will be
replaced by the generated return reference. This removes two wrapper shapes and
avoids relying on a child index after whitespace has been prepended.

**`source/parser/types.civet`**

```diff
 export type ReturnValue = ASTParent &
   type: "ReturnValue"
+  placeholder: NonNullASTNode
+  names: []
```

**`source/parser.hera`**

```diff
 ReturnValue ::ReturnValue
-  "return.value" NonIdContinue ->
-    return { type: "ReturnValue", children: [$1[0]] }
+  "return.value":placeholder NonIdContinue ->
+    { type: "ReturnValue", children: [placeholder], placeholder, names: [] }
   ReturnAsValue:value &AfterReturnShorthand -> value

 ReturnAsValue ::ReturnValue
-  Return:value -> { type: "ReturnValue", children: [value] }
+  Return:placeholder ->
+    { type: "ReturnValue", children: [placeholder], placeholder, names: [] }

-BindingIdentifier
+BindingIdentifier ::BindingIdentifier
   ...

-NWBindingIdentifier
+NWBindingIdentifier ::BindingIdentifier
   ...
   Identifier:id
-  ReturnValue ->
-    return { children: [$1], names: [] }
+  ReturnValue

-BackwardBindingIdentifier
-  ReturnValue / ReturnAsValue -> { children: [$1], names: [] }
+BackwardBindingIdentifier ::ReturnValue
+  ReturnValue
+  ReturnAsValue
```

The transform searches for and replaces the aliased placeholder within the
node, preserving any other children. For `return.value`, the placeholder is now
the complete matched string rather than the former `$1[0]` first character.

**`source/parser/function.civet`**

```diff
 function processReturnValue(func: FunctionNode)
   ...
   for each value of values
-    value.children = [ref]
+    replaceNode value.placeholder, ref, value
```

## 4. Correct binding and declaration shapes

`NamedBindingPattern.typeSuffix` is copied onto the runtime wrapper by both
construction paths and read by binding processing, so the declared type now
exposes it.

**`source/parser/types.civet`**

```diff
 export type NamedBindingPattern = ASTParent &
   type: "NamedBindingPattern"
   binding: BindingIdentifier
   pattern: BindingPattern
   subbinding?: ASTNode
+  typeSuffix?: TypeSuffix?
```

Binding rules now declare their child arrays and narrow to `Identifier` before
reading its Unicode-only metadata. Lexical rules use concrete return types, so
the previous `Binding` and `DeclarationKind` casts are unnecessary.

**`source/parser.hera`**

```diff
 BindingProperty
   ...
-    children := [ws, binding]
+    children: Children := [ws, binding]
   ...
-    children .= [ws, binding, initializer]
+    children: Children .= [ws, binding, initializer]
   ...
-    if binding.unicode
+    if binding.type is "Identifier" and binding.unicode
       children = [ws, propertyKey(binding), ": ", binding, initializer]
   ...
-      value: binding.unicode ? binding : undefined,
+      value: binding.type is "Identifier" and binding.unicode ? binding : undefined,

 LexicalDeclaration ::LexicalDeclaration
   LetOrConst:decl LexicalBinding:binding ( __ Comma __ LexicalBinding )*:tail ->
-    bindings: Binding[] := [binding as Binding].concat(tail.map(([,,,b]) => b as Binding))
+    bindings: Binding[] := [binding].concat(tail.map(([,,,b]) => b))
     thisAssignments: ThisAssignments := bindings.flatMap((b) => b.thisAssignments)
     return {
       type: "Declaration",
       children: $0,
       names: bindings.flatMap((b) => b.names),
       bindings,
-      decl: decl as DeclarationKind,
+      decl,
       ...
     }

-LexicalBinding
+LexicalBinding ::Binding
   ...

-LetOrConst
+LetOrConst ::DeclarationKind
   ( "let" / "const" ) NonIdContinue ->
     ...

-VariableDeclarationList
+VariableDeclarationList ::Omit<Declaration, "decl">
   ...
```

The rest-parameter rewrite marks its cloned binding as JS-only. Binding-pattern
types now declare that generator flag, so the clone can retain ordinary spread
syntax without hiding an excess-property error behind `Object.assign`, a cast,
or a one-off intersection annotation. Because `BindingPattern` already includes
`BindingIdentifier`, the rest binding also drops that redundant union arm.

**`source/parser/types.civet`**

```diff
-export type BindingPattern = BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | NamedBindingPattern | Literal | RegularExpressionLiteral
+export type BindingPattern = (
+  BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | NamedBindingPattern | Literal | RegularExpressionLiteral
+) &
+  /** Post-rest parameter rewriting emits a JS-only copy of the binding. */
+  js?: boolean

 export type BindingRestElement = ASTParent &
   ...
-  binding: BindingIdentifier | BindingPattern | EmptyBinding
+  binding: BindingPattern | EmptyBinding

 export type EmptyBinding = ASTParent &
   ...
+  js?: boolean
```

**`source/parser/function.civet`**

```diff
-        rest.rest.children[bindingIndex] = rest.rest.binding =
-          { ...rest.rest.binding, js: true }
+        binding := { ...rest.rest.binding, js: true }
+        rest.rest.children[bindingIndex] = rest.rest.binding = binding
```

## 5. Match actual function-expression nodes

The old `FunctionExpression` type described only named functions with bodies.
The parser also produces anonymous functions, Civet-specific binding names,
TypeScript overloads with `block: null`, and synthetic functions whose
async/generator arrays are explicitly absent. The signature can be a method
signature when a method is converted into a function for JSX output.

**`source/parser/types.civet`**

```diff
 export type FunctionExpression = ASTParent &
   type: "FunctionExpression"
-  name: string
+  /** String version of function name, or undefined for an anonymous function. */
+  name?: string?
-  id: Identifier
+  /** Function name as an AST node, or undefined for an anonymous function. */
+  id?: BindingIdentifier?
-  async?: ASTNode[]
+  async?: ASTNode[]?
-  generator?: ASTNode[]
+  generator?: ASTNode[]?
-  signature: FunctionSignature
+  signature: FunctionSignature | MethodSignature
-  block: BlockStatement
+  block: BlockStatement | null
   parameters: ParametersNode
+  ts?: boolean

 export type ArrowFunction = ASTParent &
   type: "ArrowFunction"
-  name: string
+  /** String version of function name, or undefined for an anonymous function. */
+  name?: string?
   ...
+  returnType?: ReturnTypeAnnotation?
+  parenthesized?: boolean
+  parenthesizedOp?: BinaryOp
```

The grammar now has concrete return annotations and narrows the broad
`FunctionExpression` rule before treating it as a declaration. Its shorthand
alternatives use `::ParenthesizedExpression` where every return has that shape.
The mixed operator shorthand is annotated `::NonNullASTNode`, because it can
return either its synthesized `ArrowFunction` or `op.call`. Its synthesized
branch now builds complete parameter, block, and signature nodes, allowing
`satisfies ArrowFunction` to check that branch without a cast. These
discriminators let `is like` exclude the shorthands while retaining the concrete
function-expression branch. Its empty `async` array is aliased in `children`, so
`processSignature` can add an `async` keyword to both the metadata and generated
output. `name` is read only when the binding node actually exposes a string name.

**`source/parser.hera`**

```diff
 import type {
+  ParametersNode as ParsedParameters
   ...
 }

-FunctionDeclaration
+FunctionDeclaration ::FunctionExpression | ParenthesizedExpression
   # Wrap nameless function declarations with parens, as needed in JS.
-  FunctionExpression ->
+  FunctionExpression:functionExpression ->
     # Do not treat ArrowFunctions, as generated by & and (+), as declarations
-    return $skip if $1.type !== "FunctionExpression"
-    return $1 if $1.id
-    return makeLeftHandSideExpression($1)
+    return $skip unless functionExpression is like {type: "FunctionExpression"}
+    return functionExpression if functionExpression.id
+    return parenthesizeExpression(functionExpression)

-FunctionSignature
+FunctionSignature ::FunctionSignature
   ...
     id := wid?.[1]
     return {
       type: "FunctionSignature",
       id,
-      name: id?.name,
+      name: id is like {name} ? id.name : undefined,
       ...
     }

 FunctionExpression
-  FunctionSignature:signature BracedBlock?:block ->
+  FunctionSignature:signature BracedBlock?:block ::FunctionExpression ->
     ...

+  # op.call is a NonNullASTNode, so this alternative cannot use ::ArrowFunction.
-  !ArrowFunction OpenParen:open __:ws1 BinaryOp:op __:ws2 CloseParen:close ->
+  !ArrowFunction OpenParen:open __:ws1 BinaryOp:op __:ws2 CloseParen:close ::NonNullASTNode ->
     // (foo) doesn't need an arrow wrapper; just foo suffices
     return op.call if op is like {special: true} and op.call and not op.negated
     ...
+    parameterList: FunctionParameter[] := [[refA, ","], refB]
+    parameters: ParsedParameters := {
+      type: "Parameters"
+      children: ["(", parameterList, ")"]
+      parameters: parameterList
+    }
+    expressions: StatementTuple[] := [["", body]]
+    block: BlockStatement := {
+      type: "BlockStatement"
+      bare: true
+      expressions
+      children: [expressions]
+      implicitlyReturned: true
+    }
+    signature: FunctionSignature := {
+      type: "FunctionSignature"
+      modifier: {}
+      parameters
+      block
+      children: [parameters]
+    }
+    async: ASTNode[] := []
+
     return {
-      signature: {modifier: {}}
+      signature
-      children: [open, parameters, " => ", body, close]
+      children: [open, async, parameters, " => ", body, close]
       ...
+      async
+    } satisfies ArrowFunction

  # Haskell-style section
-  OpenParen:open NonPipelineAssignmentExpression:lhs __:ws1 BinaryOp:op __:ws2 CloseParen:close ->
+  OpenParen:open NonPipelineAssignmentExpression:lhs __:ws1 BinaryOp:op __:ws2 CloseParen:close ::ParenthesizedExpression ->

  # Assignment section
-  OpenParen:open ( NotDedented UpdateExpression WAssignmentOp )+:lhs __:ws2 CloseParen:close ->
+  OpenParen:open ( NotDedented UpdateExpression WAssignmentOp )+:lhs __:ws2 CloseParen:close ::ParenthesizedExpression ->

  # Pattern section
-  OpenParen:open __:ws1 IsLike:op __:ws2 PatternExpressionList:rhs CloseParen:close ->
+  OpenParen:open __:ws1 IsLike:op __:ws2 PatternExpressionList:rhs CloseParen:close ::ParenthesizedExpression ->

  # Right-hand section
-  OpenParen:open __:ws1 ... BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ->
+  OpenParen:open __:ws1 ... BinaryOp:op __:ws2 NonPipelineAssignmentExpression:rhs CloseParen:close ::ParenthesizedExpression ->
```

Signature processing stops for TypeScript overloads because their null block
contains no body to inspect. Synthetic IIFEs explicitly initialize the matching
signature field, and helper return types state that these constructors never
return nullish AST nodes.

**`source/parser/function.civet`**

```diff
 function processSignature(f: FunctionNode): void
   {block, signature} := f
+  return unless block
```

**`source/parser/util.civet`**

```diff
-function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorStar?: ASTNode): ASTNode
+function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorStar?: ASTNode): NonNullASTNode
   ...
   signature: FunctionSignature := {}
     type: "FunctionSignature"
+    block: null
     modifier:
       ...
```

Class expressions use the same AST-node/string split. A class binding is a
`BindingIdentifier`, so its string name must be guarded rather than read with
optional chaining from every possible binding variant.

**`source/parser.hera`**

```diff
 ClassExpression
   Decorators?:decorators ( Abstract __ )?:abstract Class:class_ !":" ClassBinding?:binding ClassHeritage?:heritage ClassBody:body ->
+    id := binding?.[0]
     return {
       ...
-      id: binding?.[0],
-      name: binding?.[0]?.name,
+      id,
+      name: id is like {name} ? id.name : undefined,
       ...
     }
```

## 6. Separate function and method signatures

Previously, `FunctionSignature` represented both `type` discriminators and
`MethodSignature` extended it. That forced incompatible `id`, `name`, and
`block` fields into one shape. `FunctionSignatureBase` now holds only shared
metadata; each concrete signature supplies its own identity and body fields.

**`source/parser/types.civet`**

```diff
-export type FunctionSignature = ASTParent &
-  type: "MethodSignature" | "FunctionSignature"
-  /** undefined means anonymous (e.g. arrow function) */
-  name?: ASTNode
-  id?: Identifier?
+export type FunctionSignatureBase = ASTParent &
   async?: ASTNode[]?
   generator?: ASTNode[]?
   modifier: MethodModifier
   optional?: ASTNode?
   returnType?: ReturnTypeAnnotation?
   parameters: ParametersNode
-  block?: BlockStatement | null
   implicitReturn?: boolean?

+export type FunctionSignature = FunctionSignatureBase &
+  type: "FunctionSignature"
+  /** String version of function name, or undefined for an anonymous function. */
+  name?: string?
+  /** Function name as an AST node, or undefined for an anonymous function. */
+  id?: BindingIdentifier?
+  block: BlockStatement | null
+
 export type OperatorSignature = FunctionSignature &
-  type: "FunctionSignature"
   id: Identifier
   behavior?: OperatorBehavior?

-export type MethodSignature = FunctionSignature &
+export type MethodSignature = FunctionSignatureBase &
   type: "MethodSignature"
-  name: NonNullASTNode
+  /**
+   * Method name. `ClassElementName` covers parsed method names and `ASTString`
+   * covers synthesized ones. When this is a computed property name, the `name`
+   * property below is undefined.
+   */
+  id: ClassElementName | ASTString
+  /** String version of method name. */
+  name?: string?
```

`MethodDefinition` follows the same convention: `id` retains the parsed or
synthesized method name, while `name` is its optional static string form.

**`source/parser/types.civet`**

```diff
 export type MethodDefinition = ASTParent &
   type: "MethodDefinition"
-  name: NonNullASTNode
+  id: ClassElementName | ASTString
+  name?: string?
   async?: ASTNode[]?
   generator?: ASTNode[]?
-  signature: FunctionSignature
+  signature: MethodSignature
   ...
```

The grammar stores both forms on signatures and definitions. The common
`staticPropertyName` helper handles identifiers and literal tokens but returns
undefined for computed property names.

**`source/parser.hera`**

```diff
 MethodDefinition ::MethodDefinition | MultiMethodDefinition
   Abstract __ MethodSignature:signature ->
     return {
       type: "MethodDefinition",
       children: $0,
-      name: signature.name,
+      signature.{id,name}
       ...
     }
   MethodSignature:signature ... BracedBlock?:block ->
     return {
       type: "MethodDefinition",
       children: [signature, block],
-      name: signature.name,
+      signature.{id,name}
       ...
     }

 MethodSignature ::MethodSignature
-  ConstructorShorthand NonEmptyParameters:parameters ->
+  ConstructorShorthand:id NonEmptyParameters:parameters ->
     return {
       type: "MethodSignature",
       children: $0,
-      name: $1.token,
+      id,
+      name: id.token,
       ...
     }

-  MethodModifier:modifier ClassElementName:authoredName ... ->
+  MethodModifier:modifier ClassElementName:id ... ->
-    name .= authoredName
-    if name.name
-      name = name.name
-    else if name.token
-      name = name.token.match(/^(?:"|')/) ? name.token[<..<] : name.token
+    name := staticPropertyName id
     return {
       type: "MethodSignature",
-      children: [ ...modifier.children, authoredName, ws1, optional, ws2, parameters, returnType ],
+      children: [ ...modifier.children, id, ws1, optional, ws2, parameters, returnType ],
       async: modifier.async,
       generator: modifier.generator,
+      id,
       name,
       ...
     }
```

**`source/parser/lib.civet`**

```diff
+/**
+ * Return the static string name of a property key, if it has one.
+ */
+function staticPropertyName(id: NonNullASTNode): string?
+  return id if id <? "string"
+  return unless isASTNodeObject id
+  return id.name if "name" in id and id.name <? "string"
+  if "token" in id and id.token <? "string"
+    token := id.token
+    return token.match(/^(?:"|')/) ? token[<..<] : token

-function makeGetterMethod(name: ASTNode, ...): MethodDefinition
+function makeGetterMethod(id: ClassElementName | ASTString, ...): MethodDefinition
   ...
-  children := [kind, " ", name, parameters, returnType, block]
+  name := staticPropertyName id
+  children := [kind, " ", id, parameters, returnType, block]
   return {
     type: "MethodDefinition"
     children
+    id
     name
     signature: {
       type: "MethodSignature"
       ...
+      id
       name
       ...
     }
   }

 function convertFunctionToMethod(id: any, exp: any)
   return {
     ...exp,
     type: "MethodDefinition",
+    id,
     name: id.name,
     ...
   }

 function convertArrowFunctionToMethod(id: any, exp: any)
   exp = {
     ...exp,
     type: "MethodDefinition",
+    id,
     name: id.name,
     ...
   }

 function processCoffeeClasses(statements: StatementTuple[]): void
   ...
   signature: MethodSignature := {}
     type: "MethodSignature"
     children: [ "constructor(", parameters, ")" ]
+    id: "constructor"
     name: "constructor"
     ...
```

## 7. Preserve computed methods in JSX object attributes

In JSX `{object}` shorthand, only identifier-named methods can be emitted as
named function expressions.  Computed, string, numeric, symbol, getter, and
setter methods must remain method definitions inside the generated object
spread. `convertMethodToFunction` now states that contract in its return type
and returns undefined when conversion would lose the authored method form.

The `async` anchor is empty when absent and otherwise always has separate token
and whitespace children. Synthesized async now uses `["async", " "]`, matching
the authored structure, so conversion can fill an empty whitespace child
directly. The final-child index is asserted as the tuple's whitespace slot, so
TypeScript can type its optional length access precisely.

**`source/parser/types.civet`**

```diff
 export type MethodSignature = FunctionSignatureBase &
   ...
+  /**
+   * Async keyword/token and following whitespace, or empty when absent.
+   */
+  async?: [] | [ASTString | Keyword, Whitespace]
```

**`source/parser/function.civet`**

```diff
-      overload.async.push "async "
+      overload.async.push "async", " "
```

**`source/parser/util.civet`**

```diff
-    async.push "async "
+    async.push "async", " "
```

The `util.civet` replacement applies to both explicit-async and inferred-await
IIFE branches.

**`source/parser/lib.civet`**

```diff
-// Given a MethodDefinition, convert into a FunctionExpression.
-// Returns undefined if the method is a getter or setter.
-function convertMethodToFunction(method: any)
+/**
+ * Given a MethodDefinition, convert into a FunctionExpression.
+ * Returns undefined if the method must remain a method.
+ */
+function convertMethodToFunction(method: MethodDefinition): (FunctionExpression & {id: Identifier, name: string})?
   { signature, block } := method
-  { async, modifier, optional } := signature
+  { async, id, modifier, optional } := signature
   return if modifier?.get or modifier?.set
+  /* c8 ignore next -- object-literal MethodDefinitions always have blocks; this guard helps TypeScript understand that invariant */
+  return unless block
+  return unless id is like {type: "Identifier"}
+  {name} := id
-  func := ["function "]
+  func: Children := ["function "]
   if async?
     func.unshift async
-    // ensure space after `async` (absent in e.g. `async* f()`)
-    if async# and not async.-1?.#
-      async.push " "
+    // Ensure a space after `async` (absent in e.g. `async* f()`).
+    // Nonempty MethodSignature.async is a [keyword/token, whitespace] tuple;
+    // help TypeScript understand that the computed final index is its
+    // whitespace slot (1).
+    async[async# - 1 as 1] = " " if async# > 1 and not async[async# - 1 as 1]?#
   ...
   return {
     ...signature
-    id: signature.name
+    id
+    name
     signature
     type: "FunctionExpression"
     ...
   }

 function convertObjectToJSXAttributes(obj: ObjectExpression): Children
   ...
   when "MethodDefinition"
-    const func = convertMethodToFunction(part)
-    if func
-      parts.push([part.name, '={', convertMethodToFunction(part), '}'])
+    if func := convertMethodToFunction part
+      parts.push [func.name, '={', func, '}']
     else
       rest.push(part)
```

The regression test confirms that a computed method name remains method syntax
in the spread object instead of being assigned an invalid function name.

**`test/jsx/objects.civet`**

```diff
+  testCase """
+    computed method name in braces
+    ---
+    <div {[foo()](x){x}} />
+    ---
+    <div {...{[foo()](x){return x}}} />
+  """
```

## 8. Model import and export declarations precisely

`NamedImports` obtains `rest` with `find`, so the field's value can be
undefined even when the property exists.

**`source/parser/types.civet`**

```diff
 export type ImportClause = ASTParent & DeclarationProbe &
   ...
-  rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>
+  rest?: Extract<NamedImportElement, { type: "BindingRestProperty" }>?
```

Exported declarations do not all have a `ts` property, so the three reads now
narrow with `"ts" in declaration`. `ExportVarDec` explicitly records the
selected declaration kind instead of encoding it only in the inserted token.
Its `autoExport` marker remains on the declaration until `auto-dec.civet`
decides whether to split the export, so it is represented as optional
`Declaration` AST metadata.

**`source/parser/types.civet`**

```diff
 export type Declaration = ASTParent &
   ...
+  autoExport?: true
```

**`source/parser.hera`**

```diff
 ExportDeclaration
   Decorators? Export __ Default __ (...):declaration ->
-    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
+    return { type: "ExportDeclaration", declaration, ts: "ts" in declaration and declaration.ts, children: $0 }
   ...
-        ts: declaration.ts,
+        ts: "ts" in declaration and declaration.ts,
         ...
-    return { type: "ExportDeclaration", declaration, ts: declaration.ts, children: $0 }
+    return { type: "ExportDeclaration", declaration, ts: "ts" in declaration and declaration.ts, children: $0 }

-ExportVarDec
+ExportVarDec ::Declaration
   InsertVar VariableDeclarationList ->
-    token := config.autoConst ? "const " : config.autoLet ? "let " : "var "
+    decl := config.autoConst ? "const" : config.autoLet ? "let" : "var"
     return {
       ...$2,
-      children: [{...$1, token}, ...$2.children]
+      children: [{...$1, token: `${decl} `}, ...$2.children]
+      decl
       autoExport: true
     }
```

The Unicode type-declaration export test exercises the `ts` metadata path when
the declaration must also be split into a local declaration and string-named
export.

**`test/identifier.civet`**

```diff
+    testCase """
+      export type declaration with unicode name
+      ---
+      export declare const 😊: string
+      ---
+      declare const u$1F60A$: string; export { u$1F60A$ as "😊" }
+    """
```

## 9. Give statement and expression rules concrete outputs

Several grammar rules already return known AST shapes but previously inferred
broad tuple or unknown types. Declaring their results lets downstream code use
normal narrowing and removes casts without changing emitted syntax.

Statement-list maps are explicitly `StatementTuple[]`, and the no-comma rules
declare their `ASTNode` result.

**`source/parser.hera`**

```diff
 SingleLineStatements
-  expressions := stmts.map(([prefix, statement, delim]) => [prefix, statement, delim])
+  expressions: StatementTuple[] := stmts.map(([prefix, statement, delim]) => [prefix, statement, delim])

 PostfixedSingleLineStatements
-  children := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
+  children: StatementTuple[] := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])

 PostfixedSingleLineNoCommaStatements
-  children := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])
+  children: StatementTuple[] := stmts.map(([prefix, statement, delim]) => [prefix[0], statement, delim])

-NoCommaStatementListItem
+NoCommaStatementListItem ::ASTNode
   Declaration
   PostfixedNoCommaStatement

-PostfixedNoCommaStatement
+PostfixedNoCommaStatement ::ASTNode
   ...
```

Nested literals and nested expressions now expose their non-null concrete
forms to their callers.

**`source/parser.hera`**

```diff
-NestedBulletedArray
+NestedBulletedArray ::ArrayExpression
   ...

-NestedImplicitObjectLiteral
+NestedImplicitObjectLiteral ::ObjectExpression
   ...

-MaybeNestedExpression ::unknown
+MaybeNestedExpression ::NonNullASTNode
   ...
```

`LabelledItem` is a broad grammar union whose alternatives both return AST
objects. Annotating the union rule captures that invariant statically, so the
labelled-statement rule needs no runtime assertion or temporary.

**`source/parser.hera`**

```diff
-LabelledItem
+LabelledItem ::ASTNodeObject
   Statement
   FunctionDeclaration
```

Helper return types likewise state that expressionization and postfix wrapping
always produce actual AST nodes.

**`source/parser/lib.civet`**

```diff
-function expressionizeIfStatement(statement: IfStatement): ASTNode
+function expressionizeIfStatement(statement: IfStatement): NonNullASTNode
   ...

-function attachPostfixStatementAsExpression(exp: ASTNode, post: [...])
+function attachPostfixStatementAsExpression(exp: ASTNode, post: [...]): NonNullASTNode
   ...
```

## 10. Handle literal and primitive type nodes accurately

The unclosed-string rule returns a child collection rather than a semantic AST
object. A heregex body can contain substitutions, but that case returns before
source reconstruction. Excluding the substitution alternative leaves only
`ASTLeaf` nodes; the explicit cast records that control-flow invariant without
adding an unreachable runtime fallback.

**`source/parser.hera`**

```diff
-UnclosedSingleLineStringLiteral
+UnclosedSingleLineStringLiteral ::Children
   ...

-    source := body.map(.token).join("")
+    // Excluding the `type: "Substitution"` HeregexPart leaves only ASTLeaf.
+    source := (body as ASTLeaf[]).map(.token).join("")
```

The parser already emits `UniqueSymbolType` for the two-token TypeScript
primitive. Adding its parent-node type to both `TypeNode` and `TypeLiteralNode`
makes that existing runtime shape visible to the type system. The suffix naming
matches other primitive or leaf-like forms such as `VoidType`, `ThisType`, and
`ImportType`, even though two tokens require an `ASTParent` here.

**`source/parser/types.civet`**

```diff
 export type TypeNode =
   ...
+  | UniqueSymbolType
   | VoidType

+export type UniqueSymbolType = ASTParent &
+  type: "UniqueSymbolType"
+
-export type TypeLiteralNode = ASTLeaf | ASTString | VoidType
+export type TypeLiteralNode = ASTLeaf | ASTString | UniqueSymbolType | VoidType
```

## 11. Supporting imports and exports

The implementation changes above require the corresponding concrete types and
helpers at their use sites. These are grouped here so the behavioral sections
can focus on the code that uses them.

**`source/parser.hera`**

```diff
 import {
   ...
+  staticPropertyName,
   ...
 } from "./parser/lib.civet"

 import type {
   ...
+  ArrayExpression,
+  ASTNodeObject,
+  BindingIdentifier,
+  FunctionSignature,
+  TypeDeclarationBinding,
+  TypeLexicalDeclaration,
   ...
 }
```

**`source/parser/lib.civet`**

```diff
 import type {
   ...
+  ASTString
+  FunctionExpression
+  Identifier
+  NonNullASTNode
   ...
 }

 export {
   ...
+  staticPropertyName
   ...
 }
```

## 12. Avoid redundant leading source-map segments

Automatically inserted `async` syntax is represented as separate keyword and
whitespace children. When both children precede the first mapped token on a
generated line, the whitespace previously emitted a redundant unmapped segment.
Although the generated JavaScript was unchanged, c8 interpreted that segment as
extra branches after remapping the bundled language server. The source-map
emitter now carries the complete generated prefix width into the first real
mapping and emits an unmapped segment only when it must terminate an earlier
mapping on the same line.

**`source/sourcemap.civet`**

```diff
       else if l != 0
-        @lines[@line].push [l]
+        if @lines[@line]#
+          @lines[@line].push [l]
+        else
+          // No mapping precedes this generated text, so an unmapped segment is
+          // redundant. Carry its width into the first real mapping instead.
+          @colOffset += l
```

A focused regression test synthesizes two prefix children before the first
located token and checks that the result contains one mapping at the combined
generated offset. Rendering that map also covers the multi-character VLQ path.

**`test/sourcemap.civet`**

```diff
+  it "does not emit redundant unmapped segments before the first mapping", ->
+    sourceMap := new SourceMap "function", "input.civet"
+    sourceMap.updateSourceMap "generated-prefix"
+    sourceMap.updateSourceMap " "
+    sourceMap.updateSourceMap "function", 0
+
+    assert.deepEqual sourceMap.lines, [
+      [[17, 0, 0, 0]]
+    ]
+    assert sourceMap.json("output.js").mappings
```

</details>