### PR TITLE
Better declaration error handling, and fix more type diagnostics

### DIFF
--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1662,7 +1662,7 @@ FieldDefinition
   # name: (param1, param2) ->
   # name: (param1, param2) => which gets wrapped in bind in constructor
   CoffeeClassesEnabled ClassElementName:id _? Colon __ AssignmentExpression:exp ->
-    assert exp and "type" in exp, "AssignmentExpression must exist"
+    assert (exp is like { type }), "AssignmentExpression must exist"
 
     switch exp.type
       when "FunctionExpression"

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -9630,11 +9630,12 @@ NestedTypeBulletedTuple ::TypeTuple
     // Remove implicit comma from last element
     // NOTE: TypeElementList always returns arrays of objects (TypeElement /
     // TypeBulletedTuple), not bare arrays, so Array.isArray(last) arm dead.
-    last := content[content# - 1]
-    children .= last?.children
-    if children?.at(-1).implicit
-      children = children.slice(0, -1)
-      content[content# - 1] = { ...last, children }
+    if { children, ...lastChildProps } := content.-1
+      if children and children.-1 is like { implicit: true }
+          content.-1 = {
+            ...lastChildProps
+            children |> .slice(0, -1)
+          }
 
     return {
       type: "TypeTuple",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -190,6 +190,7 @@ import type {
   TypeDeclaration,
   TypeDeclarationBinding,
   TypeArgument,
+  TypeArguments,
   TypeArgumentList,
   TypeFunction,
   TypeLexicalDeclaration,
@@ -586,14 +587,15 @@ ImplicitArguments
     }
 
 ExplicitArguments
-  OpenParen:open AllowAll ( PostfixedArgumentList ( __ Comma )? )?:args __:ws RestoreAll CloseParen:close ->
-    if args
-      if args[1] // trailing comma
-        args = [ ...args[0], args[1] ]
+  OpenParen:open AllowAll ( PostfixedArgumentList ( __ Comma )? )?:postArgs __:ws RestoreAll CloseParen:close ->
+    args := if postArgs
+      if postArgs[1] // trailing comma
+        [ ...postArgs[0], postArgs[1] ]
       else // no trailing comma
-        args = args[0]
+        postArgs[0]
     else // no arguments
-      args = []
+      []
+
     return {
       type: "Call",
       args,
@@ -1108,8 +1110,7 @@ ArrowFunction
 FatArrow
   # Ensures at least one space before arrow
   _?:ws FatArrowToken:arrow ->
-    ws = " " unless ws
-    return [ ws, arrow ]
+    return [ ws || " ", arrow ]
 
 FatArrowToken
   "=>" / "⇒" ->
@@ -1143,8 +1144,7 @@ FatArrowBody
     // object literal. Skip so we fall through to NoCommaBracedOrEmptyBlock.
     return $skip if config.esBraceBlock and exp!.type is "ObjectExpression"
     // Ensure object literal is wrapped in parens
-    exp = makeExpressionStatement(exp)
-    expressions := [["", exp]]
+    expressions := [["", makeExpressionStatement(exp)]]
     return {
       type: "BlockStatement",
       bare: true,
@@ -1313,7 +1313,7 @@ ParenthesizedExpression
   OpenParen:open AllowAll ( PostfixedCommaExpression __ CloseParen )? RestoreAll ::ParenthesizedExpression ->
     return $skip unless $3
     [expression, ws, close] := $3
-    if expression!.type is "ParenthesizedExpression" and (expression as any).implicit
+    if expression is like { type: "ParenthesizedExpression", implicit: true }
       return {
         ...expression,
         children: [open, (expression as any).expression, ws, close],
@@ -1394,9 +1394,8 @@ ClassBinding
 # https://262.ecma-international.org/#prod-ClassHeritage
 ClassHeritage
   ExtendsClause:extendsClause WithClause?:withClause ImplementsClause?:implementsClause ->
-    if withClause
-      extendsClause = convertWithClause(withClause, extendsClause)
-    return [ extendsClause, implementsClause ]
+    clause := withClause ? convertWithClause(withClause, extendsClause) : extendsClause
+    return [ clause, implementsClause ]
 
   WithClause?:withClause ImplementsClause?:implementsClause ->
     return [ convertWithClause(withClause), implementsClause ] if withClause
@@ -1411,9 +1410,9 @@ ExtendsClause
 WithClause ::WithClause
   # Nested form where C, D appear on separate lines, indented
   # Also allows for arbitrary expressions
-  NotDedented With PushIndent ( Nested Expression _? Comma? )*:targets PopIndent ->
-    return $skip unless targets#
-    targets = targets.map(($) => $.slice(0, -1)) // strip Comma?
+  NotDedented With PushIndent ( Nested Expression _? Comma? )*:targetNodes PopIndent ->
+    return $skip unless targetNodes#
+    targets := targetNodes.map(.slice(0, -1)) // strip Comma?
     return {
       type: "WithClause",
       children: $0,
@@ -1476,11 +1475,11 @@ ExtendsTarget
 ImplementsClause
   # Nested form where interfaces appear on separate lines, indented
   # Allows for implicit type arguments
-  ImplementsToken:i PushIndent ( Nested TypeIdentifier ArrayBulletDelimiter )*:targets PopIndent ->
-    return $skip unless targets#
+  ImplementsToken:i PushIndent ( Nested TypeIdentifier ArrayBulletDelimiter )*:targetsNodes PopIndent ->
+    return $skip unless targetsNodes#
     // remove final comma
-    last := targets.at(-1)!.slice(0, -1)
-    targets = targets.slice(0, -1).concat(last)
+    last := targetsNodes.at(-1)!.slice(0, -1)
+    targets := [...targetsNodes.slice(0, -1), ...last]
     return {
       ts: true,
       children: [i, targets],
@@ -1503,8 +1502,7 @@ ImplementsToken
     return { children }
 
   NotDedented "implements" NonIdContinue ->
-    $2 = { $loc, token: $2 }
-    return [$1, $2]
+    return [$1, { $loc, token: $2 }]
 
 ImplementsShorthand
   "<:" ->
@@ -1664,14 +1662,14 @@ FieldDefinition
   # name: (param1, param2) ->
   # name: (param1, param2) => which gets wrapped in bind in constructor
   CoffeeClassesEnabled ClassElementName:id _? Colon __ AssignmentExpression:exp ->
-    switch (exp!.type) {
-      case "FunctionExpression": {
+    assert exp and "type" in exp, "AssignmentExpression must exist"
+
+    switch exp.type
+      when "FunctionExpression"
         return convertFunctionToMethod(id, exp)
-      }
-      case "ArrowFunction": {
+      when "ArrowFunction"
         return convertArrowFunctionToMethod(id, exp)
-      }
-      default:
+      else
         // CoffeeScript-compatible: `name: value` becomes a prototype
         // assignment (`Class.prototype.name = value`) lifted out of the
         // class body in processCoffeeClasses. The empty children make
@@ -1694,7 +1692,6 @@ FieldDefinition
           exp,
           children: [],
         }
-    }
 
   # NOTE: Added readonly semantic equivalent of const field assignment
   InsertReadonly:readonly ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedPostfixedExpressionOrCommaLoop ->
@@ -9626,9 +9623,9 @@ NestedTypeElement
 
 # NOTE: Nested bulleted tuple starts with an indentation.
 NestedTypeBulletedTuple ::TypeTuple
-  ( InsertSpace InsertOpenBracket ):open PushIndent NestedTypeBullet*:content InsertCloseBracket:close PopIndent ->
-    return $skip unless content#
-    content = content.flat() // combine bullets into one array
+  ( InsertSpace InsertOpenBracket ):open PushIndent NestedTypeBullet*:nestedContent InsertCloseBracket:close PopIndent ->
+    return $skip unless nestedContent#
+    content := nestedContent.flat() // combine bullets into one array
 
     // Remove implicit comma from last element
     // NOTE: TypeElementList always returns arrays of objects (TypeElement /

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1678,7 +1678,7 @@ FieldDefinition
     // intact rather than emit invalid `Foo.prototype.#x = ...`.
     // The PrivateIdentifier rule normalises to type "Identifier"
     // with a `#`-prefixed name, so detect by name prefix.
-    if id is like { name } and id.name <? "string" and id.name.startsWith("#")
+    if id is like { name: /^#/ }
       return {
         type: "FieldDefinition"
         id

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6963,11 +6963,11 @@ ExportDeclaration
   Decorators? Export __ Default __ !FunctionDeclaration ( LexicalDeclaration / VariableStatement / TypeAliasDeclaration / NamespaceDeclaration / EnumDeclaration / OperatorDeclaration ):declaration ->
     let id, error
     if declaration.type is "Declaration"
-      names := declaration.names
+      names := declaration.names ?? []
       if names# !== 1
         error = {
           type: "Error",
-          message: `export default with ${names#} variable declaration (should be 1)`
+          message: `export default with ${names#} variable declarations (should be 1)`
         }
       id = names[0]
     else
@@ -8866,7 +8866,7 @@ JSXChildExpression
   Whitespace? LexicalDeclaration:d ->
     decl := d!
     // Add refs from thisAssignments to list of names
-    names .= decl.names.concat(
+    names .= (decl.names ?? []).concat(
       decl.thisAssignments!.map((a: any) => a[1][1])
     )
     // Remove duplicate names
@@ -8874,7 +8874,7 @@ JSXChildExpression
     names = names.filter((name: string, i: number) => i is 0 or name !== names[i-1])
     d = {
       ...decl,
-      hoistDec: {
+      hoistDec: if names# then {
         type: "Declaration",
         children: [
           "let ",
@@ -8893,6 +8893,12 @@ JSXChildExpression
     else if d.splices?#
       (d.children as any[]).push(...d.splices)
     (d.children as any[]).push(",void 0")
+    unless decl.names
+      (d.children as any[]).push {
+        type: "Error"
+        message: "JSX declaration must declare identifiers"
+        $loc
+      } satisfies ASTError
     return d
   # NOTE: Using PostfixedExpressionOrCommaLoop to allow If/Switch expressions and postfixes
   Whitespace? ( DotDotDot Whitespace? )? PostfixedExpressionOrCommaLoop

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -6963,7 +6963,7 @@ ExportDeclaration
   Decorators? Export __ Default __ !FunctionDeclaration ( LexicalDeclaration / VariableStatement / TypeAliasDeclaration / NamespaceDeclaration / EnumDeclaration / OperatorDeclaration ):declaration ->
     let id, error
     if declaration.type is "Declaration"
-      names := declaration.names ?? []
+      names := namesOf(declaration)
       if names# !== 1
         error = {
           type: "Error",
@@ -8866,7 +8866,7 @@ JSXChildExpression
   Whitespace? LexicalDeclaration:d ->
     decl := d!
     // Add refs from thisAssignments to list of names
-    names .= (decl.names ?? []).concat(
+    names .= namesOf(decl).concat(
       decl.thisAssignments!.map((a: any) => a[1][1])
     )
     // Remove duplicate names

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -1662,36 +1662,35 @@ FieldDefinition
   # name: (param1, param2) ->
   # name: (param1, param2) => which gets wrapped in bind in constructor
   CoffeeClassesEnabled ClassElementName:id _? Colon __ AssignmentExpression:exp ->
-    assert (exp is like { type }), "AssignmentExpression must exist"
+    if exp is like { type }
+      switch exp.type
+        when "FunctionExpression"
+          return convertFunctionToMethod(id, exp)
+        when "ArrowFunction"
+          return convertArrowFunctionToMethod(id, exp)
 
-    switch exp.type
-      when "FunctionExpression"
-        return convertFunctionToMethod(id, exp)
-      when "ArrowFunction"
-        return convertArrowFunctionToMethod(id, exp)
-      else
-        // CoffeeScript-compatible: `name: value` becomes a prototype
-        // assignment (`Class.prototype.name = value`) lifted out of the
-        // class body in processCoffeeClasses. The empty children make
-        // this entry invisible in the emitted class body.
-        // PrivateIdentifier (`#x`) is JS-only — CoffeeScript has no
-        // private fields — so leave the original class-field semantics
-        // intact rather than emit invalid `Foo.prototype.#x = ...`.
-        // The PrivateIdentifier rule normalises to type "Identifier"
-        // with a `#`-prefixed name, so detect by name prefix.
-        if (id?.name?.startsWith?.("#")) {
-          return {
-            type: "FieldDefinition",
-            id,
-            children: [id, " = ", exp],
-          }
-        }
-        return {
-          type: "CoffeeClassPrototype",
-          id,
-          exp,
-          children: [],
-        }
+    // CoffeeScript-compatible: `name: value` becomes a prototype
+    // assignment (`Class.prototype.name = value`) lifted out of the
+    // class body in processCoffeeClasses. The empty children make
+    // this entry invisible in the emitted class body.
+    // PrivateIdentifier (`#x`) is JS-only — CoffeeScript has no
+    // private fields — so leave the original class-field semantics
+    // intact rather than emit invalid `Foo.prototype.#x = ...`.
+    // The PrivateIdentifier rule normalises to type "Identifier"
+    // with a `#`-prefixed name, so detect by name prefix.
+    if id is like { name } and id.name <? "string" and id.name.startsWith("#")
+      return {
+        type: "FieldDefinition"
+        id
+        children: [id, " = ", exp]
+      }
+
+    return {
+      type: "CoffeeClassPrototype"
+      id
+      exp
+      children: []
+    }
 
   # NOTE: Added readonly semantic equivalent of const field assignment
   InsertReadonly:readonly ClassElementName:id TypeSuffix?:typeSuffix __ ConstAssignment:ca MaybeNestedPostfixedExpressionOrCommaLoop ->

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -33,15 +33,13 @@ function findDecs(statements: ASTNode)
 
   return new Set globals ++ declarationNames
 
-function createConstLetDecs(statements: any, scopes: any, letOrConst: "let" | "const"): void
-  function findVarDecs(statements: any, _decs: any): Set<string>
-    declarationNames := gatherRecursive statements, (node) =>
-      node.type is "Declaration" and
-      node.children and
-      node.children# > 0 and
-      node.children[0]!.token and
-      node.children[0]!.token.startsWith("var") or
-      node.type is "FunctionExpression"
+function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "let" | "const"): void
+  function findVarDecs(statements: any): Set<string>
+    declarationNames := gatherRecursive statements, (node) => Boolean
+      if { type: "Declaration", children: [{ token }, ...]} := node
+        token?.startsWith("var")
+      else if node.type is "FunctionExpression"
+        true
     .filter .type is "Declaration"
     .flatMap .names
     new Set declarationNames
@@ -124,7 +122,7 @@ function createConstLetDecs(statements: any, scopes: any, letOrConst: "let" | "c
         continue
       // Synthetic assignments (such as a `do` expression's result ref) may
       // not introduce any source-level names.
-      names := (node.names ?? []).filter (name: string) => not hasDec name
+      names := ((node.names if "names" in node) ?? []).filter not hasDec .
       if node.type is "AssignmentExpression"
         undeclaredIdentifiers.push ...names
       for each name of names
@@ -138,14 +136,13 @@ function createConstLetDecs(statements: any, scopes: any, letOrConst: "let" | "c
         and statement[1].type is "AssignmentExpression"
         and statement[1].names# is 1
         and statement[1].names[0] is undeclaredIdentifiers[0]
-        and firstIdentifier and firstIdentifier.names == undeclaredIdentifiers[0]
+        and firstIdentifier.names.join(',') is undeclaredIdentifiers[0]
         and gatherNodes(statement[1], .type is "ObjectBindingPattern")# is 0)
         statement[1].children.unshift [`${letOrConst} `]
       else
-        tail .= "\n"
         // Does this statement start with a newline?
-        if gatherNodes(indent, .token and .token.endsWith("\n"))#
-          tail = undefined
+        tail := ("\n" unless gatherNodes(indent, (is like { token: /\n$/ }))#)
+
         // Have to use 'let' instead of 'const' if the assignment is inside an expression
         targetStatements.push [indent, {
           type: "Declaration"
@@ -221,9 +218,11 @@ function createVarDecs(block: BlockStatement, scopes: any, pushVar?: any): void
   if varIds.length
     // get indent from first statement
     const indent = getIndent(statements[0])
-    let delimiter = ";"
-    if statements[0][1]?.parent?.root
-      delimiter = ";\n"
+    delimiter :=
+      if statements[0][1] is like { parent: { root: true } }
+        ";\n"
+      else
+        ";"
     // TODO: Declaration ast node
     braceBlock block
     statements.unshift([indent, {

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -41,7 +41,8 @@ function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "le
       else if node.type is "FunctionExpression"
         true
     .filter .type is "Declaration"
-    .flatMap .names
+    // The declarations matched above are `var` declarations, which have names.
+    .flatMap .names!
     new Set declarationNames
 
   declaredIdentifiers .= findVarDecs statements

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -13,6 +13,7 @@ import {
 
 import {
   isFunction
+  namesOf
 } from ./util.civet
 
 import {
@@ -41,8 +42,7 @@ function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "le
       else if node.type is "FunctionExpression"
         true
     .filter .type is "Declaration"
-    // The declarations matched above are `var` declarations, which have names.
-    .flatMap .names!
+    .flatMap namesOf
     new Set declarationNames
 
   declaredIdentifiers .= findVarDecs statements
@@ -123,7 +123,7 @@ function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "le
         continue
       // Synthetic assignments (such as a `do` expression's result ref) may
       // not introduce any source-level names.
-      names := ((node.names if "names" in node) ?? []).filter not hasDec .
+      names := namesOf(node).filter not hasDec .
       if node.type is "AssignmentExpression"
         undeclaredIdentifiers.push ...names
       for each name of names

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -36,10 +36,8 @@ function findDecs(statements: ASTNode)
 
 function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "let" | "const"): void
   function findVarDecs(statements: any): Set<string>
-    declarationNames := gatherRecursive statements, (node) => Boolean
-      (or)
-        node is like { type: "Declaration", children: [{ token: /^var/ }, ...]}
-        node.type is "FunctionExpression"
+    declarationNames := gatherRecursive statements,
+      (is like { type: "Declaration", children: [{ token: /^var/ }, ...]}, { type: "FunctionExpression" })
     .filter .type is "Declaration"
     .flatMap namesOf
     new Set declarationNames
@@ -134,9 +132,8 @@ function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "le
       firstIdentifier .= gatherNodes(statement[1], .type is "Identifier")[0]
       if (undeclaredIdentifiers# is 1
         and statement[1].type is "AssignmentExpression"
-        and statement[1].names# is 1
-        and statement[1].names[0] is undeclaredIdentifiers[0]
-        and firstIdentifier.names.join(',') is undeclaredIdentifiers[0]
+        and statement[1].names is like [^undeclaredIdentifiers[0]]
+        and firstIdentifier.names is like [^undeclaredIdentifiers[0]]
         and gatherNodes(statement[1], .type is "ObjectBindingPattern")# is 0)
         statement[1].children.unshift [`${letOrConst} `]
       else

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -37,10 +37,9 @@ function findDecs(statements: ASTNode)
 function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "let" | "const"): void
   function findVarDecs(statements: any): Set<string>
     declarationNames := gatherRecursive statements, (node) => Boolean
-      if { type: "Declaration", children: [{ token }, ...]} := node
-        token?.startsWith("var")
-      else if node.type is "FunctionExpression"
-        true
+      (or)
+        node is like { type: "Declaration", children: [{ token: /^var/ }, ...]}
+        node.type is "FunctionExpression"
     .filter .type is "Declaration"
     .flatMap namesOf
     new Set declarationNames
@@ -142,7 +141,7 @@ function createConstLetDecs(statements: any, scopes: Set<any>[], letOrConst: "le
         statement[1].children.unshift [`${letOrConst} `]
       else
         // Does this statement start with a newline?
-        tail := ("\n" unless gatherNodes(indent, (is like { token: /\n$/ }))#)
+        tail := "\n" unless gatherNodes(indent, (is like { token: /\n$/ }))#
 
         // Have to use 'let' instead of 'const' if the assignment is inside an expression
         targetStatements.push [indent, {

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -92,7 +92,9 @@ function adjustBindingElements(elements: ArrayBindingPatternContent): {
     rest := elements[restIndex] as BindingRestElement
     after := elements[restIndex + 1..]
 
-    restIdentifier := rest.binding.ref or rest.binding
+    restIdentifier := (or)
+      rest.binding.ref if "ref" in rest.binding
+      rest.binding
     /* fallback when rest binding is PinPattern or Literal (neither sets names); prevents crash in `[a, ...^x] .= arr` shape */
     names.push ...rest.names or []
 
@@ -231,7 +233,7 @@ function patternBindings(pattern: ASTNodeObject): BindingIdentifier[]
 Simplify `{name: name}` to just `{name}` that results from
 the parser expanding `{name^: pattern}` into `{name: name^pattern}`
 */
-function simplifyBindingProperties(node: ASTNode)
+function simplifyBindingProperties(node: ASTNode): void
   for each p of gatherRecursiveAll node, .type is "BindingProperty"
     { name, value } := p
     if value?.type is "NamedBindingPattern" and value.binding is name
@@ -243,9 +245,9 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
   splices: unknown[] := []
 
   function insertRestSplices(s: ASTNode, p: unknown[], thisAssignments: ThisAssignments): void
-    for each let n of gatherRecursiveAll(s, (n) => (or)
-      n.blockPrefix
-      opts?.injectParamProps and n.accessModifier
+    for each let n of gatherRecursiveAll(s, (n) => Boolean (or)
+      n.blockPrefix if "blockPrefix" in n
+      opts?.injectParamProps and n.accessModifier if "accessModifier" in n
       n.type is "AtBinding"
       opts?.assignPins and n.type is like "PinPattern", "PinProperty"
     )
@@ -274,8 +276,9 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
 
       if opts?.assignPins
         if n.type is "PinProperty"
+          { name, value } := n
           n.children = n.children.flatMap
-            & is n.name ? [ n.name, ": ", n.value ] : &
+            & is name ? [ name, ": ", value ] : &
           updateParentPointers n
           // Fall through to handle PinPattern
           // (It won't be found by gatherRecursiveAll because wasn't a child)
@@ -302,7 +305,7 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
             js: true
         continue
 
-      { blockPrefix } := n
+      blockPrefix := n.blockPrefix if "blockPrefix" in n
       p.push(blockPrefix)
 
       // Search for any further nested splices, and at bindings
@@ -342,7 +345,8 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
           { typeSuffix, initializer } .= elem
           switch elem.type
             when "BindingElement", "BindingRestElement"
-              typeSuffix ??= elem.binding?.typeSuffix
+              { binding } := elem
+              typeSuffix ?= (binding.typeSuffix if "typeSuffix" in binding?)
           count++ if typeSuffix
           typeSuffix ?= typeSuffixForExpression trimFirstSpace initializer.expression if initializer?
           let delim: ASTNode?
@@ -370,7 +374,8 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
       let restType: ASTNode?
       types: ASTNode[] :=
         for each prop of pattern.properties
-          { typeSuffix, initializer } .= prop
+          { typeSuffix } .= prop
+          initializer .= prop.initializer if "initializer" in prop
           if value := prop.value
             if "typeSuffix" in value
               typeSuffix ??= value.typeSuffix

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -305,11 +305,10 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
             js: true
         continue
 
-      blockPrefix := n.blockPrefix if "blockPrefix" in n
-      p.push(blockPrefix)
-
-      // Search for any further nested splices, and at bindings
-      insertRestSplices(blockPrefix, p, thisAssignments)
+      if { blockPrefix } := n
+        p.push(blockPrefix)
+        // Search for any further nested splices, and at bindings
+        insertRestSplices(blockPrefix, p, thisAssignments)
 
   insertRestSplices(statements, splices, thisAssignments)
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -345,7 +345,7 @@ function gatherBindingPatternTypeSuffix(pattern: ArrayBindingPattern | ObjectBin
           switch elem.type
             when "BindingElement", "BindingRestElement"
               { binding } := elem
-              typeSuffix ?= (binding.typeSuffix if "typeSuffix" in binding?)
+              typeSuffix ?= binding.typeSuffix if "typeSuffix" in binding?
           count++ if typeSuffix
           typeSuffix ?= typeSuffixForExpression trimFirstSpace initializer.expression if initializer?
           let delim: ASTNode?

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -93,7 +93,7 @@ function adjustBindingElements(elements: ArrayBindingPatternContent): {
     after := elements[restIndex + 1..]
 
     restIdentifier := (or)
-      rest.binding.ref if "ref" in rest.binding
+      "ref" in rest.binding and rest.binding.ref
       rest.binding
     /* fallback when rest binding is PinPattern or Literal (neither sets names); prevents crash in `[a, ...^x] .= arr` shape */
     names.push ...namesOf(rest)
@@ -246,8 +246,8 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
 
   function insertRestSplices(s: ASTNode, p: unknown[], thisAssignments: ThisAssignments): void
     for each let n of gatherRecursiveAll(s, (n) => Boolean (or)
-      n.blockPrefix if "blockPrefix" in n
-      opts?.injectParamProps and n.accessModifier if "accessModifier" in n
+      "blockPrefix" in n and n.blockPrefix
+      opts?.injectParamProps and "accessModifier" in n and n.accessModifier
       n.type is "AtBinding"
       opts?.assignPins and n.type is like "PinPattern", "PinProperty"
     )

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -96,7 +96,7 @@ function adjustBindingElements(elements: ArrayBindingPatternContent): {
       rest.binding.ref if "ref" in rest.binding
       rest.binding
     /* fallback when rest binding is PinPattern or Literal (neither sets names); prevents crash in `[a, ...^x] .= arr` shape */
-    names.push ...rest.names or []
+    names.push ...namesOf(rest)
 
     l .= after#
 

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -142,18 +142,17 @@ function getIndent(statement: StatementTuple)
   .map (n: any) => n.token
 
 function hoistRefDecs(statements: StatementTuple[]): void
-  gatherRecursiveAll(statements, (s) => s.hoistDec)
-    .forEach (node) =>
+  gatherRecursiveAll(statements, (s) => Boolean "hoistDec" in s and s.hoistDec)
+    |> as (ASTNodeObject & hoistDec: ASTNode)![]
+    |> .forEach (node) =>
       { hoistDec } := node
-      node.hoistDec = null
+      node.hoistDec = undefined
 
-      { ancestor, child } := findAncestor node, (ancestor) =>
+      { ancestor, child } := findAncestor node, (ancestor) => Boolean
         ancestor.type is "BlockStatement" and (!ancestor.bare or ancestor.root)
 
       assert ancestor, "hoistRefDecs: ancestor not found"
-      insertHoistDec(ancestor, child, hoistDec)
-
-      return
+      insertHoistDec(ancestor as BlockStatement, child, hoistDec)
 
 function insertHoistDec(block: BlockStatement, node: ASTNode | StatementTuple, dec: ASTNode): void
   statement: StatementTuple := [ "", dec, ";" ]
@@ -215,18 +214,18 @@ function processBlocks(statements: StatementTuple[]): void
       // Remove implicit names added to props
       for each prop of object.properties
         // Remove implicit square brackets around e.g. template strings
-        if prop.name is like {type: "ComputedPropertyName", implicit: true}
+        if prop is like { name: { type: "ComputedPropertyName", implicit: true } }
           replaceNode prop.name, prop.name.expression, prop
         // Remove implicit commas between properties; implicit-name props are
         // all identifiers, so the next prop can never start with a character
         // that would need a semicolon to break ASI.
-        if prop.delim?.implicit
+        if prop is like { delim: { implicit: true }}
           replaceNode prop.delim, undefined, prop
           prop.delim = undefined
         // Remove implicit `name: ` added to properties
         colon := prop.children!.indexOf ": "
         continue if colon < 0
-        assert prop.children![colon-1] is prop.name, "unwrapObject: expected prop.name right before ': '"
+        assert prop.children![colon-1] is (prop.name if "name" in prop), "unwrapObject: expected prop.name right before ': '"
         prop.children!.splice colon-1, 2
 
     processBlocks block.expressions

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -225,7 +225,8 @@ function processBlocks(statements: StatementTuple[]): void
         // Remove implicit `name: ` added to properties
         colon := prop.children!.indexOf ": "
         continue if colon < 0
-        assert prop.children![colon-1] is (prop.name if "name" in prop), "unwrapObject: expected prop.name right before ': '"
+        assert "name" in prop and prop.name, "unwrapObject: expected prop.name"
+        assert prop.children![colon-1] is prop.name, "unwrapObject: expected prop.name right before ': '"
         prop.children!.splice colon-1, 2
 
     processBlocks block.expressions

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -142,9 +142,10 @@ function getIndent(statement: StatementTuple)
   .map (n: any) => n.token
 
 function hoistRefDecs(statements: StatementTuple[]): void
-  gatherRecursiveAll(statements, (s) => Boolean "hoistDec" in s and s.hoistDec)
-    |> as (ASTNodeObject & hoistDec: ASTNode)![]
-    |> .forEach (node) =>
+  gatherRecursiveAll(statements, (s): s is ASTNodeObject & { hoistDec: ASTNode } =>
+    Boolean "hoistDec" in s and s.hoistDec
+  )
+    .forEach (node) =>
       { hoistDec } := node
       node.hoistDec = undefined
 

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -17,6 +17,7 @@ import {
 } from ./traversal.civet
 
 import {
+  assert
   hasAwait
   makeNode
   wrapIIFE
@@ -43,7 +44,8 @@ function expressionizeComptime(statement: ComptimeStatement): ComptimeExpression
 function processComptime(statements: StatementTuple[]): void | Promise<void>
   // Prevent comptime setting from being overridden by directives
   // by looking at initialConfig instead of config
-  return unless getInitialConfig()?.comptime
+  initialConfig := getInitialConfig()
+  return unless initialConfig is like { comptime } and initialConfig.comptime
 
   promises := runComptime statements
   if getSync()
@@ -80,7 +82,9 @@ function runComptime(statements: StatementTuple[]): unknown[]
     let output: unknown, context: NodeJS.Dict<unknown>, contextGlobal?: NodeJS.Dict<unknown>
     try
       context = vm.createContext?() ?? globalThis
-      filename := context.__filename = resolve getFilename()
+      originalFilename := getFilename()
+      assert originalFilename <? "string", "runComptime: name of parsed file must be a string"
+      filename := context.__filename = resolve originalFilename
       context.__dirname = dirname filename
       context.require = createRequire filename
       if vm.runInContext?
@@ -287,6 +291,8 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
         stack.delete val
         /* c8 ignore next -- c8 sourcemap doesn't attribute the compiled `return str` to this line */
         str
+      else
+        throw new TypeError `cannot serialize value with type of "${typeof val}"`
   recurse value
 
 export {

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -155,7 +155,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
       when "number"
         if Object.is -0, val then '-0' else val.toString()
       when "boolean", "undefined"
-        String val // not toString to accomodate null/undefined
+        String val // not toString to accomodate undefined
       when "bigint"
         `${val}n`
       when "function"

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -148,17 +148,17 @@ function runComptime(statements: StatementTuple[]): unknown[]
 function serialize(value: ???, context?: NodeJS.Dict<any>): string
   stack := new Set<object>
   function recurse(val: ???): string
-    switch val
-      <? "string"
+    switch typeof val
+      when "string"
         // Using JSON.stringify to handle escape sequences
         JSON.stringify val
-      <? "number"
+      when "number"
         if Object.is -0, val then '-0' else val.toString()
-      <? "boolean", == null
+      when "boolean", "undefined"
         String val // not toString to accomodate null/undefined
-      <? "bigint"
+      when "bigint"
         `${val}n`
-      <? "function"
+      when "function"
         // Some functions can actually be serialized
         string .= Function::toString.call val
         if /\{\s+\[native code]\s+\}$/.test string
@@ -209,7 +209,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
 
         stack.delete val
         string
-      <? "symbol"
+      when "symbol"
         if key? := Symbol.keyFor val
           return `Symbol.for(${JSON.stringify key})`
         // Handle well-known symbols
@@ -219,7 +219,8 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
           if val is sym
             return `Symbol.${name}`
         throw new TypeError "cannot serialize unique symbol"
-      <? "object"
+      when "object"
+        return "null" if val === null
         if stack.has val
           throw new Error "circular reference detected"
         stack.add val
@@ -291,8 +292,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
         stack.delete val
         /* c8 ignore next -- c8 sourcemap doesn't attribute the compiled `return str` to this line */
         str
-      else
-        throw new TypeError `cannot serialize value with type of "${typeof val}"`
+
   recurse value
 
 export {

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -17,7 +17,6 @@ import {
 } from ./traversal.civet
 
 import {
-  assert
   hasAwait
   makeNode
   wrapIIFE
@@ -82,9 +81,8 @@ function runComptime(statements: StatementTuple[]): unknown[]
     let output: unknown, context: NodeJS.Dict<unknown>, contextGlobal?: NodeJS.Dict<unknown>
     try
       context = vm.createContext?() ?? globalThis
-      originalFilename := getFilename()
-      assert originalFilename <? "string", "runComptime: name of parsed file must be a string"
-      filename := context.__filename = resolve originalFilename
+      filename := context.__filename = resolve getFilename() ??
+        throw new TypeError "runComptime: name of parsed file must be a string"
       context.__dirname = dirname filename
       context.require = createRequire filename
       if vm.runInContext?

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -81,8 +81,9 @@ function runComptime(statements: StatementTuple[]): unknown[]
     let output: unknown, context: NodeJS.Dict<unknown>, contextGlobal?: NodeJS.Dict<unknown>
     try
       context = vm.createContext?() ?? globalThis
-      filename := context.__filename = resolve getFilename() ??
-        throw new TypeError "runComptime: name of parsed file must be a string"
+      filename := context.__filename = resolve getFilename()
+        /* c8 ignore next -- defensive; should be unreachable */
+        ?? throw new TypeError "runComptime: could not retreive name of parsed file"
       context.__dirname = dirname filename
       context.require = createRequire filename
       if vm.runInContext?
@@ -289,6 +290,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
         stack.delete val
         /* c8 ignore next -- c8 sourcemap doesn't attribute the compiled `return str` to this line */
         str
+      /* c8 ignore next 2 -- should be unreachable */
       else
         throw new TypeError `cannot serialize ${typeof val} value`
 

--- a/source/parser/comptime.civet
+++ b/source/parser/comptime.civet
@@ -148,17 +148,17 @@ function runComptime(statements: StatementTuple[]): unknown[]
 function serialize(value: ???, context?: NodeJS.Dict<any>): string
   stack := new Set<object>
   function recurse(val: ???): string
-    switch typeof val
-      when "string"
+    switch val
+      <? "string"
         // Using JSON.stringify to handle escape sequences
         JSON.stringify val
-      when "number"
+      <? "number"
         if Object.is -0, val then '-0' else val.toString()
-      when "boolean", "undefined"
-        String val // not toString to accomodate undefined
-      when "bigint"
+      <? "boolean", == null
+        String val // not toString to accomodate null/undefined
+      <? "bigint"
         `${val}n`
-      when "function"
+      <? "function"
         // Some functions can actually be serialized
         string .= Function::toString.call val
         if /\{\s+\[native code]\s+\}$/.test string
@@ -209,7 +209,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
 
         stack.delete val
         string
-      when "symbol"
+      <? "symbol"
         if key? := Symbol.keyFor val
           return `Symbol.for(${JSON.stringify key})`
         // Handle well-known symbols
@@ -219,8 +219,7 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
           if val is sym
             return `Symbol.${name}`
         throw new TypeError "cannot serialize unique symbol"
-      when "object"
-        return "null" if val === null
+      <? "object"
         if stack.has val
           throw new Error "circular reference detected"
         stack.add val
@@ -292,8 +291,11 @@ function serialize(value: ???, context?: NodeJS.Dict<any>): string
         stack.delete val
         /* c8 ignore next -- c8 sourcemap doesn't attribute the compiled `return str` to this line */
         str
+      else
+        throw new TypeError `cannot serialize ${typeof val} value`
 
   recurse value
+
 
 export {
   expressionizeComptime

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -377,8 +377,8 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
 
   processDeclarationCondition expression, condition.expression, s
 
-  ref := expression.ref if "ref" in expression
-  pattern := expression.pattern if "pattern" in expression
+  ref := expression.ref if expression is like { ref }
+  pattern := expression.pattern if expression is like { pattern }
 
   if pattern
     conditions := getPatternConditions(pattern, ref)
@@ -416,9 +416,10 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
 
   // Move declaration to after the statement for until loops,
   // and for unless conditions with a guaranteed exit in the then clause.
-  blockPrefix := condition.expression.blockPrefix if "blockPrefix" in condition.expression
-  if "negated" in s and s.negated and
-    blockPrefix and
+  conditionExpression := condition.expression
+  blockPrefix := conditionExpression.blockPrefix if conditionExpression is like { blockPrefix }
+  if blockPrefix and
+    s is like { negated: true } and
     (s.type is "IfStatement" and isExit(s.then) or
     s.type is "IterationStatement")
 
@@ -482,10 +483,11 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
       // Only add a declaration when a temp ref was needed (non-simple initializer).
       // For simple initializers (literals, identifiers), blockPrefix already has
       // the full declaration; adding a declStatement would produce invalid JS like `let 0;`.
-      if not statementDeclaration and "hoistDec" in condition.expression and condition.expression.hoistDec
+      conditionExpression := condition.expression
+      if not statementDeclaration and conditionExpression is like { hoistDec } and conditionExpression.hoistDec
         declStatement: StatementTuple := ["", [{
           type: "Declaration",
-          children: ["let ", ...condition.expression.children],
+          children: ["let ", ...conditionExpression.children],
         }], ";"]
         blockPrefix.unshift declStatement
 

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -21,7 +21,6 @@ import type {
   IterationStatement
   LexicalDeclaration
   ObjectExpression
-  ParenthesizedExpression
   StatementTuple
   StringLiteral
   SwitchStatement
@@ -125,9 +124,10 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
 
   children := [decl, binding]
 
+  names := pattern.names if "names" in pattern
   makeNode<LexicalDeclaration> {
     type: "Declaration"
-    pattern.names
+    names
     decl
     bindings: [binding]
     splices
@@ -238,6 +238,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
       pre.unshift ["", refDec, ";"]
     else
       wrapIterationReturningResults statement, => undefined
+      assert statement.resultsRef, "statement must have resultsRef"
       ref = initializer.expression = initializer.children[2] = statement.resultsRef
   else
     ref = initializer.expression = initializer.children[2] = makeRef()
@@ -376,7 +377,8 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
 
   processDeclarationCondition expression, condition.expression, s
 
-  { ref, pattern } := expression
+  ref := expression.ref if "ref" in expression
+  pattern := expression.pattern if "pattern" in expression
 
   if pattern
     conditions := getPatternConditions(pattern, ref)
@@ -394,16 +396,18 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
     if conditions#
       children .= condition.children
       // For negated conditions, put conditions inside the negation
-      if s.negated
-        assert
-          condition.expression is like {
-            type: 'UnaryExpression'
-            subtype: 'Negation'
-            expression: { type: 'ParenthesizedExpression' }
-          }
-          "Unsupported negated condition"
+      if "negated" in s and s.negated
+        if {
+          type: 'UnaryExpression'
+          subtype: 'Negation'
+          expression: {
+            type: 'ParenthesizedExpression'
+            children: expressionChildren
+        }} := condition.expression
+          children = expressionChildren
+        else
+          throw new Error "Unsupported negated condition"
 
-        { children } = condition.expression.expression as ParenthesizedExpression
       children.unshift "("
       for each c of conditions
         children.push " && ", c
@@ -411,8 +415,9 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
 
   // Move declaration to after the statement for until loops,
   // and for unless conditions with a guaranteed exit in the then clause.
-  { blockPrefix } := condition.expression
-  if s.negated and blockPrefix and
+  blockPrefix := condition.expression.blockPrefix if "blockPrefix" in condition.expression
+  if "negated" in s and s.negated and
+    blockPrefix and
     (s.type is "IfStatement" and isExit(s.then) or
     s.type is "IterationStatement")
 
@@ -476,7 +481,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
       // Only add a declaration when a temp ref was needed (non-simple initializer).
       // For simple initializers (literals, identifiers), blockPrefix already has
       // the full declaration; adding a declStatement would produce invalid JS like `let 0;`.
-      if not statementDeclaration and condition.expression.hoistDec
+      if not statementDeclaration and "hoistDec" in condition.expression and condition.expression.hoistDec
         declStatement: StatementTuple := ["", [{
           type: "Declaration",
           children: ["let ", ...condition.expression.children],
@@ -625,11 +630,14 @@ function processStaticImport(decl: ImportDeclaration)
     ts: decl.ts
   } as ImportDeclaration
 
-function dynamizeImportDeclaration(decl: any)
+function dynamizeImportDeclaration(decl: ImportDeclaration)
   { imports } := decl
-  { star, binding, specifiers } .= imports
+  star := imports.star if "star" in imports?
+  binding := imports.binding if "binding" in imports?
+  specifiers := imports.specifiers if "specifiers" in imports?
+
   justDefault := binding and not specifiers and not star
-  pattern := do
+  pattern :=
     if binding
       if specifiers
         makeRef()
@@ -676,7 +684,8 @@ function dynamizeImportDeclaration(decl: any)
       pattern: pattern2
       initializer: initializer2
       children: [pattern2, initializer2]
-    pattern3 := convertNamedImportsToObject(imports.children.at(-1), true)
+
+    pattern3 := convertNamedImportsToObject(imports!.children.at(-1), true)
     initializer3: Initializer := {
       type: "Initializer"
       expression: pattern
@@ -684,13 +693,13 @@ function dynamizeImportDeclaration(decl: any)
     }
     bindings.push
       type: "Binding"
-      names: specifiers.names
+      names: specifiers.names if "names" in specifiers
       pattern: pattern3
       initializer: initializer3
       children: [pattern3, initializer3]
   {
     type: "Declaration"
-    names: imports.names
+    names: imports?.names
     bindings
     decl: c
     children: [
@@ -728,6 +737,8 @@ function dynamizeImportDeclarationExpression($0: [ASTNode, Whitespace, ASTNode, 
       parenthesizeExpression awaitExpression
     when "Declaration" // named imports
       object := convertNamedImportsToObject imports
+      // Type system disagress that object.type will always be "ObjectExpression"
+      assert object.type is "ObjectExpression", "convertNamedImportsToObject should have returned an ObjectExpression"
       processCallMemberExpression
         type: "CallExpression"
         children: []

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -405,6 +405,7 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
             children: expressionChildren
         }} := condition.expression
           children = expressionChildren
+        /* c8 ignore next 2 -- defensive guard: should be unreachable but types disagree */
         else
           throw new Error "Unsupported negated condition"
 

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -694,7 +694,7 @@ function dynamizeImportDeclaration(decl: ImportDeclaration)
     }
     bindings.push
       type: "Binding"
-      names: specifiers.names if "names" in specifiers
+      names: pattern3.names
       pattern: pattern3
       initializer: initializer3
       children: [pattern3, initializer3]

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -742,8 +742,6 @@ function dynamizeImportDeclarationExpression($0: [ASTNode, Whitespace, ASTNode, 
       parenthesizeExpression awaitExpression
     when "Declaration" // named imports
       object := convertNamedImportsToObject imports
-      // Type system disagress that object.type will always be "ObjectExpression"
-      assert object.type is "ObjectExpression", "convertNamedImportsToObject should have returned an ObjectExpression"
       processCallMemberExpression
         type: "CallExpression"
         children: []

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -417,7 +417,9 @@ function processDeclarationConditionStatement(s: IfStatement | IterationStatemen
   // Move declaration to after the statement for until loops,
   // and for unless conditions with a guaranteed exit in the then clause.
   conditionExpression := condition.expression
-  blockPrefix := conditionExpression.blockPrefix if conditionExpression is like { blockPrefix }
+  // processDeclarationCondition attaches statement tuples here, unlike the
+  // single PostRestBindingElements node stored on array binding patterns.
+  { blockPrefix } := conditionExpression as { blockPrefix?: StatementTuple[] }
   if blockPrefix and
     s is like { negated: true } and
     (s.type is "IfStatement" and isExit(s.then) or
@@ -649,7 +651,7 @@ function dynamizeImportDeclaration(decl: ImportDeclaration)
     else
       convertNamedImportsToObject(imports, true)
   c := "const"
-  expression := [
+  expression: ASTNode := [
     if justDefault then "("
     {type: "Await", children: ["await"]}
     " "
@@ -672,7 +674,7 @@ function dynamizeImportDeclaration(decl: ImportDeclaration)
   if binding and specifiers
     // import x, {y} --> const ref = await import(...), x = ref.default, {y} = ref
     pattern2 := binding
-    exp2 := [
+    exp2: ASTNode := [
       pattern
       ".default"
     ]

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -283,8 +283,8 @@ function forRange(
   startRef .= if stepRef then start else maybeRef(start, "start")
   endRef .= maybeRef(end, "end")
 
-  startRefDec := (startRef !== start) ? [startRef, " = ", start, ", "] : []
-  endRefDec := (endRef !== end) ? [endRef, " = ", end, ", "] : []
+  startRefDec: ASTNode[] := (startRef !== start) ? [startRef, " = ", start, ", "] : []
+  endRefDec: ASTNode[] := (endRef !== end) ? [endRef, " = ", end, ", "] : []
 
   let ascDec: ASTNode[] = [], ascRef
   if stepExp

--- a/source/parser/for.civet
+++ b/source/parser/for.civet
@@ -89,7 +89,7 @@ function pushForBlockDeclaration(
   previousImplicitLift := previous? and "implicitLift" in previous and previous.implicitLift
   if previous?.type is "Declaration" and Boolean(previousImplicitLift) is implicitLift and previous.decl is decl.decl
     previous.children.push ", ", binding, " = ", value
-    previous.names.push ...namesOf(decl)
+    previous.names!.push ...namesOf(decl)
   else
     blockPrefix.push ["", {
       type: "Declaration"
@@ -108,7 +108,7 @@ function pushForBlockDeclaration(
     patternPrevious := blockPrefix.-1![1] as Declaration | ForControlDeclaration
     [, ...patternChildren] := patternDeclaration.children
     patternPrevious.children.push ", ", ...trimFirstSpace(patternChildren)
-    patternPrevious.names.push ...namesOf(patternDeclaration)
+    patternPrevious.names!.push ...namesOf(patternDeclaration)
   blockPrefix.push ...patternPrefix
 
 function processRangeExpression(start: ASTNode, ws1: ASTNode, range: RangeDots, end: ASTNode)

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -420,7 +420,7 @@ function nameAbstractClass(exp: ClassExpression): ASTNode
 // Maybe these insertion modifications can be refactored to be more DRY eventually.
 function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode) => ASTNode): void
   // TODO: unify this with the `exp` switch
-  if node and "type" in node
+  if node is like { type }
     switch node.type
       when "BlockStatement"
         if node.expressions#
@@ -536,7 +536,8 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
         return
 
   // Insert push wrapping expression
-  parent := node[1].parent if node[1] and "parent" in node[1]
+  node_1 := node[1]
+  parent := node_1.parent if node_1 is like { parent }
   node[1] = collect(node[1])
   updateParentPointers parent if parent?
 
@@ -607,7 +608,7 @@ function insertReturn(node: ASTNode): void
       else
         [] as ASTNode
 
-      assert "parent" in outer, "Delcaration must have a parent"
+      assert (outer is like { parent }), "Delcaration must have a parent"
       { parent } := outer
       assert "expressions" in parent?, "Delcaration parent must have an expression"
       { expressions } := parent
@@ -1213,7 +1214,7 @@ function processParams(f: FunctionNode): void
     } satisfies Declaration
   prefix ++= thisAssignments
   // Add indentation and delimiters
-  prefix = prefix.map (s) => "js" in s? and s.js
+  prefix = prefix.map (s) => s is like { js } and s.js
     ? ["", makeNode {
       // TODO: figure out how to get JS only statement tuples
       ...s

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -298,9 +298,8 @@ function processReturnValue(func: FunctionNode)
 
   // Transform existing `return` -> `return ret`
   gatherRecursiveWithinFunction block,
-    (r) => r.type is "ReturnStatement" and not r.expression
-  |> as ReturnStatement[]
-  |> .forEach (r) =>
+    (r): r is ReturnStatement => r.type is "ReturnStatement" and not r.expression
+  .forEach (r) =>
     r.expression = ref
     r.children.splice -1, 1, " ", ref
 
@@ -424,17 +423,17 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   if node and "type" in node
     switch node.type
       when "BlockStatement"
-        if node!.expressions.length
-          assignResults(node!.expressions.-1, collect)
+        if node.expressions#
+          assignResults(node.expressions.-1, collect)
         else
-          node!.expressions.push(["", collect("void 0"), ";"])
+          node.expressions.push(["", collect("void 0"), ";"])
           updateParentPointers node
         return
       when "CaseClause"
         // CaseClauses don't get a result assigned
         return
       when "WhenClause", "DefaultClause", "PatternClause"
-        assignResults(node!.block, collect)
+        assignResults(node.block, collect)
         return
 
   assert Array.isArray(node), "assignResults: node must be a statement tuple or a handled node type"
@@ -973,7 +972,7 @@ function processParams(f: FunctionNode): void
     else
       append param
 
-  parameters.names = before.flatMap ("names" in & and &.names) || []
+  parameters.names = before.flatMap ("names" in & and &.names || [])
   parameters.parameters[..] = []
   parameters.parameters.push tt if tt
   parameters.parameters.push ...before
@@ -996,7 +995,7 @@ function processParams(f: FunctionNode): void
           message: "Non-end rest parameter cannot be binding pattern"
 
       after = trimFirstSpace after
-      names := after.flatMap ("names" in & and &.names) || []
+      names := after.flatMap ("names" in & and &.names || [])
       elements := (after as (Parameter | ASTError)[]).map (p) =>
         return p if p.type is "Error"
         {

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -608,8 +608,10 @@ function insertReturn(node: ASTNode): void
       else
         [] as ASTNode
 
-      unless { parent^: { expressions } } := outer
-        throw new Error "Declaration must have parent"
+      assert "parent" in outer, "Delcaration must have a parent"
+      { parent } := outer
+      assert "expressions" in parent?, "Delcaration parent must have an expression"
+      { expressions } := parent
 
       index := findChildIndex expressions, outer
       assert.notEqual index, -1, "Could not find declaration in parent"
@@ -629,6 +631,7 @@ function insertReturn(node: ASTNode): void
       // Add return after function declaration if it has an id to not interfere with hoisting
       if exp.id
         unless { parent^: { expressions } } := outer
+          /* c8 ignore next -- defensive: should be unreachable but types disagree */
           throw new Error "Declaration must have parent"
 
         index := findChildIndex expressions, outer

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -30,6 +30,7 @@ import type {
   Parameter
   ParametersNode
   PostRestBindingElements
+  ReturnStatement
   ReturnTypeAnnotation
   StatementTuple
   SwitchStatement
@@ -255,7 +256,7 @@ function processReturnValue(func: FunctionNode)
     declaration ??= child if ancestor  // remember binding
 
   // Compute default return type
-  returnType: ReturnTypeAnnotation? .= func.returnType ?? func.signature?.returnType
+  returnType: ReturnTypeAnnotation? .= func.signature?.returnType
   if returnType
     { t } := returnType
     switch t.type
@@ -283,7 +284,7 @@ function processReturnValue(func: FunctionNode)
 
   // Modify existing declaration, or add declaration of return.value after {
   if declaration
-    unless declaration.typeSuffix?
+    unless "typeSuffix" in declaration and declaration.typeSuffix?
       declaration.children![1] = declaration.typeSuffix = returnType
   else
     block.expressions.unshift [
@@ -298,9 +299,10 @@ function processReturnValue(func: FunctionNode)
   // Transform existing `return` -> `return ret`
   gatherRecursiveWithinFunction block,
     (r) => r.type is "ReturnStatement" and not r.expression
-  .forEach (r) =>
+  |> as ReturnStatement[]
+  |> .forEach (r) =>
     r.expression = ref
-    r.children!.splice -1, 1, " ", ref
+    r.children.splice -1, 1, " ", ref
 
   // Implicit return before }
   unless block.children.-2?.type is "ReturnStatement"
@@ -344,9 +346,9 @@ function patternAsValue(pattern: ASTNodeObject): ASTNodeObject
           index := children.indexOf pattern.initializer
           assert.notEqual index, -1, "failed to find initializer in BindingElement"
           children.splice index, 1
-        if pattern.value?
-          children = children.map & is pattern.value ?
-            patternAsValue pattern.value : &
+        if value := pattern.value
+          children = children.map & is value ?
+            patternAsValue value : &
       { ...pattern, children }
     when "AtBindingProperty"
       children := [...pattern.children]
@@ -419,24 +421,25 @@ function nameAbstractClass(exp: ClassExpression): ASTNode
 // Maybe these insertion modifications can be refactored to be more DRY eventually.
 function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode) => ASTNode): void
   // TODO: unify this with the `exp` switch
-  switch node!.type
-    when "BlockStatement"
-      if node!.expressions.length
-        assignResults(node!.expressions.-1, collect)
-      else
-        node!.expressions.push(["", collect("void 0"), ";"])
-        updateParentPointers node
-      return
-    when "CaseClause"
-      // CaseClauses don't get a result assigned
-      return
-    when "WhenClause", "DefaultClause", "PatternClause"
-      assignResults(node!.block, collect)
-      return
+  if node and "type" in node
+    switch node.type
+      when "BlockStatement"
+        if node!.expressions.length
+          assignResults(node!.expressions.-1, collect)
+        else
+          node!.expressions.push(["", collect("void 0"), ";"])
+          updateParentPointers node
+        return
+      when "CaseClause"
+        // CaseClauses don't get a result assigned
+        return
+      when "WhenClause", "DefaultClause", "PatternClause"
+        assignResults(node!.block, collect)
+        return
 
   assert Array.isArray(node), "assignResults: node must be a statement tuple or a handled node type"
   [, exp, semi] .= node
-  return if semi?.type is "SemicolonDelimiter"
+  return if semi is like { type: "SemicolonDelimiter" }
   return if isExit exp
 
   exp = exp as ASTNodeObject
@@ -534,7 +537,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
         return
 
   // Insert push wrapping expression
-  parent := node[1]!.parent
+  parent := node[1].parent if node[1] and "parent" in node[1]
   node[1] = collect(node[1])
   updateParentPointers parent if parent?
 
@@ -604,31 +607,36 @@ function insertReturn(node: ASTNode): void
         [" ", patternAsValue(exp.bindings.-1.pattern)]
       else
         [] as ASTNode
-      parent := outer.parent as BlockStatement?
-      index := findChildIndex parent?.expressions, outer
+
+      unless { parent^: { expressions } } := outer
+        throw new Error "Declaration must have parent"
+
+      index := findChildIndex expressions, outer
       assert.notEqual index, -1, "Could not find declaration in parent"
-      parent!.expressions.splice index+1, 0, ["",
+      expressions.splice index+1, 0, ["",
         type: "ReturnStatement"
         expression: value
         children: [
-          ";" unless parent!.expressions[index][2] is ";"
+          ";" unless expressions[index][2] is ";"
           "return"
           value
         ]
         parent: exp
       ]
-      braceBlock parent!
+      braceBlock parent
       return
     when "FunctionExpression"
       // Add return after function declaration if it has an id to not interfere with hoisting
       if exp.id
-        parent := outer.parent as BlockStatement?
-        index := findChildIndex parent?.expressions, outer
+        unless { parent^: { expressions } } := outer
+          throw new Error "Declaration must have parent"
+
+        index := findChildIndex expressions, outer
         assert.notEqual index, -1, "Could not find function declaration in parent"
-        parent!.expressions.splice index+1, 0, ["",
+        expressions.splice index+1, 0, ["",
           wrapWithReturn exp.id, exp, true
         ]
-        braceBlock parent!
+        braceBlock parent
         return
       /* c8 ignore next 3 */
       // This is currently never hit because anonymous FunctionExpressions are already wrapped in parens by this point
@@ -931,40 +939,45 @@ function processParams(f: FunctionNode): void
   function append(p: FunctionParameter | ASTError): void
     (rest ? after : before).push(p)
   for each param of parameters.parameters
-    switch param.type
-      when "ThisType"
-        if tt
-          append
-            type: "Error"
-            message: "Only one typed this parameter is allowed"
-          append param
+    if "type" in param
+      switch param.type
+        when "ThisType"
+          if tt
+            append
+              type: "Error"
+              message: "Only one typed this parameter is allowed"
+            append param
+          else
+            tt = trimFirstSpace(param) as ThisType
+            if before# or rest // moving ThisType to front
+              delim .= tt.children.-1
+              delim = delim.-1 if Array.isArray delim
+              unless delim is like {token: ","}
+                tt = {
+                  ...tt
+                  children: [...tt.children, ", "]
+                }
+        when "FunctionRestParameter"
+          if rest
+            append
+              type: "Error"
+              message: "Only one rest parameter is allowed"
+            append param
+          else
+            rest = param
         else
-          tt = trimFirstSpace(param) as ThisType
-          if before# or rest // moving ThisType to front
-            delim .= tt.children.-1
-            delim = delim.-1 if Array.isArray delim
-            unless delim is like {token: ","}
-              tt = {
-                ...tt
-                children: [...tt.children, ", "]
-              }
-      when "FunctionRestParameter"
-        if rest
-          append
-            type: "Error"
-            message: "Only one rest parameter is allowed"
           append param
-        else
-          rest = param
-      else
-        append param
+    else
+      append param
 
-  parameters.names = before.flatMap .names
+  parameters.names = before.flatMap ("names" in & and &.names) || []
   parameters.parameters[..] = []
   parameters.parameters.push tt if tt
   parameters.parameters.push ...before
   if rest
-    restIdentifier := rest.binding.ref or rest.binding
+    restIdentifier := (or)
+      rest.binding.ref if "ref" in rest.binding
+      rest.binding
     parameters.names.push ...(rest.names ?? [])
     rest.children.pop() // remove delimiter
 
@@ -980,7 +993,7 @@ function processParams(f: FunctionNode): void
           message: "Non-end rest parameter cannot be binding pattern"
 
       after = trimFirstSpace after
-      names := after.flatMap .names
+      names := after.flatMap ("names" in & and &.names) || []
       elements := (after as (Parameter | ASTError)[]).map (p) =>
         return p if p.type is "Error"
         {
@@ -1156,7 +1169,8 @@ function processParams(f: FunctionNode): void
           // (Currently just handle `@prop ::` individual typing,
           // where parent is AtBindingProperty or BindingElement,
           // or when the parent is the whole Parameter.)
-          typeSuffix := binding.parent?.typeSuffix
+          { parent } := binding
+          typeSuffix := parent.typeSuffix if "typeSuffix" in parent?
           continue unless accessModifier or typeSuffix
           // Remove accessModifier from parameter if we lift it to a field
           if parameter.accessModifier
@@ -1197,7 +1211,7 @@ function processParams(f: FunctionNode): void
     } satisfies Declaration
   prefix ++= thisAssignments
   // Add indentation and delimiters
-  prefix = prefix.map (s) => s?.js
+  prefix = prefix.map (s) => "js" in s? and s.js
     ? ["", makeNode {
       // TODO: figure out how to get JS only statement tuples
       ...s

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -348,8 +348,7 @@ function patternAsValue(pattern: ASTNodeObject): ASTNodeObject
           assert.notEqual index, -1, "failed to find initializer in BindingElement"
           children.splice index, 1
         if value := pattern.value
-          children = children.map & is value ?
-            patternAsValue value : &
+          children = children.map & is value ? patternAsValue(value) : &
       { ...pattern, children }
     when "AtBindingProperty"
       children := [...pattern.children]
@@ -1216,7 +1215,7 @@ function processParams(f: FunctionNode): void
     } satisfies Declaration
   prefix ++= thisAssignments
   // Add indentation and delimiters
-  prefixStatements: StatementTuple[] := prefix.map (s) => s is like { js } and s.js
+  prefixStatements: StatementTuple[] := prefix.map (s) => s is like { js: true }
     ? ["", makeNode {
       // TODO: figure out how to get JS only statement tuples
       ...s

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -32,6 +32,7 @@ import type {
   PostRestBindingElements
   ReturnStatement
   ReturnTypeAnnotation
+  SemicolonDelimiter
   StatementTuple
   SwitchStatement
   ThisType
@@ -978,7 +979,7 @@ function processParams(f: FunctionNode): void
   parameters.parameters.push tt if tt
   parameters.parameters.push ...before
   if rest
-    restIdentifier := (or)
+    restIdentifier: ASTNode := (or)
       rest.binding.ref if "ref" in rest.binding
       rest.binding
     parameters.names.push ...(rest.names ?? [])
@@ -987,7 +988,7 @@ function processParams(f: FunctionNode): void
     // `(a, ...) ->` keeps the rest param to preserve the function's arity in
     // its type, but the synthesized name is unused — `_`-prefix silences TS.
     if rest.binding.type is "EmptyBinding" and not after#
-      restIdentifier.base = restIdentifier.id = "_ref"
+      rest.binding.ref.base = rest.binding.ref.id = "_ref"
 
     if after#  // non-end rest
       if rest.binding.type is like "ArrayBindingPattern", "ObjectBindingPattern", "NamedBindingPattern"
@@ -1014,7 +1015,7 @@ function processParams(f: FunctionNode): void
       } satisfies ArrayBindingPattern
       |> gatherBindingPatternTypeSuffix
       |> as ArrayBindingPattern
-      blockPrefix := parameters.blockPrefix = makeNode {
+      blockPrefix: PostRestBindingElements := parameters.blockPrefix = makeNode {
         type: "PostRestBindingElements"
         children: [
           pattern, " = ", restIdentifier, ".splice(-", after#.toString(), ")"
@@ -1027,7 +1028,7 @@ function processParams(f: FunctionNode): void
       if rest.typeSuffix
         // In TypeScript, use ref for rest parameter to assign correct type
         ref := makeRef "rest"
-        restRef := [
+        restRef: ASTNode := [
           { children: [ ref ], ts: true }
           { children: [ restIdentifier ], js: true }
         ]
@@ -1040,7 +1041,7 @@ function processParams(f: FunctionNode): void
           ]
         bindingIndex := rest.rest.children.indexOf rest.rest.binding
         assert.notEqual bindingIndex, -1, "Could not find binding in rest parameter"
-        binding := { ...rest.rest.binding, js: true }
+        binding := { ...rest.rest.binding, js: true as const }
         rest.rest.children[bindingIndex] = rest.rest.binding = binding
         rest.rest.children.splice bindingIndex+1, 0,
           children: [ ref ]
@@ -1190,7 +1191,7 @@ function processParams(f: FunctionNode): void
           // Only the first definition gets an indent, stolen from fStatement
           fStatement[0] = ""
 
-  delimiter :=
+  delimiter: SemicolonDelimiter :=
     type: "SemicolonDelimiter"
     children: [";"]
 
@@ -1214,7 +1215,7 @@ function processParams(f: FunctionNode): void
     } satisfies Declaration
   prefix ++= thisAssignments
   // Add indentation and delimiters
-  prefix = prefix.map (s) => s is like { js } and s.js
+  prefixStatements: StatementTuple[] := prefix.map (s) => s is like { js } and s.js
     ? ["", makeNode {
       // TODO: figure out how to get JS only statement tuples
       ...s
@@ -1222,12 +1223,12 @@ function processParams(f: FunctionNode): void
     }]
     : [indent, s, delimiter]
 
-  return unless prefix#
+  return unless prefixStatements#
   // In constructor definition, insert prefix after first super() call
   index .= -1
   if isConstructor
     index = findSuperCall block
-  expressions.splice(index + 1, 0, ...prefix)
+  expressions.splice(index + 1, 0, ...prefixStatements)
   updateParentPointers block
   braceBlock block
 

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -539,7 +539,7 @@ function assignResults(node: StatementTuple[] | ASTNode, collect: (node: ASTNode
   // Insert push wrapping expression
   node_1 := node[1]
   parent := node_1.parent if node_1 is like { parent }
-  node[1] = collect(node[1])
+  node[1] = collect(node_1)
   updateParentPointers parent if parent?
 
 // [indent, statement, semicolon]
@@ -609,9 +609,9 @@ function insertReturn(node: ASTNode): void
       else
         [] as ASTNode
 
-      assert (outer is like { parent }), "Delcaration must have a parent"
+      assert (outer is like { parent }), "Declaration must have a parent"
       { parent } := outer
-      assert "expressions" in parent?, "Delcaration parent must have an expression"
+      assert "expressions" in parent?, "Declaration parent must have an expression"
       { expressions } := parent
 
       index := findChildIndex expressions, outer

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -980,7 +980,7 @@ function processParams(f: FunctionNode): void
   parameters.parameters.push ...before
   if rest
     restIdentifier: ASTNode := (or)
-      rest.binding.ref if "ref" in rest.binding
+      "ref" in rest.binding and rest.binding.ref
       rest.binding
     parameters.names.push ...namesOf(rest)
     rest.children.pop() // remove delimiter

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -99,6 +99,7 @@ import {
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
   makeNode
+  namesOf
   replaceNode
   startsWithPredicate
   trimFirstSpace
@@ -974,7 +975,7 @@ function processParams(f: FunctionNode): void
     else
       append param
 
-  parameters.names = before.flatMap ("names" in & and &.names || [])
+  parameters.names = before.flatMap namesOf
   parameters.parameters[..] = []
   parameters.parameters.push tt if tt
   parameters.parameters.push ...before
@@ -982,7 +983,7 @@ function processParams(f: FunctionNode): void
     restIdentifier: ASTNode := (or)
       rest.binding.ref if "ref" in rest.binding
       rest.binding
-    parameters.names.push ...(rest.names ?? [])
+    parameters.names.push ...namesOf(rest)
     rest.children.pop() // remove delimiter
 
     // `(a, ...) ->` keeps the rest param to preserve the function's arity in
@@ -997,7 +998,7 @@ function processParams(f: FunctionNode): void
           message: "Non-end rest parameter cannot be binding pattern"
 
       after = trimFirstSpace after
-      names := after.flatMap ("names" in & and &.names || [])
+      names := after.flatMap namesOf
       elements := (after as (Parameter | ASTError)[]).map (p) =>
         return p if p.type is "Error"
         {

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1329,10 +1329,9 @@ function processAssignments(statements: ASTNode): void
           post.push(")")
 
         // Use refs to avoid duplicating side-effectful member access and indices
-        /* c8 ignore next 2 -- defensive guard: tests always reach this with `.children` populated */
-        assigned := expr.assigned if "assigned" in expr
-        children := assigned.children if "children" in assigned?
-        return assigned unless children
+        assigned := "assigned" in expr and expr.assigned
+        children := assigned and "children" in assigned and assigned.children
+        assert children, "AssignmentExpression|UpdateExpression: must always reach here with `.children` populated"
 
         // Find the terminal member access (last PropertyAccess or Index)
         j .= children.findLastIndex (c: any) => c?.type is like "PropertyAccess", "Index"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1278,17 +1278,19 @@ function processBindingPatternLHS(lhs: any, tail: any): void
     atBinding.type = undefined
     atBinding.children = thisExpr
     // Update blockPrefixes that use this ref as a rest identifier (e.g. [...@x, y] = z)
-    for each nodeWithPrefix of
-        gatherRecursiveAll(lhs, (n) => Boolean(n.blockPrefix if "blockPrefix" in n))
-        |> as Array<ASTNodeObject & { blockPrefix: PostRestBindingElements }>
-      { blockPrefix } := nodeWithPrefix
+    for each { blockPrefix } of gatherRecursiveAll(lhs,
+        (n): n is ASTNodeObject & { blockPrefix: PostRestBindingElements } => Boolean
+          n.blockPrefix if "blockPrefix" in n
+        )
+
       blockPrefix.children = blockPrefix.children.map (c: any) => c is ref ? thisExpr : c
 
   // Also handle AtBindings inside blockPrefixes (e.g. post-rest @x in [a, ..., @x] = y)
-  for each nodeWithPrefix of
-      gatherRecursiveAll(lhs, (n) => Boolean(n.blockPrefix if "blockPrefix" in n))
-      |> as Array<ASTNodeObject & { blockPrefix: PostRestBindingElements }>
-    { blockPrefix } := nodeWithPrefix
+  for each { blockPrefix } of gatherRecursiveAll(lhs,
+      (n): n is ASTNodeObject & { blockPrefix: PostRestBindingElements } => Boolean
+        n.blockPrefix if "blockPrefix" in n
+      )
+
     for each atBinding of gatherRecursiveAll blockPrefix, .type is "AtBinding"
       atBinding.type = undefined
       atBinding.children = ["this.", atBinding.ref.id]

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1331,9 +1331,10 @@ function processAssignments(statements: ASTNode): void
           post.push(")")
 
         // Use refs to avoid duplicating side-effectful member access and indices
-        assigned := "assigned" in expr and expr.assigned
-        children := assigned and "children" in assigned and assigned.children
-        assert children, "AssignmentExpression|UpdateExpression: must always reach here with `.children` populated"
+        unless { assigned^: { children } }:= expr
+          /* c8 ignore next -- defensive guard: tests always reach this with `.children` populated */
+          throw new Error 'expected .assigned.children'
+        assert children, "expected children"
 
         // Find the terminal member access (last PropertyAccess or Index)
         j .= children.findLastIndex (c: any) => c?.type is like "PropertyAccess", "Index"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -394,12 +394,9 @@ function canExpressionizeIfAsTernary(statement: IfStatement): boolean
     e ? canExpressionizeBlock e.block : true
 
 // Mirror of `expressionizeBlock`'s success condition — keep in sync.
-function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
-  if { expressions } := blockOrExpression
-    for every [, s] of expressions
-      isExpression(s)
-  else
-    false
+function canExpressionizeBlock(blockOrExpression: BlockStatement): boolean
+  for every [, s] of blockOrExpression.expressions
+    isExpression(s)
 
 function expressionizeIfStatement(statement: IfStatement): NonNullASTNode
   { condition, then: b, else: e } := statement
@@ -1330,9 +1327,10 @@ function processAssignments(statements: ASTNode): void
         else
           pre.push(["(", lhs, ", "])
           post.push(")")
+
         // Use refs to avoid duplicating side-effectful member access and indices
+        /* c8 ignore next 2 -- defensive guard: tests always reach this with `.children` populated */
         assigned := expr.assigned if "assigned" in expr
-        /* c8 ignore next -- defensive guard: tests always reach this with `.children` populated */
         children := assigned.children if "children" in assigned?
         return assigned unless children
 

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -14,6 +14,7 @@ import type {
   ASTNodeObject
   ASTRef
   ASTString
+  Binding
   BlockStatement
   BreakStatement
   Call
@@ -48,11 +49,13 @@ import type {
   MethodSignature
   NonNullASTNode
   NormalCatchParameter
+  ObjectBindingPattern
   ObjectExpression
   ObjectProperty
   ParametersNode
   ParenthesizedExpression
   Placeholder
+  PostRestBindingElements
   Property
   StatementTuple
   SwitchStatement
@@ -210,8 +213,9 @@ import {
 } from ../parser.hera
 
 function addPostfixStatement(statement: ASTNode, ws: ASTNode, post: IterationStatement | ForStatement | IfStatement)
+  blockPrefix := post.blockPrefix if "blockPrefix" in post
   expressions := [
-    ...post.blockPrefix or []
+    ...blockPrefix or []
     ["", statement]
   ]
 
@@ -394,6 +398,8 @@ function canExpressionizeBlock(blockOrExpression: ASTNode): boolean
   if { expressions } := blockOrExpression
     for every [, s] of expressions
       isExpression(s)
+  else
+    false
 
 function expressionizeIfStatement(statement: IfStatement): NonNullASTNode
   { condition, then: b, else: e } := statement
@@ -852,7 +858,7 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
               isWhitespaceOrEmpty(part.children[0]) ? part.children[0] : ""
               name
               isWhitespaceOrEmpty(part.children[2]) ? part.children[2] : ""
-              part.children[3]?.token is ":" ? part.children[3] : ":"
+              part.children[3] is like { token: ":" } ? part.children[3] : ":"
               value
               part.delim // comma delimiter
             ]
@@ -995,10 +1001,10 @@ function processCallMemberExpression(node: CallExpression | MemberExpression): A
 // * unary suffix applied to above
 // * comma operators applied to above
 function makeExpressionStatement(expression: ASTNode): ASTNode
-  if Array.isArray(expression) and expression[1]?[0]?[0]?[1]?.token is "," // CommaExpression
+  if expression is like [_, [ [ [_, { token: "," }, ...], ...], ...], ...] // CommaExpression
     [
       makeExpressionStatement expression[0]
-      expression[1].map ([comma, exp]: [any, any]) => // CommaDelimiter AssignmentExpression
+      expression[1].map ([comma, exp]: ASTNode & [any, any]) => // CommaDelimiter AssignmentExpression
         [comma, makeExpressionStatement exp]
     ]
   else if expression?.type is "ObjectExpression" or
@@ -1134,7 +1140,7 @@ function convertArrowFunctionToMethod(id: any, exp: any)
   exp
 
 // Convert NamedImports into equivalent ObjectExpression or ObjectBindingPattern
-function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynamic" | "destructuring" = "dynamic")
+function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynamic" | "destructuring" = "dynamic"): ObjectExpression | ObjectBindingPattern
   properties := node.specifiers.map (specifier: any) =>
     if specifier.ts
       { type: "Error", message: `cannot use \`type\` in ${kind} import` }
@@ -1163,7 +1169,7 @@ function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynami
       properties
       node.children.-1 // }
     ]
-  }
+  } as ObjectExpression | ObjectBindingPattern
 
 // Convert an ObjectExpression (with `properties`)
 // into a set of JSX attributes.
@@ -1275,11 +1281,16 @@ function processBindingPatternLHS(lhs: any, tail: any): void
     atBinding.type = undefined
     atBinding.children = thisExpr
     // Update blockPrefixes that use this ref as a rest identifier (e.g. [...@x, y] = z)
-    for each nodeWithPrefix of gatherRecursiveAll lhs, (n) => n.blockPrefix
+    for each nodeWithPrefix of
+        gatherRecursiveAll(lhs, (n) => Boolean(n.blockPrefix if "blockPrefix" in n))
+        |> as Array<ASTNodeObject & { blockPrefix: PostRestBindingElements }>
       { blockPrefix } := nodeWithPrefix
       blockPrefix.children = blockPrefix.children.map (c: any) => c is ref ? thisExpr : c
+
   // Also handle AtBindings inside blockPrefixes (e.g. post-rest @x in [a, ..., @x] = y)
-  for each nodeWithPrefix of gatherRecursiveAll lhs, (n) => n.blockPrefix
+  for each nodeWithPrefix of
+      gatherRecursiveAll(lhs, (n) => Boolean(n.blockPrefix if "blockPrefix" in n))
+      |> as Array<ASTNodeObject & { blockPrefix: PostRestBindingElements }>
     { blockPrefix } := nodeWithPrefix
     for each atBinding of gatherRecursiveAll blockPrefix, .type is "AtBinding"
       atBinding.type = undefined
@@ -1320,10 +1331,10 @@ function processAssignments(statements: ASTNode): void
           pre.push(["(", lhs, ", "])
           post.push(")")
         // Use refs to avoid duplicating side-effectful member access and indices
-        { assigned } := expr
+        assigned := expr.assigned if "assigned" in expr
         /* c8 ignore next -- defensive guard: tests always reach this with `.children` populated */
-        return assigned unless assigned?.children
-        { children } := assigned
+        children := assigned.children if "children" in assigned?
+        return assigned unless children
 
         // Find the terminal member access (last PropertyAccess or Index)
         j .= children.findLastIndex (c: any) => c?.type is like "PropertyAccess", "Index"
@@ -1346,7 +1357,7 @@ function processAssignments(statements: ASTNode): void
         // Cache the terminal Index expression if it has side effects
         terminal := children[j]
         outerTerminal .= terminal
-        if terminal?.type is "Index"
+        if terminal is like { type: "Index" }
           { ref, refAssignment } := maybeRefAssignment terminal.expression
           if refAssignment
             replaceNode terminal.expression, (if postfix then ref else refAssignment), terminal
@@ -1593,7 +1604,7 @@ function processAssignments(statements: ASTNode): void
           [ws1, ...children, ws2, op, ...assigns, $2]
 
         if newMemberExp !== lhs
-          if newMemberExp.usesRef
+          if "usesRef" in newMemberExp and newMemberExp.usesRef
             exp.hoistDec =
               type: "Declaration"
               children: ["let ", optionalChainRef]
@@ -1609,6 +1620,7 @@ function processAssignments(statements: ASTNode): void
     // Add any additional binding refs that need to be declared to our hoisted declarations
     if refsToDeclare.size
       if exp.hoistDec
+        assert "children" in exp.hoistDec and exp.hoistDec.children, "hoisted declaration must have children"
         exp.hoistDec.children.push [...refsToDeclare].map [",", &]
       else
         exp.hoistDec =
@@ -1855,7 +1867,7 @@ function processStatementExpressions(statements: StatementTuple[]): void
         replaceNode statement, wrapIIFE([["", statement]]), exp
 
 function processNegativeIndexAccess(statements: StatementTuple[]): void
-  gatherRecursiveAll(statements, (n) => n.type is "NegativeIndex")
+  gatherRecursiveAll(statements, (n) => "type" in n and n.type is "NegativeIndex")
     .forEach (exp): void =>
       parent := exp.parent!
       { children } := parent
@@ -2270,7 +2282,7 @@ function processPlaceholders(statements: StatementTuple[]): void
         // Skip this node of its child told us to
         prevImplicitLift := implicitLift
         {implicitLift} = ancestor as Declaration
-        return if prevImplicitLift
+        return false if prevImplicitLift
 
         {type} := ancestor
         if type is "IfStatement"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1285,7 +1285,7 @@ function processBindingPatternLHS(lhs: any, tail: any): void
     // Update blockPrefixes that use this ref as a rest identifier (e.g. [...@x, y] = z)
     for each { blockPrefix } of gatherRecursiveAll(lhs,
         (n): n is ASTNodeObject & { blockPrefix: PostRestBindingElements } => Boolean
-          n.blockPrefix if "blockPrefix" in n
+          "blockPrefix" in n and n.blockPrefix
         )
 
       blockPrefix.children = blockPrefix.children.map (c: any) => c is ref ? thisExpr : c
@@ -1293,7 +1293,7 @@ function processBindingPatternLHS(lhs: any, tail: any): void
   // Also handle AtBindings inside blockPrefixes (e.g. post-rest @x in [a, ..., @x] = y)
   for each { blockPrefix } of gatherRecursiveAll(lhs,
       (n): n is ASTNodeObject & { blockPrefix: PostRestBindingElements } => Boolean
-        n.blockPrefix if "blockPrefix" in n
+        "blockPrefix" in n and n.blockPrefix
       )
 
     for each atBinding of gatherRecursiveAll blockPrefix, .type is "AtBinding"

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1139,6 +1139,9 @@ function convertArrowFunctionToMethod(id: any, exp: any)
   exp
 
 // Convert NamedImports into equivalent ObjectExpression or ObjectBindingPattern
+function convertNamedImportsToObject(node: any, pattern?: false, kind?: "dynamic" | "destructuring"): ObjectExpression
+function convertNamedImportsToObject(node: any, pattern: true, kind?: "dynamic" | "destructuring"): ObjectBindingPattern
+function convertNamedImportsToObject(node: any, pattern?: boolean, kind?: "dynamic" | "destructuring"): ObjectExpression | ObjectBindingPattern
 function convertNamedImportsToObject(node: any, pattern?: boolean, kind: "dynamic" | "destructuring" = "dynamic"): ObjectExpression | ObjectBindingPattern
   properties := node.specifiers.map (specifier: any) =>
     if specifier.ts

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -12,6 +12,7 @@ import type {
   ASTLeaf
   ASTNode
   ASTNodeObject
+  ASTNodeParent
   ASTRef
   ASTString
   Binding
@@ -97,6 +98,7 @@ import {
   isComma
   isEmptyBareBlock
   isFunction
+  isParent
   isWhitespaceOrEmpty
   literalValue
   makeLeftHandSideExpression
@@ -214,7 +216,7 @@ import {
 
 function addPostfixStatement(statement: ASTNode, ws: ASTNode, post: IterationStatement | ForStatement | IfStatement)
   blockPrefix := post.blockPrefix if "blockPrefix" in post
-  expressions := [
+  expressions: StatementTuple[] := [
     ...blockPrefix or []
     ["", statement]
   ]
@@ -1348,7 +1350,7 @@ function processAssignments(statements: ASTNode): void
           // in the AST for hoistDec resolution.
           innerBase := makeLeftHandSideExpression (if postfix then baseRef else baseRefAssignment)
           children.splice 0, j, innerBase
-          innerBase.parent = assigned
+          innerBase.parent = assigned as ASTNodeParent
           j = 1  // terminal is now at index 1 after splice
           if postfix
             (baseRefAssignment as ASTNodeObject).parent = exp
@@ -1356,7 +1358,7 @@ function processAssignments(statements: ASTNode): void
 
         // Cache the terminal Index expression if it has side effects
         terminal := children[j]
-        outerTerminal .= terminal
+        outerTerminal: ASTNode .= terminal
         if terminal is like { type: "Index" }
           { ref, refAssignment } := maybeRefAssignment terminal.expression
           if refAssignment
@@ -1373,7 +1375,7 @@ function processAssignments(statements: ASTNode): void
         /* c8 ignore next -- defensive: tests always reach this with either a hoisted refAssignment or a replaced terminal */
         return assigned unless baseRefAssignment or outerTerminal is not terminal
         outerBase := if baseRefAssignment then [baseRef] else children.slice 0, j
-        { ...assigned, children: [...outerBase, outerTerminal, ...children.slice j + 1] }
+        { ...assigned, children: [...outerBase, outerTerminal, ...children.slice j + 1] } as ASTNode
 
     const pre: Children = [], post: Children = []
     switch exp.type
@@ -1620,7 +1622,7 @@ function processAssignments(statements: ASTNode): void
     // Add any additional binding refs that need to be declared to our hoisted declarations
     if refsToDeclare.size
       if exp.hoistDec
-        assert "children" in exp.hoistDec and exp.hoistDec.children, "hoisted declaration must have children"
+        assert isParent(exp.hoistDec), "hoisted declaration must have children"
         exp.hoistDec.children.push [...refsToDeclare].map [",", &]
       else
         exp.hoistDec =

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -57,10 +57,13 @@ precedenceCustomDefault := precedenceMap.get("custom")!
 function getPrecedence(op: BinaryOp): number
   if op.type is "PatternTest"
     precedenceRelational
-  else if op.prec <? "number"
+  else if "prec" in op and op.prec <? "number"
     op.prec
   else
-    precedenceMap.get(op.prec ?? op.token) ??
+    precedenceMap.get(
+      (op.prec if "prec" in op and op.prec !<? "number") ??
+      (op.token if "token" in op)
+    ) ??
     if op.relational then precedenceRelational else precedenceCustomDefault
 
 /**
@@ -73,6 +76,7 @@ function isShortCircuitOp(op: BinaryOp): boolean
   if {token} := op
     return isShortCircuitOp token
   // Strip = from ||=, &&=, ??=
+  assert op <? "string", "must be a string"
   if op.endsWith("=") and not op.endsWith("==")
     op = op[<-1]
   op is like "||", "&&", "??"

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -55,15 +55,15 @@ precedenceRelational := precedenceMap.get("==")!
 precedenceCustomDefault := precedenceMap.get("custom")!
 
 function getPrecedence(op: BinaryOp): number
-  if op.type is "PatternTest"
-    precedenceRelational
-  else if "prec" in op and op.prec <? "number"
-    op.prec
-  else
-    precedenceMap.get(
-      (op.prec if "prec" in op and op.prec !<? "number") ??
-      (op.token if "token" in op)
-    ) ??
+  return  precedenceRelational if op is like { type: "PatternTest" }
+
+  prec := op.prec if op is like { prec }
+
+  return prec if prec <? "number"
+
+  precedenceKey := prec ?? (op.token if op is like { token })
+
+  precedenceMap.get(precedenceKey) ??
     if op.relational then precedenceRelational else precedenceCustomDefault
 
 /**

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -76,7 +76,7 @@ function isShortCircuitOp(op: BinaryOp): boolean
   if {token} := op
     return isShortCircuitOp token
   // Strip = from ||=, &&=, ??=
-  assert op <? "string", "must be a string"
+  assert op <? "string", "op must must be a string"
   if op.endsWith("=") and not op.endsWith("==")
     op = op[<-1]
   op is like "||", "&&", "??"

--- a/source/parser/op.civet
+++ b/source/parser/op.civet
@@ -55,7 +55,7 @@ precedenceRelational := precedenceMap.get("==")!
 precedenceCustomDefault := precedenceMap.get("custom")!
 
 function getPrecedence(op: BinaryOp): number
-  return  precedenceRelational if op is like { type: "PatternTest" }
+  return precedenceRelational if op is like { type: "PatternTest" }
 
   prec := op.prec if op is like { prec }
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -25,6 +25,7 @@ import {
 } from ./traversal.civet
 
 import {
+  assert
   flatJoin
   isExit
   makeLeftHandSideExpression
@@ -207,7 +208,7 @@ function getPatternConditions(
   switch pattern.type
     when "ArrayBindingPattern"
       const { elements, length } = pattern,
-        hasRest = Boolean(pattern.omittedRest) or elements.some((e) => e.rest),
+        hasRest = Boolean(pattern.omittedRest) or elements.some((e) => e.rest if "rest" in e),
         l = (length - +hasRest).toString(),
         lengthCheck = hasRest
         ? [ref, ".length >= ", l]
@@ -319,7 +320,7 @@ function getPatternBlockPrefix(
   // Gather bindings
   [splices, thisAssignments] .= gatherBindingCode(pattern)
   patternBindings := nonMatcherBindings(pattern)
-  typeSuffix = patternBindings.typeSuffix if "typeSuffix" in patternBindings
+  typeSuffix = patternBindings.typeSuffix if "typeSuffix" in patternBindings?
   subbindings := gatherSubbindings patternBindings
   simplifyBindingProperties patternBindings
   simplifyBindingProperties subbindings
@@ -375,9 +376,9 @@ function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternConte
         { children, name, value } := p
         [ws] := children
 
-        shouldElide := (or)
-          name.type is "NumericLiteral" and !value?.name
-          name.type is "ComputedPropertyName" and value?.subtype is "NumericLiteral"
+        shouldElide := (and)
+          name.type is "ComputedPropertyName"
+          value and "subtype" in value and value.subtype is "NumericLiteral"
         if shouldElide
           continue
         else
@@ -470,7 +471,8 @@ function aggregateDuplicateBindings(bindings: ASTNode)
   propsGroupedByName := new Map<string, ASTNodeObject[]>
 
   for each p of props
-    { name, value } := p
+    { name } := p
+    value := p.value if "value" in p
 
     // JavaScript does not bind a property that gets matched against
     // an array or object pattern
@@ -479,7 +481,11 @@ function aggregateDuplicateBindings(bindings: ASTNode)
       continue
 
     // This is to handle aliased props, non-aliased props, and binding identifiers in arrays
-    const key = value?.name or name?.name or name
+    key := (or)
+      value.name if "name" in value?
+      name.name if name is like { name }
+      name
+
     if key?.type is "NumericLiteral" or key?.type is "ComputedPropertyName"
       continue
 
@@ -533,13 +539,14 @@ function aliasBinding(p: ASTNodeObject, ref: ASTRef): void
     p.children[0] = ref
   else if p.type is "BindingRestElement"
     aliasBinding p.binding, ref
-  else if p.value?.type is "Identifier"
+  else if "value" in p and p.value?.type is "Identifier"
     // aliased property binding
     aliasBinding p.value, ref
   else
     // non-aliased property binding
     p.value = ref
-    index := p.children.indexOf p.name
+    assert p.children, "children is required"
+    index := p.children |> as ???[] |> .indexOf(p.name if "name" in p)
     p.children.splice index + 1, 0, ": ", ref
 
 export {

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -5,7 +5,6 @@ import type {
   ASTRef
   BindingProperty
   BindingRestElement
-  BindingRestProperty
   BlockStatement
   Condition
   ContinueStatement
@@ -25,7 +24,6 @@ import {
 } from ./traversal.civet
 
 import {
-  assert
   flatJoin
   isExit
   makeLeftHandSideExpression
@@ -456,19 +454,24 @@ function nonMatcherBindings(pattern: ASTNodeObject): ASTNodeObject?
     else
       pattern
 
+type DuplicateBinding =
+  | BindingProperty
+  | Identifier
+  | (BindingRestElement & { binding: Identifier })
+
 function aggregateDuplicateBindings(bindings: ASTNode)
   props := gatherRecursiveAll bindings,
-    ($): $ is BindingProperty | BindingRestProperty | Identifier | BindingRestElement => (or)
+    ($): $ is DuplicateBinding => (or)
       $.type is "BindingProperty"
       // Don't deduplicate ...rest properties; user should do so manually
       // because ...rest can be named arbitrarily
       //$.type is "BindingRestProperty"
       $.type is "Identifier" and $.parent?.type is "BindingElement"
-      $.type is "BindingRestElement"
+      $.type is "BindingRestElement" and $.binding.type is "Identifier"
 
   declarations: ASTNode[] := []
 
-  propsGroupedByName := new Map<string, ASTNodeObject[]>
+  propsGroupedByName := new Map<string, DuplicateBinding[]>
 
   for each p of props
     { name } := p
@@ -486,7 +489,7 @@ function aggregateDuplicateBindings(bindings: ASTNode)
       name.name if name is like { name }
       name
 
-    if key?.type is "NumericLiteral" or key?.type is "ComputedPropertyName"
+    if key is like { type } and key.type is like "NumericLiteral", "ComputedPropertyName"
       continue
 
     if propsGroupedByName.has key
@@ -495,7 +498,6 @@ function aggregateDuplicateBindings(bindings: ASTNode)
       propsGroupedByName.set key, [p]
 
   propsGroupedByName.forEach (shared, key) =>
-    return unless key
     // NOTE: Allows pattern matching reserved word keys by binding to
     // inaccessible refs; explicit `_` prefix because Civet-only reserved
     // words (`is`, `loop`, ...) are valid JS so makeRef leaves them bare
@@ -531,7 +533,7 @@ function aggregateDuplicateBindings(bindings: ASTNode)
  * Adjust the alias of a binding property, adding an alias if one doesn't exist or
  * replacing an existing alias. This mutates the property in place.
  */
-function aliasBinding(p: ASTNodeObject, ref: ASTRef): void
+function aliasBinding(p: DuplicateBinding, ref: ASTRef): void
   if p.type is "Identifier"
     // Array element binding
     // TODO: This ignores `name` and `names` properties of Identifier and
@@ -539,14 +541,13 @@ function aliasBinding(p: ASTNodeObject, ref: ASTRef): void
     p.children[0] = ref
   else if p.type is "BindingRestElement"
     aliasBinding p.binding, ref
-  else if "value" in p and p.value?.type is "Identifier"
+  else if p.value?.type is "Identifier"
     // aliased property binding
     aliasBinding p.value, ref
   else
     // non-aliased property binding
     p.value = ref
-    assert p.children, "children is required"
-    index := p.children |> as ???[] |> .indexOf(p.name if "name" in p)
+    index := p.children.indexOf(p.name)
     p.children.splice index + 1, 0, ": ", ref
 
 export {

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -547,7 +547,7 @@ function aliasBinding(p: DuplicateBinding, ref: ASTRef): void
   else
     // non-aliased property binding
     p.value = ref
-    index := p.children.indexOf(p.name)
+    index := p.children.indexOf p.name
     p.children.splice index + 1, 0, ": ", ref
 
 export {

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -24,6 +24,7 @@ import {
 } from ./traversal.civet
 
 import {
+  assert
   flatJoin
   isExit
   makeLeftHandSideExpression
@@ -487,6 +488,9 @@ function aggregateDuplicateBindings(bindings: ASTNode)
 
     if key is like { type } and key.type is like "NumericLiteral", "ComputedPropertyName"
       continue
+
+    // Only source-level binding names can be aggregated into a declaration.
+    assert key <? "string", "Expected a binding name"
 
     if propsGroupedByName.has key
       propsGroupedByName.get(key)!.push(p)

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -371,48 +371,44 @@ function elideMatchersFromPropertyBindings(properties: ObjectBindingPatternConte
   for each p of properties
     switch p.type
       when "BindingProperty", "PinProperty"
-        { children, name, value } := p
-        [ws] := children
+        { children^: [ws], name, value } := p
 
-        shouldElide := (and)
-          name.type is "ComputedPropertyName"
-          value and "subtype" in value and value.subtype is "NumericLiteral"
-        if shouldElide
-          continue
+        continue if name.type is "NumericLiteral" and not (value is like { name } and value.name)
+        continue if name.type is "ComputedPropertyName" and value is like { subtype: "NumericLiteral" }
+
+        let contents: (BindingProperty | PinProperty)?
+        switch value?.type
+          when "ArrayBindingPattern", "ObjectBindingPattern"
+            bindings := nonMatcherBindings value
+            contents = {
+              ...p
+              value: bindings
+              children: [ws, propertyKey(name), bindings && ": ", bindings, p.delim]
+            }
+          when "Identifier", undefined
+            contents = p
+          when "NamedBindingPattern"
+            bindings := nonMatcherBindings value.pattern
+            contents = {
+              ...p
+              subbinding: if bindings?.type is like "ArrayBindingPattern", "ObjectBindingPattern", "Identifier"
+                . bindings
+                . " = "
+                . name
+            }
+            // Similar to `simplifyBindingProperties`,
+            // simplify `{name: name}` to just `{name}`
+            // This occurs because the parser expands `{name^: pattern}`
+            // into `{name: name^pattern}`
+            if p.name is value.binding
+              contents!.children = [ws, propertyKey(name), p.delim]
+          else // "Literal", "RegularExpressionLiteral", "StringLiteral"
+            contents = undefined
+
+        if contents
+          contents
         else
-
-          let contents: (BindingProperty | PinProperty)?
-          switch value?.type
-            when "ArrayBindingPattern", "ObjectBindingPattern"
-              bindings := nonMatcherBindings value
-              contents = {
-                ...p
-                value: bindings
-                children: [ws, propertyKey(name), bindings && ": ", bindings, p.delim]
-              }
-            when "Identifier", undefined
-              contents = p
-            when "NamedBindingPattern"
-              bindings := nonMatcherBindings value.pattern
-              contents = {
-                ...p
-                subbinding: if bindings?.type is like "ArrayBindingPattern", "ObjectBindingPattern", "Identifier"
-                  . bindings
-                  . " = "
-                  . name
-              }
-              // Similar to `simplifyBindingProperties`,
-              // simplify `{name: name}` to just `{name}`
-              // This occurs because the parser expands `{name^: pattern}`
-              // into `{name: name^pattern}`
-              if p.name is value.binding
-                contents!.children = [ws, propertyKey(name), p.delim]
-            else // "Literal", "RegularExpressionLiteral", "StringLiteral"
-              contents = undefined
-          if contents
-            contents
-          else
-            continue
+          continue
       else // "BindingRestProperty"
         p
 

--- a/source/parser/pattern-matching.civet
+++ b/source/parser/pattern-matching.civet
@@ -207,7 +207,7 @@ function getPatternConditions(
   switch pattern.type
     when "ArrayBindingPattern"
       const { elements, length } = pattern,
-        hasRest = Boolean(pattern.omittedRest) or elements.some((e) => e.rest if "rest" in e),
+        hasRest = Boolean(pattern.omittedRest) or elements.some((e) => "rest" in e and e.rest),
         l = (length - +hasRest).toString(),
         lengthCheck = hasRest
         ? [ref, ".length >= ", l]
@@ -482,8 +482,8 @@ function aggregateDuplicateBindings(bindings: ASTNode)
 
     // This is to handle aliased props, non-aliased props, and binding identifiers in arrays
     key := (or)
-      value.name if "name" in value?
-      name.name if name is like { name }
+      "name" in value? and value.name
+      name is like { name } and name.name
       name
 
     if key is like { type } and key.type is like "NumericLiteral", "ComputedPropertyName"

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -50,7 +50,7 @@ function constructInvocation(fn: ExprWithComments, arg: ASTNode!): NewExpression
   expr .= fn.expr
   while expr.type is "ParenthesizedExpression"
     expr = expr.expression
-  if "ampersandBlock" in expr and expr.ampersandBlock
+  if expr is like { ampersandBlock: true }
     { ref, body, placeholders } := expr as AmpersandFunction
 
     (ref as { type: "Ref" | "PipedExpression" }).type = "PipedExpression"
@@ -107,13 +107,14 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
   children .= [[fn.leadingComment, fn.expr, fn.trailingComment].map(skipIfOnlyWS), " ", arg]
 
   // Handle special non-function cases
-  if "token" in fn.expr
-    switch fn.expr.token
+  { expr } := fn
+  if expr is like { token }
+    switch expr.token
       when "await"
-        // fn.expr is the literal `await` keyword token here (the switch on
-        // `fn.expr.token` narrowed it to a leaf-shape).  Cast to satisfy
+        // expr is the literal `await` keyword token here (the switch on
+        // `expr.token` narrowed it to a leaf-shape).  Cast to satisfy
         // processUnaryExpression's tighter signature.
-        children = processUnaryExpression([fn.expr as! UnaryOpElement], arg, undefined)
+        children = processUnaryExpression([expr as! UnaryOpElement], arg, undefined)
         continue switch
       when "yield"
         return [

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -17,6 +17,8 @@ type {
   ThrowStatement
   UnaryOpElement
   UnwrappedExpression
+  NewExpression
+  CallExpression
 } from ./types.civet
 { gatherRecursiveAll } from ./traversal.civet
 {
@@ -43,12 +45,12 @@ type ExprWithComments
   leadingComment: ASTNode
   trailingComment: ASTNode
 
-function constructInvocation(fn: ExprWithComments, arg: ASTNode!)
+function constructInvocation(fn: ExprWithComments, arg: ASTNode!): NewExpression | CallExpression | UnwrappedExpression
   // Unwrap ampersand blocks
   expr .= fn.expr
   while expr.type is "ParenthesizedExpression"
     expr = expr.expression
-  if expr.ampersandBlock
+  if "ampersandBlock" in expr and expr.ampersandBlock
     { ref, body, placeholders } := expr as AmpersandFunction
 
     (ref as { type: "Ref" | "PipedExpression" }).type = "PipedExpression"
@@ -105,36 +107,37 @@ function constructPipeStep(fn: ExprWithComments, arg: ASTNode!, returning: ASTNo
   children .= [[fn.leadingComment, fn.expr, fn.trailingComment].map(skipIfOnlyWS), " ", arg]
 
   // Handle special non-function cases
-  switch fn.expr.token
-    when "await"
-      // fn.expr is the literal `await` keyword token here (the switch on
-      // `fn.expr.token` narrowed it to a leaf-shape).  Cast to satisfy
-      // processUnaryExpression's tighter signature.
-      children = processUnaryExpression([fn.expr as! UnaryOpElement], arg, undefined)
-      continue switch
-    when "yield"
-      return [
-        children
-        returning
-      ]
-    when "throw"
-      statement: ThrowStatement := makeNode { type: "ThrowStatement", children }
-      return
-        . makeNode {
-            type: "StatementExpression"
-            statement
-            children: [statement]
-          }
-        . null
-    when "return"
-      // Return ignores ||> returning argument
-      return
-        . makeNode {
-            type: "ReturnStatement"
-            expression: arg
-            children: children as Children
-          } satisfies ReturnStatement
-        . null
+  if "token" in fn.expr
+    switch fn.expr.token
+      when "await"
+        // fn.expr is the literal `await` keyword token here (the switch on
+        // `fn.expr.token` narrowed it to a leaf-shape).  Cast to satisfy
+        // processUnaryExpression's tighter signature.
+        children = processUnaryExpression([fn.expr as! UnaryOpElement], arg, undefined)
+        continue switch
+      when "yield"
+        return [
+          children
+          returning
+        ]
+      when "throw"
+        statement: ThrowStatement := makeNode { type: "ThrowStatement", children }
+        return
+          . makeNode {
+              type: "StatementExpression"
+              statement
+              children: [statement]
+            }
+          . null
+      when "return"
+        // Return ignores ||> returning argument
+        return
+          . makeNode {
+              type: "ReturnStatement"
+              expression: arg
+              children: children as Children
+            } satisfies ReturnStatement
+          . null
 
   return [
     constructInvocation(fn, arg)

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -613,6 +613,7 @@ export type DoStatement = ASTParent &
 
 export type ForStatement = ASTParent &
   type: "ForStatement"
+  blockPrefix?: StatementTuple[]
   declaration: (Declaration | ForDeclaration | ForControlDeclaration)?
   /** Optional value used for implicit loop body. */
   iterand?: ASTNode
@@ -987,7 +988,8 @@ export type DeclarationKind = "let" | "const" | "var" | Keyword | ASTLeaf
 
 export type Declaration = ASTParent &
   type: "Declaration"
-  names: string[]
+  /** Undefined for invalid lexical LHSs; operator declarations use this to reject them. */
+  names: string[]?
   bindings: Binding[]
   decl: DeclarationKind
   autoExport?: true
@@ -1130,7 +1132,7 @@ export type BindingPattern = (
 // but aren't patterns by themselves
 export type BindingPatternComponent = BindingProperty | AtBindingProperty | BindingRestProperty | BindingElement | BindingRestElement | BindingPattern
 
-export type PatternExpression = BindingPattern | ConditionFragment
+export type PatternExpression = BindingPattern | ConditionFragment | ASTRef
 
 export type ConditionFragment = ASTParent &
   type: "ConditionFragment"
@@ -1223,7 +1225,7 @@ export type Whitespace = ASTString | (ASTLeaf | ASTString | CommentNode)[]?
 export type Delimiter = ASTLeaf | ASTString | Delimiter[]
 
 export type PropertyName =
-  Literal | ComputedPropertyName | Identifier
+  Literal | NumericLiteral | StringLiteral | ComputedPropertyName | Identifier
 
 export type ComputedPropertyName =
   type: "ComputedPropertyName"
@@ -1236,7 +1238,8 @@ export type BindingProperty = ASTParent &
   type: "BindingProperty"
   name: PropertyName | AtBinding
   names: string[]
-  value: (BindingIdentifier | BindingPattern)?
+  /** Duplicate-binding aggregation can replace the value with a generated ref. */
+  value: (BindingIdentifier | BindingPattern | ASTRef)?
   typeSuffix: TypeSuffix?
   initializer: Initializer?
   delim: ASTNode

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -269,7 +269,7 @@ function astNodeAsAstLeaf(node: ASTNode): ASTLeaf?
 
 function stripTrailingImplicitComma(children: ASTNode[])
   last := children.-1
-  if isComma(last) and "implicit" in last? and last.implicit
+  if "implicit" in last? and last.implicit and isComma(last)
     children[...-1]
   else
     children
@@ -688,7 +688,7 @@ function makeLeftHandSideExpression(expression: ASTNode)
     expression = item
   if isASTNodeObject expression
     return expression if "token" in expression and expression.token
-    return expression if "parenthesized" in expression
+    return expression if "parenthesized" in expression and expression.parenthesized
     return expression if expression.type? and skipParens.has expression.type
     // `new Foo` and `new Foo.Bar` need parenthesization;
     // `new Foo(args)` does not

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -26,6 +26,7 @@ import type {
   TemplateLiteral
   TypeNode
   TypeSuffix
+  Whitespace
 } from ./types.civet
 
 import {
@@ -36,7 +37,7 @@ import {
 // Types need to be upfront to allow for TypeScript `asserts`
 assert: {
   <T>(a: T, msg: string): asserts a
-  equal(a: unknown, b: unknown, msg: string): asserts a is b
+  equal(a: unknown, b: unknown, msg: string): asserts a is typeof b
   notEqual(a: unknown, b: unknown, msg: string): void
   notNull<T>(a: T, msg: string): asserts a is NonNullable<T>
 } := Object.assign(
@@ -159,7 +160,7 @@ function isStatement(node: ASTNode): node is StatementNode
     node.type?  // forbid leaf
     statementTypes.has node.type
 
-function isWhitespaceOrEmpty(node: any): boolean
+function isWhitespaceOrEmpty(node: any): node is Whitespace? | ""
   if (!node) return true
   if (node.type is "Ref") return false
   if (node.token) return /^\s*$/.test(node.token)
@@ -256,14 +257,19 @@ function isLoopStatement(node: ASTNodeObject): node is IterationStatement
  * Returns the node whose `token` is ",", or else undefined.
  */
 function isComma(node: ASTNode): (ASTLeaf & { token: "," }) | undefined
-  if node?.token is ","
-    node
-  else if Array.isArray(node) and node.-1?.token is ","
-    node.-1
+  astLeaf .= astNodeAsAstLeaf(node)
+  astLeaf ?= (astNodeAsAstLeaf(node.-1) if Array.isArray(node))
+
+  if astLeaf?.token == ","
+    astLeaf as ASTLeaf & { token: "," }
+
+function astNodeAsAstLeaf(node: ASTNode): ASTLeaf?
+  if node is like { $loc, type?: undefined }
+    node as ASTLeaf
 
 function stripTrailingImplicitComma(children: ASTNode[])
   last := children.-1
-  if isComma(last) and last.implicit
+  if isComma(last) and "implicit" in last? and last.implicit
     children[...-1]
   else
     children
@@ -413,30 +419,34 @@ function literalValue(literal: Literal)
       throw new Error("Unrecognized literal " + JSON.stringify(literal))
 
 /** TypeScript type for given literal */
-function literalType(literal: Literal | RegularExpressionLiteral | TemplateLiteral): TypeNode
-  let t: ASTString
-  switch literal.type
-    when "RegularExpressionLiteral"
-      t = "RegExp"
-    when "TemplateLiteral"
-      t = "string"
-    when "Literal"
-      // Literal.subtype is "NullLiteral" | "BooleanLiteral" | "NumericLiteral"
-      // | "StringLiteral" | "RegularExpressionLiteral".  The sole caller
-      // typeOfExpression filters NullLiteral and never passes a Literal whose
-      // subtype is RegularExpressionLiteral (those arrive with type
-      // "RegularExpressionLiteral" and are handled above), so only the three
-      // cases below are reachable.
-      switch literal.subtype
-        when "BooleanLiteral"
-          t = "boolean"
-        when "NumericLiteral"
-          if literal.raw.endsWith 'n'
-            t = "bigint"
-          else
-            t = "number"
-        when "StringLiteral"
-          t = "string"
+function literalType(literal:
+  (Literal & { subtype: Exclude<Literal."subtype", "NullLiteral" | "RegularExpressionLiteral"> })
+  | RegularExpressionLiteral
+  | TemplateLiteral
+): TypeNode
+  t: ASTString :=
+    switch literal.type
+      when "RegularExpressionLiteral"
+        "RegExp"
+      when "TemplateLiteral"
+        "string"
+      when "Literal"
+        // Literal.subtype is "NullLiteral" | "BooleanLiteral" | "NumericLiteral"
+        // | "StringLiteral" | "RegularExpressionLiteral".  The sole caller
+        // typeOfExpression filters NullLiteral and never passes a Literal whose
+        // subtype is RegularExpressionLiteral (those arrive with type
+        // "RegularExpressionLiteral" and are handled above), so only the three
+        // cases below are reachable.
+        switch literal.subtype
+          when "BooleanLiteral"
+            "boolean"
+          when "NumericLiteral"
+            if literal.raw.endsWith 'n'
+              "bigint"
+            else
+              "number"
+          when "StringLiteral"
+            "string"
   {}
     type: "TypeLiteral"
     t
@@ -449,7 +459,6 @@ function literalType(literal: Literal | RegularExpressionLiteral | TemplateLiter
  * or something TypeScript wouldn't infer like `null` or `undefined`.
  */
 function typeOfExpression(expression: ASTNode): TypeNode?
-  let t: TypeNode
   return unless isASTNodeObject expression
   switch expression.type
     when "Literal"
@@ -457,16 +466,20 @@ function typeOfExpression(expression: ASTNode): TypeNode?
         when "NullLiteral"
           // `let x = null` doesn't infer type for `x`
           return
+        when "RegularExpressionLiteral"
+          // the comment above in funtion literalType() claims this is impossible but the types disagree
+          assert false, "expression.subtype should not be RegularExpressionLiteral"
+          continue switch // prevents a `break` from being emitted as dead code
         else
-          t = literalType expression
+          literalType expression as typeof expression & { subtype: typeof expression.subtype }
     when "RegularExpressionLiteral", "TemplateLiteral"
-      t = literalType expression
+      literalType expression
     when "Identifier"
       // `let x = undefined` doesn't infer type for `x`
       return if expression.name is "undefined"
       continue switch
     when "MemberExpression"
-      t = {}
+      {}
         type: "TypeTypeof"
         children: ["typeof ", expression]
         expression
@@ -474,7 +487,6 @@ function typeOfExpression(expression: ASTNode): TypeNode?
       // TypeScript's typeof doesn't support arguments
       // beyond identifiers and member expressions
       return
-  t
 
 function typeSuffixForExpression(expression: ASTNode): TypeSuffix?
   t := typeOfExpression expression
@@ -676,9 +688,9 @@ function makeLeftHandSideExpression(expression: ASTNode)
   while [ item ] := expression
     expression = item
   if isASTNodeObject expression
-    return expression if expression.token
-    return expression if expression.parenthesized
-    return expression if skipParens.has expression.type
+    return expression if "token" in expression and expression.token
+    return expression if "parenthesized" in expression
+    return expression if expression.type? and skipParens.has expression.type
     // `new Foo` and `new Foo.Bar` need parenthesization;
     // `new Foo(args)` does not
     return expression if expression.type is "NewExpression" and
@@ -812,7 +824,7 @@ const typeNeedsNoParens = new Set [
  * Parenthesize type if it might need it in some contexts.
  */
 function parenthesizeType(type: ASTNode)
-  return type if typeNeedsNoParens.has type.type
+  return type if type?.type? and typeNeedsNoParens.has type?.type
   makeNode
     type: "TypeParenthesized"
     ts: true
@@ -877,7 +889,6 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
       type: "FunctionExpression"
       signature
       parameters
-      returnType: undefined
       async
       block
       generator
@@ -888,7 +899,6 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
       type: "ArrowFunction"
       signature
       parameters
-      returnType: undefined
       async
       block
       children: [ ...signature.children, "=>", block ]
@@ -933,7 +943,9 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
 
   return exp
 
-function wrapWithReturn(expression?: ASTNode, parent: Parent = expression?.parent, semi = false): ASTNode
+function wrapWithReturn(expression?: ASTNode, parent?: Parent, semi = false): ASTNode
+  parent ?= (expression.parent if "parent" in expression?)
+
   children := expression ? ["return ", expression] : ["return"]
   children.unshift ";" if semi
 

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -466,10 +466,9 @@ function typeOfExpression(expression: ASTNode): TypeNode?
         when "NullLiteral"
           // `let x = null` doesn't infer type for `x`
           return
+        /* c8 ignore next 2 -- the comment above in funtion literalType() claims this is unreachable but the types disagree */
         when "RegularExpressionLiteral"
-          // the comment above in funtion literalType() claims this is impossible but the types disagree
-          assert false, "expression.subtype should not be RegularExpressionLiteral"
-          continue switch // prevents a `break` from being emitted as dead code
+          throw new Error "expression.subtype should not be RegularExpressionLiteral"
         else
           literalType expression as typeof expression & { subtype: typeof expression.subtype }
     when "RegularExpressionLiteral", "TemplateLiteral"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -269,7 +269,7 @@ function astNodeAsAstLeaf(node: ASTNode): ASTLeaf?
 
 function stripTrailingImplicitComma(children: ASTNode[])
   last := children.-1
-  if "implicit" in last? and last.implicit and isComma(last)
+  if last is like { implicit: true } and isComma(last)
     children[...-1]
   else
     children
@@ -943,7 +943,7 @@ function wrapIIFE(expressions: StatementTuple[], asyncFlag?: boolean, generatorS
   return exp
 
 function wrapWithReturn(expression?: ASTNode, parent?: Parent, semi = false): ASTNode
-  parent ?= (expression.parent if "parent" in expression?)
+  parent ?= (expression.parent if expression is like { parent })
 
   children := expression ? ["return ", expression] : ["return"]
   children.unshift ";" if semi

--- a/test/compat/coffee-classes.civet
+++ b/test/compat/coffee-classes.civet
@@ -88,6 +88,20 @@ describe "coffeeClasses", ->
   """
 
   testCase """
+    colon field binary expression
+    ---
+    "civet coffeeClasses"
+    class A
+      value: 1 + 2
+    ---
+    A = (()=>{
+      class A {
+    }
+      A.prototype.value = 1 + 2
+      return A})()
+  """
+
+  testCase """
     symbol-keyed colon field value
     ---
     "civet coffeeClasses"

--- a/test/export.civet
+++ b/test/export.civet
@@ -1,4 +1,7 @@
 {testCase, throws} from ./helper.civet
+assert from node:assert/strict
+{ compile, generate } from ../source/main.civet
+{ gatherRecursiveAll } from ../source/parser/traversal.civet
 
 describe "export", ->
   testCase """
@@ -107,6 +110,21 @@ describe "export", ->
   """
 
   describe "export default extensions", ->
+    throws """
+      default export rejects a declaration without binding names
+      ---
+      export default x.y := z
+      ---
+      ParseErrors: unknown:1:25 export default with 0 variable declarations (should be 1)
+    """
+
+    it "retains an invalid default-export declaration and following code", ->
+      ast := await compile "export default x.y := z\nafter()", ast: true
+      errors := gatherRecursiveAll ast, .type is "Error"
+      assert.equal errors.length, 1
+      assert.equal errors[0].message, "export default with 0 variable declarations (should be 1)"
+      assert.equal (generate ast, js: true), "const x.y = z;\nafter()"
+
     testCase """
       export default const
       ---
@@ -152,7 +170,7 @@ describe "export", ->
       ---
       export default const x = 5, y = 10
       ---
-      ParseErrors: unknown:1:36 export default with 2 variable declaration (should be 1)
+      ParseErrors: unknown:1:36 export default with 2 variable declarations (should be 1)
     """
 
   testCase """

--- a/test/jsx/code.civet
+++ b/test/jsx/code.civet
@@ -1,6 +1,41 @@
-{ testCase } from ../helper.civet
+{ testCase, throws } from ../helper.civet
+assert from node:assert/strict
+{ compile, generate } from ../../source/main.civet
+{ gatherRecursiveAll } from ../../source/parser/traversal.civet
 
 describe "jsxCode", ->
+  throws """
+    JSX rejects a declaration without binding names
+    ---
+    <div>{x.y := z}</div>
+    ---
+    ParseErrors: unknown:1:7 JSX declaration must declare identifiers
+  """
+
+  it "retains an invalid JSX declaration and following code without an empty hoist", ->
+    ast := await compile "<div>{x.y := z}</div>\nafter()", ast: true
+    errors := gatherRecursiveAll ast, .type is "Error"
+    assert.equal errors.length, 1
+    assert.equal errors[0].message, "JSX declaration must declare identifiers"
+    assert.equal errors[0].$loc?.pos, 6
+    assert.equal (generate ast, js: true), "<div>{x.y = z,void 0}</div>\nafter()"
+
+  testCase """
+    JSX empty array binding does not need a hoist
+    ---
+    <div>{[] := z}</div>
+    ---
+    <div>{[] = z,void 0}</div>
+  """
+
+  testCase """
+    JSX empty object binding does not need a hoist
+    ---
+    <div>{{} := z}</div>
+    ---
+    <div>{{} = z,void 0}</div>
+  """
+
   testCase """
     nested
     ---

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -2023,6 +2023,18 @@ describe "switch", ->
           x}
     """
 
+    testCase """
+      numeric property preserves nested array binding
+      ---
+      switch x
+        {0: [a]}
+          a
+      ---
+      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
+      if(typeof x === 'object' && x != null && 0 in x && Array.isArray(x[0]) && len(x[0], 1)) {const {0: [a]} = x;
+          a}
+    """
+
     // #1230
     testCase """
       duplicate nested object bindings

--- a/test/switch.civet
+++ b/test/switch.civet
@@ -2023,18 +2023,6 @@ describe "switch", ->
           x}
     """
 
-    testCase """
-      numeric property preserves nested array binding
-      ---
-      switch x
-        {0: [a]}
-          a
-      ---
-      function len<T extends readonly unknown[], N extends number>(arr: T, length: N): arr is T & { length: N } { return arr.length === length }
-      if(typeof x === 'object' && x != null && 0 in x && Array.isArray(x[0]) && len(x[0], 1)) {const {0: [a]} = x;
-          a}
-    """
-
     // #1230
     testCase """
       duplicate nested object bindings

--- a/test/types/class.civet
+++ b/test/types/class.civet
@@ -580,6 +580,15 @@ describe "[TS] class", ->
       }
     """
 
+    throws """
+      pinned @-binding in typed constructor parameter
+      ---
+      class UserAccount
+        @({^@name}: {name: string})
+      ---
+      ParseErrors: unknown:2:18 Pinned properties do not yet work with @binding
+    """
+
     testCase """
       nested array fields
       ---


### PR DESCRIPTION
Fixes a few type errors without changing code behavior. Along the way, also fix these bugs:

- **Invalid default-export declarations no longer crash**, e.g. `export default x.y := z`. They produce a normal diagnostic and retain the declaration and following code in the AST.
- **Invalid JSX declarations likewise report an error instead of crashing**, with a source location and best-effort AST recovery.
- **Empty JSX bindings no longer generate an invalid empty `let` declaration**, e.g. `<div>{[] := z}</div>` and the equivalent `{}` binding.
- **Combined default/named imports get correct binding-name metadata** when converted to dynamic imports. The named binding now reads names from the converted pattern instead of `specifiers.names`, which was undefined.
- **Name collection avoids introducing `undefined` entries** for nodes without binding names, by using `namesOf`.

Each chunk of changes in each commit is independent from the others and can be evaluated and/or accepted on a case-by-case basis.

## Updated type-diff

```
Old: 647 diagnostics  →  New: 534 diagnostics
Net: -113
Deduped 10 noise pairs (code-class reshuffles, union reordering, target-type rewrites).
Regressions: 27
Fixed: 140

Regressions (27):
  source/parser/declaration.civet
    130:5 TS2322 Type 'string[] | undefined' is not assignable to type 'string[]'.
    431:50 TS2488 Type 'PostRestBindingElements' must have a '[Symbol.iterator]()' method that returns an iterator.
    442:62 TS2339 Property 'length' does not exist on type 'PostRestBindingElements'.
    459:36 TS2345 Argument of type 'PostRestBindingElements | undefined' is not assignable to parameter of type 'StatementTuple[] | undefined'.
    464:34 TS2345 Argument of type 'PostRestBindingElements | undefined' is not assignable to parameter of type 'StatementTuple[] | undefined'.
    472:35 TS2345 Argument of type 'PostRestBindingElements' is not assignable to parameter of type 'StatementTuple[] | undefined'.
    490:21 TS2339 Property 'unshift' does not exist on type 'PostRestBindingElements'.
    496:32 TS2345 Argument of type 'PostRestBindingElements' is not assignable to parameter of type 'StatementTuple[] | undefined'.
    679:7 TS2322 Type '(string | any[] | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 150 more ... | undefined)[]' is not assignable to type 'ASTNode'.
  source/parser/function.civet
    989:22 TS2339 Property 'base' does not exist on type 'Identifier | ASTRef | AtBinding | EmptyBinding | ReturnValue | (Literal & { js?: boolean; }) | (ASTObject & { ...; } & { ...; } & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ObjectBindingPattern & { ...; }) | (ASTObject & ... 2 more ... & { ...; })'.
    989:44 TS2339 Property 'id' does not exist on type 'Identifier | ASTRef | AtBinding | EmptyBinding | ReturnValue | (Literal & { js?: boolean; }) | (ASTObject & { ...; } & { ...; } & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ObjectBindingPattern & { ...; }) | (ASTObject & ... 2 more ... & { ...; })'.
    1033:9 TS2322 Type '({ children: ASTRef[]; ts: boolean; js?: never; } | { children: (Identifier | ASTRef | AtBinding | EmptyBinding | ReturnValue | ... 5 more ... | (ASTObject & ... 2 more ... & { ...; }))[]; js: boolean; ts?: never; })[]' is not assignable to type 'string | Identifier | ASTRef | AtBinding | ArrayBindingPattern | EmptyBinding | ReturnValue | ... 4 more ... | (ASTObject & ... 2 more ... & { ...; })'.
    1035:11 TS2353 Object literal may only specify known properties, and 'ts' does not exist in type 'Identifier | ASTRef | AtBinding | ArrayBindingPattern | EmptyBinding | ReturnValue | (Literal & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ObjectBindingPattern & { ...; }) | (ASTObject & ... 2 more ... & { ...; })'.
    1083:11 TS2353 Object literal may only specify known properties, and 'ts' does not exist in type 'Identifier | ASTRef | AtBinding | ArrayBindingPattern | EmptyBinding | ReturnValue | (Literal & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ASTObject & ... 2 more ... & { ...; }) | (ObjectBindingPattern & { ...; }) | (ASTObject & ... 2 more ... & { ...; })'.
    1216:3 TS2322 Type '((string | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 148 more ... | UntypedNode)[] | (ASTString | ... 157 more ... | undefined)[])[]' is not assignable to type 'ASTNode[]'.
    1220:26 TS2322 Type 'ASTNode | { type: string; children: string[]; }' is not assignable to type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 314 more ... | undefined'.
    1220:41 TS2322 Type '{ type: string; children: string[]; }' is not assignable to type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 314 more ... | undefined'.
  source/parser/lib.civet
    218:8 TS2488 Type '{}' must have a '[Symbol.iterator]()' method that returns an iterator.
    1350:11 TS2322 Type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 139 more ... | UntypedNode' is not assignable to type '(ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; empty?: boolean; implicit?: boolean; ... 5 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 144 more ... | undefined'.
    1384:15 TS2322 Type 'AwaitExpression | ASTRef | Await | Yield | { children: ("" | ASTString | Children | BlockStatement | ... 156 more ... | undefined)[]; ... 12 more ...; trailing?: ASTNode[]; } | ... 143 more ... | { ...; }' is not assignable to type 'NonNullASTNode'.
    1388:11 TS2322 Type 'AwaitExpression | ASTRef | Await | Yield | { children: ("" | ASTString | Children | BlockStatement | ... 156 more ... | undefined)[]; ... 12 more ...; trailing?: ASTNode[]; } | ... 143 more ... | { ...; }' is not assignable to type 'ASTNode'.
    1388:26 TS2322 Type 'AwaitExpression | ASTRef | Await | Yield | { children: ("" | ASTString | Children | BlockStatement | ... 156 more ... | undefined)[]; ... 12 more ...; trailing?: ASTNode[]; } | ... 143 more ... | { ...; }' is not assignable to type 'ASTNode'.
    1623:31 TS2349 This expression is not callable.
  source/parser/pattern-matching.civet
    495:31 TS2345 Argument of type 'string | AtBinding | PropertyName' is not assignable to parameter of type 'string'.
    496:30 TS2345 Argument of type 'string | AtBinding | PropertyName' is not assignable to parameter of type 'string'.
    498:30 TS2345 Argument of type 'string | AtBinding | PropertyName' is not assignable to parameter of type 'string'.
    549:5 TS2322 Type 'ASTRef' is not assignable to type 'BindingIdentifier | BindingPattern | undefined'.

Fixed (140):
  source/parser.hera
    1146:5 TS2322 Type 'ASTNode' is not assignable to type 'ExpressionNode'.
    1506:5 TS2322 Type '{ $loc: Loc; token: "implements"; }' is not assignable to type '"implements"'.
    4408:11 TS2698 Spread types may only be created from object types.
    4678:5 TS2322 Type 'string' is not assignable to type '(string | ASTLeaf | { $loc: Loc; token: any; } | { readonly type: "Comment"; readonly $loc: Loc; readonly token: `/*${string}*/`; })[]'.
    4692:5 TS2322 Type '[]' is not assignable to type '[{ readonly type: "Star"; readonly $loc: Loc; readonly token: "*"; }, "" | (ASTLeaf | CommentNode)[]]'.
    7432:27 TS2339 Property 'type' does not exist on type '{ $loc: Loc; token: string; } | { type: string; children: ("" | ASTString | Children | BlockStatement | BreakStatement | ... 149 more ... | undefined)[]; } | ... 5 more ... | { ...; }'.
    8270:5 TS2322 Type '(ASTLeaf | "<>" | "</>" | { children: [[string | ASTLeaf | undefined, { $loc: Loc; token: any; }, string | ASTLeaf | undefined][], Unwrap<MaybeResult<ASTNode | ... 4 more ... | { ...; }>> | { ...; }][]; jsxChildren: (Unwrap<...> | { ...; })[]; } | undefined)[]' is not assignable to type '[undefined, "<>", { children: [[string | ASTLeaf | undefined, { $loc: Loc; token: any; }, string | ASTLeaf | undefined][], Unwrap<MaybeResult<ASTNode | ... 4 more ... | { ...; }>> | { ...; }][]; jsxChildren: (Unwrap<...> | { ...; })[]; } | undefined, ASTLeaf | undefined, "</>"]'.
    8624:28 TS2339 Property 'type' does not exist on type 'ASTString | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 151 more ... | ASTNode[]'.
    8755:27 TS2769 Argument of type '{ children: [[[string | ASTLeaf | undefined, { $loc: Loc; token: any; }][], { $loc: Loc; token: any; level: number; }], (Unwrap<MaybeResult<ASTNode | (string | { $loc: Loc; token: any; })[] | [...] | { ...; } | { ...; } | { ...; }>> | { ...; })[]][]; jsxChildren: never[]; } | { ...; }' is not assignable to parameter of type 'ConcatArray<Unwrap<MaybeResult<ASTNode | (string | { $loc: Loc; token: any; })[] | [{ $loc: Loc; token: string; }, Unwrap<MaybeResult<LexicalDeclaration | [ASTLeaf | undefined, [...] | undefined, ASTNode]>> | { ...; }, { ...; }] | { ...; } | { ...; } | { ...; }>>>'.
    9281:5 TS2322 Type '["" | (ASTLeaf | CommentNode)[], RegExpMatchArray]' is not assignable to type '["" | (ASTLeaf | CommentNode)[], RegExpMatchArray, true]'.
    9631:5 TS2322 Type 'ASTNode[]' is not assignable to type 'ASTNode[][]'.
    9637:23 TS2339 Property 'children' does not exist on type 'ASTNode[]'.
    9640:42 TS2353 Object literal may only specify known properties, and 'children' does not exist in type 'ASTNode[]'.
    9836:32 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9836:32 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9836:32 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9847:5 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9847:5 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9847:5 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9847:5 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
    9859:5 TS2749 'TypeArguments' refers to a value, but is being used as a type here. Did you mean 'typeof TypeArguments'?
  source/parser/auto-dec.civet
    42:25 TS2339 Property 'token' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    43:25 TS2339 Property 'token' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    49:26 TS2554 Expected 2 arguments, but got 1.
    52:50 TS7006 Parameter '$4' implicitly has an 'any' type.
    127:22 TS2339 Property 'names' does not exist on type 'BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | Declaration | ... 149 more ... | UntypedNode'.
    147:33 TS2339 Property 'token' does not exist on type 'ASTNodeObject'.
    147:44 TS2339 Property 'token' does not exist on type 'ASTNodeObject'.
    148:11 TS2322 Type 'undefined' is not assignable to type 'string'.
    225:26 TS2339 Property 'parent' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
  source/parser/binding.civet
    95:36 TS2339 Property 'ref' does not exist on type 'EmptyBinding | BindingPattern'.
    247:9 TS2339 Property 'blockPrefix' does not exist on type 'ASTNodeObject'.
    248:36 TS2339 Property 'accessModifier' does not exist on type 'ASTNodeObject'.
    278:20 TS2339 Property 'name' does not exist on type 'ASTNodeObject'.
    278:31 TS2339 Property 'name' does not exist on type 'ASTNodeObject'.
    278:45 TS2339 Property 'value' does not exist on type 'ASTNodeObject'.
    305:9 TS2339 Property 'blockPrefix' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 149 more ... | UntypedNode'.
    345:44 TS2339 Property 'typeSuffix' does not exist on type 'EmptyBinding | BindingIdentifier | BindingPattern'.
    373:25 TS2339 Property 'initializer' does not exist on type 'ASTError | AtBindingProperty | BindingProperty | BindingRestProperty | PinProperty'.
  source/parser/block.civet
    145:43 TS2339 Property 'hoistDec' does not exist on type 'ASTNodeObject'.
    147:9 TS2339 Property 'hoistDec' does not exist on type 'ASTNodeObject'.
    148:12 TS2339 Property 'hoistDec' does not exist on type 'ASTNodeObject'.
    154:22 TS2345 Argument of type '(ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; empty?: boolean; implicit?: boolean; ... 5 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 143 more ... | (ASTObject & ... 3 more ... & object)' is not assignable to parameter of type 'BlockStatement'.
    218:17 TS2339 Property 'name' does not exist on type 'ObjectProperty'.
    219:28 TS2339 Property 'name' does not exist on type 'ObjectProperty'.
    219:39 TS2339 Property 'name' does not exist on type 'ObjectProperty'.
    219:56 TS2345 Argument of type 'ObjectProperty' is not assignable to parameter of type '(ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; empty?: boolean; implicit?: boolean; ... 5 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 144 more ... | undefined'.
    223:17 TS2339 Property 'delim' does not exist on type 'ObjectProperty'.
    224:28 TS2339 Property 'delim' does not exist on type 'ObjectProperty'.
    224:46 TS2345 Argument of type 'ObjectProperty' is not assignable to parameter of type '(ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; empty?: boolean; implicit?: boolean; ... 5 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 144 more ... | undefined'.
    225:16 TS2339 Property 'delim' does not exist on type 'ObjectProperty'.
    229:48 TS2339 Property 'name' does not exist on type 'ObjectProperty'.
  source/parser/comptime.civet
    46:37 TS2339 Property 'comptime' does not exist on type '{}'.
    83:48 TS2345 Argument of type 'string | null | undefined' is not assignable to parameter of type 'string'.
  source/parser/comptime.civet.tsx
    350:21 TS2322 Type 'undefined' is not assignable to type 'string'.
  source/parser/declaration.civet
    130:13 TS2339 Property 'names' does not exist on type 'BindingIdentifier | BindingPattern'.
    194:5 TS2322 Type 'ASTNode' is not assignable to type 'Whitespace'.
    241:7 TS2322 Type 'ASTRef | undefined' is not assignable to type 'ASTRef'.
    379:5 TS2339 Property 'ref' does not exist on type 'NonNullable<ASTNode>'.
    379:10 TS2339 Property 'pattern' does not exist on type 'NonNullable<ASTNode>'.
    397:12 TS2339 Property 'negated' does not exist on type 'IfStatement | IterationStatement | SwitchStatement'.
    406:45 TS2339 Property 'expression' does not exist on type 'NonNullable<ASTNode>'.
    414:5 TS2339 Property 'blockPrefix' does not exist on type 'NonNullable<ASTNode>'.
    415:8 TS2339 Property 'negated' does not exist on type 'IfStatement | IterationStatement | SwitchStatement'.
    479:60 TS2339 Property 'hoistDec' does not exist on type 'NonNullable<ASTNode>'.
    482:54 TS2339 Property 'children' does not exist on type 'NonNullable<ASTNode>'.
  source/parser/function.civet
    258:45 TS2339 Property 'returnType' does not exist on type 'FunctionNode'.
    287:46 TS2339 Property 'typeSuffix' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 148 more ... | UntypedNode'.
    302:7 TS2339 Property 'expression' does not exist on type 'ASTNodeObject'.
    349:28 TS2345 Argument of type 'BindingIdentifier | BindingPattern | undefined' is not assignable to parameter of type 'ASTNodeObject'.
    422:16 TS2339 Property 'type' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple[]'.
    424:16 TS2339 Property 'expressions' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple[]'.
    425:29 TS2339 Property 'expressions' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple[]'.
    427:15 TS2339 Property 'expressions' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple[]'.
    434:27 TS2339 Property 'block' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple[]'.
    439:19 TS2339 Property 'type' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple'.
    537:22 TS2339 Property 'parent' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 153 more ... | StatementTuple'.
    607:23 TS2339 Property 'parent' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    608:31 TS2345 Argument of type 'StatementTuple[] | undefined' is not assignable to parameter of type 'Children | ASTNodeObject'.
    625:25 TS2339 Property 'parent' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    626:33 TS2345 Argument of type 'StatementTuple[] | undefined' is not assignable to parameter of type 'Children | ASTNodeObject'.
    934:18 TS2339 Property 'type' does not exist on type 'FunctionParameter'.
    958:11 TS2322 Type 'FunctionParameter' is not assignable to type 'FunctionRestParameter | undefined'.
    962:38 TS2339 Property 'names' does not exist on type 'FunctionParameter'.
    967:36 TS2339 Property 'ref' does not exist on type 'EmptyBinding | BindingIdentifier | BindingPattern'.
    983:31 TS2339 Property 'names' does not exist on type 'FunctionParameter'.
    1159:41 TS2339 Property 'typeSuffix' does not exist on type '(ASTObject & { children: Children; } & { type: "BlockStatement"; expressions: StatementTuple[]; bare: boolean; semicolon?: ";"; empty?: boolean; implicit?: boolean; ... 5 more ...; trailing?: ASTNode[]; } & { ...; } & object) | ... 143 more ... | (ASTObject & ... 3 more ... & object)'.
    1200:33 TS2339 Property 'js' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    1203:7 TS2698 Spread types may only be created from object types.
    1204:31 TS2339 Property 'children' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
  source/parser/lib.civet
    214:13 TS2339 Property 'blockPrefix' does not exist on type 'ForStatement | IfStatement | IterationStatement'.
    536:21 TS2304 Cannot find name 'Binding'.
    998:36 TS7053 Element implicitly has an 'any' type because expression of type '0' can't be used to index type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    1001:21 TS2339 Property 'map' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    1278:65 TS2339 Property 'blockPrefix' does not exist on type 'ASTNodeObject'.
    1279:9 TS2339 Property 'blockPrefix' does not exist on type 'ASTNodeObject'.
    1282:63 TS2339 Property 'blockPrefix' does not exist on type 'ASTNodeObject'.
    1283:7 TS2339 Property 'blockPrefix' does not exist on type 'ASTNodeObject'.
    1323:11 TS2339 Property 'assigned' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 149 more ... | UntypedNode'.
    1542:19 TS2339 Property 'token' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    1596:27 TS2339 Property 'usesRef' does not exist on type 'CallExpression | MemberExpression | { children: (string | Children | BlockStatement | BreakStatement | ... 152 more ... | undefined)[]; usesRef: boolean; parent?: (ASTObject & ... 3 more ... & object) | ... 144 more ... | undefined; type: "CallExpression"; implicit?: boolean; } | { ...; }'.
    1612:22 TS2339 Property 'children' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
  source/parser/lib.civet.tsx
    426:5 TS2322 Type 'undefined' is not assignable to type 'boolean'.
  source/parser/op.civet
    60:14 TS2339 Property 'prec' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | ((ASTLeaf | Keyword | (Partial<ASTLeaf> & { ...; })) & { ...; }) | (ChainOp & { ...; })'.
    61:8 TS2339 Property 'prec' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | ((ASTLeaf | Keyword | (Partial<ASTLeaf> & { ...; })) & { ...; }) | (ChainOp & { ...; })'.
    63:26 TS2339 Property 'prec' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | ((ASTLeaf | Keyword | (Partial<ASTLeaf> & { ...; })) & { ...; }) | (ChainOp & { ...; })'.
    76:9 TS2339 Property 'endsWith' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | (Partial<ASTLeaf> & { special: true; } & { spaced?: boolean; special?: true; ... 8 more ...; suffix?: ASTNode; }) | (ASTObject & ... 2 more ... & { ...; }) | (ChainOp & { ...; })'.
    76:34 TS2339 Property 'endsWith' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | (Partial<ASTLeaf> & { special: true; } & { spaced?: boolean; special?: true; ... 8 more ...; suffix?: ASTNode; }) | (ASTObject & ... 2 more ... & { ...; }) | (ChainOp & { ...; })'.
    77:7 TS2339 Property 'slice' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | (Partial<ASTLeaf> & { special: true; } & { spaced?: boolean; special?: true; ... 8 more ...; suffix?: ASTNode; }) | (ASTObject & ... 2 more ... & { ...; }) | (ChainOp & { ...; })'.
    193:32 TS2339 Property 'token' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
  source/parser/pattern-matching.civet
    210:74 TS2339 Property 'rest' does not exist on type 'ArrayBindingPatternElement'.
    322:62 TS18048 'patternBindings' is possibly 'undefined'.
    379:53 TS2339 Property 'name' does not exist on type 'PinPattern | BindingIdentifier | BindingPattern'.
    380:58 TS2339 Property 'subtype' does not exist on type 'PinPattern | BindingIdentifier | BindingPattern'.
    473:13 TS2339 Property 'value' does not exist on type 'Identifier | BindingProperty | BindingRestElement | BindingRestProperty'.
    482:38 TS2339 Property 'name' does not exist on type 'string | AtBinding | PropertyName'.
    536:13 TS2339 Property 'value' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 148 more ... | UntypedNode'.
    538:20 TS2339 Property 'value' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 148 more ... | UntypedNode'.
    541:7 TS2339 Property 'value' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 148 more ... | UntypedNode'.
    542:14 TS18048 'p.children' is possibly 'undefined'.
    542:25 TS2349 This expression is not callable.
    542:35 TS2339 Property 'name' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 148 more ... | UntypedNode'.
    543:5 TS18048 'p.children' is possibly 'undefined'.
  source/parser/pipe.civet
    51:11 TS2339 Property 'ampersandBlock' does not exist on type '(string & { name?: never; spaced?: never; special?: never; relational?: never; assoc?: never; type?: undefined; }) | ASTLeaf | Keyword | (ASTLeaf & { spaced?: boolean; ... 9 more ...; suffix?: ASTNode; }) | ... 153 more ... | (ASTObject & ... 1 more ... & { ...; })'.
    108:18 TS2339 Property 'token' does not exist on type 'NonNullable<ASTNode>'.
  source/parser/util.civet
    39:60 TS2749 'b' refers to a value, but is being used as a type here. Did you mean 'typeof b'?
    260:5 TS2322 Type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode' is not assignable to type '(ASTLeaf & { token: ","; }) | undefined'.
    261:44 TS2339 Property 'token' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    262:5 TS2322 Type 'ASTNode' is not assignable to type '(ASTLeaf & { token: ","; }) | undefined'.
    266:24 TS18048 'last' is possibly 'undefined'.
    266:29 TS2339 Property 'implicit' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    442:5 TS2454 Variable 't' is used before being assigned.
    443:16 TS2454 Variable 't' is used before being assigned.
    517:37 TS2339 Property 'token' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
    679:37 TS2339 Property 'token' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 150 more ... | UntypedNode'.
    680:37 TS2339 Property 'parenthesized' does not exist on type 'BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | DebuggerStatement | ... 150 more ... | UntypedNode'.
    681:41 TS2345 Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
    815:40 TS18048 'type' is possibly 'undefined'.
    815:40 TS2345 Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
    936:76 TS2339 Property 'parent' does not exist on type 'ASTString | Children | BlockStatement | BreakStatement | ComptimeStatement | ContinueStatement | ... 152 more ... | UntypedNode'.
```

## First commit: uncontroversial

The first commit focuses on changes that are mostly type annotations.

Summary of scripts/typecheck-diff.civet (comparing to main branch):
```
Old: 684 diagnostics  →  New: 664 diagnostics
Net: -20
Deduped 2 noise pairs (code-class reshuffles, union reordering, target-type rewrites).
Regressions: 13
Fixed: 33
```

The "regressions" are actually just type errors uncovered by these fixes.

## Second commit: more controversial

The second commit fixes type errors by using the `in` operator and `is like {...}` in a few places.

### `in`

E.g.
```diff
- if s.negated
+ if "negated" in s and s.negated
```

I'm not sure how we feel about sprinkling the `in` operator through the codebase. They are both unnecessary at runtime and they reduce the clarity of the code's intentions.

AFAIU, TypeScript doesn't have a way to just turn off type errors caused by accessing properties the type doesn't know about, even though at runtime it's totally fine. I assume the plan is to improve the AST types so that these checks wouldn't be necessary for the type checker. In the meantime, do we use `in` where necessary for the type checker or do we focus on improving the AST?

### `is like {...}`

`is like {...}` can allow for far more concise and clear code but under the hood it almost always performs unnecessary work. I don't have a sense of the performance implications of that, though.
