### PR TITLE
wip(debug): add editor breakpoints and simple debug config

### DIFF
--- a/lsp/vscode/README.md
+++ b/lsp/vscode/README.md
@@ -58,3 +58,25 @@ export default {
 ```
 
 See also: [example CoffeeScript Plugin](integration/project-test/.civet/coffee-plugin.mjs)
+
+
+Debugging
+---
+
+Clicking `create a launch.json file` inside the Debug menu and using NodeJS as the debugger creates a simple debug configuration for your Civet project that has some sane defaults.
+To make this work a `tasks.json` is expected and may need to be created. You can use the following template for it:
+
+```json: tasks.json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "civet: build",
+      "type": "shell",
+      "command": "npm run build:dev",
+      "group": "build",
+      "problemMatcher": []
+    }
+  ]
+}
+```

--- a/lsp/vscode/package.json
+++ b/lsp/vscode/package.json
@@ -22,7 +22,9 @@
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
-    "onLanguage:typescriptreact"
+    "onLanguage:typescriptreact",
+    "onDebugInitialConfigurations",
+    "onDebugResolve:pwa-node"
   ],
   "main": "./dist/extension",
   "contributes": {
@@ -84,6 +86,11 @@
         "embeddedLanguages": {
           "meta.embedded.block.civet": "civet"
         }
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "civet"
       }
     ],
     "commands": [

--- a/lsp/vscode/source/extension.civet
+++ b/lsp/vscode/source/extension.civet
@@ -1,4 +1,4 @@
-type { ExtensionContext } from vscode
+type { ExtensionContext, WorkspaceFolder, DebugConfiguration, CancellationToken  } from vscode
 
 * as path from path
 * as vscode from vscode
@@ -16,6 +16,7 @@ let client: LanguageClient
 export function activate(context: ExtensionContext)
   activateClient context
   activateCommands context
+  activateDebugging context
 
 function activateClient(context: ExtensionContext)
   // The server is implemented in node
@@ -82,6 +83,54 @@ function activateCommands(context: ExtensionContext)
     await client.start()
 
   context.subscriptions.push commandDisposable
+
+function activateDebugging(context: ExtensionContext)
+  provider :=
+    provideDebugConfigurations: (_folder: WorkspaceFolder) =>
+      [
+        {
+          type: 'pwa-node'
+          request: 'launch'
+          name: 'Debug Civet (Build Output)'
+          skipFiles: ['<node_internals>/**']
+          program: '${workspaceFolder}/dist/src/main.js'
+          preLaunchTask: 'civet: build'
+          cwd: '${workspaceFolder}'
+          sourceMaps: true
+          outFiles: ['${workspaceFolder}/dist/**/*.js']
+          resolveSourceMapLocations: ['${workspaceFolder}/dist/**', '!**/node_modules/**']
+        }
+      ]
+
+    resolveDebugConfiguration: (_folder: WorkspaceFolder, config: DebugConfiguration) =>
+      // Auto-defaults only for pwa-node when Civet is in play
+      isPwa := config?.type is 'pwa-node'
+      program := config?.program
+      isCivetProgram := typeof program is 'string' and program.endsWith ".civet"
+
+      if isPwa and isCivetProgram
+        config.sourceMaps ?= true
+        config.cwd ?= '${workspaceFolder}'
+        config.outFiles ?= ['${workspaceFolder}/dist/**/*.js' + ' // adjust as needed', '!**/node_modules/**']
+        config.resolveSourceMapLocations ?= ['${workspaceFolder}/**']
+        config.skipFiles ?= ['<node_internals>/**']
+
+      config
+
+    resolveDebugConfigurationWithSubstitutedVariables: async (folder: WorkspaceFolder | undefined, config: DebugConfiguration, _token?: CancellationToken) =>
+      isPwa := config?.type is 'pwa-node'
+      program := config?.program
+      isCivetProgram := typeof program is 'string' and program.endsWith ".civet"
+
+      if isPwa and isCivetProgram
+        try
+          await vscode.workspace.fs.stat vscode.Uri.file(config.program)
+        catch
+          vscode.window.showErrorMessage(`Could not find main entry file (launch.json -> program: ${config.program})`)
+
+
+  disposable := vscode.debug.registerDebugConfigurationProvider('pwa-node', provider)
+  context.subscriptions.push disposable
 
 export function deactivate()
   client?.stop()


### PR DESCRIPTION
Hi!
As I had some trouble to get debugging working with the current VSCode Civet extension (may have also been caused by me not having worked much in the NodeJS ecosystem before), I took the liberty to add some parts that have fixed those issues for me.
I amende package.json to get the ability to set breakpoints in the editor. Also, I added activation events to create new debug configurations with simple defaults and possibly amend an existing config.

KR,
niontrix