### PR TITLE
Fix private getter/shorter shorthand with `!` non-null assertion

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -4614,10 +4614,6 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
       if not name then ({ name } = base!)
       return $skip unless name
 
-      // Remove leading # from private identifier since it makes no
-      // sense for a private getter to point to itself
-      if name[0] is "#" then name = name.slice(1)
-
       // Skip autoReturn for identifiers with an explicit block like `get foo { true }`
       autoReturn := not block or base!.type !== "Identifier"
       return makeGetterMethod(name, ws, base, returnType, block, kind, autoReturn)

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1235,7 +1235,12 @@ function makeGetterMethod(id: ClassElementName | ASTString, ws: ASTNode, value: 
 
     expressions.push finalStatement
 
-  name := staticPropertyName id
+  name .= staticPropertyName id
+  // Remove leading # from private identifier since it makes no
+  // sense for a private getter to point to itself
+  if name?[0] is "#"
+    name = name[1..]
+    id = name
   children := [kind, " ", id, parameters, returnType, block]
 
   return {

--- a/test/class.civet
+++ b/test/class.civet
@@ -1506,6 +1506,19 @@ describe "class", ->
     """
 
     testCase """
+      private get shorthand with non-null assertion (issue #2200)
+      ---
+      class A
+        #x = 0
+        get #x!
+      ---
+      class A {
+        #x = 0
+        get x(){ return this.#x! }
+      }
+    """
+
+    testCase """
       brace expansion
       ---
       class A
@@ -1670,6 +1683,19 @@ describe "class", ->
         #y = 0
         set x(value){ this.#x = value }
         set y(value1){ this.#y = value1 }
+      }
+    """
+
+    testCase """
+      private set shorthand with non-null assertion (issue #2200)
+      ---
+      class A
+        #x = 0
+        set #x!
+      ---
+      class A {
+        #x = 0
+        set x(value){ this.#x = value! }
       }
     """
 


### PR DESCRIPTION
Stacked on #2201 (my first stack!) because its `makeGetterMethod` refactor centralizes the accessor identifier and static-name handling. This lets the fix normalize both `id` and `name` cleanly in one place instead of duplicating name handling in the grammar.

## Summary

Fixes #2200: correctly handle private getter/setter shorthand with a non-null assertion:

```js
class A
  #x = 0
  get #x!
```

Previously this incorrectly generated a private accessor pointing back to its private backing field. Now it compiles to:

```ts
class A {
  #x = 0
  get x(){ return this.#x! }
}
```

Likewise, `set #x!` generates a public setter whose assignment preserves the non-null assertion:

```ts
set x(value){ this.#x = value! }
```

Core change: The leading `#` normalization happens centrally in `makeGetterMethod`, updating both the rendered accessor identifier and its static name.