### PR TITLE
Fix compiler crash when misusing `operator`

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3073,7 +3073,12 @@ FunctionExpression
 # NOTE: Dynamic infix operators
 OperatorDeclaration ::OperatorDeclaration
   # `operator {x, y} := ...` declaration while blessing
-  Operator:op OperatorBehavior?:behavior _:w LexicalDeclaration:decl ->
+  Operator OperatorBehavior?:behavior _:w Loc:loc LexicalDeclaration:decl ->
+    unless Array.isArray decl.names
+      return {}
+        type: "Error"
+        message: "Operator declaration must declare identifiers"
+        loc.$loc
     decl.names.forEach((name: string) => setOperatorBehavior(name, behavior))
     decl = prepend(behavior.error, decl) if behavior?.error
     decl = prepend(trimFirstSpace(w), decl)

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -225,6 +225,7 @@ export type ASTError =
   // include ASTError.  Typed as undefined here to let destructuring
   // succeed without adding real shape — an ASTError never carries these.
   delim?: ASTNode
+  id?: undefined
   name?: undefined
   names?: undefined
   typeSuffix?: undefined

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -949,6 +949,7 @@ export type OperatorDeclaration =
   | LexicalDeclaration
   | OperatorFunctionDeclaration
   | OperatorIdentifierDeclaration
+  | ASTError
 
 export type Star =
   type: "Star"

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -998,6 +998,32 @@ describe "custom identifier infix operators", ->
     max(min(a, b), c)
   """
 
+  throws """
+    invalid lexical operator declarations
+    ---
+    operator x.y := z
+    operator x.y .= z
+    operator x#y := z
+    operator x# := z
+    operator x! := z
+    operator x!y := z
+    operator x@y := z
+    operator x?y := z
+    operator x{y} := z
+    operator x[x] := z
+    ---
+    ParseErrors: unknown:1:10 Operator declaration must declare identifiers
+    unknown:2:10 Operator declaration must declare identifiers
+    unknown:3:10 Operator declaration must declare identifiers
+    unknown:4:10 Operator declaration must declare identifiers
+    unknown:5:10 Operator declaration must declare identifiers
+    unknown:6:10 Operator declaration must declare identifiers
+    unknown:7:10 Operator declaration must declare identifiers
+    unknown:8:10 Operator declaration must declare identifiers
+    unknown:9:10 Operator declaration must declare identifiers
+    unknown:10:10 Operator declaration must declare identifiers
+  """
+
   testCase """
     import operator
     ---


### PR DESCRIPTION
Fix #2204 by fixing compiler crashes on invalid operator declarations such as:

```civet
operator x.y := z
```

Invalid lexical declarations now produce a recoverable, targeted parse error instead of assuming `decl.names` exists. This lets parsing continue and report additional errors.