### PR TITLE
Literal patterns only in pattern matching: `1 := y` is now a parse error

### DIFF
--- a/source/main.civet
+++ b/source/main.civet
@@ -84,6 +84,10 @@ uncacheable := new Set [
   "RestoreInlineObjectLiteral"
   "RestoreSnugTernaryThen"
 
+  "EnableMatchPattern"
+  "DisableMatchPattern"
+  "RestoreMatchPattern"
+
 ]
 
 export type CompilerOptions

--- a/source/main.civet
+++ b/source/main.civet
@@ -135,7 +135,10 @@ export function decode(src: string | Buffer): string
   else
     src.toString 'utf8'
 
-export function compile<const T extends CompilerOptions>(src: string | Buffer, options?: T): T extends { sync: true } ? CompileOutput<T> : Promise<CompileOutput<T>>
+/** compile's return type: synchronous output when `sync: true`, otherwise a promise of it. */
+export type CompileResult<T extends CompilerOptions> = T extends { sync: true } ? CompileOutput<T> : Promise<CompileOutput<T>>
+
+export function compile<const T extends CompilerOptions>(src: string | Buffer, options?: T): CompileResult<T>
   src = decode src
 
   // `CIVET_THREADS=0` (including in browser build) forces no threads
@@ -272,10 +275,8 @@ export function compile<const T extends CompilerOptions>(src: string | Buffer, o
 
     return result
 
-  if ast.then?
-    ast.then rest
-  else
-    rest ast
+  // TypeScript can't relate the runtime branch to the deferred conditional type.
+  (if ast <? Promise then ast.then rest else rest ast) as CompileResult<T>
 
 type CacheKey = [string, number, number, string]
 

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -3701,7 +3701,7 @@ BlockStatementPart
 
 # https://262.ecma-international.org/#prod-Literal
 Literal
-  /(?=[0-9.'"tfyno])/ LiteralContent:literal ::Literal ->
+  /(?=[0-9.'"tfyno])/ LiteralContent:literal ::LiteralType ->
     return {
       type: "Literal",
       subtype: literal.type,
@@ -7519,7 +7519,7 @@ CoffeeDoubleQuotedStringCharacters
     return { $loc, token: $0 }
 
 # https://262.ecma-international.org/#prod-RegularExpressionLiteral
-RegularExpressionLiteral
+RegularExpressionLiteral ::RegularExpressionLiteralType
   HeregexLiteral
   $("/" RegularExpressionBody "/" RegularExpressionFlags):raw ->
     return {

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -118,7 +118,9 @@ import type {
   ComptimeStatement,
   ComputedPropertyName as ComputedPropertyNameType,
   Condition,
+  ConditionFragment,
   ConstructedExportSpecifier,
+  ContinueStatement,
   DebuggerStatement,
   Declaration,
   DeclarationCondition as DeclarationConditionType,
@@ -127,6 +129,7 @@ import type {
   DoStatement,
   ElisionElement,
   ElseClause,
+  EmptyBinding,
   EmptyCondition,
   EmptyStatement,
   EnumBlock,
@@ -162,6 +165,7 @@ import type {
   LabelledStatement,
   LexicalDeclaration,
   Literal as LiteralType,
+  LiteralPattern as LiteralPatternType,
   MemberExpression as MemberExpressionType,
   MethodDefinition,
   MethodSignature,
@@ -257,6 +261,8 @@ interface ParserState
   forbidPipeline: boolean[]
   forbidColonArgument: boolean[]
   forbidInlineObjectLiteral: boolean[]
+  /** Inside a pattern-matching PatternExpression: literals are patterns. */
+  matchPattern: boolean[]
   JSXTagStack: unknown[]
   indentLevels: { level: number, token?: string }[]
   operators: Map<string, OperatorBehavior?>
@@ -277,6 +283,7 @@ interface ParserState
   readonly pipelineForbidden: number
   readonly colonArgumentForbidden: number
   readonly inlineObjectLiteralForbidden: number
+  readonly matchPatternEnabled: number
   readonly currentJSXTag: unknown
 
 export const state = {    // parser state
@@ -291,6 +298,7 @@ export const state = {    // parser state
   forbidPipeline: [false],
   forbidColonArgument: [false],
   forbidInlineObjectLiteral: [false],
+  matchPattern: [false],
   JSXTagStack: [undefined],
 } as! ParserState
 
@@ -356,6 +364,11 @@ Object.defineProperties(state, {
       {forbidInlineObjectLiteral: s} := state
       s[s#-1]
   },
+  matchPatternEnabled: {
+    get()
+      {matchPattern: s} := state
+      s[s#-1]
+  },
   currentJSXTag: {
     get()
       {JSXTagStack: s} := state
@@ -377,7 +390,8 @@ function setOperatorBehavior(name: string, behavior: OperatorBehavior?)
 
 export function getStateKey()
   stateInt :=
-    ((state.currentIndent.level % 256) << 11) |
+    ((state.currentIndent.level % 256) << 12) |
+    (state.matchPatternEnabled << 11) |
     (state.classImplicitCallForbidden << 10) |
     (state.indentedApplicationForbidden << 9) |
     (state.bracedApplicationForbidden << 8) |
@@ -2595,6 +2609,7 @@ PinPattern ::PinPattern
       children: [expression],
       expression: expression as Identifier,
       typeSuffix: typeSuffixForExpression(expression),
+      names: [],
     }
   Caret SingleLineExpressionWithIndentedApplicationForbidden:expression ->
     return {
@@ -2602,6 +2617,7 @@ PinPattern ::PinPattern
       children: [expression],
       expression,
       typeSuffix: typeSuffixForExpression(expression),
+      names: [],
     }
   ActualMemberExpression:expression ->
     return {
@@ -2609,6 +2625,7 @@ PinPattern ::PinPattern
       children: [expression],
       expression,
       typeSuffix: typeSuffixForExpression(expression),
+      names: [],
     }
   # Handle unary numeric in switch patterns
   ([+-] NumericLiteral):expression ->
@@ -2617,6 +2634,7 @@ PinPattern ::PinPattern
       children: [expression],
       expression: expression as ASTNode,
       typeSuffix: typeSuffixForExpression(expression as ASTNode),
+      names: [],
     }
   # Handle undefined in switch patterns
   Undefined:expression ->
@@ -2625,12 +2643,13 @@ PinPattern ::PinPattern
       children: [expression],
       expression,
       typeSuffix: typeSuffixForExpression(expression),
+      names: [],
     }
 
 # `name^ pattern` means bind the whole thing to `name`,
 # but also destructure/match `pattern`
 NamedBindingPattern
-  BindingIdentifier:binding Caret _?:ws BindingPattern:pattern ::NamedBindingPattern ->
+  BindingIdentifier:binding Caret _?:ws ( BindingPattern / LiteralPattern ):pattern ::NamedBindingPattern ->
     pattern = prepend(ws, pattern)
     return {
       type: "NamedBindingPattern",
@@ -2640,6 +2659,7 @@ NamedBindingPattern
       pattern,
       subbinding: [pattern, " = ", binding],
       typeSuffix: pattern.typeSuffix,
+      names: [...namesOf(binding), ...namesOf(pattern)],
     }
 
 # https://262.ecma-international.org/#prod-BindingPattern
@@ -2647,9 +2667,30 @@ BindingPattern
   ObjectBindingPattern
   ArrayBindingPattern
   PinPattern
-  Literal
-  RegularExpressionLiteral
   NamedBindingPattern
+
+# Literals only match in pattern matching (`switch` cases), where
+# PatternExpression enables them for the whole, possibly nested, pattern.
+LiteralPattern ::LiteralPatternType
+  MatchPatternEnabled ( Literal / RegularExpressionLiteral ) -> $2
+
+MatchPatternEnabled
+  "" ->
+    return $skip unless state.matchPatternEnabled
+
+EnableMatchPattern
+  "" ->
+    state.matchPattern.push(true);
+
+# Expressions (initializers, right-hand sides) never see match mode, even
+# when nested inside a pattern.
+DisableMatchPattern
+  "" ->
+    state.matchPattern.push(false);
+
+RestoreMatchPattern
+  "" ->
+    state.matchPattern.pop();
 
 # https://262.ecma-international.org/#prod-ObjectBindingPattern
 # NOTE: Simplified from spec
@@ -2751,7 +2792,7 @@ BindingProperty
 
   # NOTE: Allow ::T type suffix before value
   # NOTE: name^ means we should bind name despite having a value
-  _?:ws1 PropertyName:name QuestionMarkTypeSuffix?:optional Caret?:bind _?:ws2 Colon:colon _?:ws3 ( BindingPattern / BindingIdentifier ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _?:ws1 PropertyName:name QuestionMarkTypeSuffix?:optional Caret?:bind _?:ws2 Colon:colon _?:ws3 ( BindingPattern / LiteralPattern / BindingIdentifier ):value BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     if optional // merge into typeSuffix
       if typeSuffix and not typeSuffix.optional
         typeSuffix = {
@@ -2763,6 +2804,8 @@ BindingProperty
         typeSuffix ?= optional
     // Convert `name^: pattern` into `name: name^pattern`
     if bind
+      // Literal keys can't double as bindings
+      return $skip if name is like {type: "StringLiteral"}, {type: "NumericLiteral"}
       // For unicode `name`, PropertyName rewrote it to render as `"src"`.
       // The binding side (collapsed shorthand on LHS, subbinding `= name`
       // on RHS) needs the mangled JS identifier — `name.identifier`.
@@ -2776,7 +2819,7 @@ BindingProperty
         pattern,
         subbinding: [pattern, " = ", binding],
         typeSuffix: pattern.typeSuffix,
-        names: value.names,
+        names: [...namesOf(binding), ...namesOf(pattern)],
       }
     return {
       type: "BindingProperty",
@@ -2785,7 +2828,7 @@ BindingProperty
       value,
       typeSuffix,
       initializer,
-      names: value.names,
+      names: namesOf(value),
     }
 
   # NOTE: ^name is short for property `name: ^name`
@@ -2899,10 +2942,10 @@ BindingElement
   BindingRestElement
 
   # NOTE: Merged in SingleNameBinding
-  _?:ws ( BindingPattern / BindingIdentifier ):binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
+  _?:ws ( BindingPattern / LiteralPattern / BindingIdentifier ):binding BindingTypeSuffix?:typeSuffix Initializer?:initializer ->
     return {
       type: "BindingElement",
-      names: binding.names,
+      names: namesOf(binding),
       typeSuffix,
       binding,
       children: [ws, binding, initializer],
@@ -2926,7 +2969,7 @@ BindingRestElement ::BindingRestElement
       dots,
       binding,
       typeSuffix,
-      name: binding.name,
+      name: "name" in binding ? binding.name : undefined,
       names: binding.names,
       rest: true,
     }
@@ -2937,13 +2980,13 @@ BindingRestElement ::BindingRestElement
       children: [...(ws || []), dots, binding],
       dots,
       binding,
-      name: binding.name,
+      name: "name" in binding ? binding.name : undefined,
       names: binding.names,
       rest: true,
     }
 
 # NOTE: Allows for empty binding rest pattern like in CoffeeScript
-EmptyBindingPattern
+EmptyBindingPattern ::EmptyBinding
   "" ->
     ref := makeRef()
     return {
@@ -3205,17 +3248,16 @@ OperatorPrecedence ::OperatorBehavior
   # inspired by https://docs.raku.org/language/functions#Precedence
   _? ( "tighter" / "looser" / "same" ):mod NonIdContinue _? ( Identifier / ( OpenParen BinaryOp CloseParen ) ):op ->
     let prec: number, error: ASTError?
-    if op.type is "Identifier"
-      if state.operators.has(op.name)
-        prec = state.operators.get(op.name)?.prec ?? precedenceCustomDefault
-      else
-        prec = precedenceCustomDefault
-        error = {
-          type: "Error",
-          message: `Precedence refers to unknown operator ${op.name}`,
-        }
+    if Array.isArray op // parenthesized operator
+      prec = getPrecedence(op[1])
+    else if state.operators.has(op.name)
+      prec = state.operators.get(op.name)?.prec ?? precedenceCustomDefault
     else
-      prec = getPrecedence((op as any)[1])
+      prec = precedenceCustomDefault
+      error = {
+        type: "Error",
+        message: `Precedence refers to unknown operator ${op.name}`,
+      }
 
     switch mod
       case "tighter":
@@ -4657,7 +4699,7 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
         if lastAccess
           ({ name } = lastAccess)
 
-      if not name then ({ name } = base!)
+      name = base.name if not name and base is like {type: "Identifier"}
       return $skip unless name
 
       // Skip autoReturn for identifiers with an explicit block like `get foo { true }`
@@ -6050,8 +6092,10 @@ PatternExpressionList
     return [first, ...rest.map(([, , , p]) => p)]
 
 PatternExpression
-  BindingPattern
-  ForbidIndentedApplication ( ( BindingIdentifier Caret? )? SingleLineBinaryOpRHS+ )?:body RestoreIndentedApplication ->
+  EnableMatchPattern ( BindingPattern / LiteralPattern )?:pattern RestoreMatchPattern ->
+    return $skip unless pattern
+    return pattern
+  ForbidIndentedApplication ( ( BindingIdentifier Caret? )? SingleLineBinaryOpRHS+ )?:body RestoreIndentedApplication ::ConditionFragment ->
     return $skip unless body
     [ named, rhs ] := body
     let binding
@@ -6216,7 +6260,8 @@ BoundedCondition
     }
 
 DeclarationCondition ::DeclarationConditionType
-  ForbidBracedApplication ForbidIndentedApplication ForbidNewlineBinaryOp LexicalDeclaration?:declaration RestoreNewlineBinaryOp RestoreBracedApplication RestoreIndentedApplication ->
+  # Declaration conditions pattern match, so literal patterns are enabled.
+  ForbidBracedApplication ForbidIndentedApplication ForbidNewlineBinaryOp EnableMatchPattern LexicalDeclaration?:declaration RestoreMatchPattern RestoreNewlineBinaryOp RestoreBracedApplication RestoreIndentedApplication ->
     return $skip unless declaration
 
     return {
@@ -6497,11 +6542,13 @@ KeywordStatement
     }
 
   # NOTE: `continue switch` for fallthrough
-  Continue _ Switch ->
+  Continue _ Switch ::ContinueStatement ->
     return {
       type: "ContinueStatement",
       special: $3.token,
       children: [],
+      with: undefined,
+      label: undefined,
     }
 
   # https://262.ecma-international.org/#prod-ContinueStatement
@@ -7229,12 +7276,14 @@ LexicalDeclaration ::LexicalDeclaration
   # NOTE: Added const/let shorthands
   # NOTE: Using Expression to allow for If/SwitchExpressions
   # NOTE: Using PostfixExpression to allow postfix if/unless/for
-  Loc:loc ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix NotDedented:ws ( ConstAssignment / LetAssignment ):assign MaybeNestedPostfixedExpressionOrCommaLoop:e ->
+  Loc:loc ( BindingPattern / BindingIdentifier ):pattern TypeSuffix?:typeSuffix NotDedented:ws ( ConstAssignment / LetAssignment ):assign DisableMatchPattern MaybeNestedPostfixedExpressionOrCommaLoop?:e RestoreMatchPattern ->
+    return $skip unless e
     return processAssignmentDeclaration
       { loc.$loc, token: assign.decl } // like InsertConst or InsertLet
       pattern, typeSuffix, ws, assign, e
   # Backward const/let shorthands: `y =: x` -> `const x = y`
-  Loc:loc PostfixedExpressionOrCommaLoop:e NotDedented:ws ( BackwardConstAssignment / BackwardLetAssignment ):assign NotDedented:bindingWs ( BindingPattern / BackwardBindingIdentifier / BindingIdentifier ):pattern TypeSuffix?:typeSuffix ->
+  Loc:loc DisableMatchPattern PostfixedExpressionOrCommaLoop?:e RestoreMatchPattern NotDedented:ws ( BackwardConstAssignment / BackwardLetAssignment ):assign NotDedented:bindingWs ( BindingPattern / BackwardBindingIdentifier / BindingIdentifier ):pattern TypeSuffix?:typeSuffix ->
+    return $skip unless e
     return processAssignmentDeclaration
       { loc.$loc, token: assign.decl } // like InsertConst or InsertLet
       prepend trimFirstSpace(bindingWs), pattern
@@ -7299,11 +7348,13 @@ LexicalBinding ::Binding
 
 # https://262.ecma-international.org/#prod-Initializer
 Initializer ::Initializer
-  __ Equals MaybeNestedPostfixedExpression:expression -> {
-    type: "Initializer",
-    expression,
-    children: $0,
-  }
+  __:ws Equals:eq DisableMatchPattern MaybeNestedPostfixedExpression?:expression RestoreMatchPattern ->
+    return $skip unless expression
+    return {
+      type: "Initializer",
+      expression,
+      children: [ws, eq, expression],
+    }
 
 # https://262.ecma-international.org/#prod-VariableStatement
 VariableStatement ::Declaration
@@ -10315,6 +10366,7 @@ Reset
     state.forbidPipeline = [false]
     state.forbidColonArgument = [false]
     state.forbidInlineObjectLiteral = [false]
+    state.matchPattern = [false]
     state.JSXTagStack = [undefined]
 
     state.operators = new Map

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -45,6 +45,7 @@ import {
   makeAmpersandFunction,
   makeExpressionStatement,
   makeGetterMethod,
+  makeAssignment,
   makeLeftHandSideExpression,
   makeRef,
   maybeRef,
@@ -5739,15 +5740,9 @@ CoffeeForStatementParameters ::ForStatementControl
 
       // index is actually value in Coffee "for of", y = z[x]
       if index
-        rhs := [exp, "[", declarationExp, "]"]
-        blockPrefix./**/push(["", {
-          type: "AssignmentExpression",
-          children: [index, " = ", rhs],
-          names: index.names,
-          lhs: [],
-          assigned: index,
-          expression: rhs,
-        }, ";"])
+        blockPrefix./**/push(["",
+          makeAssignment(index, [exp, "[", declarationExp, "]"], { names: index.names }),
+        ";"])
 
       kind.token = "in"
     else if kind.token is "in" // CoffeeScript loop comprehensions
@@ -5784,15 +5779,9 @@ CoffeeForStatementParameters ::ForStatementControl
         pushForBlockDeclaration blockPrefix, varRef,
           [expRef, "[", indexAssignment, counterRef, "]"], true
       else
-        rhs := [expRef, "[", indexAssignment, counterRef, "]"]
-        blockPrefix./**/push(["", {
-          type: "AssignmentExpression",
-          children: [varRef, " = ", rhs],
-          names: assignmentNames,
-          lhs: [],
-          assigned: varRef,
-          expression: rhs,
-        }, ";"])
+        blockPrefix./**/push(["",
+          makeAssignment(varRef, [expRef, "[", indexAssignment, counterRef, "]"], { names: assignmentNames }),
+        ";"])
 
       // The for-head Declaration (`let i = 0, len = arr.length` or, for a
       // literal negative step, `let i = arr.length - 1`). Distinct from the

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -2463,7 +2463,7 @@ ParameterList
 NestedParameterList
   PushIndent NestedParameter*:params PopIndent ->
     return $skip unless params#
-    return params
+    return params.flat()
 
 NestedParameter
   # Allow one or more parameters on one line

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -120,7 +120,9 @@ import type {
   ElseClause,
   EmptyCondition,
   EmptyStatement,
+  EnumBlock,
   EnumDeclaration,
+  EnumProperty,
   ExpressionNode,
   Extends,
   CoffeeForBindingAssignment,
@@ -140,6 +142,7 @@ import type {
   Initializer,
   InterfaceDeclaration,
   ImportDeclaration,
+  ImportAssertion,
   ImportClause,
   Index,
   IterationExpression,
@@ -152,6 +155,7 @@ import type {
   LexicalDeclaration,
   MethodDefinition,
   MethodSignature,
+  ModuleSpecifier,
   MultiMethodDefinition,
   NamedBindingPattern,
   NamedImportElement,
@@ -2379,7 +2383,7 @@ AfterReturnShorthand
 # The parameters in a function definition
 Parameters
   NonEmptyParameters
-  TypeParameters?:tp Loc:p ->
+  TypeParameters?:tp Loc:p ::ParsedParameters ->
     parameters: FunctionParameter[] := []
     return {
       type: "Parameters",
@@ -2392,10 +2396,10 @@ Parameters
 
 # Allow for [a, b] => ... or {a, b} -> ...
 ShortArrowParameters
-  ( ObjectBindingPattern / ArrayBindingPattern ):binding ->
+  ( ObjectBindingPattern / ArrayBindingPattern ):binding ::ParsedParameters ->
     // Based on ParameterElement
     { typeSuffix } := binding
-    parameter := {
+    parameter: Parameter := {
       type: "Parameter"
       children: [ binding, typeSuffix ]
       names: binding.names
@@ -2410,8 +2414,8 @@ ShortArrowParameters
 
 # In esArrowFunction mode, allow single bare identifier as arrow parameter (ES-style: x => ...)
 ESArrowIdentifierParameters
-  ESArrowFunctionEnabled Identifier:id ->
-    parameter := {
+  ESArrowFunctionEnabled Identifier:id ::ParsedParameters ->
+    parameter: Parameter := {
       type: "Parameter"
       children: [id]
       id.names
@@ -2441,7 +2445,7 @@ ThinArrowParameters
   Parameters
 
 NonEmptyParameters
-  TypeParameters?:tp OpenParen:open ParameterList:parameters ( __ CloseParen ):close ::ParametersNode ->
+  TypeParameters?:tp OpenParen:open ParameterList:parameters ( __ CloseParen ):close ::ParsedParameters ->
     return {
       type: "Parameters",
       children: [ tp, open, parameters, close ],
@@ -2471,7 +2475,7 @@ NestedParameter
     // Attach whitespace to first parameter
     params = [...params]
     params[0] = prepend(ws, params[0])
-    return params
+    return params.flat()
 
 Parameter
   ThisType ::ThisType
@@ -3097,7 +3101,8 @@ FunctionExpression
 OperatorDeclaration ::OperatorDeclaration
   # `operator {x, y} := ...` declaration while blessing
   Operator OperatorBehavior?:behavior _:w Loc:loc LexicalDeclaration:decl ->
-    unless Array.isArray decl.names
+    // Pin patterns (`operator x.y := …`) and literals declare no names.
+    unless decl.names#
       return {}
         type: "Error"
         message: "Operator declaration must declare identifiers"
@@ -3977,7 +3982,7 @@ ArrayElementExpression
       type: "SpreadElement",
       children: [ws, dots, exp],
       expression: exp,
-      names: exp.names,
+      names: namesOf(exp),
     }
 
   # NOTE: Using PostfixedExpression, a superset of Expression to allow If/Switch expressions
@@ -3991,14 +3996,14 @@ ArrayElementExpression
           type: "ArrayElement",
           children: [exp],
           expression: exp,
-          names: exp!.names,
+          names: namesOf(exp),
         }
       else
         return {
           type: "SpreadElement",
           children: [...spread, exp],
           expression: exp,
-          names: exp!.names,
+          names: namesOf(exp),
         }
 
     return {
@@ -4303,7 +4308,7 @@ PropertyDefinition
     return {
       type: "SpreadProperty",
       children,
-      names: exp.names,
+      names: namesOf(exp),
       dots,
       value: exp,
     }
@@ -4361,7 +4366,7 @@ PropertyDefinition
     return {
       type: "SpreadProperty",
       children: [ws, dots, exp],
-      names: exp.names,
+      names: namesOf(exp),
       dots,
       value: exp,
     }
@@ -4440,7 +4445,7 @@ PropertyDefinition
       return {
         type: "SpreadProperty",
         children: [ws, dots, paren],
-        names: value!.names,
+        names: namesOf(value),
         dots,
         value: paren,
       }
@@ -4468,7 +4473,7 @@ PropertyDefinition
 
 NamedProperty
   # NOTE: Optional named property { y?: value } → { ...(value != null ? {y: value} : {}) }
-  PropertyName:name "?" _? Colon _? PostfixedExpression:exp ->
+  PropertyName:name "?" _? Colon _? PostfixedExpression:exp ::SpreadProperty ->
     { ref, refAssignment } := maybeRefAssignment(exp)
     checkExp := refAssignment ? parenthesizeExpression(refAssignment) : exp
     dots := { $loc, token: "..." }
@@ -4483,7 +4488,7 @@ NamedProperty
     }
   # NOTE: CoverInitializedName early error doesn't seem necessary with this parser
   # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
-  PropertyName:name _? Colon PostfixedExpression:exp ->
+  PropertyName:name _? Colon PostfixedExpression:exp ::Property ->
     return {
       type: "Property",
       children: $0,
@@ -4496,7 +4501,7 @@ NamedProperty
 # used to distinguish between braceless inline objects and ternary expression conditions
 # Allow postfixed expression only if this first property isn't the last
 SnugNamedProperty
-  PropertyName:name Colon:colon MaybeNestedExpression:expression ( ( _? PostfixStatement ) &( Nested NamedProperty ) )?:post ->
+  PropertyName:name Colon:colon MaybeNestedExpression:expression ( ( _? PostfixStatement ) &( Nested NamedProperty ) )?:post ::Property ->
     if post
       // post[0] drops the lookahead assertion
       expression = attachPostfixStatementAsExpression(expression, post[0])
@@ -4505,6 +4510,7 @@ SnugNamedProperty
       children: [name, colon, expression],
       name,
       names: namesOf(expression),
+      value: expression,
     }
 
 PropertyName
@@ -6808,7 +6814,7 @@ FromClause ::FromClause
 # https://github.com/tc39/proposal-import-attributes
 # https://devblogs.microsoft.com/typescript/announcing-typescript-5-3/#import-attributes
 # NOTE: Forbid newline before `with` which could mean a function call
-ImportAssertion
+ImportAssertion ::ImportAssertion
   _? ( "with" / "assert" ):keyword NonIdContinue _? ObjectLiteral:object ->
     return {
       type: "ImportAssertion",
@@ -6919,7 +6925,7 @@ ModuleExportName
   IdentifierName
 
 # https://262.ecma-international.org/#prod-ModuleSpecifier
-ModuleSpecifier
+ModuleSpecifier ::ModuleSpecifier
   UnprocessedModuleSpecifier:module ImportAssertion?:assertion ->
     module = rewriteModuleSpecifier(module)
 
@@ -9228,7 +9234,7 @@ EnumDeclaration ::EnumDeclaration
       }]
     }
 
-EnumBlock
+EnumBlock ::EnumBlock
   __ OpenBrace NestedEnumProperties:props __ CloseBrace ->
     return {
       properties: props.properties,
@@ -9261,7 +9267,7 @@ NestedEnumPropertyLine
       children: pair,
     }))
 
-EnumProperty
+EnumProperty ::EnumProperty
   Identifier:name ( __ Equals MaybeNestedExpression )?:initializer ObjectPropertyDelimiter ->
     return {
       type: "EnumProperty",
@@ -9797,7 +9803,8 @@ TypeFunction
   # NOTE: Forbid declaration operators after return type to avoid treating `f: (x: T) => y := z`
   # as a typed const; prefer implicit object/arrow function interpretation.
   ( Abstract _? )?:abstract ( Async _? )?:async ( New _? )?:new_ Parameters __ TypeFunctionArrow ( ReturnType / Loc ):returnType !TrailingDeclaration ::TypeFunction ->
-    children := [ abstract, ...$0.slice(2, -1) ] // omit async and trailing lookahead
+    // omit async (wrapped into the return type below) and trailing lookahead
+    children: Children := [ abstract, new_, $4, $5, $6, returnType ]
     if abstract and not new_
       children[1] = {
         type: "Error",

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -86,11 +86,12 @@ import {
   wrapTypeInPromise,
 } from "./parser/lib.civet"
 import type {
+  AccessStart as AccessStartType,
   AccessStart,
   Argument,
-  ArrayExpression,
   ArrayBindingPattern,
   ArrayBindingPatternContent as ArrayBindingPatternContentType,
+  ArrayExpression,
   ArrowFunction,
   AssignmentExpression,
   ASTError,
@@ -104,19 +105,27 @@ import type {
   Binding,
   BindingIdentifier,
   BindingRestElement,
+  BindingRestProperty as BindingRestPropertyType,
   BlockStatement,
+  Call,
+  CallExpression as CallExpressionType,
   CaseBlock,
   CaseClause,
   Children,
+  CoffeeForBindingAssignment,
+  CoffeeForDeclaration as CoffeeForDeclarationType,
   CommentNode,
   ComptimeStatement,
+  ComputedPropertyName as ComputedPropertyNameType,
   Condition,
   ConstructedExportSpecifier,
-  Declaration,
-  DeclarationKind,
   DebuggerStatement,
+  Declaration,
+  DeclarationCondition as DeclarationConditionType,
+  DeclarationKind,
   DefaultClause,
   DoStatement,
+  ElisionElement,
   ElseClause,
   EmptyCondition,
   EmptyStatement,
@@ -125,13 +134,12 @@ import type {
   EnumProperty,
   ExpressionNode,
   Extends,
-  CoffeeForBindingAssignment,
-  CoffeeForDeclaration as CoffeeForDeclarationType,
-  ForReduction,
+  FinallyClause as FinallyClauseType,
   ForControlDeclaration,
   ForDeclaration,
-  ForStatementControl,
+  ForReduction,
   ForStatement,
+  ForStatementControl,
   FromClause,
   FunctionExpression,
   FunctionParameter,
@@ -139,12 +147,12 @@ import type {
   FunctionSignature,
   Identifier,
   IfStatement,
-  Initializer,
-  InterfaceDeclaration,
-  ImportDeclaration,
   ImportAssertion,
   ImportClause,
+  ImportDeclaration,
   Index,
+  Initializer,
+  InterfaceDeclaration,
   IterationExpression,
   IterationFamily,
   IterationStatement,
@@ -153,16 +161,20 @@ import type {
   Label,
   LabelledStatement,
   LexicalDeclaration,
+  Literal as LiteralType,
+  MemberExpression as MemberExpressionType,
   MethodDefinition,
   MethodSignature,
   ModuleSpecifier,
   MultiMethodDefinition,
   NamedBindingPattern,
-  NamedImportElement,
   NamedExports,
+  NamedImportElement,
   NamespaceDeclaration,
+  NegativeIndex,
   NonNullAssertion,
   NonNullASTNode,
+  NumericLiteral as NumericLiteralType,
   ObjectBindingPattern,
   ObjectExpression,
   ObjectProperty,
@@ -171,41 +183,55 @@ import type {
   OperatorImportClause,
   OperatorImportSpecifier,
   OperatorSignature,
+  Optional,
   Parameter,
   ParametersNode as ParsedParameters,
   ParenthesizedExpression,
   PatternClause,
   PinPattern,
+  PipelineExpression as PipelineExpressionType,
   Property,
+  PropertyAccess as PropertyAccessType,
+  PropertyBind as PropertyBindType,
+  PropertyGlob as PropertyGlobType,
+  PropertyName as PropertyNameType,
   RangeEnd,
+  RangeExpression as RangeExpressionType,
   RangeExpression,
+  RegularExpressionLiteral as RegularExpressionLiteralType,
   ReturnTypeAnnotation,
   ReturnValue,
+  SliceExpression,
+  SpreadElement,
   SpreadProperty,
   StatementExpression,
   StatementTuple,
+  StringLiteral as StringLiteralType,
+  Substitution,
   SwitchStatement,
+  TemplateLiteral as TemplateLiteralType,
+  ThisAssignments,
   ThisType,
   ThrowStatement,
   TryStatement,
-  ThisAssignments,
-  TypeConditional,
+  TypeArgument,
+  TypeArgumentList,
+  TypeArguments as TypeArgumentsType,
   TypeCondition,
+  TypeConditional,
   TypeDeclaration,
   TypeDeclarationBinding,
-  TypeArgument,
-  TypeArguments as TypeArgumentsType,
-  TypeArgumentList,
   TypeFunction,
   TypeLexicalDeclaration,
   TypeNode,
   TypeParameters,
   TypeSuffix,
   TypeTuple,
+  UntypedNode,
   VoidType,
   WhenClause,
-  WSArray,
   WithClause,
+  WSArray,
   Yield,
   YieldExpression,
 } from "./parser/types.civet"
@@ -469,7 +495,7 @@ SingleLineExpression
 NonPipelineExpression
   NonPipelineAssignmentExpression ::ExpressionNode
 
-NestedExpressionizedStatement
+NestedExpressionizedStatement ::CallExpressionType
   # Allow trailing call expressions at two levels:
   # within the indentation and outside
   &EOS PushIndent ( Nested ExpressionizedStatementWithTrailingCallExpressions )?:expression PopIndent AllowedTrailingCallExpressions?:trailing ->
@@ -534,21 +560,21 @@ CommaExpressionSpread
     return $0
 
 AssignmentExpressionSpread
-  _? DotDotDot AssignmentExpression:expression ->
+  _? DotDotDot AssignmentExpression:expression ::SpreadElement ->
     return {
       type: "SpreadElement",
       children: $0,
       expression,
       names: namesOf(expression),
     }
-  AssignmentExpression:expression ( _? DotDotDot )? ->
-    return $1 unless $2
+  AssignmentExpression:expression _? DotDotDot ::SpreadElement ->
     return {
       type: "SpreadElement",
-      children: [ ...$2, $1 ],
+      children: [ $2, $3, expression ],
       expression,
       names: namesOf(expression),
     }
+  AssignmentExpression
   _? DotDotDot AssignmentExpression:expression ->
     return {
       type: "SpreadElement",
@@ -578,7 +604,7 @@ Arguments
     return args if args
     return $skip
 
-ImplicitArguments
+ImplicitArguments ::Call
   ApplicationStart InsertOpenParen:open Trimmed_?:ws ForbidNestedBinaryOp ForbidPipeline ArgumentList?:args RestorePipeline RestoreNestedBinaryOp InsertCloseParen:close ->
     return $skip unless args
     // Don't treat as call if this is a postfix for/while/until/if/unless
@@ -590,7 +616,7 @@ ImplicitArguments
       children: [open, ws, args, close]
     }
 
-ExplicitArguments
+ExplicitArguments ::Call
   OpenParen:open AllowAll ( PostfixedArgumentList ( __ Comma )? )?:args __:ws RestoreAll CloseParen:close ->
     if args
       if args[1] // trailing comma
@@ -643,7 +669,7 @@ ForbiddenImplicitCalls
 ReservedBinary
   /(as|of|by|satisfies|then|when|implements|xor|xnor)(?!\p{ID_Continue}|[\u200C\u200D$])/
 
-ArgumentsWithTrailingCallExpressions
+ArgumentsWithTrailingCallExpressions ::[Call, ...ASTNode[]]
   Arguments:args AllowedTrailingCallExpressions?:trailing ->
     return [ args, ...trailing ?? [] ]
 
@@ -1204,7 +1230,7 @@ PipelineExpression
   PipelineAllowed _?:ws PipelineHeadItem:head PipelineExpressionBody:body AllowedTrailingCallExpressions?:trailing ->
     // NOTE: Ampersand-block heads (`&.foo |> bar`) are unwrapped later in
     // pipe.civet's constructInvocation; we don't need special handling here.
-    node := {
+    node: PipelineExpressionType := {
       type: "PipelineExpression",
       children: [ws, head, body]
     }
@@ -1686,7 +1712,7 @@ FieldDefinition
         // intact rather than emit invalid `Foo.prototype.#x = ...`.
         // The PrivateIdentifier rule normalises to type "Identifier"
         // with a `#`-prefixed name, so detect by name prefix.
-        if (id?.name?.startsWith?.("#")) {
+        if (id?.type === "Identifier" && id.name.startsWith("#")) {
           return {
             type: "FieldDefinition",
             id,
@@ -1754,7 +1780,7 @@ ThisLiteral
   HashThis
   # NOTE: Added @identifier shorthand, also works for private identifiers
   # Converts 'IdentifierName' node to string so this won't interfere with refs
-  AtThis:at $( Hash? IdentifierName ):id ->
+  AtThis:at $( Hash? IdentifierName ):id ::MemberExpressionType ->
     // `@😊` → `this["😊"]` to match the binding-side bracket form, but
     // `@#😊` → `this.#u$1F60A$` since private fields can't be string-keyed.
     escaped := escapeIdentifier(id)
@@ -1804,9 +1830,10 @@ BasicThisLiteral
 # This is slightly different from how https://262.ecma-international.org/#sec-relational-operators handles relational operators
 # grammatically but should be equivalent in practice
 HashThis
-  AtThis?:at LengthShorthand:id ( &( _ ( Not __ )? ActualIn ) "" )?:beforeIn ->
-    return [ '"', id.name, '"' ] if beforeIn? and not at?
-
+  # `# in x` → `"length" in x` (branded check)
+  LengthShorthand:id &( _ ( Not __ )? ActualIn ) ::Children ->
+    return [ '"', id.name, '"' ]
+  AtThis?:at LengthShorthand:id ::MemberExpressionType ->
     return {
       type: "MemberExpression",
       children: [at ?? "this", {
@@ -1820,7 +1847,7 @@ HashThis
   PrivateIdentifier:id &( _ ( Not __ )? ActualIn ) ->
     return id
 
-  PrivateIdentifier:id ->
+  PrivateIdentifier:id ::MemberExpressionType ->
     return {
       type: "MemberExpression",
       children: ["this", {
@@ -1908,9 +1935,9 @@ CallExpressionRest
   # But x<y>z and x<y>0 is a comparison chain.
   TypeArguments !( IdentifierName / NumericLiteral ) -> $1
   # perf: assertion to exit early
-  /(?=['"`])/ ( TemplateLiteral / StringLiteral ):literal ->
+  /(?=['"`])/ ( TemplateLiteral / StringLiteral ):literal ::ASTString | TemplateLiteralType ->
     if literal.type is "StringLiteral"
-      literal = "`" + literal.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
+      return "`" + literal.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
     return literal
   # NOTE: Tracking trailing member expressions based on indentation level for implicit arguments
   OptionalShorthand?:optional ArgumentsWithTrailingCallExpressions:argsWithTrailing ->
@@ -1930,9 +1957,9 @@ ExplicitCallExpressionRest
   # But x<y>z and x<y>0 is a comparison chain.
   TypeArguments !( IdentifierName / NumericLiteral ) -> $1
   # perf: assertion to exit early
-  /(?=['"`])/ ( TemplateLiteral / StringLiteral ):literal ->
+  /(?=['"`])/ ( TemplateLiteral / StringLiteral ):literal ::ASTString | TemplateLiteralType ->
     if literal.type is "StringLiteral"
-      literal = "`" + literal.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
+      return "`" + literal.token.slice(1, -1).replace(/(`|\$\{)/g, "\\$1") + "`"
     return literal
   OptionalShorthand?:optional ExplicitArguments:call ->
     return call unless optional
@@ -1944,7 +1971,7 @@ ExplicitCallExpressionRest
     }
 
 # NOTE: Added shorthand x?(3) -> x?.(3)
-OptionalShorthand
+OptionalShorthand ::Optional
   # perf: assertion to exit early
   /(?=[\/?])/ InlineComment*:comments QuestionMark:q OptionalDot:d ->
     return {
@@ -2016,7 +2043,7 @@ MemberExpressionRestBody
   NonNullAssertion
 
 # Handles indexing and slicing
-MemberBracketContent
+MemberBracketContent ::SliceExpression | Index
   OpenBracket:open ( SliceParameters / PostfixedExpression ):expression __:ws CloseBracket:close ->
     // Some kind of slice
     if expression!.type is "SliceParameters"
@@ -2053,6 +2080,7 @@ MemberBracketContent
     return {
       type: "Index",
       children: [open, ws1, ws2, close],
+      expression: undefined,
       random: true,
     }
 
@@ -2191,8 +2219,8 @@ PropertyAccess
     }
 
   # NOTE: Added shorthand x.-1 -> x[x.length-1]
-  AccessStart:dot "-":neg IntegerLiteral:num ->
-    len := {
+  AccessStart:dot "-":neg IntegerLiteral:num ::NegativeIndex ->
+    len: UntypedNode := {
       children: []
     }
     children := [
@@ -2209,11 +2237,11 @@ PropertyAccess
       len,
     }
 
-  AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ->
+  AccessStart:dot InlineComment*:comments ( IdentifierName / PrivateIdentifier / LengthShorthand ):id ::Index | PropertyAccessType ->
     // `data.😊` → `data["😊"]` since `u$1F60A$` isn't the real property.
     if id.unicode
       key := propertyKey(id)
-      expression := {
+      expression: LiteralType := {
         type: "Literal",
         subtype: "StringLiteral",
         children: [key],
@@ -2238,7 +2266,7 @@ PropertyAccess
     }
 
   # NOTE: For LSP completion / robustness, parse `foo.` but with an error node
-  ExplicitAccessStart:dot &EOS ->
+  ExplicitAccessStart:dot &EOS ::PropertyAccessType ->
     return {
       type: "PropertyAccess",
       name: "",
@@ -2252,7 +2280,7 @@ PropertyAccess
       ]
     }
 
-  ImplicitAccessStart:dot ( PrivateIdentifier / LengthShorthand ):id ->
+  ImplicitAccessStart:dot ( PrivateIdentifier / LengthShorthand ):id ::PropertyAccessType ->
     return {
       type: "PropertyAccess",
       name: id.name,
@@ -2261,10 +2289,10 @@ PropertyAccess
     }
 
   # NOTE: Added CoffeeScript :: prototype shorthand only when enabled
-  CoffeePrototypeEnabled PropertyAccessModifier?:modifier DoubleColon:p IdentifierName?:id ->
+  CoffeePrototypeEnabled PropertyAccessModifier?:modifier DoubleColon:p IdentifierName?:id ::PropertyAccessType ->
     dot := {token: ".", $loc: p.$loc}
     // Based on AccessStart
-    start := {
+    start: AccessStartType := {
       type: "AccessStart",
       children: modifier ? [modifier, dot] : [dot],
       optional: modifier?.token === "?",
@@ -2309,7 +2337,7 @@ AccessLiteral
 ExplicitPropertyGlob
   &ExplicitAccessStart PropertyGlob -> $2
 
-PropertyGlob
+PropertyGlob ::PropertyGlobType
   # NOTE: Added shorthand obj.{a,b:c} -> {a: obj.a, c: obj.b}
   ( PropertyAccessModifier? OptionalDot ):dot InlineComment* BracedObjectLiteral:object ->
     return {
@@ -2319,7 +2347,7 @@ PropertyGlob
       children: $0,
     }
 
-PropertyBind
+PropertyBind ::PropertyBindType
   # NOTE: foo@.bar and foo@bar shorthand for foo.bar.bind(foo)
   # foo@bar(baz) shorthand for foo.bar.bind(foo, baz)
   PropertyAccessModifier?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id Arguments?:args ->
@@ -2338,7 +2366,7 @@ PropertyBind
     }
 
 # Variation on PropertyBind that forbids implicit arguments (for JSX)
-PropertyBindExplicitArguments
+PropertyBindExplicitArguments ::PropertyBindType
   PropertyAccessModifier?:modifier At OptionalDot:dot ( IdentifierName / PrivateIdentifier ):id ExplicitArguments?:args ->
     children := id.unicode
       ? [modifier, modifier?.token is "?" ? dot : null, "[", propertyKey(id), "]"]
@@ -2738,7 +2766,7 @@ BindingProperty
       // For unicode `name`, PropertyName rewrote it to render as `"src"`.
       // The binding side (collapsed shorthand on LHS, subbinding `= name`
       // on RHS) needs the mangled JS identifier — `name.identifier`.
-      binding := name.identifier ?? name
+      binding := name.type is "Identifier" and name.identifier or name
       pattern := value
       value = {
         type: "NamedBindingPattern",
@@ -2882,7 +2910,7 @@ BindingElement
     }
 
   # NOTE: Merged in ElisionElement
-  &( _? "," ) ->
+  &( _? "," ) ::ElisionElement ->
     return {
       type: "ElisionElement",
       children: [""],
@@ -3571,7 +3599,7 @@ PostfixedSingleLineNoCommaStatements
       bare: true,
     }
 
-NestedBlockStatements
+NestedBlockStatements ::BlockStatement
   PushIndent NestedBlockStatement*:statements TrailingNestedComments:trailing PopIndent ->
     return $skip unless statements# or trailing#
 
@@ -3583,13 +3611,14 @@ NestedBlockStatements
     children: ASTNode[] := [expressions]
     children.push(trailing) if trailing#
 
-    return {
+    block: BlockStatement := {
       type: "BlockStatement",
       expressions,
       children,
       bare: true,
-      trailing: trailing# ? trailing : undefined,
     }
+    block.trailing = trailing if trailing#
+    return block
 
 NestedBlockStatement
   Nested:nested BlockStatementPart+:statements ->
@@ -3715,8 +3744,13 @@ SymbolLiteral
       }
 
 # :symbol as element of object or class
-SymbolElement
-  SymbolLiteral -> [ "[", $1, "]" ]
+SymbolElement ::ComputedPropertyNameType
+  SymbolLiteral:expression ->
+    return {
+      type: "ComputedPropertyName",
+      children: [ "[", expression, "]" ],
+      expression,
+    }
 
 # https://262.ecma-international.org/#prod-Identifier
 # Extended: identifiers may include non-identifier Unicode (emoji, math
@@ -3784,7 +3818,7 @@ _ArrayLiteral
   # NOTE: Check ArrayBindingPattern case of lhs destructuring
   ArrayBindingPattern UpcomingAssignment -> $1
   # NOTE: Added [] followed by elements
-  OpenBracket:open CloseBracket:close ApplicationStart AllowAll ( NestedElementList / SingleLineElementList )?:content RestoreAll ->
+  OpenBracket:open CloseBracket:close ApplicationStart AllowAll ( NestedElementList / SingleLineElementList )?:content RestoreAll ::ArrayExpression ->
     return $skip unless content
 
     // Remove trailing comma
@@ -3803,7 +3837,7 @@ _ArrayLiteral
       children: [open, ...content, close],
       names: content.flatMap(namesOf)
     }
-  OpenBracket:open AllowAll ( ArrayLiteralContent __ CloseBracket )? RestoreAll ->
+  OpenBracket:open AllowAll ( ArrayLiteralContent __ CloseBracket )? RestoreAll ::ArrayExpression | RangeExpressionType ->
     return $skip unless $3
     [ content, ws, close ] := $3
 
@@ -4029,7 +4063,7 @@ NestedBulletedArray ::ArrayExpression
 
 # NOTE: Bulleted array intended for beginning of lines,
 # when leading indentation has already been consumed.
-BulletedArray
+BulletedArray ::ArrayExpression
   InsertOpenBracket:open ( ArrayBullet NestedArrayBullet* )?:content InsertCloseBracket:close ->
     return $skip unless content
     content = [
@@ -4091,14 +4125,12 @@ Bullet
 
 BulletedArrayWithTrailing
   BulletedArray:array AllowedTrailingCallExpressions?:trailing ( NotDedented Pipe __ PipelineTailItem )*:pipeline ->
-    if trailing
-      array = [ array, trailing ]
-    if pipeline#
-      array = {
-        type: "PipelineExpression",
-        children: [ undefined, array, pipeline ],
-      }
-    return array
+    head: ASTNode := trailing ? [ array, trailing ] : array
+    return head unless pipeline#
+    return {
+      type: "PipelineExpression",
+      children: [ undefined, head, pipeline ],
+    }
 
 # https://262.ecma-international.org/#prod-ObjectLiteral
 # NOTE: Slightly simplified from spec
@@ -4240,11 +4272,14 @@ NestedPropertyDefinition
 # but where the indentation has already been consumed.
 # They can span multiple lines at the same indentation level.
 # They must start with a snug property, and all properties must have a colon.
-ImplicitObjectLiteral
+ImplicitObjectLiteral ::ObjectExpression
   InsertInlineOpenBrace:open SnugNamedProperty:first ( ImplicitObjectPropertyDelimiter NamedProperty )*:rest ( _? Comma )?:trailing InsertCloseBrace:close ->
+    properties := [first, ...rest.map(([, prop]) => prop)]
     return {
       type: "ObjectExpression",
       children: [open, first, ...rest, trailing, close],
+      names: properties.flatMap(namesOf),
+      properties,
     }
 
 # This is different from ObjectPropertyDelimiter because the braces are implicit so we can't look ahead to find the closing one
@@ -4258,11 +4293,14 @@ ImplicitObjectPropertyDelimiter
 # They must start with a snug property, and all properties must have a colon.
 # Disabled in the "then" of a snug ternary `a?b:c` so `{b:c}` doesn't
 # swallow the ternary colon.
-InlineObjectLiteral
+InlineObjectLiteral ::ObjectExpression
   !InlineObjectLiteralForbidden InsertInlineOpenBrace:open SnugNamedProperty:first ( InlineObjectPropertyDelimiter NamedProperty )*:rest ( _? Comma &Dedented )?:trailing InsertCloseBrace:close ->
+    properties := [first, ...rest.map(([, prop]) => prop)]
     return {
       type: "ObjectExpression",
       children: [open, first, ...rest, trailing, close],
+      names: properties.flatMap(namesOf),
+      properties,
     }
 
 InlineObjectPropertyDelimiter
@@ -4325,7 +4363,7 @@ PropertyDefinition
         type: "Property",
         children: [ws, id, ": ", value],
         name: id,
-        names: id.names,
+        names: namesOf(id),
         value,
         flagToggle: toggle,
       }
@@ -4333,7 +4371,7 @@ PropertyDefinition
     // `{ 😊 }` → `{ "😊": u$1F60A$ }`. PropertyName already rewrote `id`'s
     // children to render the quoted source; `id.identifier` is the original
     // Identifier whose children render the mangled local-variable reference.
-    if id.unicode
+    if id.type is "Identifier" and id.identifier
       return {
         type: "Property",
         children: [ws, id, ": ", id.identifier],
@@ -4346,7 +4384,7 @@ PropertyDefinition
       type: "Property",
       children: [ws, id],
       name: id,
-      names: id.names,
+      names: namesOf(id),
       value: id,
       implicitName: true,
     }
@@ -4439,7 +4477,7 @@ PropertyDefinition
     if name[0] is "#" then name = name.slice(1)
 
     // { y? } → { ...((y != null) && {y}) }
-    if not (pre# or rhs# or pipeline#) and post?.token is "?" and value!.type is "Identifier"
+    if not (pre# or rhs# or pipeline#) and post is like {token: "?"} and value!.type is "Identifier"
       dots := { $loc, token: "..." }
       paren := parenthesizeExpression({ children: ["(", value, " != null) && {", name, "}"] })
       return {
@@ -4513,7 +4551,7 @@ SnugNamedProperty
       value: expression,
     }
 
-PropertyName
+PropertyName ::PropertyNameType
   # https://262.ecma-international.org/#prod-LiteralPropertyName
   NumericLiteral
   ComputedPropertyName
@@ -4523,9 +4561,10 @@ PropertyName
   # NOTE: Content-Type -> "Content-Type"
   $(IdentifierName? "-" /(?:\p{ID_Continue}|[\u200C\u200D$-])*/) ->
     return {
+      type: "StringLiteral",
       token: `"${$1}"`,
       $loc,
-    }
+    } as const
   # Unicode `id` renders quoted via children so PropertyName consumers emit
   # the source name automatically; `id.identifier` carries the original for
   # shorthand value-side reads.
@@ -4533,7 +4572,7 @@ PropertyName
     return id unless id.unicode
     return {
       ...id,
-      children: [{$loc: id.children[0].$loc, token: `"${id.unicode}"`}],
+      children: [propertyKey(id)],
       identifier: id,
     }
   LengthShorthand
@@ -4542,14 +4581,14 @@ PropertyName
 ComputedPropertyName
   # https://262.ecma-international.org/#prod-ComputedPropertyName
   # NOTE: Using PostfixedExpression to allow If/Switch expressions and postfixes
-  OpenBracket PostfixedExpression:expression __ CloseBracket ->
+  OpenBracket PostfixedExpression:expression __ CloseBracket ::ComputedPropertyNameType ->
     return {
       type: "ComputedPropertyName",
       children: $0,
       expression,
     }
   # NOTE: Extending to allow template literals without brackets
-  InsertOpenBracket TemplateLiteral:expression InsertCloseBracket ->
+  InsertOpenBracket TemplateLiteral:expression InsertCloseBracket ::ComputedPropertyNameType | StringLiteralType ->
     // Check for CoffeeScript interpolated double-quote string
     // without interpolation
     return $2 if $2.type is "StringLiteral"
@@ -4559,7 +4598,7 @@ ComputedPropertyName
       expression,
       implicit: true,
     }
-  InsertOpenBracket [+-] NumericLiteral InsertCloseBracket ->
+  InsertOpenBracket [+-] NumericLiteral InsertCloseBracket ::ComputedPropertyNameType ->
     expression := [ $2, $3 ]
     return {
       type: "ComputedPropertyName",
@@ -4625,9 +4664,11 @@ MethodDefinition ::MethodDefinition | MultiMethodDefinition
       autoReturn := not block or base!.type !== "Identifier"
       return makeGetterMethod(name, ws, base, returnType, block, kind, autoReturn)
 
-    last .= rest[rest#-1]
+    // Unwrap trailing tuples (e.g. `[Call, ...trailing]`) to the final node
+    last: ASTNode .= rest[rest#-1]
     while Array.isArray(last)
       last = last[last#-1]
+    assert last, "getter shorthand: expected a trailing member or call"
 
     switch last.type
       case "Call":
@@ -4715,7 +4756,7 @@ MethodSignature ::MethodSignature
       type: "MethodSignature",
       children: $0,
       id,
-      name: id.token,
+      name: id.name,
       modifier: {},
       returnType: undefined,
       parameters,
@@ -5562,7 +5603,9 @@ ForStatementControlWithWhen ::ForStatementControl
     return control unless condition
     expressions: StatementTuple[] := [["", {
       type: "ContinueStatement",
-      children: ["continue"]
+      children: ["continue"],
+      with: undefined,
+      label: undefined,
     }]]
     block: BlockStatement := {
       type: "BlockStatement",
@@ -5570,11 +5613,19 @@ ForStatementControlWithWhen ::ForStatementControl
       children: [expressions],
       bare: true,
     }
+    guard: Condition := {
+      type: "ParenthesizedExpression",
+      children: ["(!", makeLeftHandSideExpression(trimFirstSpace(condition)), ")"],
+      expression: condition,
+    }
     blockPrefix: StatementTuple[] := [...control.blockPrefix ?? [],
       ["", {
         type: "IfStatement",
+        condition: guard,
+        negated: undefined,
         then: block,
-        children: ["if (!", makeLeftHandSideExpression(trimFirstSpace(condition)), ") ", block],
+        else: undefined,
+        children: ["if ", guard, " ", block],
         // & placeholders in the condition came from outside the for-body,
         // so they should lift past it (otherwise `continue` ends up trapped
         // inside an arrow function — issue #1788).
@@ -5646,10 +5697,14 @@ CoffeeForStatementParameters ::ForStatementControl
 
       // index is actually value in Coffee "for of", y = z[x]
       if index
+        rhs := [exp, "[", declarationExp, "]"]
         blockPrefix./**/push(["", {
           type: "AssignmentExpression",
-          children: [index, " = ", exp, "[", declarationExp, "]"],
+          children: [index, " = ", rhs],
           names: index.names,
+          lhs: [],
+          assigned: index,
+          expression: rhs,
         }, ";"])
 
       kind.token = "in"
@@ -5673,7 +5728,7 @@ CoffeeForStatementParameters ::ForStatementControl
       if index
         index = trimFirstSpace(index)
         indexAssignment = [index, "="]
-        assignmentNames./**/push(...index!.names)
+        assignmentNames./**/push(...namesOf(index))
 
       expRefDec := (expRef !== exp)
         // Trim a single leading space if present
@@ -5687,10 +5742,14 @@ CoffeeForStatementParameters ::ForStatementControl
         pushForBlockDeclaration blockPrefix, varRef,
           [expRef, "[", indexAssignment, counterRef, "]"], true
       else
+        rhs := [expRef, "[", indexAssignment, counterRef, "]"]
         blockPrefix./**/push(["", {
           type: "AssignmentExpression",
-          children: [varRef, " = ", expRef, "[", indexAssignment, counterRef, "]"],
+          children: [varRef, " = ", rhs],
           names: assignmentNames,
+          lhs: [],
+          assigned: varRef,
+          expression: rhs,
         }, ";"])
 
       // The for-head Declaration (`let i = 0, len = arr.length` or, for a
@@ -5742,10 +5801,7 @@ CoffeeForIndex
   _?:ws1 Comma _?:ws2 BindingIdentifier:id ->
     ws2 = trimFirstSpace(ws1)
 
-    return {
-      ...id,
-      children: [...ws1 || [], ...ws2 || [], ...id.children]
-    }
+    return prepend([...ws1 or [], ...ws2 or []], id)
 
 CoffeeForDeclaration ::CoffeeForDeclarationType | CoffeeForBindingAssignment
   # NOTE: Coffee doesn't allow expression bindings like `for a.x in b`
@@ -6027,7 +6083,7 @@ CaseExpression
   PropertyName:value &( _? Colon ) ->
     if value.type is "ComputedPropertyName"
       return value.expression if value.implicit
-      return {...value, type: "ArrayExpression"}
+      return { type: "ArrayExpression", children: value.children } as const
     return value
   ExpressionWithObjectApplicationForbidden
 
@@ -6078,7 +6134,7 @@ WFinallyClause
     return prepend($1, $2)
 
 # https://262.ecma-international.org/#prod-Finally
-FinallyClause
+FinallyClause ::FinallyClauseType
   Finally ( BracedThenClause / BracedOrEmptyBlock ):block ->
     return {
       type: "FinallyClause",
@@ -6159,7 +6215,7 @@ BoundedCondition
       expression,
     }
 
-DeclarationCondition
+DeclarationCondition ::DeclarationConditionType
   ForbidBracedApplication ForbidIndentedApplication ForbidNewlineBinaryOp LexicalDeclaration?:declaration RestoreNewlineBinaryOp RestoreBracedApplication RestoreIndentedApplication ->
     return $skip unless declaration
 
@@ -6597,7 +6653,7 @@ ImportDeclaration ::ImportDeclaration
     // Replace `import` with `const` in JS output
     imp := [
       { ...$1, ts: true },
-      { ...$1, token: "const", js: true },
+      { ...$1, token: "const" as const, js: true },
     ]
     return {
       type: "ImportDeclaration",
@@ -6759,7 +6815,7 @@ NamedImports ::ImportClause
     }
 
 # `...rest` in named imports — triggers namespace+const desugar.
-NamedImportRest
+NamedImportRest ::BindingRestPropertyType
   __:ws DotDotDot:dots BindingIdentifier:binding ObjectPropertyDelimiter:delim ->
     return {
       type: "BindingRestProperty",
@@ -6767,6 +6823,7 @@ NamedImportRest
       dots,
       binding,
       delim,
+      typeSuffix: undefined,
     }
 
 OperatorNamedImports ::OperatorImportClause
@@ -7070,7 +7127,7 @@ NamedExports
       type: "NamedExports"
       children: $0
       specifiers
-      constructed: specifiers.filter (s): s is ConstructedExportSpecifier => not Array.isArray(s) and s?.type is "ConstructedExportSpecifier"
+      constructed: specifiers.filter (s): s is ConstructedExportSpecifier => s is like {type: "ConstructedExportSpecifier"}
     }
   # Unbraced version: export x, y
   InsertInlineOpenBrace:open ImplicitExportSpecifier:first ( ImplicitObjectPropertyDelimiter ImplicitExportSpecifier )*:rest InsertCloseBrace:close &( StatementDelimiter / ( __ From )) ->
@@ -7084,7 +7141,7 @@ ExportSpecifier
     children :=
       if rename
         [ws1, ts, local, rename[0], rename[1], rename[2], propertyKey(rename[3]), delim]
-      else if local.unicode
+      else if local.type is "Identifier" and local.unicode
         [ws1, ts, local, " as ", propertyKey(local), delim]
       else
         [ws1, ts, local, delim]
@@ -7119,7 +7176,7 @@ ImplicitExportSpecifier
   !Default ModuleExportName:local ( __ As __ ModuleExportName )?:rename ->
     if rename
       return [local, rename[0], rename[1], rename[2], propertyKey(rename[3])]
-    if local.unicode
+    if local.type is "Identifier" and local.unicode
       return [local, " as ", propertyKey(local)]
     return [local, rename]
 
@@ -7274,7 +7331,7 @@ VariableDeclarationList ::Omit<Declaration, "decl">
 # NOTE: No leading minus sign
 NumericLiteral
   # perf: short circuit if no possibility of being a number
-  /(?=[0-9.])/ NumericLiteralKind:token ::NumericLiteral ->
+  /(?=[0-9.])/ NumericLiteralKind:token ::NumericLiteralType ->
     return { type: "NumericLiteral", $loc, token } as const
 
 NumericLiteralKind
@@ -7316,7 +7373,7 @@ HexIntegerLiteral
 # NOTE: Integer variation of NumericLiteral
 IntegerLiteral
   # perf: short circuit if no possibility of being an integer
-  /(?=[0-9])/ IntegerLiteralKind:token ::NumericLiteral ->
+  /(?=[0-9])/ IntegerLiteralKind:token ::NumericLiteralType ->
     return { type: "NumericLiteral", $loc, token } as const
 
 IntegerLiteralKind
@@ -7334,7 +7391,7 @@ DecimalIntegerLiteral
 # NOTE: This includes unprocessed double-quoted strings.  If you might want to
 # accept a template literal in the form of a CoffeeScript double-quoted string
 # interpolation, be sure to check TemplateLiteral before StringLiteral.
-StringLiteral ::StringLiteral
+StringLiteral ::StringLiteralType
   DoubleQuote DoubleStringCharacters:str DoubleQuote ->
     return {
       type: "StringLiteral",
@@ -7359,7 +7416,7 @@ SingleStringCharacters
 
 # StringLiteral but without literal newlines, used for module names
 SingleLineStringLiteral
-  $( DoubleQuote /(?:\\.|[^"\n])*/ DoubleQuote ) / $( SingleQuote /(?:\\.|[^'\n])*/ SingleQuote ) ::StringLiteral ->
+  $( DoubleQuote /(?:\\.|[^"\n])*/ DoubleQuote ) / $( SingleQuote /(?:\\.|[^'\n])*/ SingleQuote ) ::StringLiteralType ->
     return {
       type: "StringLiteral",
       $loc,
@@ -7428,7 +7485,7 @@ RegularExpressionClassCharacters
   /(?:\\.|[^\]])*/ ->
     return { $loc, token: $0 }
 
-HeregexLiteral
+HeregexLiteral ::RegularExpressionLiteralType
   TripleSlash:open HeregexBody:body TripleSlash:close RegularExpressionFlags:flags ->
     hasSubstitutions .= body.some (part) => part.type is "Substitution"
 
@@ -7495,8 +7552,8 @@ heregexEscapes: Record<string, string> := {
 HeregexPart
   RegularExpressionClass
 
-  CoffeeInterpolationEnabled CoffeeStringSubstitution -> { type: "Substitution", children: $2 }
-  TemplateSubstitution -> { type: "Substitution", children: $1 }
+  CoffeeInterpolationEnabled CoffeeStringSubstitution ::Substitution -> { type: "Substitution", children: $2 }
+  TemplateSubstitution ::Substitution -> { type: "Substitution", children: $1 }
 
   $( /\\./ ):escape -> { $loc, token: heregexEscapes[escape[1]] ?? escape }
 
@@ -7536,11 +7593,13 @@ RegularExpressionFlags
 
 # https://262.ecma-international.org/#prod-TemplateLiteral
 # NOTE: Simplified template grammar
-TemplateLiteral
+TemplateLiteral ::TemplateLiteralType | StringLiteralType
   # perf: assertion to exit early
   /(?=[`'"])/ _TemplateLiteral -> $2
 
-_TemplateLiteral
+# NOTE: CoffeeScript interpolated strings without interpolation collapse to a
+# StringLiteral.
+_TemplateLiteral ::TemplateLiteralType | StringLiteralType
   TripleTick ( TemplateBlockCharacters / TemplateSubstitution )* TripleTick ->
     return dedentBlockSubstitutions($0, config.tab)
 
@@ -7807,9 +7866,15 @@ Comptime
   "comptime" NonIdContinue !":" ->
     return { type: "Keyword" as const, $loc, token: $1 }
 
-ConstructorShorthand
+ConstructorShorthand ::Identifier
   "@" ->
-    return { $loc, token: "constructor" }
+    name := "constructor"
+    return {
+      type: "Identifier",
+      name,
+      names: [name],
+      children: [{ $loc, token: name }],
+    }
 
 Declare
   "declare" NonIdContinue ->
@@ -8480,12 +8545,12 @@ JSXAttribute
   # NOTE: @foo and @@foo shorthands
   # for foo={this.foo} and foo={this.foo.bind(this)}
   AtThis:at Identifier?:id InlineJSXCallExpressionRest*:rest &JSXAttributeSpace ::JSXAttribute ->
-    children := [ at, ...rest.flat() ]
+    children: Children := [ at, ...rest.flat() ]
     if id
       children.splice(1, 0, {
         type: "PropertyAccess",
         children: [".", id],
-        name: id,
+        name: id.name,
       })
     expr := processCallMemberExpression({
       type: "CallExpression",
@@ -8628,7 +8693,7 @@ JSXAttributeValue
     // double-quoted string that didn't end up actually interpolating.
     // Instead parse using the following string literal rule,
     // which avoids e.g. converting newlines into \n.
-    return $skip if value!.type is "StringLiteral"
+    return $skip if value is like {type: "StringLiteral"}
     return [open, value, close]  // omit &JSXAttributeSpace
   # NOTE: InlineJSXAttributeValue which contains TemplateLiteral must be before
   # StringLiteral, so that CoffeeScript interpolated strings get checked first.
@@ -9285,8 +9350,8 @@ TypeProperty
 TypeIndexSignature
   # NOTE: QuestionMark will be parsed by following TypeSuffix
   ( [+-]? Readonly NotDedented )?:prefix OpenBracket:open TypeIndex:index CloseBracket:close ( __ [+-] &( _? QuestionMark ) )?:suffix ->
-    suffix = [suffix[0], suffix[1]] if suffix
-    return [prefix, open, index, close, suffix]
+    // omit the lookahead assertion from suffix
+    return [prefix, open, index, close, suffix and [suffix[0], suffix[1]]]
 
 TypeIndex
   __ Identifier TypeSuffix

--- a/source/parser.hera
+++ b/source/parser.hera
@@ -190,6 +190,7 @@ import type {
   TypeDeclaration,
   TypeDeclarationBinding,
   TypeArgument,
+  TypeArguments as TypeArgumentsType,
   TypeArgumentList,
   TypeFunction,
   TypeLexicalDeclaration,
@@ -9836,7 +9837,7 @@ TypeFunctionArrow
     return { $loc, token: "=>" }
 
 TypeArguments
-  OpenAngleBracket:open ( __ TypeArgumentDelimited )+:args __:ws CloseAngleBracket:close ::TypeArguments ->
+  OpenAngleBracket:open ( __ TypeArgumentDelimited )+:args __:ws CloseAngleBracket:close ::TypeArgumentsType ->
     flatArgs := args.flatMap(([ws, [arg, delim]]) => [prepend(ws, arg), delim]) as TypeArgumentList
     flatArgs.pop() // remove last delimiter
     return {
@@ -9847,7 +9848,7 @@ TypeArguments
     }
 
 ImplicitTypeArguments
-  TypeApplicationStart InsertOpenAngleBracket:open Trimmed_?:ws TypeArgumentList:args InsertCloseAngleBracket:close ::TypeArguments ->
+  TypeApplicationStart InsertOpenAngleBracket:open Trimmed_?:ws TypeArgumentList:args InsertCloseAngleBracket:close ::TypeArgumentsType ->
     // Remove trailing comma which is forbidden in TypeScript type arguments
     last := args[args# - 1]
     args = args.slice(0, -1) if isComma last
@@ -9870,7 +9871,7 @@ ForbiddenImplicitTypeCalls
   /(extends|not|is)(?!\p{ID_Continue}|[\u200C\u200D$])/
 
 # Based on ArgumentList
-TypeArgumentList
+TypeArgumentList ::TypeArgumentList
   # Check for same line arguments then nested arguments
   !EOS TypeArgument ( CommaDelimiter !EOS WTypeArgument )* ( CommaDelimiter ( NestedTypeBulletedTuple / NestedInterfaceBlock / NestedTypeArgumentList ) )+ ->
     return [
@@ -9882,7 +9883,7 @@ TypeArgumentList
     ]
   # NOTE: Added nested arguments on separate new lines
   ( NestedTypeBulletedTuple / NestedInterfaceBlock ) ( CommaDelimiter ( NestedTypeBulletedTuple / NestedInterfaceBlock / NestedTypeArgumentList ) )* ->
-    rest: [ASTNode, ASTNode][] := $2
+    rest := $2
     return [
       trimFirstSpace($1),
       ...rest.flatMap(([comma, args]) =>

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -13,6 +13,7 @@ import {
 
 import {
   isFunction
+  namesOf
 } from ./util.civet
 
 import {
@@ -124,7 +125,7 @@ function createConstLetDecs(statements: any, scopes: any, letOrConst: "let" | "c
         continue
       // Synthetic assignments (such as a `do` expression's result ref) may
       // not introduce any source-level names.
-      names := (node.names ?? []).filter (name: string) => not hasDec name
+      names := namesOf(node).filter (name) => not hasDec name
       if node.type is "AssignmentExpression"
         undeclaredIdentifiers.push ...names
       for each name of names
@@ -138,7 +139,7 @@ function createConstLetDecs(statements: any, scopes: any, letOrConst: "let" | "c
         and statement[1].type is "AssignmentExpression"
         and statement[1].names# is 1
         and statement[1].names[0] is undeclaredIdentifiers[0]
-        and firstIdentifier and firstIdentifier.names == undeclaredIdentifiers[0]
+        and firstIdentifier and firstIdentifier.names[0] is undeclaredIdentifiers[0]
         and gatherNodes(statement[1], .type is "ObjectBindingPattern")# is 0)
         statement[1].children.unshift [`${letOrConst} `]
       else

--- a/source/parser/auto-dec.civet
+++ b/source/parser/auto-dec.civet
@@ -12,6 +12,7 @@ import {
 } from ./traversal.civet
 
 import {
+  assert
   isFunction
   namesOf
 } from ./util.civet
@@ -187,7 +188,9 @@ function createVarDecs(block: BlockStatement, scopes: any, pushVar?: any): void
   scopes.push decs
   varIds: string[] := []
   assignmentStatements := findAssignments statements, scopes
-  undeclaredIdentifiers := assignmentStatements.flatMap ?.names or []
+  undeclaredIdentifiers := assignmentStatements.flatMap (statement) =>
+    assert statement.names, "auto-dec: assignment names are resolved by processAssignments"
+    statement.names
 
   // Unique, undeclared identifiers in this scope
   undeclaredIdentifiers.filter((x, i, a) => {

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -93,8 +93,7 @@ function adjustBindingElements(elements: ArrayBindingPatternContent): {
     after := elements[restIndex + 1..]
 
     restIdentifier := rest.binding.ref or rest.binding
-    /* fallback when rest binding is PinPattern or Literal (neither sets names); prevents crash in `[a, ...^x] .= arr` shape */
-    names.push ...rest.names or []
+    names.push ...rest.names
 
     l .= after#
 

--- a/source/parser/binding.civet
+++ b/source/parser/binding.civet
@@ -26,11 +26,12 @@ import {
 import {
   assert
   isComma
+  makeAssignment
   namesOf
   parenthesizeType
   trimFirstSpace
-  updateParentPointers
   typeSuffixForExpression
+  updateParentPointers
 } from ./util.civet
 
 /**
@@ -284,13 +285,7 @@ function gatherBindingCode(statements: ASTNode, opts?: { injectParamProps?: bool
             n.expression!.type is "Identifier" ? n.expression.name : "pin"
           n.children = [n.ref]
           updateParentPointers n
-          thisAssignments.push
-            type: "AssignmentExpression"
-            children: [n.expression, " = ", n.ref]
-            names: []
-            lhs: n.expression as any
-            assigned: n.expression
-            expression: n.ref
+          thisAssignments.push makeAssignment n.expression!, n.ref
           continue
 
       if opts?.injectParamProps and n.type is "Parameter" and n.accessModifier

--- a/source/parser/block.civet
+++ b/source/parser/block.civet
@@ -6,6 +6,7 @@ import type {
   Loc
   ObjectExpression
   ParenthesizedExpression
+  Property
   StatementTuple
 } from ./types.civet
 
@@ -205,8 +206,8 @@ function processBlocks(statements: StatementTuple[]): void
        }
       object := (block.expressions[0][1] as ParenthesizedExpression).expression as ObjectExpression
       // Don't process `...spread` or `name: value` or `method() ...`
-      continue unless for every prop of object.properties
-        prop.type is "Property" and prop.implicitName
+      continue unless object.properties.every (prop): prop is Property =>
+        prop.type is "Property" and !!prop.implicitName
       // Unwrap parentheses
       block.expressions[0][1] =
         (block.expressions[0][1] as ParenthesizedExpression).expression
@@ -215,8 +216,9 @@ function processBlocks(statements: StatementTuple[]): void
       // Remove implicit names added to props
       for each prop of object.properties
         // Remove implicit square brackets around e.g. template strings
-        if prop.name is like {type: "ComputedPropertyName", implicit: true}
-          replaceNode prop.name, prop.name.expression, prop
+        { name } := prop
+        if name is like {type: "ComputedPropertyName", implicit: true}
+          replaceNode name, name.expression, prop
         // Remove implicit commas between properties; implicit-name props are
         // all identifiers, so the next prop can never start with a character
         // that would need a semicolon to break ASI.

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -64,11 +64,12 @@ import {
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
   makeNode
+  namesOf
   parenthesizeExpression
   replaceNode
   spliceChild
-  typeOfExpression
   trimFirstSpace
+  typeOfExpression
   updateParentPointers
 } from ./util.civet
 
@@ -127,7 +128,7 @@ function processAssignmentDeclaration(decl: ASTLeaf, pattern: Binding["pattern"]
 
   makeNode<LexicalDeclaration> {
     type: "Declaration"
-    pattern.names
+    names: namesOf pattern
     decl
     bindings: [binding]
     splices

--- a/source/parser/declaration.civet
+++ b/source/parser/declaration.civet
@@ -62,6 +62,7 @@ import {
   insertTrimmingSpace
   isExit
   isWhitespaceOrEmpty
+  makeAssignment
   makeLeftHandSideExpression
   makeNode
   namesOf
@@ -226,10 +227,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
     if statement.type is "DoStatement"
       ref = initializer.expression = initializer.children[2] = makeRef()
       assignResults blockStatement, (resultNode) =>
-        //@ts-ignore
-        makeNode
-          type: "AssignmentExpression"
-          children: [ref, " = ", resultNode]
+        makeAssignment ref, resultNode!
 
       refDec :=
         type: "Declaration"
@@ -244,10 +242,7 @@ function prependStatementExpressionBlock(initializer: Initializer, statement: AS
     ref = initializer.expression = initializer.children[2] = makeRef()
 
     assignResults blockStatement, (resultNode) =>
-      //@ts-ignore
-      makeNode
-        type: "AssignmentExpression"
-        children: [ref, " = ", resultNode]
+      makeAssignment ref, resultNode!
 
     refDec :=
       type: "Declaration"

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -97,6 +97,7 @@ import {
   isWhitespaceOrEmpty
   makeLeftHandSideExpression
   makeNode
+  namesOf
   replaceNode
   startsWithPredicate
   trimFirstSpace
@@ -959,7 +960,7 @@ function processParams(f: FunctionNode): void
       else
         append param
 
-  parameters.names = before.flatMap .names
+  parameters.names = before.flatMap namesOf
   parameters.parameters[..] = []
   parameters.parameters.push tt if tt
   parameters.parameters.push ...before
@@ -980,7 +981,7 @@ function processParams(f: FunctionNode): void
           message: "Non-end rest parameter cannot be binding pattern"
 
       after = trimFirstSpace after
-      names := after.flatMap .names
+      names := after.flatMap namesOf
       elements := (after as (Parameter | ASTError)[]).map (p) =>
         return p if p.type is "Error"
         {

--- a/source/parser/function.civet
+++ b/source/parser/function.civet
@@ -966,7 +966,7 @@ function processParams(f: FunctionNode): void
   parameters.parameters.push ...before
   if rest
     restIdentifier := rest.binding.ref or rest.binding
-    parameters.names.push ...(rest.names ?? [])
+    parameters.names.push ...rest.names
     rest.children.pop() // remove delimiter
 
     // `(a, ...) ->` keeps the rest param to preserve the function's arity in

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -63,6 +63,7 @@ import type {
   TypeConditional
   TypeNode
   TypeSuffix
+  UnaryExpression
   UnaryOpSymbolLeaf
   WSNode
 } from ./types.civet
@@ -314,22 +315,23 @@ function rewriteDynamicImportCall(call: Call): Call
 // Negate expression inside condition.  `notLoc` is the source location of
 // the `unless`/`until` keyword being rewritten — the synthesized `!` leaf
 // inherits it so the output stays source-mapped.
-function negateCondition(condition: Condition, notLoc: Loc)
-  { expression } .= condition
+function negateCondition(condition: Condition, notLoc: Loc): Condition
+  { expression } := condition
   children := condition.children.slice()
   i := children.indexOf(expression)
   assert.notEqual i, -1, "negateCondition: expression must be directly in condition.children"
   bang: UnaryOpSymbolLeaf := { $loc: notLoc, token: "!" }
   pre := [bang]
-  expression = makeLeftHandSideExpression expression
-  children[i] = expression = {
+  operand := makeLeftHandSideExpression expression
+  negation: UnaryExpression := {
     type: "UnaryExpression"
     subtype: "Negation"
-    children: [pre, expression]
+    children: [pre, operand]
     pre
-    expression
+    expression: operand
   }
-  { ...condition, expression, children }
+  children[i] = negation
+  { ...condition, expression: negation, children }
 
 /**
 Somewhat incomplete detection of expressions used to

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -98,6 +98,7 @@ import {
   isFunction
   isWhitespaceOrEmpty
   literalValue
+  makeAssignment
   makeLeftHandSideExpression
   makeNode
   maybeWrap
@@ -1656,9 +1657,7 @@ function unchainOptionalMemberExpression(exp: MemberExpression | CallExpression,
 
       if j > 1 or needsRef children[0]
         usesRef = true
-        base = makeLeftHandSideExpression
-          type: "AssignmentExpression"
-          children: [ref, " = ", children.splice(0, j)]
+        base = makeLeftHandSideExpression makeAssignment ref, children.splice(0, j), implicit: true
 
         base.parent = child
         children.unshift ref
@@ -1992,14 +1991,7 @@ function makePrototypeAssignment(className: ASTNode, id: ClassElementName, exp: 
     // round-trip via bracket access.
     else
       ["[", id, "]"]
-  return makeNode {
-    type: "AssignmentExpression"
-    children: [className, ".prototype", access, " = ", exp]
-    lhs: className as any
-    assigned: className
-    expression: exp as any
-    names: []
-  }
+  makeAssignment [className, ".prototype", access], exp
 
 function processCoffeeClasses(statements: StatementTuple[]): void
   for each ce of gatherRecursiveAll statements, .type is "ClassExpression"
@@ -2286,8 +2278,8 @@ function processPlaceholders(statements: StatementTuple[]): void
           type is "PipelineExpression"
           // Declaration
           type is "Initializer"
-          // Right-hand side of assignment
-          type is "AssignmentExpression" and
+          // Right-hand side of a source assignment (not a ref wrapper)
+          type is "AssignmentExpression" and not ancestor.implicit and
             findChildIndex(ancestor, child) is
             ancestor.children.indexOf ancestor.expression
           type is "ReturnStatement"
@@ -2565,6 +2557,7 @@ export {
   makeGetterMethod
   makeLeftHandSideExpression
   makeRef
+  makeAssignment
   maybeRef
   maybeRefAssignment
   modifyString

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -1041,9 +1041,8 @@ function lastAccessInCallExpression(exp: any)
 /**
  * Return the static string name of a property key, if it has one.
  */
-function staticPropertyName(id: NonNullASTNode): string?
+function staticPropertyName(id: ASTNodeObject | ASTString): string?
   return id if id <? "string"
-  return unless isASTNodeObject id
   return id.name if "name" in id and id.name <? "string"
   if "token" in id and id.token <? "string"
     token := id.token

--- a/source/parser/lib.civet
+++ b/source/parser/lib.civet
@@ -22,20 +22,20 @@ import type {
   CatchBinding
   CatchClause
   Children
+  ClassElementName
+  CoffeeClassPrototype
   ComptimeStatement
   Condition
   ContinueStatement
   Declaration
   DoStatement
   ElseClause
-  FinallyClause
-  ClassElementName
-  CoffeeClassPrototype
   ExpressionNode
+  FinallyClause
   ForStatement
   FunctionExpression
-  IfStatement
   Identifier
+  IfStatement
   Index
   Initializer
   IterationExpression
@@ -43,6 +43,7 @@ import type {
   Label
   LabelledStatement
   Literal
+  Loc
   MemberExpression
   MethodDefinition
   MethodSignature
@@ -55,13 +56,13 @@ import type {
   Placeholder
   Property
   StatementTuple
+  StringLiteral
   SwitchStatement
   TypeArgument
   TypeArguments
   TypeConditional
   TypeNode
   TypeSuffix
-  Loc
   UnaryOpSymbolLeaf
   WSNode
 } from ./types.civet
@@ -250,9 +251,10 @@ function adjustIndexAccess(dot: AccessStart): AccessStart
 
   return dot
 
-function rewriteModuleSpecifier(module: ASTLeaf): ASTLeaf
+function rewriteModuleSpecifier(module: StringLiteral): StringLiteral
+function rewriteModuleSpecifier(module: ASTLeaf | StringLiteral): ASTLeaf | StringLiteral
 function rewriteModuleSpecifier(module: Literal): Literal
-function rewriteModuleSpecifier(module: ASTLeaf | Literal): ASTLeaf | Literal
+function rewriteModuleSpecifier(module: ASTLeaf | StringLiteral | Literal): ASTLeaf | StringLiteral | Literal
   switch module.type
     when "Literal"
       return module unless module.subtype is "StringLiteral"
@@ -1974,10 +1976,9 @@ function processBreaksContinues(statements: StatementTuple[]): void
  */
 function makePrototypeAssignment(className: ASTNode, id: ClassElementName, exp: ExpressionNode | ASTRef): ASTNode
   access: ASTNode .=
-    // SymbolElement already has the form `["[", SymbolLiteral, "]"]`
-    if Array.isArray id then id
-    // ComputedPropertyName children already include the brackets.
-    else if id.type is "ComputedPropertyName" then id
+    // ComputedPropertyName (including symbol elements) children already
+    // include the brackets.
+    if id.type is "ComputedPropertyName" then id
     // Plain identifier (including LengthShorthand) gets dot access,
     // unless its name was a non-ASCII unicode identifier that had to
     // be rendered via brackets to preserve the original source name.

--- a/source/parser/pipe.civet
+++ b/source/parser/pipe.civet
@@ -23,6 +23,7 @@ type {
   checkValidLHS
   deepCopy
   makeLeftHandSideExpression
+  makeAssignment
   makeNode
   parenthesizeExpression
   removeHoistDecs
@@ -213,11 +214,7 @@ function processPipelineExpression(s: PipelineExpression): void
             // checkValidLHS above validates the last access before we remove it.
 
             usingRef = makeRef()
-            initRef = makeNode {
-              type: "AssignmentExpression"
-              children: [usingRef, " = ", arg, pipelineReturns ? ";" : comma]
-              // missing `lhs`, hence cast below
-            } as AssignmentExpression
+            initRef = makeAssignment usingRef, arg, implicit: true, trailing: [pipelineReturns ? ";" : comma]
 
             arg = makeNode {
               type: "MemberExpression"
@@ -383,11 +380,7 @@ function processPipelineExpression(s: PipelineExpression): void
       if ref := needsRef arg
         // Use the existing ref if present
         usingRef ?= ref
-        arg = parenthesizeExpression makeNode {
-          type: "AssignmentExpression"
-          children: [usingRef, " = ", arg]
-          // missing `lhs`, hence cast below
-        } as AssignmentExpression
+        arg = parenthesizeExpression makeAssignment usingRef, arg!, implicit: true
         returning = usingRef
 
     let result

--- a/source/parser/ref.civet
+++ b/source/parser/ref.civet
@@ -1,5 +1,4 @@
 import type {
-  AssignmentExpression
   ASTNode
   ASTNodeObject
   ASTRef
@@ -13,7 +12,7 @@ import {
 
 import {
   isWhitespaceOrEmpty
-  makeNode
+  makeAssignment
 } from ./util.civet
 
 import {
@@ -84,15 +83,13 @@ function makeRefAssignment(ref: ASTNode, exp: ASTNode): {
   refAssignment: ASTNodeObject
   refAssignmentComma: ASTNode[]
 }
-  refAssignment := makeNode({
-    type: "AssignmentExpression"
-    children: [ref, " = ", exp]
+  refAssignment := makeAssignment ref!, exp!,
+    implicit: true
     hoistDec: {
       type: "Declaration"
       children: ["let ", ref]
       names: []
     } as! Declaration
-  } as! AssignmentExpression)
   {
     refAssignment
     refAssignmentComma: [refAssignment, ","]

--- a/source/parser/string.civet
+++ b/source/parser/string.civet
@@ -3,7 +3,9 @@ import type {
   ASTNode
   ExpressionNode
   Loc,
+  StringLiteral
   TabConfig
+  TemplateLiteral
   Whitespace
 } from ./types.civet
 
@@ -84,10 +86,10 @@ function dedentBlockString({ $loc, token: str }: ASTLeaf, tab: TabConfig, dedent
 
   { $loc, token: str }
 
-function dedentBlockSubstitutions($0: [ASTLeaf, (ASTLeaf | (ASTNode[] & {token: never}))[], ASTLeaf], tab: TabConfig)
+function dedentBlockSubstitutions($0: [ASTLeaf, (ASTLeaf | (ASTNode[] & {token: never}))[], ASTLeaf], tab: TabConfig): TemplateLiteral
   [s, strWithSubstitutions, e] := $0
 
-  return $0 unless strWithSubstitutions.length
+  return { type: "TemplateLiteral", children: $0 } unless strWithSubstitutions.length
 
   // Compute shared indentation of all string parts, concatenated
   stringPart :=
@@ -110,7 +112,7 @@ function dedentBlockSubstitutions($0: [ASTLeaf, (ASTLeaf | (ASTNode[] & {token: 
   type: "TemplateLiteral"
   children: results
 
-function processCoffeeInterpolation(s: ASTLeaf, parts: (ASTLeaf | [ASTLeaf, ExpressionNode, Whitespace, ASTLeaf])[], e: ASTLeaf, $loc: Loc)
+function processCoffeeInterpolation(s: ASTLeaf, parts: (ASTLeaf | [ASTLeaf, ExpressionNode, Whitespace, ASTLeaf])[], e: ASTLeaf, $loc: Loc): StringLiteral | TemplateLiteral
   // Check for no interpolations
   if parts.length is 0
     return {

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -109,10 +109,12 @@ export type OtherNode =
   | ComputedPropertyName
   | ConditionFragment
   | ConstructedExportSpecifier
+  | DeclarationCondition
   | DefaultClause
   | ElisionElement
   | ElseClause
   | EmptyBinding
+  | EmptyCondition
   | EnumProperty
   | Extends
   | FieldDefinition
@@ -134,9 +136,11 @@ export type OtherNode =
   | MultiMethodDefinition
   | NamedBindingPattern
   | NamedExports
+  | NegativeIndex
   | NonNullAssertion
   | NormalCatchParameter
   | ObjectBindingPattern
+  | Optional
   | Parameter
   | ParametersNode
   | PatternClause
@@ -156,6 +160,7 @@ export type OtherNode =
   | SliceExpression
   | SpreadElement
   | Star
+  | Substitution
   | SymbolLiteral
   | ThisType
   | TypeArgument
@@ -412,6 +417,8 @@ export type AssignmentExpressionLHS = [undefined, NonNullASTNode, [WSNode, [stri
 
 export type MemberExpression = ASTParent &
   type: "MemberExpression"
+  /** `@x` / `#` shorthand for `this.x` / `this.length`; suppresses implicit-call prefixing. */
+  thisShorthand?: boolean
   privateShorthand?: boolean
   privateId?: Identifier
 
@@ -731,6 +738,11 @@ export type EmptyStatement = ASTParent &
 export type EmptyCondition = ASTParent &
   type: "EmptyCondition"
 
+/** `if x := …` / `while x := …`: a declaration used as a condition. */
+export type DeclarationCondition = ASTParent &
+  type: "DeclarationCondition"
+  declaration: LexicalDeclaration
+
 export type Extends = ASTParent &
   type: "Extends"
   negated?: boolean
@@ -779,6 +791,15 @@ export type Index = ASTParent &
   type: "Index"
   expression: ASTNode
   optional?: Optional?
+  /** `x[i%]`: index modulo length; cleared once rewritten. */
+  mod?: boolean
+  /** `x[?]`: random index (no expression); cleared once rewritten. */
+  random?: boolean
+
+/** `x.-1` → `x[x.length-1]`; `len` is filled in by processNegativeIndexAccess. */
+export type NegativeIndex = ASTParent &
+  type: "NegativeIndex"
+  len: UntypedNode
 
 export type SliceExpression = ASTParent &
   type: "SliceExpression"
@@ -1161,7 +1182,12 @@ export type ConditionFragment = ASTParent &
 
 export type RegularExpressionLiteral = ASTParent &
   type: "RegularExpressionLiteral"
-  raw: string
+  /** Source text of a plain `/…/` literal; heregexes have no static form. */
+  raw?: string
+
+/** Interpolated part of a heregex, rendered inside `RegExp(\`…\`)`. */
+export type Substitution = ASTParent &
+  type: "Substitution"
 
 export type TemplateLiteral = ASTParent &
   type: "TemplateLiteral"
@@ -1245,7 +1271,7 @@ export type Whitespace = ASTString | (ASTLeaf | ASTString | CommentNode)[]?
 export type Delimiter = ASTLeaf | ASTString | Delimiter[]
 
 export type PropertyName =
-  Literal | ComputedPropertyName | Identifier
+  Identifier | StringLiteral | NumericLiteral | ComputedPropertyName
 
 export type ComputedPropertyName =
   type: "ComputedPropertyName"
@@ -1283,6 +1309,9 @@ export type AtBindingProperty = ASTParent &
 
 export type BindingRestProperty = ASTParent &
   type: "BindingRestProperty"
+  /** Set by NamedImportRest; the destructuring forms spread the identifier instead. */
+  dots?: ASTLeaf
+  binding?: BindingIdentifier
   typeSuffix: TypeSuffix?
   delim: ASTNode
   // AtBinding case
@@ -1578,24 +1607,11 @@ export type CoffeeClassPrivate = ASTParent &
 /**
  * The shape returned by the ClassElementName grammar rule:
  *   PropertyName / LengthShorthand / PrivateIdentifier / SymbolElement.
- * PropertyName branches to bare-leaf forms (hyphenated names) plus
- * NumericLiteral / ComputedPropertyName / StringLiteral / Identifier;
- * LengthShorthand and PrivateIdentifier both normalise to Identifier.
- * SymbolElement is a `[ "[", SymbolLiteral, "]" ]` tuple.
+ * Hyphenated names are StringLiteral leaves, LengthShorthand and
+ * PrivateIdentifier normalise to Identifier, and SymbolElement is a
+ * ComputedPropertyName wrapping the SymbolLiteral.
  */
-export type ClassElementName =
-  | NumericLiteral
-  | StringLiteral
-  | ASTLeaf
-  | Identifier
-  | ComputedPropertyName
-  | SymbolElement
-
-export type SymbolElement = [
-  ASTLeaf | ASTString
-  SymbolLiteral
-  ASTLeaf | ASTString
-]
+export type ClassElementName = PropertyName
 
 export type CoffeeClassPrototype = ASTParent &
   type: "CoffeeClassPrototype"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -412,6 +412,12 @@ export type AssignmentExpression = ASTParent &
   assigned: ASTNode
   expression: NonNullASTNode
   hoistDec?: ASTNode
+  /**
+   * Manufactured wrapper around an existing expression (e.g. `ref = exp`),
+   * as opposed to an assignment written in the source.  Placeholder
+   * lifting looks through implicit assignments.
+   */
+  implicit?: boolean
 
 export type AssignmentExpressionLHS = [undefined, NonNullASTNode, [WSNode, [string, WSNode]], ASTLeaf][]
 

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -113,6 +113,7 @@ export type OtherNode =
   | ElisionElement
   | ElseClause
   | EmptyBinding
+  | EnumProperty
   | Extends
   | FieldDefinition
   | FinallyClause
@@ -576,6 +577,10 @@ export type IterationStatement = ASTParent &
   negated: boolean?
   /** From grammar `( _? Star )?`: optional [whitespace, Star] tuple. */
   generator: [Whitespace, Star] | undefined
+  /** Only `for` loops reduce; declared absent so IterationFamily consumers can test it. */
+  reduction?: undefined
+  /** Only `for` and `if` carry a blockPrefix; declared absent for uniform postfix handling. */
+  blockPrefix?: undefined
   object?: boolean
   resultsRef: ASTRef?
   resultsParent?: boolean // inherit resultsRef from parent loop
@@ -588,6 +593,9 @@ export type BreakStatement = ASTParent &
 export type ComptimeStatement = ASTParent &
   type: "ComptimeStatement"
   block: BlockStatement
+  /** Never a generator or reduction; declared absent so IterationFamily consumers can test them. */
+  generator?: undefined
+  reduction?: undefined
   /**
    * Source blocks preserved so consumers can read the original `then`/`else`
    * independently of which one `block` selected.
@@ -610,6 +618,8 @@ export type DoStatement = ASTParent &
   block: BlockStatement
   /** From grammar `( _? Star )?`: optional [whitespace, Star] tuple. */
   generator: [Whitespace, Star] | undefined
+  /** Only `for` loops reduce; declared absent so IterationFamily consumers can test it. */
+  reduction?: undefined
 
 export type ForStatement = ASTParent &
   type: "ForStatement"
@@ -624,6 +634,8 @@ export type ForStatement = ASTParent &
   resultsParent?: boolean // inherit resultsRef from parent loop
   reduction?: ForReduction
   object?: boolean
+  /** Statements to run at the start of the body, inherited from ForStatementControl. */
+  blockPrefix?: StatementTuple[]?
 
 export type ForStatementControl = ASTParent &
   declaration?: ASTNode | null
@@ -952,6 +964,16 @@ export type EnumDeclaration = ASTParent &
   type: "EnumDeclaration"
   id: Identifier
 
+/** Braced or indented enum body; untyped node (no `type`) like other block wrappers. */
+export type EnumBlock = ASTParent &
+  properties: EnumProperty[]
+
+export type EnumProperty = ASTParent &
+  type: "EnumProperty"
+  name: Identifier
+  /** From grammar `( __ Equals MaybeNestedExpression )?`. */
+  initializer: [Whitespace, ASTLeaf, NonNullASTNode]?
+
 export type OperatorFunctionDeclaration = FunctionExpression &
   operator: true
 
@@ -976,7 +998,7 @@ export type Star =
 export type ModuleSpecifier = ASTParent &
   type: "ModuleSpecifier"
   module: ASTLeaf | StringLiteral
-  assertion?: ImportAssertion
+  assertion?: ImportAssertion?
 
 export type ImportAssertion = ASTParent &
   type: "ImportAssertion"

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -842,6 +842,8 @@ export type ASTRef = ASTObject &
 export type AtBinding =
   type: "AtBinding"
   ref: ASTRef
+  /** Never carries a type suffix; declared for uniform BindingPattern access. */
+  typeSuffix?: undefined
   at?: ASTLeaf
   children: Children & [ASTRef]
   parent?: Parent
@@ -1071,6 +1073,8 @@ export type Identifier =
   type: "Identifier"
   name: string
   names: string[]
+  /** Never carries a type suffix; declared for uniform BindingPattern access. */
+  typeSuffix?: undefined
   /**
    * Keyword covers the `import` → Identifier path that promotes the Import
    * keyword node into an identifier reference. ASTRef covers
@@ -1094,6 +1098,8 @@ export type ReturnValue = ASTParent &
   type: "ReturnValue"
   placeholder: NonNullASTNode
   names: []
+  /** Never carries a type suffix; declared for uniform BindingPattern access. */
+  typeSuffix?: undefined
 
 export type StatementExpression = ASTParent &
   type: "StatementExpression"
@@ -1164,7 +1170,7 @@ export type FinallyToken = "finally " | (Keyword & { token: "finally" })
 export type BindingIdentifier = AtBinding | Identifier | ReturnValue
 
 export type BindingPattern = (
-  BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | NamedBindingPattern | Literal | RegularExpressionLiteral
+  BindingIdentifier | ObjectBindingPattern | ArrayBindingPattern | PinPattern | NamedBindingPattern
 ) &
   /** Post-rest parameter rewriting emits a JS-only copy of the binding. */
   js?: boolean
@@ -1173,7 +1179,10 @@ export type BindingPattern = (
 // but aren't patterns by themselves
 export type BindingPatternComponent = BindingProperty | AtBindingProperty | BindingRestProperty | BindingElement | BindingRestElement | BindingPattern
 
-export type PatternExpression = BindingPattern | ConditionFragment
+/** Literal matchers, valid only inside pattern matching. */
+export type LiteralPattern = Literal | RegularExpressionLiteral
+
+export type PatternExpression = BindingPattern | LiteralPattern | ConditionFragment
 
 export type ConditionFragment = ASTParent &
   type: "ConditionFragment"
@@ -1182,6 +1191,8 @@ export type ConditionFragment = ASTParent &
 
 export type RegularExpressionLiteral = ASTParent &
   type: "RegularExpressionLiteral"
+  /** Never carries a type suffix; declared for uniform pattern access. */
+  typeSuffix?: undefined
   /** Source text of a plain `/…/` literal; heregexes have no static form. */
   raw?: string
 
@@ -1216,7 +1227,7 @@ export type PostRestBindingElements = ASTParent &
 export type BindingElement = ASTParent &
   type: "BindingElement"
   names: string[]
-  binding: BindingIdentifier | BindingPattern
+  binding: BindingIdentifier | BindingPattern | LiteralPattern
   typeSuffix?: TypeSuffix?
   initializer?: Initializer?
   delim?: ASTNode
@@ -1224,7 +1235,8 @@ export type BindingElement = ASTParent &
 export type BindingRestElement = ASTParent &
   type: "BindingRestElement"
   dots: ASTLeaf
-  name: string
+  /** Identifier bindings only. */
+  name: string?
   names: string[]
   rest: true
   typeSuffix?: TypeSuffix?
@@ -1253,13 +1265,17 @@ export type Placeholder = ASTObject &
 export type PinPattern = ASTParent &
   type: "PinPattern"
   expression: ASTNode
+  /** Pins compare against an existing value; they declare nothing. */
+  names: []
   ref?: ASTRef
   typeSuffix?: TypeSuffix?
 
 export type NamedBindingPattern = ASTParent &
   type: "NamedBindingPattern"
-  binding: BindingIdentifier
-  pattern: BindingPattern
+  /** `{[key]^: pattern}` binds through a computed key. */
+  binding: BindingIdentifier | ComputedPropertyName
+  pattern: BindingPattern | LiteralPattern
+  names: string[]
   subbinding?: ASTNode
   typeSuffix?: TypeSuffix?
 
@@ -1284,7 +1300,7 @@ export type BindingProperty = ASTParent &
   type: "BindingProperty"
   name: PropertyName | AtBinding
   names: string[]
-  value: (BindingIdentifier | BindingPattern)?
+  value: (BindingIdentifier | BindingPattern | LiteralPattern)?
   typeSuffix: TypeSuffix?
   initializer: Initializer?
   delim: ASTNode
@@ -1628,6 +1644,8 @@ export type CoffeeClassPublic = ASTParent &
 export type Literal =
   type: "Literal"
   subtype: "NullLiteral" | "BooleanLiteral" | "NumericLiteral" | "StringLiteral" | "RegularExpressionLiteral"
+  /** Never carries a type suffix; declared for uniform pattern access. */
+  typeSuffix?: undefined
   children: Children & (LiteralContent | ASTLeaf | string)[]
   parent?: Parent
   raw: string

--- a/source/parser/types.civet
+++ b/source/parser/types.civet
@@ -1650,10 +1650,13 @@ export type TypeIdentifier = ASTParent &
 export type TypeArguments = ASTParent &
   type: "TypeArguments"
   ts: true
-  // Should alternate: argument, delimiter, argument, delimiter, ..., argument
   args: TypeArgumentList
 
-export type TypeArgumentList = (TypeArgument | Delimiter)[]
+// Alternates argument, delimiter, argument, ..., argument.  Nested forms
+// (`NestedTypeBulletedTuple`, `NestedInterfaceBlock`) contribute TypeTuple
+// nodes and spread their raw children (including the whitespace tuples from
+// `CommaDelimiter` / `( _? Comma )`) directly into the list.
+export type TypeArgumentList = (TypeArgument | TypeTuple | Delimiter | Children | undefined)[]
 
 export type TypeArgument = ASTObject &
   type: "TypeArgument"

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -36,7 +36,7 @@ import {
 // Types need to be upfront to allow for TypeScript `asserts`
 assert: {
   <T>(a: T, msg: string): asserts a
-  equal(a: unknown, b: unknown, msg: string): asserts a is b
+  equal<T>(a: unknown, b: T, msg: string): asserts a is T
   notEqual(a: unknown, b: unknown, msg: string): void
   notNull<T>(a: T, msg: string): asserts a is NonNullable<T>
 } := Object.assign(

--- a/source/parser/util.civet
+++ b/source/parser/util.civet
@@ -1,5 +1,6 @@
 import type {
   ASTLeaf
+  AssignmentExpression
   ASTNode
   ASTNodeObject
   ASTNodeParent
@@ -747,6 +748,29 @@ function makeNode<T extends ASTNodeObject>(node: T): T
   node
 
 /**
+ * Synthesize a `target = expression` AssignmentExpression.  Parser-built
+ * assignments carry the parsed `lhs` tuples; synthesized ones have none,
+ * so `lhs` is empty and `assigned` is the target itself.  `trailing`
+ * children (e.g. a `;` or `,`) follow the expression.
+ */
+function makeAssignment(
+  target: NonNullASTNode
+  expression: NonNullASTNode
+  options?: { names?: string[], hoistDec?: ASTNode, trailing?: ASTNode[], implicit?: boolean }
+): AssignmentExpression
+  node: AssignmentExpression := {
+    type: "AssignmentExpression"
+    children: [target, " = ", expression, ...options?.trailing ?? []]
+    names: options?.names ?? []
+    lhs: []
+    assigned: target
+    expression
+  }
+  node.hoistDec = options.hoistDec if options?.hoistDec
+  node.implicit = true if options?.implicit
+  makeNode node
+
+/**
  * Used to ignore the result of __ if it is only whitespace
  * Useful to preserve spacing around comments
  */
@@ -990,6 +1014,7 @@ export {
   literalType
   typeOfExpression
   typeSuffixForExpression
+  makeAssignment
   makeLeftHandSideExpression
   makeNode
   makeNumericLiteral

--- a/test/assignment.civet
+++ b/test/assignment.civet
@@ -248,6 +248,30 @@ describe "assignment", ->
   """
 
   throws """
+    literal is not a binding pattern
+    ---
+    1 := y
+    ---
+    ParseError
+  """
+
+  throws """
+    literal key cannot be a named binding
+    ---
+    {"a"^: [x]} := y
+    ---
+    ParseError
+  """
+
+  throws """
+    nested literal is not a binding pattern
+    ---
+    {a: 1} := y
+    ---
+    ParseError
+  """
+
+  throws """
     const assignment shorthand forbids comma expressions
     ---
     x := 1, y = 2

--- a/test/binary-op.civet
+++ b/test/binary-op.civet
@@ -1525,6 +1525,14 @@ describe "is like pattern matching test", ->
   """
 
   testCase """
+    is like inside access shorthand lifts the placeholder function
+    ---
+    cs.some .a is like {t}
+    ---
+    let m;cs.some($ => (m = $.a,typeof m === 'object' && m != null && 't' in m))
+  """
+
+  testCase """
     multiple patterns
     ---
     x is like [1, x, 3], []

--- a/test/class.civet
+++ b/test/class.civet
@@ -10,6 +10,20 @@ describe "class", ->
   """
 
   testCase """
+    numeric method name
+    ---
+    class X
+      0()
+        1
+    ---
+    class X {
+      0() {
+        return 1
+      }
+    }
+  """
+
+  testCase """
     one-line
     ---
     class X { a = 5; b = 10 }

--- a/test/compat/auto-var.civet
+++ b/test/compat/auto-var.civet
@@ -551,6 +551,29 @@ describe "auto-var", ->
   """
 
   testCase """
+    nested parameter list declares no vars for parameters
+    ---
+    'civet autoVar'
+    function f(
+      a
+      b
+    )
+      a = 1
+      b = 2
+      c = 3
+    ---
+    function f(
+      a,
+      b
+    ) {
+      var c;
+      a = 1
+      b = 2
+      return c = 3
+    }
+  """
+
+  testCase """
     autoVar with undefined parseOptions.globals does not crash
     ---
     'civet autoVar'

--- a/test/infra/config.civet
+++ b/test/infra/config.civet
@@ -112,7 +112,7 @@ describe "findConfig", ->
         @skip() if process.platform is 'win32' and
                    (error as NodeJS.ErrnoException).code is 'EPERM'
         throw error
-      await fs.writeFile join(dir, "civet.config.yaml"), "jsOutput: true\n"
+      await fs.writeFile join(dir, "civet.config.yaml"), "js: true\n"
       result := await findInDir(dir)
       assert result, "should fall through to civet.config.yaml"
       assert result!.endsWith("civet.config.yaml")
@@ -121,7 +121,7 @@ describe "findConfig", ->
     await withTempDir async (dir) =>
       configEntry := join dir, "civetconfig.json"
       await fs.writeFile configEntry, "{}"
-      await fs.writeFile join(dir, "civet.config.yaml"), "jsOutput: true\n"
+      await fs.writeFile join(dir, "civet.config.yaml"), "js: true\n"
       await withStatEACCES configEntry, async =>
         result := await findInDir(dir)
         assert result, "should fall through to civet.config.yaml"
@@ -130,7 +130,7 @@ describe "findConfig", ->
   it "ignores a config entry that is a directory, not a file", ->
     await withTempDir async (dir) ->
       await fs.mkdir join(dir, "civetconfig.json")
-      await fs.writeFile join(dir, "civet.config.yaml"), "jsOutput: true\n"
+      await fs.writeFile join(dir, "civet.config.yaml"), "js: true\n"
       result := await findInDir(dir)
       assert result, "should fall through to civet.config.yaml"
       assert result!.endsWith("civet.config.yaml")
@@ -166,7 +166,7 @@ describe "findInDir", ->
 
   it "finds civet.config.yaml", ->
     await withTempDir async (dir) ->
-      await fs.writeFile join(dir, "civet.config.yaml"), "jsOutput: true\n"
+      await fs.writeFile join(dir, "civet.config.yaml"), "js: true\n"
       result := await findInDir(dir)
       assert result, "should find civet.config.yaml"
       assert result!.endsWith("civet.config.yaml")
@@ -175,18 +175,18 @@ describe "loadConfig", ->
   it "loads plain JSON config", ->
     await withTempDir async (dir) ->
       configPath := join dir, "civetconfig.json"
-      await fs.writeFile configPath, '{"jsOutput": true}'
+      await fs.writeFile configPath, '{"js": true}'
       config := await loadConfig(configPath)
-      assert.equal config.jsOutput, true
+      assert.equal config.js, true
 
   it "loads package.json with civetConfig key", ->
     await withTempDir async (dir) ->
       configPath := join dir, "package.json"
       await fs.writeFile configPath, JSON.stringify
         name: "my-package"
-        civetConfig: { jsOutput: true }
+        civetConfig: { js: true }
       config := await loadConfig(configPath)
-      assert.equal config.jsOutput, true
+      assert.equal config.js, true
 
   it "returns empty object for package.json without civetConfig key", ->
     await withTempDir async (dir) ->
@@ -206,23 +206,23 @@ describe "loadConfig", ->
   it "loads YAML config", ->
     await withTempDir async (dir) ->
       configPath := join dir, "civet.config.yaml"
-      await fs.writeFile configPath, "jsOutput: true\n"
+      await fs.writeFile configPath, "js: true\n"
       config := await loadConfig(configPath)
-      assert.equal config.jsOutput, true
+      assert.equal config.js, true
 
   it "loads YAML config with civetConfig key", ->
     await withTempDir async (dir) ->
       configPath := join dir, "civet.config.yaml"
-      await fs.writeFile configPath, "civetConfig:\n  jsOutput: true\n"
+      await fs.writeFile configPath, "civetConfig:\n  js: true\n"
       config := await loadConfig(configPath)
-      assert.equal config.jsOutput, true
+      assert.equal config.js, true
 
   it "loads .yml config", ->
     await withTempDir async (dir) ->
       configPath := join dir, "civet.config.yml"
-      await fs.writeFile configPath, "jsOutput: true\n"
+      await fs.writeFile configPath, "js: true\n"
       config := await loadConfig(configPath)
-      assert.equal config.jsOutput, true
+      assert.equal config.js, true
 
   it "throws on malformed YAML config", ->
     await withTempDir async (dir) ->
@@ -235,9 +235,9 @@ describe "loadConfig", ->
   it "loads JS config file", ->
     await withTempDir async (dir) ->
       configPath := join dir, "civet.config.js"
-      await fs.writeFile configPath, "export default { jsOutput: true }"
+      await fs.writeFile configPath, "export default { js: true }"
       config := await loadConfig(configPath)
-      assert.equal config.jsOutput, true
+      assert.equal config.js, true
 
   it "throws on broken JS config file", ->
     await withTempDir async (dir) ->

--- a/test/sourcemap.civet
+++ b/test/sourcemap.civet
@@ -1,7 +1,7 @@
 { compile } from ../source/main.civet
 assert from assert
 
-{ SourceMap, base64Encode, decodeVLQ } from ../source/sourcemap.civet
+{ SourceMap, base64Encode, decodeVLQ, type SourceMapJSON, type SourceMapLines } from ../source/sourcemap.civet
 { remapPosition } from ../source/ts-diagnostic.civet
 { transform } from esbuild
 
@@ -116,12 +116,12 @@ describe "source map", ->
     originalSource := "```\nx := 5\n```"
     originalFilename := "original.hera"
 
-    assertShiftedSourceMap := (srcMapJSON, lines) =>
+    assertShiftedSourceMap := (srcMapJSON: SourceMapJSON, lines: SourceMapLines) =>
       // Resolved 4-slot entries are
       // [generatedColumnDelta, sourceFileDelta, sourceLine, sourceColumn].
       mappedEntries := lines[0].filter (entry) => entry.length is 4
-      assert.equal srcMapJSON.sources[0], originalFilename
-      assert.equal srcMapJSON.sourcesContent[0], originalSource
+      assert.equal srcMapJSON.sources![0], originalFilename
+      assert.equal srcMapJSON.sourcesContent![0], originalSource
       // The composed map should preserve Civet's segment structure while
       // shifting all mapped source positions down to Hera line 1.
       assert.deepEqual mappedEntries, [
@@ -256,13 +256,13 @@ describe "source map", ->
           [colDelta, sourceFileIndex, srcLine + 1, srcCol + 2]
 
     it "does not backfill columns before the first upstream mapping on a line", ->
-      upstreamLines := [
+      upstreamLines: SourceMapLines := [
         [
           [6]
           [92, 0, 252, 8]
         ]
       ]
-      downstreamLines := [
+      downstreamLines: SourceMapLines := [
         [
           [20, 0, 0, 28]
           [80, 0, 0, 108]
@@ -396,22 +396,22 @@ describe "source map", ->
 
   describe "composeLines edge cases", ->
     it "passes through length-1 (unmapped) downstream entries unchanged", ->
-      upstreamLines := [[[0, 0, 0, 0]]]
-      downstreamLines := [[[5]]]  // length-1 entry: no source mapping
+      upstreamLines: SourceMapLines := [[[0, 0, 0, 0]]]
+      downstreamLines: SourceMapLines := [[[5]]]  // length-1 entry: no source mapping
       result := SourceMap.composeLines upstreamLines, downstreamLines
       assert.deepEqual result, [[[5]]]
 
     it "handles length-5 downstream entries (entries with name index)", ->
-      upstreamLines := [[[0, 0, 0, 0]]]
+      upstreamLines: SourceMapLines := [[[0, 0, 0, 0]]]
       // [colDelta, sourceFileIndex, srcLine, srcCol, nameIndex]
-      downstreamLines := [[[0, 0, 0, 0, 3]]]
+      downstreamLines: SourceMapLines := [[[0, 0, 0, 0, 3]]]
       result := SourceMap.composeLines upstreamLines, downstreamLines
       assert.equal result[0][0].length, 5
       assert.equal result[0][0][4], 3  // name index preserved
 
     it "returns undefined for downstream entry referencing missing upstream line", ->
-      upstreamLines := []  // no upstream lines
-      downstreamLines := [[[5, 0, 0, 0]]]  // references srcLine=0 which doesn't exist
+      upstreamLines: SourceMapLines := []  // no upstream lines
+      downstreamLines: SourceMapLines := [[[5, 0, 0, 0]]]  // references srcLine=0 which doesn't exist
       result := SourceMap.composeLines upstreamLines, downstreamLines
       // When upstream line is missing, entry degrades to length-1 (unmapped)
       assert.deepEqual result, [[[5]]]


### PR DESCRIPTION
Adds the missing `import type`s for `StringLiteral`, `NumericLiteral`, `Literal`, and `TypeArguments` in `parser.hera`. Without them the `::` annotations resolved to the grammar rule functions (TS2749), so those rules and everything downstream were effectively `any`. Each exposed error was followed to its producer rather than widened.

**Behavior change:** literal and regex patterns are only valid in pattern-matching contexts (`switch`/`catch` patterns, `is like`, and the pattern of `if x := …` declaration conditions). A validation pass right after `addParentPointers` rejects them in binding positions (declarations, assignment targets, parameters, loop bindings, import bindings), following binding positions only, so `{0: a} := x` and `{a = 1} := x` stay valid. `1 := y` and `{a: 1} := y` now report `Literal patterns can only appear in pattern matching` instead of emitting `const 1 = y`. No parser state is involved.

Bugs found by the types along the way:
- multi-line parameter lists were returned unflattened, so autoVar re-declared parameters as `var`
- `{a^: [x]}` named patterns never set `names`
- `SnugNamedProperty` was the only `Property` producer without `value`
- `xs.some .a is like {t}` had no test; synthesized ref assignments now carry an `implicit` flag that placeholder lifting looks through

Also: `PropertyName`/`ClassElementName` retyped to what the grammar emits (hyphenated names are `StringLiteral`, symbol keys are `ComputedPropertyName`), a `makeAssignment` helper replaces the ad-hoc synthesized assignments, and ~40 untyped `{type, children}` producers got annotations.

Typecheck: 647 → 529 errors, 0 regressions per `scripts/typecheck-diff.civet`.

Related: #2210 fixes a largely disjoint set of errors by narrowing at consumers; several of its regressions and guards are resolved by the type changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Sfe2VL834j4UETFQjcGnA