### PR TITLE
Fix tests on macOS that typecheck files under `os.tmpdir()`

### DIFF
--- a/test/cli.civet
+++ b/test/cli.civet
@@ -2,7 +2,7 @@ assert from assert
 path from path
 { parseArgs, makeOutputFilename, type Options, type ParsedArgs } from ../source/cli.civet
 { cli, version } from ../source/cli.civet
-{ writeFile, mkdir, rm, readFile } from fs/promises
+{ writeFile, mkdir, rm, readFile, realpath } from fs/promises
 { tmpdir } from os
 
 function argsParse(args: string | string[], parsed: ParsedArgs): Promise<void>
@@ -839,7 +839,7 @@ describe "CLI --typecheck", ->
     // (which has include:["source", ...] and would pull source/** into
     // scope — surfacing as 800+ TS diagnostics on any test that drives
     // the TSService load path, e.g. --typecheck --js).
-    tmpDir = path.join tmpdir(), "civet-cli-typecheck-" + Math.random().toString(36).substring(2, 15)
+    tmpDir = path.join await realpath(tmpdir()), "civet-cli-typecheck-" + Math.random().toString(36).substring(2, 15)
     await mkdir tmpDir, { recursive: true }
     // Explicit `files: [_placeholder.ts]` keeps the stub tsconfig valid
     // (TS18003 fires only when neither files nor include matches anything)

--- a/test/infra/unplugin.civet
+++ b/test/infra/unplugin.civet
@@ -6,7 +6,7 @@ assert from assert
 esbuildCivetPlugin from ../../source/unplugin/esbuild.civet
 viteCivetPlugin from ../../source/unplugin/vite.civet
 { slash, rawPlugin, type PluginOptions } from ../../source/unplugin/unplugin.civet
-{ readFile, readdir, writeFile, mkdir, rm } from fs/promises
+{ readFile, readdir, writeFile, mkdir, rm, realpath } from fs/promises
 // Default import: the same mutable module object whose readFileSync the
 // plugin's vinxi support substitutes during route analysis.  Call it via
 // property access (fsSync.readFileSync) so the swap is visible.
@@ -329,7 +329,7 @@ describe "unplugin: file system", ->
 
   describe "bundler sourcemaps", ->
     function createSourcemapFixture(name: string)
-      projectDir := path.join tmpDir, `${name}-${fileNum++}`
+      projectDir := path.join await realpath(tmpDir), `${name}-${fileNum++}`
       pkgDir := path.join projectDir, "node_modules", "civet-pkg"
       await mkdir path.join(projectDir, "src", "imported"), recursive: true
       await mkdir path.join(projectDir, "src", "nested"), recursive: true


### PR DESCRIPTION
On macOS (Tahoe 26.6.2, at least), tests that attempt to typecheck files under `os.tmpdir()` fail with TS6059 ("File ... is not under 'rootDir' ... . 'rootDir' is expected to contain all source files."):

Here's one of the 5 failed test cases:
```
  1) CLI --typecheck
       typechecks a valid .civet file without errors:

      AssertionError [ERR_ASSERTION]: valid file typechecks cleanly; stderr: error TS6059: File '/var/folders/l0/dyn0pysx507flgl8gw6d5_180000gn/T/civet-cli-typecheck-64dxfe5llk6/input-0.civet.tsx' is not under 'rootDir' '/private/var/folders/l0/dyn0pysx507flgl8gw6d5_180000gn/T/civet-cli-typecheck-64dxfe5llk6'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Root file specified for compilation

1 TypeScript diagnostic.

      + expected - actual

      -1
      +0
      
      at Context.<anonymous> (test/cli.civet:880:12)
```

Here are the discrepant paths lined up so you can see the problem:

```diff
File              '/var/folders/l0/dyn0pysx507flgl8gw6d5_180000gn/T/civet-cli-typecheck-64dxfe5llk6/input-0.civet.tsx'
'rootDir' '/private/var/folders/l0/dyn0pysx507flgl8gw6d5_180000gn/T/civet-cli-typecheck-64dxfe5llk6'
```


The problem seems to be that Node's `os.tmpdir()` reports it as under `/var/...`, but if you get the `realpath` of it, it's `/private/var/...`.

```
🐱> os.tmpdir()
... 
'/var/folders/l0/dyn0pysx507flgl8gw6d5_180000gn/T'
🐱> await realpath os.tmpdir()
... 
'/private/var/folders/l0/dyn0pysx507flgl8gw6d5_180000gn/T'
```

Somewhere in the compilation or typechecking chain, TS ends up comparing source paths against rootDir in a way that there is a mismatch between the file's path and the rootDir's path.

## Is this a bug in Civet or the tests?

This PR assumes that the bug is in the tests, not the implementation. It simply calls `realpath` on `os.tmpdir()` for the tests that are affected by this so that the tests will pass on macOS.

If that's the right assumption, then this PR demonstrates how to fix the problem. (Although maybe it'd be best DRY'd up it a bit)

If this is actually a bug in Civet, then  https://github.com/nicholaides/Civet/commit/020bc41cd13f6363a2dff70361e410eba9080f0a adds a test case that triggers the bug in a way that should fail on Linux, too, because it doesn't depend on macOS's unique `os.tmpdir()` behavior. 