### PR TITLE
LSP: improve `import` and `@` completions

### DIFF
--- a/lsp/server/source/lib/completions.civet
+++ b/lsp/server/source/lib/completions.civet
@@ -43,6 +43,17 @@ export looksLikeImportContext := /\b(from|import|require)(\s+['"]?)?$/
 export function likelyImportContext(text: string): boolean
   looksLikeImportContext.test(text)
 
+missingBackwardModulePrefix := /\bfrom[ \t]+$/
+followingImport := /^import\b/
+
+export function missingBackwardModuleContext(
+  lineText: string
+  cursorOffset: number
+): boolean
+  linePrefix := lineText[< cursorOffset]
+  missingBackwardModulePrefix.test(linePrefix) and
+    followingImport.test lineText[>= cursorOffset]
+
 // -- import-path extraction --------------------------------------------------
 
 // Extract information about an import statement under the cursor.  The three

--- a/lsp/server/source/server.civet
+++ b/lsp/server/source/server.civet
@@ -54,6 +54,7 @@
   getCurrentLineText
   likelyImportContext
   measureTokenLength
+  missingBackwardModuleContext
   parseErrorsToDiagnostics
   resolvePathAliasDir
 } from ./lib/completions.civet
@@ -444,14 +445,15 @@ export function startServer(connection: Connection, dependencies: ServerDependen
         if statement is 'from' or statement is 'require'
           show.otherLspCompletions = false
 
-        // Hardcode special-case cursor offset
-        //
-        //     Source:      import a from ./a|
-        //     Transpiled:  import a from "./a"|
-        //     Adjusted:    import a from "./a|"
-        //
-        if not qt or qt !== endqt then cursorOffsetAdjustment = -1
-        if qt and qt !== endqt then closingQuoteSuffix = qt
+        // Hardcode cursor offsets for the quotes Civet adds while recovering
+        // import paths.  An unquoted path's mapped cursor is one character
+        // early because of its inserted opening quote; an unclosed quoted
+        // path's mapped cursor is after its inserted closing quote.
+        if not qt
+          cursorOffsetAdjustment = +1
+        else if qt !== endqt
+          cursorOffsetAdjustment = -1
+          closingQuoteSuffix = qt
 
         importPath = pathText
         show.relative = importPath.startsWith('./') or importPath.startsWith('../')
@@ -483,8 +485,9 @@ export function startServer(connection: Connection, dependencies: ServerDependen
     assert document
 
     // Fast path for space trigger
-    linePrefix := getCurrentLineText(document, position).slice(0, position.character)
-    isLikelyImportContext := likelyImportContext(linePrefix)
+    lineText := getCurrentLineText document, position
+    linePrefix := lineText[< position.character]
+    isLikelyImportContext := likelyImportContext linePrefix
     if context?.triggerCharacter is ' ' and not isLikelyImportContext
       return []
 
@@ -543,32 +546,47 @@ export function startServer(connection: Connection, dependencies: ServerDependen
 
     // Civet files
 
-    // … Sourcemap the line/columns
-    // Keep the original source cursor; `position` is remapped below.
-    sourcePosition := position
     meta := service.host.getMeta(sourcePath)
     return civetFileCompletions unless meta
     { sourcemapLines, transpiledDoc } := meta
     return civetFileCompletions unless transpiledDoc
+
+    // … Sourcemap the line/columns
+    // Keep the original source cursor; `position` is remapped below.
+    sourcePosition := position
+    sourceCharacter := sourcePosition.character
     if sourcemapLines
-      position = forwardMap(sourcemapLines, position)
+      mapPosition .= sourcePosition
+      // At `from |import`, the cursor shares its source offset with the
+      // following `import`, which maps to the start of the reordered output.
+      // Map from the separator so completion stays in the recovered `from ""`.
+      if sourceCharacter > 0 and
+         missingBackwardModuleContext lineText, sourcePosition.character
+        mapPosition = { ...sourcePosition, character: sourceCharacter - 1 }
+      position = forwardMap sourcemapLines, mapPosition
       logger.log 'remapped'
     p .= transpiledDoc.offsetAt(position)
 
     // … Adjust the cursor position, on a case-per-case basis, to access better completions.
     //  0: Default, when sourcemap cursor position is already perfect.
-    // -1: Gets inside closing quotes for import file completion.
+    // -1: Gets inside an inserted closing quote for import file completion.
+    // +1: Gets past an inserted opening quote for an unquoted import path.
     p += heuristics.cursorOffsetAdjustment
 
     // A bare Civet `@` maps to TS `this`, often with the sourcemapped cursor
     // inside the generated word. Move to after `this`/`this.` so TS returns
     // member completions, and ask as if `.` triggered the completion.
-    if context?.triggerCharacter is '@'
+    hasBareAtBeforeCursor :=
+      sourceCharacter > 0 and lineText[sourceCharacter - 1] is '@' and
+      (sourceCharacter < 2 or lineText[sourceCharacter - 2] is not '@')
+    isBareAtCompletion :=
+      context?.triggerCharacter is '@' or hasBareAtBeforeCursor
+    if isBareAtCompletion
       text := transpiledDoc.getText()
-      if sourcemapLines
-        sourceOffset := document.offsetAt(sourcePosition)
-        if sourceOffset > 0 and document.getText()[sourceOffset - 1] is '@'
-          p = transpiledDoc.offsetAt(forwardMap(sourcemapLines, document.positionAt(sourceOffset - 1)))
+      if sourcemapLines and hasBareAtBeforeCursor
+        atPosition := { ...sourcePosition, character: sourceCharacter - 1 }
+        mappedAtPosition := forwardMap sourcemapLines, atPosition
+        p = transpiledDoc.offsetAt mappedAtPosition
       searchStart := Math.max(0, p - 3)
       aroundP := text.slice(searchStart, p + 4)
       thisIdx := aroundP.lastIndexOf('this')
@@ -606,7 +624,7 @@ export function startServer(connection: Connection, dependencies: ServerDependen
       civetFileCompletions.concat(completions)
       closingQuoteSuffix)
 
-    if context?.triggerCharacter is '@'
+    if isBareAtCompletion
       return CompletionList.create(items, true)
     return items
 

--- a/lsp/server/test/completions.civet
+++ b/lsp/server/test/completions.civet
@@ -20,6 +20,7 @@ path from node:path
   getFileExtensionModifier
   likelyImportContext
   measureTokenLength
+  missingBackwardModuleContext
   parseErrorRange
   parseErrorsToDiagnostics
   resolvePathAliasDir
@@ -38,6 +39,19 @@ describe "completions helpers", ->
       assert likelyImportContext("x from '")
     it "does not match arbitrary text", ->
       assert not likelyImportContext("const x = 1")
+
+  describe "missingBackwardModuleContext", ->
+    it "matches the one-space boundary before import", ->
+      assert missingBackwardModuleContext("from import", "from "#)
+
+    it "matches after multiple spaces when the cursor is directly before import", ->
+      assert missingBackwardModuleContext("from  import", "from  "#)
+
+    it "does not match a cursor inside a wider separator", ->
+      assert not missingBackwardModuleContext("from  import", "from "#)
+
+    it "does not match a complete module specifier", ->
+      assert not missingBackwardModuleContext("from module import", "from "#)
 
   describe "extractImportPath", ->
     it "returns undefined when cursor isn't inside a path group", ->

--- a/lsp/server/test/lsp-features.test.civet
+++ b/lsp/server/test/lsp-features.test.civet
@@ -1158,6 +1158,40 @@ describe "LSP features (shared project server)", ->
     insertText2 := cache.insertText <? "string" ? cache.insertText : cache.insertText?.value ?? ""
     assert !insertText2.includes("this."), `cache completion should not insert this.: ${insertText2}`
 
+  for [name, suffix] of [
+    ["at-eof", ""]
+    ["before-trailing-newline", "\n"]
+    ["before-later-class-member", "\n  foo := 1\n"]
+  ]
+    it `returns HTMLElement completions for constructor @ ${name}`, ->
+      uri := docUri path.join(projectRoot, `waveform-${name}.civet`)
+      text := "class Waveform < HTMLElement\n  @()\n    super()\n    @" + suffix
+      client.notify "textDocument/didOpen", {
+        textDocument: { uri, languageId: "civet", version: 1, text }
+      }
+      await waitForDiag(client, (p) => p.uri is uri)
+
+      lines := text.split "\n"
+      atLine := lines.findIndex (l) => l.trim() is "@"
+      result := await client.request "textDocument/completion", {
+        textDocument: { uri }
+        position: { line: atLine, character: lines[atLine].indexOf("@") + 1 }
+        context: { triggerKind: 2, triggerCharacter: "@" }
+      }
+      list := result?.items ?? result
+      assert Array.isArray(list), `expected completion items array, got ${JSON.stringify(result)}`
+      assert list.some((item: any) => item.label is "classList"),
+        `expected classList member completion, got ${list.map((item: any) => item.label).join(", ")}`
+
+      manualResult := await client.request "textDocument/completion", {
+        textDocument: { uri }
+        position: { line: atLine, character: lines[atLine].indexOf("@") + 1 }
+      }
+      manualList := manualResult?.items ?? manualResult
+      assert Array.isArray(manualList), `expected manual completion items array, got ${JSON.stringify(manualResult)}`
+      assert manualList.some((item: any) => item.label is "classList"),
+        `expected classList manual completion, got ${manualList.map((item: any) => item.label).join(", ")}`
+
   it "emits diagnostics for a parse error with a civet syntax error", ->
     uri := docUri path.join(projectRoot, "parse-error.civet")
     client.notify "textDocument/didOpen", {
@@ -1217,6 +1251,58 @@ describe "LSP features (shared project server)", ->
     }
     list := result?.items ?? result
     assert Array.isArray(list), "expected completion items array"
+
+  it "returns module completions after one unquoted letter", ->
+    uri := docUri path.join(projectRoot, "imp-one-letter.civet")
+    text := "import * as ts from t"
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    result := await client.request "textDocument/completion", {
+      textDocument: { uri }
+      position: { line: 0, character: text# }
+    }
+    list := result?.items ?? result
+    assert Array.isArray(list), "expected completion items array"
+    assert list.some((item: any) => item.label is "typescript"),
+      `expected typescript module completion, got ${list.map((item: any) => item.label).join(", ")}`
+
+  it "does not parse standalone from as a backward import", ->
+    uri := docUri path.join(projectRoot, "standalone-from.civet")
+    text := "from"
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    diagnostics := await waitForDiag(client, (p) => p.uri is uri)
+
+    assert not diagnostics.diagnostics.some((diagnostic: any) => diagnostic.source is "civet"),
+      `expected no Civet parse diagnostic, got ${JSON.stringify diagnostics.diagnostics}`
+
+  for [name, text, cursor] of [
+    ["missing-module-one-space", "from import * as ts", "from "#]
+    ["missing-module-gap", "from  import * as ts", "from "#]
+    ["quoted-module", 'from "" import * as ts', "from "#]
+    ["missing-clause", 'from "" import', "from "#]
+    ["missing-type-clause", 'from "" import type', "from "#]
+    ["one-letter", "from t import * as ts", "from t"#]
+  ]
+    it `returns module completions for backward import with ${name}`, ->
+      uri := docUri path.join(projectRoot, `imp-backward-${name}.civet`)
+      client.notify "textDocument/didOpen", {
+        textDocument: { uri, languageId: "civet", version: 1, text }
+      }
+      await waitForDiag(client, (p) => p.uri is uri)
+
+      result := await client.request "textDocument/completion", {
+        textDocument: { uri }
+        position: { line: 0, character: cursor }
+      }
+      list := result?.items ?? result
+      assert Array.isArray(list), "expected completion items array"
+      assert list.some((item: any) => item.label is "typescript"),
+        `expected typescript module completion, got ${list.map((item: any) => item.label).join(", ")}`
 
   it "document symbols report top-level declarations", ->
     uri := docUri path.join(projectRoot, "symbols.civet")

--- a/lsp/vscode/e2e/at-completions.test.civet
+++ b/lsp/vscode/e2e/at-completions.test.civet
@@ -82,3 +82,21 @@ suite '@foo completions', =>
     insertText := getInsertText cache
     assert !insertText.includes('this.'),
       `Completion 'cache' has insertText containing 'this.': ${insertText}`
+
+  test 'Returns constructor member completions for bare @ without trigger metadata', async =>
+    docUri := getDocUri 'waveform-bare-at.civet'
+    await activate docUri
+
+    completions := await poll
+      => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position 3, 3
+      ) as Promise<CompletionList>
+      (list) => list?.items.some (item) => getLabel(item) is 'classList'
+
+    classList := completions.items.find (item) => getLabel(item) is 'classList'
+    assert classList, 'Expected classList member completion for bare @'
+    insertText := getInsertText classList
+    assert !insertText.includes 'this.',
+      `Completion 'classList' has insertText containing 'this.': ${insertText}`

--- a/lsp/vscode/e2e/completion.test.civet
+++ b/lsp/vscode/e2e/completion.test.civet
@@ -43,6 +43,41 @@ suite 'Completion', =>
     assert labels.includes('body'),
       `Expected 'body' in document completions, got: ${labels.join(', ')}`
 
+  test 'Returns module completions after one unquoted letter', =>
+    docUri := getDocUri('import-one-letter.civet')
+    await activate(docUri)
+
+    text := 'import * as ts from t'
+    completions := await poll(
+      () => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position(0, text#)
+      ) as Promise<CompletionList>
+      (list) => list?.items.some((item) => getLabel(item) is 'typescript')
+    )
+
+    labels := completions.items.map(getLabel)
+    assert labels.includes('typescript'),
+      `Expected typescript module completion, got: ${labels.join(', ')}`
+
+  test 'Returns module completions in an incomplete backward import', =>
+    docUri := getDocUri('import-backward.civet')
+    await activate(docUri)
+
+    completions := await poll(
+      () => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position(0, 'from '#)
+      ) as Promise<CompletionList>
+      (list) => list?.items.some((item) => getLabel(item) is 'typescript')
+    )
+
+    labels := completions.items.map(getLabel)
+    assert labels.includes('typescript'),
+      `Expected typescript module completion, got: ${labels.join(', ')}`
+
   test 'Resolves completion item details', =>
     docUri := getDocUri('console.civet')
     await activate(docUri)

--- a/lsp/vscode/e2e/fixture/import-backward.civet
+++ b/lsp/vscode/e2e/fixture/import-backward.civet
@@ -1,0 +1,1 @@
+from  import * as ts

--- a/lsp/vscode/e2e/fixture/import-one-letter.civet
+++ b/lsp/vscode/e2e/fixture/import-one-letter.civet
@@ -1,0 +1,1 @@
+import * as ts from t

--- a/lsp/vscode/e2e/fixture/waveform-bare-at.civet
+++ b/lsp/vscode/e2e/fixture/waveform-bare-at.civet
@@ -1,0 +1,4 @@
+class Waveform < HTMLElement
+	@()
+		super()
+		@

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6641,7 +6641,7 @@ ImportDeclaration ::ImportDeclaration
 
     return {
       type: "ImportDeclaration",
-      children: [i, iws, ...errors, trimFirstSpace(ows), imports, fws, from],
+      children: [i, iws, ...errors, trimFirstSpace(ows), imports, ' ', from, trimFirstSpace(fws)],
         // omit Operator and OperatorBehavior
       imports,
       from,
@@ -6649,12 +6649,25 @@ ImportDeclaration ::ImportDeclaration
   FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports ->
     return {
       type: "ImportDeclaration",
-      children: [ i, iws, t, imports, fws, from ],
+      children: [ i, iws, t, imports, ' ', from, trimFirstSpace(fws) ],
       imports,
       from,
       ts: !!t,
     }
-
+  # NOTE: Robust parsing of backward imports with a missing import clause.
+  FromClause:from SameLineOrIndentedFurther:fws Import:i _?:iws ( TypeKeyword _? )?:t &EOS ->
+    return {
+      type: "ImportDeclaration",
+      children: [
+        i, iws, t, '{}', ' ', from, trimFirstSpace(fws),
+        {
+          type: "Error",
+          message: "Expected import clause after `import`",
+        },
+      ],
+      from,
+      ts: !!t,
+    }
 ImpliedImport
   "" ->
     return { $loc, token: "import " }
@@ -6901,9 +6914,11 @@ UnquotedSpecifier
   # Currently allowing most non-whitespace characters
   # Forbidding ; (statement separator), = (assignment), > (function arrow)
   # Forbidding quotes so that unbalanced quoted strings don't match
+  # Forbidding exactly `import` so `from import` is a backward import
+  # with an error rather than a valid module specifier.
   # It may make sense to restrict this to only allow characters that are valid in a module specifier
   # Also consider URLs
-  /[^;"'\s=>]+/:spec ->
+  /(?!import(?=[;"'\s=>]|$))[^;"'\s=>]+/:spec ->
     return { $loc, token: `"${spec}"` }
 
 # https://262.ecma-international.org/#prod-ImportedBinding

--- a/test/import.civet
+++ b/test/import.civet
@@ -905,3 +905,92 @@ describe "import", ->
       ---
       ParseErrors: unknown:1:20 Unclosed string literal
     """
+
+    throws """
+      import is not an unquoted module specifier
+      ---
+      import value from import
+      ---
+      ParseError: unknown:1:19 Failed to parse
+    """
+
+    testCase """
+      quoted import remains a module specifier
+      ---
+      import value from "import"
+      ---
+      import value from "import"
+    """
+
+    testCase """
+      import prefix remains an unquoted module specifier
+      ---
+      import value from import/foo
+      ---
+      import value from "import/foo"
+    """
+
+    throws """
+      backward import with missing module
+      ---
+      from import * as THREE
+      ---
+      ParseErrors: unknown:1:6 Expected module specifier after `from`
+    """
+
+    throws """
+      backward import with missing module and import clause
+      ---
+      from  import
+      ---
+      ParseErrors: unknown:1:7 Expected module specifier after `from`
+      unknown:1:9 Expected import clause after `import`
+    """
+
+    throws """
+      backward import with missing import clause
+      ---
+      from "pkg" import
+      ---
+      ParseErrors: unknown:1:11 Expected import clause after `import`
+    """
+
+    throws """
+      backward type import with missing import clause
+      ---
+      from "pkg" import type
+      ---
+      ParseErrors: unknown:1:11 Expected import clause after `import`
+    """
+
+    testCase """
+      standalone from remains an identifier
+      ---
+      from
+      ---
+      from
+    """
+
+    testCase """
+      from remains an implicit call target
+      ---
+      from value
+      ---
+      from(value)
+    """
+
+    testCase """
+      from remains a call target before dynamic import
+      ---
+      from import("./module")
+      ---
+      from(import("./module"))
+    """
+
+    testCase """
+      from remains a call target before import.meta
+      ---
+      from import.meta
+      ---
+      from(import.meta)
+    """


### PR DESCRIPTION
Fix module and member completions at several Civet-to-TypeScript source-mapping boundaries:

- Fix #2198: Offer module completions after one unquoted module character, such as `from t|`.
- Fix #2199: Offer module completions while typing backward imports, including `from |import`.
- Fix https://github.com/DanielXMoore/Civet/pull/2197#issuecomment-5387009285 : Offer member completions after a bare `@` even when the client omits `@` trigger metadata or more source follows the cursor.

## Details

- Correct the cursor adjustment for quotes inserted around unquoted module paths.
- Preserve the original post-module whitespace mapping when transpiling reordered backward imports.
- Recover incomplete backward imports with an empty module or import clause while retaining precise parse errors.
- Reserve exactly `import` from unquoted module names so `from import` enters backward-import recovery; quoted `"import"` and paths such as `import/foo` remain valid.
- Keep standalone and expression uses of `from` unchanged.
- Detect bare `@` from the current source line and remap from the generated `this` expression for TypeScript member completions.

<details>
<summary>Annotated diff</summary>

## Overview

This change fixes three completion failures that share a boundary between Civet source and generated TypeScript:

1. An unquoted import path with one typed character mapped the TypeScript completion cursor before that character.
2. Incomplete backward imports did not always produce enough valid TypeScript for module completions.
3. A bare `@` inside a class only received member completions when the client supplied `@` as LSP trigger metadata; manual completion could instead map outside the class.

The parser recovery is intentionally narrow. A standalone `from` remains ordinary Civet syntax, while the exact word `import` is no longer accepted as an unquoted module specifier. Quoted `"import"` and longer unquoted paths such as `import/foo` remain valid.

## 1. Keep backward imports parseable while they are being typed

### Keep the original module separator on the correct side of reordering

In `from t import * as ts`, `fws` is the original whitespace immediately after the module `t`. Transpiling the backward import reorders the source into `import * as ts from "t"`, which also needs whitespace between `ts` and the generated `from`.

The old code reused `fws` for that generated gap. The emitted text looked right, but a source position at `from t| import` was thereby attached to the position `import * as ts| from "t"`: the whitespace that followed the source module now preceded the generated module.

Replacing `fws` with a synthetic space would correct that mapping but discard the original whitespace node and its source location. Instead, the new layout uses `' '` for the generated gap, emits the complete `from "t"` clause, and then retains `fws` after the module where it originated. `trimFirstSpace(fws)` removes the now-redundant leading space without discarding the node, its location, or any remaining separator content. The operator-import and ordinary-import branches use the same layout.

**`source/parser.hera`**

```diff
   # NOTE: from ... import ... reverse syntax
   FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws Operator OperatorBehavior?:behavior SameLineOrIndentedFurther:ows OperatorNamedImports:imports ->
     ...
-      children: [i, iws, ...errors, trimFirstSpace(ows), imports, fws, from],
+      children: [i, iws, ...errors, trimFirstSpace(ows), imports, ' ', from, trimFirstSpace(fws)],
     ...
   FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports ->
     return {
       type: "ImportDeclaration",
-      children: [ i, iws, t, imports, fws, from ],
+      children: [ i, iws, t, imports, ' ', from, trimFirstSpace(fws) ],
       imports,
       from,
       ts: !!t,
     }
```

### Reserve `import` for backward-import syntax

`FromClause` was already robust when no module specifier matched: it inserts an error plus `""`, which gives TypeScript a valid empty module string for completions. In the incomplete backward import `from import * as ts`, however, the broad unquoted-module rule consumed `import` as the module name. The missing-module fallback therefore never ran, and the backward-import production could not consume `import` as its keyword.

The unquoted rule now rejects only an exact `import` token. This leaves the token for the backward-import production and lets the existing `FromClause` fallback synthesize the empty module. The lookahead includes all delimiters that terminate an unquoted specifier, so `import/foo` is not accidentally rejected.

**`source/parser.hera`**

```diff
 UnquotedSpecifier
   # Currently allowing most non-whitespace characters
   # Forbidding ; (statement separator), = (assignment), > (function arrow)
   # Forbidding quotes so that unbalanced quoted strings don't match
+  # Forbidding exactly `import` so `from import` is a backward import
+  # with an error rather than a valid module specifier.
   # It may make sense to restrict this to only allow characters that are valid in a module specifier
   # Also consider URLs
-  /[^;"'\s=>]+/:spec ->
+  /(?!import(?=[;"'\s=>]|$))[^;"'\s=>]+/:spec ->
     return { $loc, token: `"${spec}"` }
```

The surrounding backward-import production still requires the following `import` declaration syntax, so a standalone `from` remains an ordinary identifier rather than becoming a recovered import.

### Recover a missing import clause at end of input

After a module is present, `from "pkg" import` and `from "pkg" import type` still lack a clause. A new end-of-input branch inserts `{}` as a recoverable import clause and attaches a precise Civet parse error. Its optional `TypeKeyword` and following whitespace preserve a partially typed type-only import, producing valid TypeScript such as `import type{} from "pkg"` or `import type {} from "pkg"`.

Like the complete backward-import branch, recovery emits `i, iws, t, …` directly: it preserves whatever optional whitespace followed the source `import` without adding a separator that correct imports do not add. The resulting declaration is sufficient for the language server to request completions without treating the source as valid Civet.

**`source/parser.hera`**

```diff
   FromClause:from SameLineOrIndentedFurther:fws Import:i SameLineOrIndentedFurther:iws ( TypeKeyword SameLineOrIndentedFurther )?:t ImportClause:imports ->
     ...
+  # NOTE: Robust parsing of backward imports with a missing import clause.
+  FromClause:from SameLineOrIndentedFurther:fws Import:i _?:iws ( TypeKeyword _? )?:t &EOS ->
+    return {
+      type: "ImportDeclaration",
+      children: [
+        i, iws, t, '{}', ' ', from, trimFirstSpace(fws),
+        {
+          type: "Error",
+          message: "Expected import clause after `import`",
+        },
+      ],
+      from,
+      ts: !!t,
+    }
```

### Parser tests define the recovery boundary

The compiler tests cover the newly forbidden exact unquoted name, its quoted and prefixed exceptions, both incomplete backward-import halves, and valid expression uses of `from`. The missing-module case uses the natural one-space form `from import`; the two-space `from  import` form remains covered when both the module and import clause are absent. These preservation cases guard against making robust parsing broader than the invalid syntax it is meant to recover.

**`test/import.civet`**

```diff
+    throws """
+      import is not an unquoted module specifier
+      ---
+      import value from import
+      ---
+      ParseError: unknown:1:19 Failed to parse
+    """
+
+    testCase """
+      quoted import remains a module specifier
+      ---
+      import value from "import"
+      ---
+      import value from "import"
+    """
+
+    testCase """
+      import prefix remains an unquoted module specifier
+      ---
+      import value from import/foo
+      ---
+      import value from "import/foo"
+    """
+
+    throws """
+      backward import with missing module
+      ---
+      from import * as THREE
+      ---
+      ParseErrors: unknown:1:6 Expected module specifier after `from`
+    """
+
+    throws """
+      backward import with missing module and import clause
+      ---
+      from  import
+      ---
+      ParseErrors: unknown:1:7 Expected module specifier after `from`
+      unknown:1:9 Expected import clause after `import`
+    """
+
+    throws """
+      backward import with missing import clause
+      ---
+      from "pkg" import
+      ---
+      ParseErrors: unknown:1:11 Expected import clause after `import`
+    """
+
+    throws """
+      backward type import with missing import clause
+      ---
+      from "pkg" import type
+      ---
+      ParseErrors: unknown:1:11 Expected import clause after `import`
+    """
+
+    testCase """
+      standalone from remains an identifier
+      ---
+      from
+      ---
+      from
+    """
+
+    testCase """
+      from remains an implicit call target
+      ---
+      from value
+      ---
+      from(value)
+    """
+
+    testCase """
+      from remains a call target before dynamic import
+      ---
+      from import("./module")
+      ---
+      from(import("./module"))
+    """
+
+    testCase """
+      from remains a call target before import.meta
+      ---
+      from import.meta
+      ---
+      from(import.meta)
+    """
```

## 2. Map import completion cursors through generated quotes correctly

Civet quotes unquoted module paths in generated TypeScript. For `import * as ts from t|`, the inserted opening quote means the source-mapped cursor is one character too early; the language server must advance by one. An unclosed source quote has the opposite shape because Civet inserts a closing quote, so that case still moves backward by one.

The old shared `-1` adjustment handled the unclosed-quote case but moved unquoted cursors in the wrong direction. The two cases are now explicit, and the closing quote suffix is assigned only in the same branch that detects an unclosed source quote.

**`lsp/server/source/server.civet`**

```diff
-        // Hardcode special-case cursor offset
-        //
-        //     Source:      import a from ./a|
-        //     Transpiled:  import a from "./a"|
-        //     Adjusted:    import a from "./a|"
-        //
-        if not qt or qt !== endqt then cursorOffsetAdjustment = -1
-        if qt and qt !== endqt then closingQuoteSuffix = qt
+        // Hardcode cursor offsets for the quotes Civet adds while recovering
+        // import paths.  An unquoted path's mapped cursor is one character
+        // early because of its inserted opening quote; an unclosed quoted
+        // path's mapped cursor is after its inserted closing quote.
+        if not qt
+          cursorOffsetAdjustment = +1
+        else if qt !== endqt
+          cursorOffsetAdjustment = -1
+          closingQuoteSuffix = qt
```

The cursor-adjustment documentation at its application site is updated to describe both directions.

**`lsp/server/source/server.civet`**

```diff
     // … Adjust the cursor position, on a case-per-case basis, to access better completions.
     //  0: Default, when sourcemap cursor position is already perfect.
-    // -1: Gets inside closing quotes for import file completion.
+    // -1: Gets inside an inserted closing quote for import file completion.
+    // +1: Gets past an inserted opening quote for an unquoted import path.
     p += heuristics.cursorOffsetAdjustment
```

For `from |import`, the cursor immediately before `import` has the same source offset as the following keyword. Because backward imports are reordered, mapping that offset normally selects the generated `import` at column zero rather than the recovered empty module. A pure completion helper recognizes this exact boundary from the text on both sides of the cursor. Its two patterns are module-scoped like the existing import-context pattern, so completion requests reuse the same regular-expression objects. The handler invokes the helper only inside the sourcemap branch where the result is needed, using the original source position rather than the position that branch is about to remap. It then forward-maps from the preceding separator; the existing quote adjustments place the TypeScript cursor inside `from ""`. A wider explicit cursor gap continues through the ordinary source-map path unless the cursor is directly before `import`.

**`lsp/server/source/lib/completions.civet`**

```diff
+missingBackwardModulePrefix := /\bfrom[ \t]+$/
+followingImport := /^import\b/
+
+export function missingBackwardModuleContext(
+  lineText: string
+  cursorOffset: number
+): boolean
+  linePrefix := lineText[< cursorOffset]
+  missingBackwardModulePrefix.test(linePrefix) and
+    followingImport.test lineText[>= cursorOffset]
```

**`lsp/server/source/server.civet`**

```diff
   likelyImportContext
   measureTokenLength
+  missingBackwardModuleContext
   parseErrorsToDiagnostics
   ...
-    linePrefix := getCurrentLineText(document, position).slice(0, position.character)
+    lineText := getCurrentLineText document, position
+    linePrefix := lineText[< position.character]
-    isLikelyImportContext := likelyImportContext(linePrefix)
+    isLikelyImportContext := likelyImportContext linePrefix
     ...
     sourcePosition := position
+    sourceCharacter := sourcePosition.character
     if sourcemapLines
-      position = forwardMap(sourcemapLines, position)
+      mapPosition .= sourcePosition
+      // At `from |import`, the cursor shares its source offset with the
+      // following `import`, which maps to the start of the reordered output.
+      // Map from the separator so completion stays in the recovered `from ""`.
+      if sourceCharacter > 0 and
+         missingBackwardModuleContext lineText, sourcePosition.character
+        mapPosition = { ...sourcePosition, character: sourceCharacter - 1 }
+      position = forwardMap sourcemapLines, mapPosition
       logger.log 'remapped'
```

The helper tests pin down the distinction between the one-space boundary that needs special mapping, a cursor directly before `import` after several spaces, a cursor still inside a wider gap, and an already-present module specifier.

**`lsp/server/test/completions.civet`**

```diff
   likelyImportContext
   measureTokenLength
+  missingBackwardModuleContext
   parseErrorRange
   ...
+  describe "missingBackwardModuleContext", ->
+    it "matches the one-space boundary before import", ->
+      assert missingBackwardModuleContext("from import", "from "#)
+
+    it "matches after multiple spaces when the cursor is directly before import", ->
+      assert missingBackwardModuleContext("from  import", "from  "#)
+
+    it "does not match a cursor inside a wider separator", ->
+      assert not missingBackwardModuleContext("from  import", "from "#)
+
+    it "does not match a complete module specifier", ->
+      assert not missingBackwardModuleContext("from module import", "from "#)
```

### Protocol tests cover forward and backward imports

The language-server suite verifies that a single unquoted `t` can complete to `typescript`, that standalone `from` produces no Civet diagnostic, and that backward imports provide the same module completion with a missing module, an empty quoted module, a missing clause, or a one-letter module. Missing-module coverage includes both the natural `from import` form and `from  import` with an explicit cursor gap.

**`lsp/server/test/lsp-features.test.civet`**

```diff
+  it "returns module completions after one unquoted letter", ->
+    uri := docUri path.join(projectRoot, "imp-one-letter.civet")
+    text := "import * as ts from t"
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    await waitForDiag(client, (p) => p.uri is uri)
+
+    result := await client.request "textDocument/completion", {
+      textDocument: { uri }
+      position: { line: 0, character: text# }
+    }
+    list := result?.items ?? result
+    assert Array.isArray(list), "expected completion items array"
+    assert list.some((item: any) => item.label is "typescript"),
+      `expected typescript module completion, got ${list.map((item: any) => item.label).join(", ")}`
+
+  it "does not parse standalone from as a backward import", ->
+    uri := docUri path.join(projectRoot, "standalone-from.civet")
+    text := "from"
+    client.notify "textDocument/didOpen", {
+      textDocument: { uri, languageId: "civet", version: 1, text }
+    }
+    diagnostics := await waitForDiag(client, (p) => p.uri is uri)
+
+    assert not diagnostics.diagnostics.some((diagnostic: any) => diagnostic.source is "civet"),
+      `expected no Civet parse diagnostic, got ${JSON.stringify diagnostics.diagnostics}`
+
+  for [name, text, cursor] of [
+    ["missing-module-one-space", "from import * as ts", "from "#]
+    ["missing-module-gap", "from  import * as ts", "from "#]
+    ["quoted-module", 'from "" import * as ts', "from "#]
+    ["missing-clause", 'from "" import', "from "#]
+    ["missing-type-clause", 'from "" import type', "from "#]
+    ["one-letter", "from t import * as ts", "from t"#]
+  ]
+    it `returns module completions for backward import with ${name}`, ->
+      uri := docUri path.join(projectRoot, `imp-backward-${name}.civet`)
+      client.notify "textDocument/didOpen", {
+        textDocument: { uri, languageId: "civet", version: 1, text }
+      }
+      await waitForDiag(client, (p) => p.uri is uri)
+
+      result := await client.request "textDocument/completion", {
+        textDocument: { uri }
+        position: { line: 0, character: cursor }
+      }
+      list := result?.items ?? result
+      assert Array.isArray(list), "expected completion items array"
+      assert list.some((item: any) => item.label is "typescript"),
+        `expected typescript module completion, got ${list.map((item: any) => item.label).join(", ")}`
```

### VS Code exercises the real completion command

Two end-to-end tests activate fixture documents and call `vscode.executeCompletionItemProvider`, confirming the protocol behavior survives extension bundling and editor integration.

**`lsp/vscode/e2e/completion.test.civet`**

```diff
+  test 'Returns module completions after one unquoted letter', =>
+    docUri := getDocUri('import-one-letter.civet')
+    await activate(docUri)
+
+    text := 'import * as ts from t'
+    completions := await poll(
+      () => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position(0, text#)
+      ) as Promise<CompletionList>
+      (list) => list?.items.some((item) => getLabel(item) is 'typescript')
+    )
+
+    labels := completions.items.map(getLabel)
+    assert labels.includes('typescript'),
+      `Expected typescript module completion, got: ${labels.join(', ')}`
+
+  test 'Returns module completions in an incomplete backward import', =>
+    docUri := getDocUri('import-backward.civet')
+    await activate(docUri)
+
+    completions := await poll(
+      () => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position(0, 'from '#)
+      ) as Promise<CompletionList>
+      (list) => list?.items.some((item) => getLabel(item) is 'typescript')
+    )
+
+    labels := completions.items.map(getLabel)
+    assert labels.includes('typescript'),
+      `Expected typescript module completion, got: ${labels.join(', ')}`
```

The corresponding new fixtures are deliberately minimal so their cursor positions are stable.

**`lsp/vscode/e2e/fixture/import-one-letter.civet`**

```diff
--- /dev/null
+++ b/lsp/vscode/e2e/fixture/import-one-letter.civet
@@
+import * as ts from t
```

**`lsp/vscode/e2e/fixture/import-backward.civet`**

```diff
--- /dev/null
+++ b/lsp/vscode/e2e/fixture/import-backward.civet
@@
+from  import * as ts
```

## 3. Offer bare-`@` member completions without trigger metadata

A Civet bare `@` becomes TypeScript `this`. The existing completion correction only ran when the LSP client explicitly reported `@` as the trigger character. A manual request—or an editor request that omitted trigger metadata—used the ordinary forward source map. With a trailing newline or later class member, that mapping could land after the generated class and return global completions instead of `HTMLElement` members.

The server now recognizes a bare `@` directly from the current line immediately before the cursor, excluding the second character of `@@`. The current line was already read for import detection, so this check does not fetch the entire document or convert the cursor through a document-wide offset. It retains support for explicit trigger metadata. Either path reuses the existing correction: map from the source `@`, locate the generated `this`/`this.`, ask TypeScript as if `.` triggered the request, and return an incomplete completion list so the client may request refinements.

**`lsp/server/source/server.civet`**

```diff
     // A bare Civet `@` maps to TS `this`, often with the sourcemapped cursor
     // inside the generated word. Move to after `this`/`this.` so TS returns
     // member completions, and ask as if `.` triggered the completion.
+    hasBareAtBeforeCursor :=
+      sourceCharacter > 0 and lineText[sourceCharacter - 1] is '@' and
+      (sourceCharacter < 2 or lineText[sourceCharacter - 2] is not '@')
+    isBareAtCompletion :=
+      context?.triggerCharacter is '@' or hasBareAtBeforeCursor
-    if context?.triggerCharacter is '@'
+    if isBareAtCompletion
       text := transpiledDoc.getText()
-      if sourcemapLines
-        sourceOffset := document.offsetAt(sourcePosition)
-        if sourceOffset > 0 and document.getText()[sourceOffset - 1] is '@'
-          p = transpiledDoc.offsetAt(forwardMap(sourcemapLines, document.positionAt(sourceOffset - 1)))
+      if sourcemapLines and hasBareAtBeforeCursor
+        atPosition := { ...sourcePosition, character: sourceCharacter - 1 }
+        mappedAtPosition := forwardMap sourcemapLines, atPosition
+        p = transpiledDoc.offsetAt mappedAtPosition
       searchStart := Math.max(0, p - 3)
       aroundP := text.slice(searchStart, p + 4)
       thisIdx := aroundP.lastIndexOf('this')
       if thisIdx is not -1
         thisEnd := searchStart + thisIdx + 4
         p = if text[thisEnd] is '.' then thisEnd + 1 else thisEnd
         completionOptions.triggerCharacter = '.' as ts.CompletionsTriggerCharacter
     ...
-    if context?.triggerCharacter is '@'
+    if isBareAtCompletion
       return CompletionList.create(items, true)
```

### Protocol coverage varies the text after the cursor

The language-server test runs the same constructor body with `@` at end of file, before a trailing newline, and before another class member. For each variant it checks both an explicit `@` trigger request and a request with no completion context. `classList` proves that TypeScript sees the `HTMLElement` instance rather than global scope.

**`lsp/server/test/lsp-features.test.civet`**

```diff
+  for [name, suffix] of [
+    ["at-eof", ""]
+    ["before-trailing-newline", "\n"]
+    ["before-later-class-member", "\n  foo := 1\n"]
+  ]
+    it `returns HTMLElement completions for constructor @ ${name}`, ->
+      uri := docUri path.join(projectRoot, `waveform-${name}.civet`)
+      text := "class Waveform < HTMLElement\n  @()\n    super()\n    @" + suffix
+      client.notify "textDocument/didOpen", {
+        textDocument: { uri, languageId: "civet", version: 1, text }
+      }
+      await waitForDiag(client, (p) => p.uri is uri)
+
+      lines := text.split "\n"
+      atLine := lines.findIndex (l) => l.trim() is "@"
+      result := await client.request "textDocument/completion", {
+        textDocument: { uri }
+        position: { line: atLine, character: lines[atLine].indexOf("@") + 1 }
+        context: { triggerKind: 2, triggerCharacter: "@" }
+      }
+      list := result?.items ?? result
+      assert Array.isArray(list), `expected completion items array, got ${JSON.stringify(result)}`
+      assert list.some((item: any) => item.label is "classList"),
+        `expected classList member completion, got ${list.map((item: any) => item.label).join(", ")}`
+
+      manualResult := await client.request "textDocument/completion", {
+        textDocument: { uri }
+        position: { line: atLine, character: lines[atLine].indexOf("@") + 1 }
+      }
+      manualList := manualResult?.items ?? manualResult
+      assert Array.isArray(manualList), `expected manual completion items array, got ${JSON.stringify(manualResult)}`
+      assert manualList.some((item: any) => item.label is "classList"),
+        `expected classList manual completion, got ${manualList.map((item: any) => item.label).join(", ")}`
```

### VS Code verifies a request without trigger metadata

The end-to-end test calls the editor completion provider without a trigger character. It also verifies that the completion edit does not insert a redundant `this.` into Civet source.

**`lsp/vscode/e2e/at-completions.test.civet`**

```diff
+  test 'Returns constructor member completions for bare @ without trigger metadata', async =>
+    docUri := getDocUri 'waveform-bare-at.civet'
+    await activate docUri
+
+    completions := await poll
+      => commands.executeCommand(
+        'vscode.executeCompletionItemProvider'
+        docUri
+        new Position 3, 3
+      ) as Promise<CompletionList>
+      (list) => list?.items.some (item) => getLabel(item) is 'classList'
+
+    classList := completions.items.find (item) => getLabel(item) is 'classList'
+    assert classList, 'Expected classList member completion for bare @'
+    insertText := getInsertText classList
+    assert !insertText.includes 'this.',
+      `Completion 'classList' has insertText containing 'this.': ${insertText}`
```

**`lsp/vscode/e2e/fixture/waveform-bare-at.civet`**

```diff
--- /dev/null
+++ b/lsp/vscode/e2e/fixture/waveform-bare-at.civet
@@
+class Waveform < HTMLElement
+	@()
+		super()
+		@
```

</details>
